### PR TITLE
Route dense conv through tensor-core GEMM + sm_90a implicit-GEMM (TMA im2col)

### DIFF
--- a/benchmarks/baselines.html
+++ b/benchmarks/baselines.html
@@ -6415,7 +6415,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 },
                 "N8xC3x224x224_K64k7s2": {
                   "layouts": {
-                    "contig": 1.311
+                    "contig": 1.074
                   }
                 }
               }

--- a/benchmarks/baselines.html
+++ b/benchmarks/baselines.html
@@ -6408,14 +6408,49 @@ document.addEventListener("DOMContentLoaded", boot);
           "dtypes": {
             "bf16": {
               "shapes": {
+                "N16xC64x32x32_K64k3s1d2": {
+                  "layouts": {
+                    "contig": 6.791
+                  }
+                },
+                "N16xC96x28x28_K192k3s2": {
+                  "layouts": {
+                    "contig": 5.337
+                  }
+                },
+                "N1xC256x14x14_K256k3s1": {
+                  "layouts": {
+                    "contig": 1.806
+                  }
+                },
+                "N1xC64x56x56_K64k3s1": {
+                  "layouts": {
+                    "contig": 1.375
+                  }
+                },
+                "N32xC128x28x28_K128k3s2": {
+                  "layouts": {
+                    "contig": 12.566
+                  }
+                },
                 "N32xC256x14x14_K256k3s1": {
                   "layouts": {
                     "contig": 1.452
                   }
                 },
+                "N32xC256x14x14_K512k1s2": {
+                  "layouts": {
+                    "contig": 3.482
+                  }
+                },
                 "N32xC256x56x56_K64k1s1": {
                   "layouts": {
                     "contig": 0.783
+                  }
+                },
+                "N32xC512x7x7_K512k3s1": {
+                  "layouts": {
+                    "contig": 2.019
                   }
                 },
                 "N32xC64x56x56_K64k3s1": {
@@ -6428,6 +6463,11 @@ document.addEventListener("DOMContentLoaded", boot);
                     "contig": 1.102
                   }
                 },
+                "N8xC128x112x112_K128k3s1": {
+                  "layouts": {
+                    "contig": 0.981
+                  }
+                },
                 "N8xC3x224x224_K64k7s2": {
                   "layouts": {
                     "contig": 1.074
@@ -6437,14 +6477,49 @@ document.addEventListener("DOMContentLoaded", boot);
             },
             "f32": {
               "shapes": {
+                "N16xC64x32x32_K64k3s1d2": {
+                  "layouts": {
+                    "contig": 7.961
+                  }
+                },
+                "N16xC96x28x28_K192k3s2": {
+                  "layouts": {
+                    "contig": 7.757
+                  }
+                },
+                "N1xC256x14x14_K256k3s1": {
+                  "layouts": {
+                    "contig": 2.278
+                  }
+                },
+                "N1xC64x56x56_K64k3s1": {
+                  "layouts": {
+                    "contig": 4.026
+                  }
+                },
+                "N32xC128x28x28_K128k3s2": {
+                  "layouts": {
+                    "contig": 12.283
+                  }
+                },
                 "N32xC256x14x14_K256k3s1": {
                   "layouts": {
                     "contig": 19.806
                   }
                 },
+                "N32xC256x14x14_K512k1s2": {
+                  "layouts": {
+                    "contig": 4.427
+                  }
+                },
                 "N32xC256x56x56_K64k1s1": {
                   "layouts": {
                     "contig": 1.866
+                  }
+                },
+                "N32xC512x7x7_K512k3s1": {
+                  "layouts": {
+                    "contig": 18.407
                   }
                 },
                 "N32xC64x56x56_K64k3s1": {
@@ -6455,6 +6530,11 @@ document.addEventListener("DOMContentLoaded", boot);
                 "N7xC48x39x53_K80k3s1": {
                   "layouts": {
                     "contig": 2.87
+                  }
+                },
+                "N8xC128x112x112_K128k3s1": {
+                  "layouts": {
+                    "contig": 7.679
                   }
                 },
                 "N8xC3x224x224_K64k7s2": {

--- a/benchmarks/baselines.html
+++ b/benchmarks/baselines.html
@@ -6410,12 +6410,12 @@ document.addEventListener("DOMContentLoaded", boot);
               "shapes": {
                 "N32xC64x56x56_K64k3s1": {
                   "layouts": {
-                    "contig": 24.351
+                    "contig": 9.373
                   }
                 },
                 "N8xC3x224x224_K64k7s2": {
                   "layouts": {
-                    "contig": 4.701
+                    "contig": 1.311
                   }
                 }
               }
@@ -6424,12 +6424,12 @@ document.addEventListener("DOMContentLoaded", boot);
               "shapes": {
                 "N32xC64x56x56_K64k3s1": {
                   "layouts": {
-                    "contig": 12.456
+                    "contig": 7.448
                   }
                 },
                 "N8xC3x224x224_K64k7s2": {
                   "layouts": {
-                    "contig": 4.138
+                    "contig": 1.964
                   }
                 }
               }

--- a/benchmarks/baselines.html
+++ b/benchmarks/baselines.html
@@ -6408,9 +6408,24 @@ document.addEventListener("DOMContentLoaded", boot);
           "dtypes": {
             "bf16": {
               "shapes": {
+                "N32xC256x14x14_K256k3s1": {
+                  "layouts": {
+                    "contig": 1.452
+                  }
+                },
+                "N32xC256x56x56_K64k1s1": {
+                  "layouts": {
+                    "contig": 0.783
+                  }
+                },
                 "N32xC64x56x56_K64k3s1": {
                   "layouts": {
-                    "contig": 9.373
+                    "contig": 0.653
+                  }
+                },
+                "N7xC48x39x53_K80k3s1": {
+                  "layouts": {
+                    "contig": 1.102
                   }
                 },
                 "N8xC3x224x224_K64k7s2": {
@@ -6422,9 +6437,24 @@ document.addEventListener("DOMContentLoaded", boot);
             },
             "f32": {
               "shapes": {
+                "N32xC256x14x14_K256k3s1": {
+                  "layouts": {
+                    "contig": 19.806
+                  }
+                },
+                "N32xC256x56x56_K64k1s1": {
+                  "layouts": {
+                    "contig": 1.866
+                  }
+                },
                 "N32xC64x56x56_K64k3s1": {
                   "layouts": {
                     "contig": 7.448
+                  }
+                },
+                "N7xC48x39x53_K80k3s1": {
+                  "layouts": {
+                    "contig": 2.87
                   }
                 },
                 "N8xC3x224x224_K64k7s2": {

--- a/benchmarks/baselines.html
+++ b/benchmarks/baselines.html
@@ -6390,9 +6390,24 @@ document.addEventListener("DOMContentLoaded", boot);
           "dtypes": {
             "bf16": {
               "shapes": {
+                "N32xC256x14x14_K256k3s1": {
+                  "layouts": {
+                    "contig": 1.452
+                  }
+                },
+                "N32xC256x56x56_K64k1s1": {
+                  "layouts": {
+                    "contig": 0.783
+                  }
+                },
                 "N32xC64x56x56_K64k3s1": {
                   "layouts": {
-                    "contig": 9.373
+                    "contig": 0.653
+                  }
+                },
+                "N7xC48x39x53_K80k3s1": {
+                  "layouts": {
+                    "contig": 1.102
                   }
                 },
                 "N8xC3x224x224_K64k7s2": {
@@ -6404,9 +6419,24 @@ document.addEventListener("DOMContentLoaded", boot);
             },
             "f32": {
               "shapes": {
+                "N32xC256x14x14_K256k3s1": {
+                  "layouts": {
+                    "contig": 19.806
+                  }
+                },
+                "N32xC256x56x56_K64k1s1": {
+                  "layouts": {
+                    "contig": 1.866
+                  }
+                },
                 "N32xC64x56x56_K64k3s1": {
                   "layouts": {
                     "contig": 7.448
+                  }
+                },
+                "N7xC48x39x53_K80k3s1": {
+                  "layouts": {
+                    "contig": 2.87
                   }
                 },
                 "N8xC3x224x224_K64k7s2": {

--- a/benchmarks/baselines.html
+++ b/benchmarks/baselines.html
@@ -6392,12 +6392,12 @@ document.addEventListener("DOMContentLoaded", boot);
               "shapes": {
                 "N32xC64x56x56_K64k3s1": {
                   "layouts": {
-                    "contig": 24.351
+                    "contig": 9.373
                   }
                 },
                 "N8xC3x224x224_K64k7s2": {
                   "layouts": {
-                    "contig": 4.701
+                    "contig": 1.311
                   }
                 }
               }
@@ -6406,12 +6406,12 @@ document.addEventListener("DOMContentLoaded", boot);
               "shapes": {
                 "N32xC64x56x56_K64k3s1": {
                   "layouts": {
-                    "contig": 12.456
+                    "contig": 7.448
                   }
                 },
                 "N8xC3x224x224_K64k7s2": {
                   "layouts": {
-                    "contig": 4.138
+                    "contig": 1.964
                   }
                 }
               }

--- a/benchmarks/baselines.html
+++ b/benchmarks/baselines.html
@@ -6397,7 +6397,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 },
                 "N8xC3x224x224_K64k7s2": {
                   "layouts": {
-                    "contig": 1.311
+                    "contig": 1.074
                   }
                 }
               }

--- a/benchmarks/baselines.html
+++ b/benchmarks/baselines.html
@@ -6390,14 +6390,49 @@ document.addEventListener("DOMContentLoaded", boot);
           "dtypes": {
             "bf16": {
               "shapes": {
+                "N16xC64x32x32_K64k3s1d2": {
+                  "layouts": {
+                    "contig": 6.791
+                  }
+                },
+                "N16xC96x28x28_K192k3s2": {
+                  "layouts": {
+                    "contig": 5.337
+                  }
+                },
+                "N1xC256x14x14_K256k3s1": {
+                  "layouts": {
+                    "contig": 1.806
+                  }
+                },
+                "N1xC64x56x56_K64k3s1": {
+                  "layouts": {
+                    "contig": 1.375
+                  }
+                },
+                "N32xC128x28x28_K128k3s2": {
+                  "layouts": {
+                    "contig": 12.566
+                  }
+                },
                 "N32xC256x14x14_K256k3s1": {
                   "layouts": {
                     "contig": 1.452
                   }
                 },
+                "N32xC256x14x14_K512k1s2": {
+                  "layouts": {
+                    "contig": 3.482
+                  }
+                },
                 "N32xC256x56x56_K64k1s1": {
                   "layouts": {
                     "contig": 0.783
+                  }
+                },
+                "N32xC512x7x7_K512k3s1": {
+                  "layouts": {
+                    "contig": 2.019
                   }
                 },
                 "N32xC64x56x56_K64k3s1": {
@@ -6410,6 +6445,11 @@ document.addEventListener("DOMContentLoaded", boot);
                     "contig": 1.102
                   }
                 },
+                "N8xC128x112x112_K128k3s1": {
+                  "layouts": {
+                    "contig": 0.981
+                  }
+                },
                 "N8xC3x224x224_K64k7s2": {
                   "layouts": {
                     "contig": 1.074
@@ -6419,14 +6459,49 @@ document.addEventListener("DOMContentLoaded", boot);
             },
             "f32": {
               "shapes": {
+                "N16xC64x32x32_K64k3s1d2": {
+                  "layouts": {
+                    "contig": 7.961
+                  }
+                },
+                "N16xC96x28x28_K192k3s2": {
+                  "layouts": {
+                    "contig": 7.757
+                  }
+                },
+                "N1xC256x14x14_K256k3s1": {
+                  "layouts": {
+                    "contig": 2.278
+                  }
+                },
+                "N1xC64x56x56_K64k3s1": {
+                  "layouts": {
+                    "contig": 4.026
+                  }
+                },
+                "N32xC128x28x28_K128k3s2": {
+                  "layouts": {
+                    "contig": 12.283
+                  }
+                },
                 "N32xC256x14x14_K256k3s1": {
                   "layouts": {
                     "contig": 19.806
                   }
                 },
+                "N32xC256x14x14_K512k1s2": {
+                  "layouts": {
+                    "contig": 4.427
+                  }
+                },
                 "N32xC256x56x56_K64k1s1": {
                   "layouts": {
                     "contig": 1.866
+                  }
+                },
+                "N32xC512x7x7_K512k3s1": {
+                  "layouts": {
+                    "contig": 18.407
                   }
                 },
                 "N32xC64x56x56_K64k3s1": {
@@ -6437,6 +6512,11 @@ document.addEventListener("DOMContentLoaded", boot);
                 "N7xC48x39x53_K80k3s1": {
                   "layouts": {
                     "contig": 2.87
+                  }
+                },
+                "N8xC128x112x112_K128k3s1": {
+                  "layouts": {
+                    "contig": 7.679
                   }
                 },
                 "N8xC3x224x224_K64k7s2": {

--- a/benchmarks/test_vision.py
+++ b/benchmarks/test_vision.py
@@ -20,6 +20,18 @@ from bench_lib.hw import Hardware
 CONV_SHAPES: dict[str, tuple[int, int, int, int, int, int, int, int]] = {
     "N32xC64x56x56_K64k3s1": (32, 64, 56, 56, 64, 3, 1, 1),
     "N8xC3x224x224_K64k7s2": (8, 3, 224, 224, 64, 7, 2, 3),
+    # Deeper-C, small-spatial ResNet stage. Same implicit-GEMM domain as the
+    # body shape above but the output row pitch (hw*2 = 392 B) is not TMA
+    # store aligned, so it exercises the scalar epilogue instead.
+    "N32xC256x14x14_K256k3s1": (32, 256, 14, 14, 256, 3, 1, 1),
+    # Nothing divides anything: C=48 pads to 64 (25% wasted reduction),
+    # out_c=80 is ragged against BM=64, H/W are both odd. Worst-case shape
+    # inside the implicit-GEMM domain.
+    "N7xC48x39x53_K80k3s1": (7, 48, 39, 53, 80, 3, 1, 1),
+    # 1x1 control: the materialized route already skips im2col for this case
+    # (the NCHW input IS the col matrix), so the implicit-GEMM route must
+    # decline it rather than regress it with an added NHWC pass.
+    "N32xC256x56x56_K64k1s1": (32, 256, 56, 56, 64, 1, 1, 0),
 }
 # (N, C, H, W, output)
 ADAPTIVE_SHAPES: dict[str, tuple[int, int, int, int, int]] = {

--- a/benchmarks/test_vision.py
+++ b/benchmarks/test_vision.py
@@ -16,22 +16,51 @@ from bench_lib.cases import DTYPES, both
 from bench_lib.check import Bench
 from bench_lib.hw import Hardware
 
-# (N, C_in, H, W, C_out, kernel, stride, padding)
-CONV_SHAPES: dict[str, tuple[int, int, int, int, int, int, int, int]] = {
-    "N32xC64x56x56_K64k3s1": (32, 64, 56, 56, 64, 3, 1, 1),
-    "N8xC3x224x224_K64k7s2": (8, 3, 224, 224, 64, 7, 2, 3),
+# (N, C_in, H, W, C_out, kernel, stride, padding, dilation)
+#
+# The first five shapes are all stride-1 dense convs, which is exactly the
+# domain of the implicit-GEMM route; the block after them deliberately leaves
+# that domain (stride 2, dilation, 1x1-with-stride, batch 1, ragged channels)
+# so the recorded numbers describe the whole op and not one fast path.
+CONV_SHAPES: dict[str, tuple[int, int, int, int, int, int, int, int, int]] = {
+    "N32xC64x56x56_K64k3s1": (32, 64, 56, 56, 64, 3, 1, 1, 1),
+    "N8xC3x224x224_K64k7s2": (8, 3, 224, 224, 64, 7, 2, 3, 1),
     # Deeper-C, small-spatial ResNet stage. Same implicit-GEMM domain as the
     # body shape above but the output row pitch (hw*2 = 392 B) is not TMA
     # store aligned, so it exercises the scalar epilogue instead.
-    "N32xC256x14x14_K256k3s1": (32, 256, 14, 14, 256, 3, 1, 1),
+    "N32xC256x14x14_K256k3s1": (32, 256, 14, 14, 256, 3, 1, 1, 1),
     # Nothing divides anything: C=48 pads to 64 (25% wasted reduction),
     # out_c=80 is ragged against BM=64, H/W are both odd. Worst-case shape
     # inside the implicit-GEMM domain.
-    "N7xC48x39x53_K80k3s1": (7, 48, 39, 53, 80, 3, 1, 1),
+    "N7xC48x39x53_K80k3s1": (7, 48, 39, 53, 80, 3, 1, 1, 1),
     # 1x1 control: the materialized route already skips im2col for this case
     # (the NCHW input IS the col matrix), so the implicit-GEMM route must
     # decline it rather than regress it with an added NHWC pass.
-    "N32xC256x56x56_K64k1s1": (32, 256, 56, 56, 64, 1, 1, 0),
+    "N32xC256x56x56_K64k1s1": (32, 256, 56, 56, 64, 1, 1, 0, 1),
+    # --- regimes OUTSIDE the implicit-GEMM domain -------------------------
+    # ResNet-50 stage transition. stride != 1 is declined by the implicit
+    # GEMM, so this is the materialized im2col route, whose gather is the
+    # dominant cost at stride 2 (measured: 362 of 409 us here).
+    "N32xC128x28x28_K128k3s2": (32, 128, 28, 28, 128, 3, 2, 1, 1),
+    # ResNet-50 shortcut: a 1x1 that CANNOT reuse the in-place col matrix
+    # (that fast path needs stride 1), so a 1x1 still materializes.
+    "N32xC256x14x14_K512k1s2": (32, 256, 14, 14, 512, 1, 2, 0, 1),
+    # Deepest ResNet-50 stage: 7x7 spatial with C=K=512 puts the per-call
+    # weight repack (a 4.7 MB tensor) on the critical path, not the GEMM.
+    "N32xC512x7x7_K512k3s1": (32, 512, 7, 7, 512, 3, 1, 1, 1),
+    # VGG-style big spatial: the largest activation in the suite, where the
+    # implicit GEMM's saved column buffer matters most.
+    "N8xC128x112x112_K128k3s1": (8, 128, 112, 112, 128, 3, 1, 1, 1),
+    # Batch-1 inference variants of the body and mid shapes: one sample is
+    # 1/32 of the GEMM rows, i.e. the regime where a tile grid either fills
+    # the machine or does not.
+    "N1xC64x56x56_K64k3s1": (1, 64, 56, 56, 64, 3, 1, 1, 1),
+    "N1xC256x14x14_K256k3s1": (1, 256, 14, 14, 256, 3, 1, 1, 1),
+    # C and K both indivisible by the 64-channel tile, at stride 2.
+    "N16xC96x28x28_K192k3s2": (16, 96, 28, 28, 192, 3, 2, 1, 1),
+    # Dilation (segmentation / ASPP). The implicit GEMM declines dilation by
+    # design; this node is what pins the fallback's cost for it.
+    "N16xC64x32x32_K64k3s1d2": (16, 64, 32, 32, 64, 3, 1, 2, 2),
 }
 # (N, C, H, W, output)
 ADAPTIVE_SHAPES: dict[str, tuple[int, int, int, int, int]] = {
@@ -68,19 +97,20 @@ SKIPPED: dict[str, str] = {}
 def test_conv2d(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
 ) -> None:
-    n, c_in, h, w, c_out, k, stride, pad = CONV_SHAPES[shape_id]
+    n, c_in, h, w, c_out, k, stride, pad, dil = CONV_SHAPES[shape_id]
     dtype = DTYPES[dtype_id]
     x_ref, x_our = both(torch.randn(n, c_in, h, w, dtype=dtype), hw, mojo_device)
     w_ref, w_our = both(
         torch.randn(c_out, c_in, k, k, dtype=dtype) * 0.1, hw, mojo_device
     )
     b_ref, b_our = both(torch.randn(c_out, dtype=dtype), hw, mojo_device)
-    h_out = (h + 2 * pad - k) // stride + 1
-    w_out = (w + 2 * pad - k) // stride + 1
+    eff_k = dil * (k - 1) + 1
+    h_out = (h + 2 * pad - eff_k) // stride + 1
+    w_out = (w + 2 * pad - eff_k) // stride + 1
     flops = 2.0 * n * c_out * h_out * w_out * c_in * k * k
     bench.run(
-        lambda: F.conv2d(x_ref, w_ref, b_ref, stride, pad),
-        lambda: F.conv2d(x_our, w_our, b_our, stride, pad),
+        lambda: F.conv2d(x_ref, w_ref, b_ref, stride, pad, dil),
+        lambda: F.conv2d(x_our, w_our, b_our, stride, pad, dil),
         flops=flops,
     )
 

--- a/conformance/known_unsupported.py
+++ b/conformance/known_unsupported.py
@@ -750,7 +750,7 @@ _ACCELERATOR_DELTAS: dict[str, dict[str, dict[str, tuple[str, ...]]]] = {
                 "bool",
             ),
             "nn_functional_batch_norm": ("float32", "bfloat16", "float16"),
-            "nn_functional_conv2d": ("bfloat16", "float16", "int64"),
+            "nn_functional_conv2d": ("bfloat16", "float16", "float32", "int64"),
             "nn_functional_instance_norm": ("float32", "bfloat16", "float16"),
             "pow": ("float32", "int64"),
         },

--- a/conformance/known_unsupported.py
+++ b/conformance/known_unsupported.py
@@ -755,7 +755,7 @@ _ACCELERATOR_DELTAS: dict[str, dict[str, dict[str, tuple[str, ...]]]] = {
                 "bool",
             ),
             "nn_functional_batch_norm": ("float32", "bfloat16", "float16"),
-            "nn_functional_conv2d": ("bfloat16", "float16", "int64"),
+            "nn_functional_conv2d": ("bfloat16", "float16", "float32", "int64"),
             "nn_functional_instance_norm": ("float32", "bfloat16", "float16"),
             "pow": ("float32", "int64"),
         },

--- a/tests/test_call_queue.py
+++ b/tests/test_call_queue.py
@@ -19,7 +19,7 @@ import gc
 import threading
 import weakref
 from collections import deque
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from pathlib import Path
 
 import pytest
@@ -653,6 +653,233 @@ def test_keepalive_survives_dropped_intermediates(mojo_gpu, forced_queue):
     finally:
         stall.release()
     torch.testing.assert_close(z.cpu(), torch.full((256,), 12.0))
+
+
+# ---------------------------------------------------------------------------
+# Convolution's im2col/GEMM keep-alive (agent-C review of PR #387): the
+# materialized im2col buffer -- or, for a 1x1 stride-1 conv, the input
+# tensor read in place -- is never seen outside `fast_aten_convolution`.
+# Nothing in these tests holds a reference to it either; its only owner is
+# the stack frame that allocates (or aliases) it, which is gone by the time
+# a queued GEMM launch that reads it actually runs. That is exactly the
+# shape of hazard queue rule 3 exists for: a raw pointer's owning tensor
+# must be in the SAME item's keepalive as the pointer, not just alive
+# somewhere in the caller at enqueue time.
+#
+# `_StalledUnits` forces every specialization the second (post-warm-up) call
+# touches to look cold, so the producer (im2col) and the GEMM both queue
+# instead of launching directly. Releasing only the producer's stall and
+# calling `pump()` (not `drain()`) launches it ALONE and stops with the GEMM
+# item still queued -- the one moment queue rule 3 says a missing keepalive
+# entry drops the buffer's last reference.
+#
+# The assertion is a `weakref` check, not a value comparison: whether the
+# buffer's Python object is still alive right there is a direct read of
+# queue rule 3, and it does not depend on whatever the device allocator
+# happens to do with freed memory (which may not corrupt a value-based
+# check promptly, or at all, on a given allocator/run -- a weakref going
+# dead is unambiguous either way).
+# ---------------------------------------------------------------------------
+
+
+def _spy_keepalive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[tuple[str, tuple[object, ...]]]:
+    """Record every ``(op, keepalive)`` pair `_call_mojo` is invoked with,
+    without changing its behavior."""
+    calls: list[tuple[str, tuple[object, ...]]] = []
+    orig_call_mojo = aten_fast._call_mojo
+
+    def spy(
+        extension: object,
+        op: str,
+        extension_args: tuple[object, ...],
+        *,
+        arg_dtypes: tuple[object, ...],
+        output_dtypes: tuple[object, ...] = (),
+        flags: object = None,
+        keepalive: tuple[object, ...],
+    ) -> object:
+        calls.append((op, keepalive))
+        return orig_call_mojo(
+            extension,
+            op,
+            extension_args,
+            arg_dtypes=arg_dtypes,
+            output_dtypes=output_dtypes,
+            flags=flags,
+            keepalive=keepalive,
+        )
+
+    monkeypatch.setattr(aten_fast, "_call_mojo", spy)
+    return calls
+
+
+def _assert_materialized_col_survives_to_gemm(
+    run: Callable[[], torch.Tensor], monkeypatch: pytest.MonkeyPatch
+) -> torch.Tensor:
+    """Warm up ``run`` (a zero-arg callable issuing one materialized conv2d
+    -- i.e. NOT the 1x1 fast path, which has no separate im2col call), then
+    replay it with every specialization forced cold. Launches the im2col
+    item alone (dropping ITS OWN keepalive, `(col, a)`), then checks -- with
+    the GEMM item still queued, not yet launched -- that the im2col buffer
+    is still alive. It can only be alive there because the GEMM item's own
+    keepalive retains it: nothing else does."""
+    calls = _spy_keepalive(monkeypatch)
+    warm = run()
+    call_queue.drain()
+    del warm
+    calls.clear()
+
+    stall = _StalledUnits(monkeypatch, limit=None)
+    col_survived = None
+    try:
+        y = run()
+        assert call_queue.active()
+        assert len(stall.stalls) >= 2, "expected im2col AND a GEMM unit to stall"
+        assert calls and calls[0][0] == "Im2col", (
+            f"expected the first call to be Im2col, got {calls[0][0] if calls else None!r}"
+        )
+        col = calls[0][1][0]  # keepalive=(col, a): index 0 is `col`
+        weak_col = weakref.ref(col)
+        del col, calls[:]  # this frame must not become col's last owner
+
+        gemm_stall = stall.stalls[-1]
+        for earlier in stall.stalls[:-1]:
+            earlier.release()
+        call_queue.pump()  # launches im2col only; the GEMM item stays queued
+        gc.collect()
+        col_survived = weak_col() is not None
+        gemm_stall.release()
+    finally:
+        stall.release()
+    call_queue.drain()
+    assert col_survived, (
+        "the im2col buffer was garbage-collected after im2col's own queued "
+        "item launched (and dropped its keepalive, rule 3) but BEFORE the "
+        "GEMM item that reads it had launched -- the GEMM item's keepalive "
+        "does not retain its own B operand, so a real cold start can free "
+        "this buffer out from under the GEMM kernel (call_queue.py:18-26)"
+    )
+    return y
+
+
+@pytest.mark.parametrize("case", ["dense_simt_bmm", "grouped_simt_matmul"])
+def test_convolution_gemm_keepalive_survives_a_cold_queued_launch(
+    mojo_gpu, forced_queue, monkeypatch: pytest.MonkeyPatch, case: str
+):
+    """Reproduces the review's use-after-free hazard for the plain SIMT
+    `Bmm` fallback (materialized conv, dense) and the grouped `Matmul` loop
+    (materialized conv, groups > 1, one queue item per (sample, group), all
+    reading the same im2col buffer).
+
+    float32 with matmul precision forced to "highest" (TF32 off) keeps this
+    off the sm_90a-gated Bmm16/TF32 routes regardless of which GPU runs the
+    suite, so it deterministically exercises the SIMT fallbacks these cases
+    target -- patched on `aten_fast.torch` rather than the global, so it
+    cannot leak into another test.
+    """
+    monkeypatch.setattr(
+        aten_fast.torch, "get_float32_matmul_precision", lambda: "highest"
+    )
+    torch.manual_seed(0)
+    if case == "grouped_simt_matmul":
+        n, c, out_c, groups = 2, 8, 8, 2
+    else:
+        n, c, out_c, groups = 2, 6, 5, 1
+    k, pad = 3, 1
+    x = torch.randn(n, c, 9, 9, device=mojo_gpu)
+    weight = torch.randn(out_c, c // groups, k, k, device=mojo_gpu) * 0.1
+    x_cpu, weight_cpu = x.cpu(), weight.cpu()
+
+    def run() -> torch.Tensor:
+        return torch.nn.functional.conv2d(
+            x, weight, None, stride=1, padding=pad, groups=groups
+        )
+
+    y = _assert_materialized_col_survives_to_gemm(run, monkeypatch)
+
+    ref = torch.nn.functional.conv2d(
+        x_cpu, weight_cpu, None, stride=1, padding=pad, groups=groups
+    )
+    torch.testing.assert_close(y.cpu(), ref, atol=1e-4, rtol=1e-4)
+
+
+def test_convolution_gemm16_keepalive_survives_a_cold_queued_launch(
+    mojo_gpu, forced_queue, monkeypatch: pytest.MonkeyPatch
+):
+    """Same hazard as `test_convolution_gemm_keepalive_survives_a_cold_
+    queued_launch`, for the sm_90a Bmm16 route `_try_gemm16_conv_bmm`
+    builds (bf16, the default fast path production actually takes on this
+    hardware) -- skipped off an sm_90a GPU, where it is not reachable."""
+    accelerator = list(get_accelerators())[0]
+    if accelerator.api != "cuda" or accelerator.architecture_name != "sm_90a":
+        pytest.skip("the Bmm16 conv route requires an sm_90a GPU")
+    torch.manual_seed(0)
+    # C = 8 < 32 declines the implicit-GEMM route (`_try_conv_igemm`), so
+    # the materialized im2col + Bmm16 route -- the one this fix touches --
+    # is what actually launches.
+    n, c, out_c, k, pad = 2, 8, 16, 3, 1
+    x = (torch.randn(n, c, 9, 9, device=mojo_gpu)).to(torch.bfloat16)
+    weight = (torch.randn(out_c, c, k, k, device=mojo_gpu) * 0.1).to(torch.bfloat16)
+    x_cpu, weight_cpu = x.float().cpu(), weight.float().cpu()
+
+    def run() -> torch.Tensor:
+        return torch.nn.functional.conv2d(x, weight, None, stride=1, padding=pad)
+
+    y = _assert_materialized_col_survives_to_gemm(run, monkeypatch)
+
+    ref = torch.nn.functional.conv2d(x_cpu, weight_cpu, None, stride=1, padding=pad)
+    torch.testing.assert_close(y.float().cpu(), ref, atol=8e-2, rtol=8e-2)
+
+
+def test_convolution_1x1_alias_keepalive_survives_a_cold_queued_launch(
+    mojo_gpu, forced_queue, monkeypatch: pytest.MonkeyPatch
+):
+    """The 1x1 stride-1 fast path never allocates a separate im2col buffer:
+    `col` in `fast_aten_convolution` IS `a`, the input tensor, read in
+    place. Once this test drops its own reference, the GEMM item's own
+    keepalive is the ONLY thing that can keep the input alive until that
+    item -- forced cold, still queued -- launches. Same TF32-off float32
+    setup as the materialized cases, for the same portability reason."""
+    monkeypatch.setattr(
+        aten_fast.torch, "get_float32_matmul_precision", lambda: "highest"
+    )
+    torch.manual_seed(0)
+    n, c, out_c = 2, 6, 5
+    x = torch.randn(n, c, 9, 9, device=mojo_gpu)
+    weight = torch.randn(out_c, c, 1, 1, device=mojo_gpu) * 0.1
+    x_cpu, weight_cpu = x.cpu(), weight.cpu()
+
+    def run() -> torch.Tensor:
+        return torch.nn.functional.conv2d(x, weight, None, stride=1, padding=0)
+
+    warm = run()
+    call_queue.drain()
+    del warm
+
+    stall = _StalledUnits(monkeypatch, limit=None)
+    x_survived = None
+    try:
+        y = run()
+        assert call_queue.active()
+        assert stall.stalls, "expected the GEMM unit to stall cold"
+        weak_x = weakref.ref(x)
+        x = None  # drop the caller's only reference to the input
+        gc.collect()
+        x_survived = weak_x() is not None
+    finally:
+        stall.release()
+    call_queue.drain()
+    assert x_survived, (
+        "the input tensor was garbage-collected while the queued GEMM item "
+        "that reads it in place (the 1x1 fast path, no separate im2col "
+        "buffer) was still cold -- its keepalive does not retain the input "
+        "(queue rule 3, call_queue.py:18-26)"
+    )
+
+    ref = torch.nn.functional.conv2d(x_cpu, weight_cpu, None, stride=1, padding=0)
+    torch.testing.assert_close(y.cpu(), ref, atol=1e-4, rtol=1e-4)
 
 
 def test_sync_read_drains_the_queue(mojo_gpu, forced_queue):

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -9499,7 +9499,8 @@ def test_fast_conv2d_tensor_core_benchmark_shapes(
 # Implicit-GEMM conv (sm_90a, bf16): the TMA im2col route that never
 # materializes the patch matrix. Ported from the standalone Mojo harness the
 # kernel was developed in, which checked EVERY output element of each case
-# against an fp64 host reference; here the reference is torch's own fp32 conv.
+# against an fp64 host reference (`_conv_igemm_reference` below is that same
+# criterion, not torch's own fp32 conv).
 # ---------------------------------------------------------------------------
 _CONV_IGEMM_SHAPES = {
     # (n, c, h, w, out_c, kh, kw, pad_h, pad_w)

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -9443,6 +9443,196 @@ def test_fast_conv2d_refuses_autograd_in_the_forward(mojo_gpu):
         )
 
 
+# Shrunk-N copies of benchmarks/test_vision.py's CONV_SHAPES: same C/H/W/kernel
+# (so the same im2col K and GEMM N the benchmark measures), a small batch so
+# the test is cheap.
+_CONV_BENCH_SHAPES = {
+    "body_N32xC64x56x56_K64k3s1": (2, 64, 56, 56, 64, 3, 1, 1),
+    "stem_N8xC3x224x224_K64k7s2": (2, 3, 224, 224, 64, 7, 2, 3),
+}
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("shape_id", _CONV_BENCH_SHAPES)
+def test_fast_conv2d_tensor_core_benchmark_shapes(
+    mojo_h100: torch.device, shape_id: str, dtype: torch.dtype
+) -> None:
+    """The benchmark body/stem conv shapes, N shrunk to 2, through whichever
+    GEMM route sm_90a picks for the dtype: Bmm16 (bf16/f16, always opt-in),
+    the opt-in TF32 BMM (f32, only past the same
+    `float32_matmul_precision() != "highest"` gate `_try_tf32_mm` uses), or
+    the plain SIMT Bmm fallback (f32 at the default "highest" precision)."""
+    n, c_in, h, w, c_out, k, stride, pad = _CONV_BENCH_SHAPES[shape_id]
+    x = torch.randn(n, c_in, h, w, dtype=dtype)
+    weight = torch.randn(c_out, c_in, k, k, dtype=dtype) * 0.1
+    bias = torch.randn(c_out, dtype=dtype)
+
+    old_precision = torch.get_float32_matmul_precision()
+    torch.set_float32_matmul_precision("high")
+    try:
+        dev = torch.nn.functional.conv2d(
+            x.to(mojo_h100), weight.to(mojo_h100), bias.to(mojo_h100), stride, pad
+        ).cpu()
+    finally:
+        torch.set_float32_matmul_precision(old_precision)
+    ref = torch.nn.functional.conv2d(
+        x.float(), weight.float(), bias.float(), stride, pad
+    )
+
+    # float16 has more mantissa bits than bfloat16, so it gets the tighter
+    # bound; both are FP32-accumulated tensor-core GEMMs (see the analogous
+    # gemm16 mm/bmm tests), just rounded to a narrower output type than the
+    # k=333 case those tests calibrate against, hence the wider margin for
+    # this k up to 576. float32 goes through TF32 (or, at default precision,
+    # plain FP32) -- the same calibrated bound the mm/addmm tensor-core tests
+    # use.
+    if dtype == torch.float16:
+        atol, rtol = 3e-2, 3e-3
+    elif dtype == torch.bfloat16:
+        atol, rtol = 8e-2, 8e-2
+    else:
+        atol, rtol = 5e-2, 5e-2
+    torch.testing.assert_close(dev.float(), ref, atol=atol, rtol=rtol)
+
+
+@pytest.mark.parametrize("op", ["bmm16", "1x1_bmm16"])
+def test_fast_conv2d_routes_dense_bf16_through_gemm16_bmm(
+    mojo_h100: torch.device, monkeypatch: pytest.MonkeyPatch, op: str
+) -> None:
+    """Dense (groups == 1) bf16 conv reaches the same Bmm16 kernel fast_aten_bmm
+    already builds -- both the general im2col path and the 1x1 stride-1
+    fast path that reads the NCHW input as the col matrix in place."""
+    calls = _spy_defined_native_calls(
+        monkeypatch, {("gemm16_matmul_ops.mojo", "Bmm16")}
+    )
+    n, c_in, h, w, c_out = 2, 8, 16, 16, 12
+    k, stride, pad = (3, 1, 1) if op == "bmm16" else (1, 1, 0)
+    x = torch.randn(n, c_in, h, w).to(torch.bfloat16)
+    weight = (torch.randn(c_out, c_in, k, k) * 0.1).to(torch.bfloat16)
+    dev = torch.nn.functional.conv2d(
+        x.to(mojo_h100), weight.to(mojo_h100), None, stride, pad
+    ).cpu()
+    ref = torch.nn.functional.conv2d(x.float(), weight.float(), None, stride, pad)
+
+    target = ("gemm16_matmul_ops.mojo", "Bmm16")
+    assert len(calls[target]) == 1, "dense bf16 conv did not reach the Bmm16 bridge"
+    torch.testing.assert_close(dev.float(), ref, atol=8e-2, rtol=8e-2)
+
+
+def test_fast_conv2d_tf32_bmm_is_opt_in_like_mm(
+    mojo_h100: torch.device, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same numerics policy as the mm/bmm TF32 routes: off by default (torch's
+    `float32_matmul_precision() == "highest"`), reachable once the caller
+    opts in with `torch.set_float32_matmul_precision("high")`. The repo has
+    no separate `torch.backends.cudnn.allow_tf32`-style policy for
+    convolution, so this deliberately follows the mm gate instead."""
+    calls = _spy_defined_native_calls(
+        monkeypatch,
+        {("tf32_matmul_ops.mojo", "Tf32BmmF32"), ("matmul_ops.mojo", "Bmm")},
+    )
+    x = torch.randn(2, 8, 16, 16)
+    weight = torch.randn(12, 8, 3, 3) * 0.1
+
+    dev_default = torch.nn.functional.conv2d(
+        x.to(mojo_h100), weight.to(mojo_h100), None, 1, 1
+    ).cpu()
+    assert not calls[("tf32_matmul_ops.mojo", "Tf32BmmF32")]
+    assert len(calls[("matmul_ops.mojo", "Bmm")]) == 1
+
+    old_precision = torch.get_float32_matmul_precision()
+    torch.set_float32_matmul_precision("high")
+    try:
+        dev_tf32 = torch.nn.functional.conv2d(
+            x.to(mojo_h100), weight.to(mojo_h100), None, 1, 1
+        ).cpu()
+    finally:
+        torch.set_float32_matmul_precision(old_precision)
+    assert len(calls[("tf32_matmul_ops.mojo", "Tf32BmmF32")]) == 1
+
+    ref = torch.nn.functional.conv2d(x, weight, None, 1, 1)
+    torch.testing.assert_close(dev_default, ref, atol=1e-3, rtol=1e-3)
+    torch.testing.assert_close(dev_tf32, ref, atol=5e-2, rtol=5e-2)
+
+
+def test_fast_conv2d_grouped_and_noncontiguous_keep_generic_route(
+    mojo_h100: torch.device, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Blast-radius guard: grouped convs and non-contiguous inputs are the
+    cases the tensor-core routes decline (grouped: no single (out_c, ckk) x
+    (ckk, cols) GEMM; non-contiguous: `_tc` materializes it back to dense
+    before either helper ever sees it, per the existing contract) -- both
+    must still land on the untouched SIMT path, not silently regress or
+    raise."""
+    calls = _spy_defined_native_calls(
+        monkeypatch,
+        {
+            ("gemm16_matmul_ops.mojo", "Bmm16"),
+            ("tf32_matmul_ops.mojo", "Tf32BmmF32"),
+            ("matmul_ops.mojo", "Matmul"),
+            ("matmul_ops.mojo", "Bmm"),
+        },
+    )
+    old_precision = torch.get_float32_matmul_precision()
+    torch.set_float32_matmul_precision("high")
+    try:
+        # Grouped conv, bf16: per (sample, group) Matmul, never Bmm16.
+        x = torch.randn(2, 8, 16, 16).to(torch.bfloat16)
+        w = torch.randn(12, 4, 3, 3).to(torch.bfloat16)
+        dev_grouped = torch.nn.functional.conv2d(
+            x.to(mojo_h100), w.to(mojo_h100), None, 1, 1, groups=2
+        ).cpu()
+        ref_grouped = torch.nn.functional.conv2d(
+            x.float(), w.float(), None, 1, 1, groups=2
+        )
+        torch.testing.assert_close(
+            dev_grouped.float(), ref_grouped, atol=8e-2, rtol=8e-2
+        )
+
+        # Non-contiguous (channels-last) f32 input, dense conv: still TF32.
+        x_nc = torch.randn(2, 8, 16, 16).to(memory_format=torch.channels_last)
+        w_nc = torch.randn(12, 8, 3, 3) * 0.1
+        dev_nc = torch.nn.functional.conv2d(
+            x_nc.to(mojo_h100), w_nc.to(mojo_h100), None, 1, 1
+        ).cpu()
+        ref_nc = torch.nn.functional.conv2d(x_nc, w_nc, None, 1, 1)
+        torch.testing.assert_close(dev_nc, ref_nc, atol=5e-2, rtol=5e-2)
+    finally:
+        torch.set_float32_matmul_precision(old_precision)
+
+    assert not calls[("gemm16_matmul_ops.mojo", "Bmm16")]
+    assert len(calls[("matmul_ops.mojo", "Matmul")]) == 2 * 2  # 2 samples x 2 groups
+    assert len(calls[("tf32_matmul_ops.mojo", "Tf32BmmF32")]) == 1
+    assert len(calls[("matmul_ops.mojo", "Bmm")]) == 0
+
+
+def test_fast_conv2d_cpu_device_matches_gpu_row_kernel(mojo_device: str) -> None:
+    """`conv_ops.mojo`'s Im2col/BiasAddChan dispatch on `ctx.api()`: the CPU
+    device (`mojo_device` here, not `mojo_gpu`) takes the scalar
+    `elementwise` path (`_im2col_scalar`/`_bias_add_chan_scalar`), unchanged
+    logic from before this file's GPU row-kernel rewrite, just extracted into
+    a named function -- this is the one test in the module that actually
+    exercises it, on both stride=1 (im2col's contiguous-read branch) and
+    stride=2 (its strided-gather branch)."""
+    torch.manual_seed(0)
+    x = torch.randn(2, 8, 16, 16)
+    w = torch.randn(12, 8, 3, 3) * 0.1
+    b = torch.randn(12)
+    dev = torch.nn.functional.conv2d(
+        x.to(mojo_device), w.to(mojo_device), b.to(mojo_device), stride=1, padding=1
+    ).cpu()
+    ref = torch.nn.functional.conv2d(x, w, b, stride=1, padding=1)
+    torch.testing.assert_close(dev, ref, atol=1e-4, rtol=1e-4)
+
+    x2 = torch.randn(3, 3, 15, 17)
+    w2 = torch.randn(6, 3, 5, 5) * 0.1
+    dev2 = torch.nn.functional.conv2d(
+        x2.to(mojo_device), w2.to(mojo_device), None, stride=2, padding=2
+    ).cpu()
+    ref2 = torch.nn.functional.conv2d(x2, w2, None, stride=2, padding=2)
+    torch.testing.assert_close(dev2, ref2, atol=1e-4, rtol=1e-4)
+
+
 @pytest.mark.parametrize("is_causal", [True, False])
 # kv_len <= 32 exercises the library softmax's warp kernel, kv_len=64 the
 # online/block kernel.

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -9528,6 +9528,56 @@ _CONV_IGEMM_SHAPES = {
     "k7_pad3": (1, 64, 16, 16, 64, 7, 7, 3, 3),
 }
 
+# 2^-24, the fp32 machine epsilon: the GEMM's tile accumulation is fp32, so
+# this is the per-term rounding unit the accumulation-error bound below is
+# built from -- ported from conv_igemm_test.mojo's host-side correctness
+# harness, not re-derived here.
+_CI_EPS_F32 = 2.0**-24
+# 2^-8: one bf16 half-ulp, the max relative error of ONE correctly-rounded
+# fp64/fp32 -> bfloat16 cast.
+_CI_BF16_HALF_ULP = 2.0**-8
+
+
+def _conv_igemm_reference(
+    x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor | None, ph: int, pw: int
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """The fp64 ground truth, a PER-ELEMENT tolerance derived from the fp32
+    accumulation error bound (not a fixed slop), and the bit-exact target --
+    ported from conv_igemm_test.mojo, the kernel's own correctness harness.
+
+    Inputs are bf16 tensors, hence already exactly representable in bf16, so
+    the only error a correct kernel can introduce is (1) the fp32 tile
+    accumulation of the GEMM reduction and (2) the bf16 rounding(s) of the
+    output. The accumulation term is `4 * eps_f32 * sqrt(k_pad) * sum|a*b|`
+    (`k_pad` includes the C-padding to the kernel's 64-channel tile, since
+    the padded zero terms still cost accumulation steps); the 4x is the same
+    safety factor the Mojo harness uses. Bias goes through a SEPARATE kernel
+    (`BiasAddChan`) that reads the already-bf16-rounded GEMM output and
+    rounds again after the add, so a biased case pays a second independent
+    half-ulp term, not a bigger accumulation term, and its bit-exact target
+    is the double-rounded value the real pipeline computes, not
+    `round_bf16(gemm + bias)` directly (double rounding can legitimately
+    differ from single rounding even in exact arithmetic).
+    """
+    c, kh, kw = x.shape[1], weight.shape[2], weight.shape[3]
+    c_pad = ((c + 63) // 64) * 64
+    k_pad = kh * kw * c_pad
+    acc_coeff = 4.0 * _CI_EPS_F32 * math.sqrt(k_pad)
+
+    x64 = x.double()
+    w64 = weight.double()
+    acc_gemm = torch.nn.functional.conv2d(x64, w64, stride=1, padding=(ph, pw))
+    mag = torch.nn.functional.conv2d(x64.abs(), w64.abs(), stride=1, padding=(ph, pw))
+    tol = _CI_BF16_HALF_ULP * acc_gemm.abs() + acc_coeff * mag
+    want_bf16 = acc_gemm.to(torch.bfloat16)
+    if bias is None:
+        return acc_gemm, tol, want_bf16
+    b64 = bias.double().view(1, -1, 1, 1)
+    acc_true = acc_gemm + b64
+    tol = tol + _CI_BF16_HALF_ULP * acc_true.abs()
+    want_bf16 = (want_bf16.double() + b64).to(torch.bfloat16)
+    return acc_true, tol, want_bf16
+
 
 @pytest.mark.parametrize("shape_id", _CONV_IGEMM_SHAPES)
 @pytest.mark.parametrize("with_bias", [False, True])
@@ -9539,6 +9589,7 @@ def test_fast_conv2d_igemm_edge_shapes(
 ) -> None:
     """Every geometry the implicit-GEMM dispatch ACCEPTS, and a check that it
     really is the route that ran."""
+    torch.manual_seed(0)  # exact_frac below is a measured bound, not a tautology
     calls = _spy_defined_native_calls(
         monkeypatch, {("conv_igemm_ops.mojo", "ConvIgemm")}
     )
@@ -9555,20 +9606,33 @@ def test_fast_conv2d_igemm_edge_shapes(
         stride=1,
         padding=(ph, pw),
     ).cpu()
-    ref = torch.nn.functional.conv2d(
-        x.float(),
-        weight.float(),
-        None if bias is None else bias.float(),
-        stride=1,
-        padding=(ph, pw),
-    )
 
     target = ("conv_igemm_ops.mojo", "ConvIgemm")
     assert len(calls[target]) == 1, f"{shape_id} did not take the implicit-GEMM route"
-    # One fp32-accumulated reduction of up to k = 3136, rounded once to
-    # bfloat16 (2^-8 relative): the same calibration the gemm16 mm/bmm tests
-    # use for a bf16 output.
-    torch.testing.assert_close(dev.float(), ref, atol=8e-2, rtol=8e-2)
+    acc, tol, want_bf16 = _conv_igemm_reference(x, weight, bias, ph, pw)
+    got = dev.double()
+    err = (got - acc).abs()
+    bad = err > tol
+    assert not bad.any(), (
+        f"{shape_id} with_bias={with_bias}: {int(bad.sum())}/{bad.numel()} "
+        f"outputs exceed the fp32-accumulation-derived tolerance; worst "
+        f"error={err.max().item():.6g} at tol={tol.flatten()[err.argmax()].item():.6g}"
+    )
+    # fp32 accumulation noise should move at most a handful of outputs off
+    # their correctly-rounded bf16 code; an indexing or accumulation bug
+    # collapses this fraction instead of nudging it. conv_igemm_test.mojo's
+    # deterministic hash-filled inputs measure exactly 1.0 on an H100 and
+    # gate at 0.999; these tests use genuinely random inputs instead (no
+    # per-case tuning), and the deepest reductions here (k7_pad3, k_pad =
+    # 3136; mid_14x14_C256, k_pad = 2304) measure ~99.87% at seed 0 -- still
+    # two orders of magnitude away from anything an indexing or
+    # accumulation bug would produce. 0.99 keeps that margin without
+    # chasing the harness's input-specific figure.
+    exact_frac = (dev == want_bf16).double().mean().item()
+    assert exact_frac >= 0.99, (
+        f"{shape_id} with_bias={with_bias}: only {exact_frac:.4%} of outputs "
+        "are bit-exact against the double-rounded reference"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -9495,6 +9495,178 @@ def test_fast_conv2d_tensor_core_benchmark_shapes(
     torch.testing.assert_close(dev.float(), ref, atol=atol, rtol=rtol)
 
 
+# ---------------------------------------------------------------------------
+# Implicit-GEMM conv (sm_90a, bf16): the TMA im2col route that never
+# materializes the patch matrix. Ported from the standalone Mojo harness the
+# kernel was developed in, which checked EVERY output element of each case
+# against an fp64 host reference; here the reference is torch's own fp32 conv.
+# ---------------------------------------------------------------------------
+_CONV_IGEMM_SHAPES = {
+    # (n, c, h, w, out_c, kh, kw, pad_h, pad_w)
+    # hw = 49: fewer pixels than one B tile, so the single im2col transaction
+    # walks past the end of the ONLY sample -- the case that would need a
+    # guard sample if the pixels-per-column tail faulted instead of
+    # zero-filling. Odd row pitch (98 B) -> scalar epilogue.
+    "batch1_pad_7x7": (1, 64, 7, 7, 64, 3, 3, 1, 1),
+    "unpadded_9x9": (2, 64, 9, 9, 64, 3, 3, 0, 0),
+    # body geometry: 16 B aligned row pitch -> TMA-store epilogue
+    "body_56x56": (2, 64, 56, 56, 64, 3, 3, 1, 1),
+    # hw = 196 (392 B) -> scalar epilogue, deep C
+    "mid_14x14_C256": (2, 256, 14, 14, 256, 3, 3, 1, 1),
+    # C = 48 padded to 64, ragged out_c = 80, awkward spatial extent
+    "awkward_C48_K80": (3, 48, 39, 53, 80, 3, 3, 1, 1),
+    # ragged out_c WITH the TMA-store epilogue
+    "ragged_K80_tma_store": (2, 64, 16, 16, 80, 3, 3, 1, 1),
+    "ragged_K96_tma_store": (1, 64, 16, 16, 96, 3, 3, 1, 1),
+    # rectangular filters with ASYMMETRIC padding (pad_h != pad_w), both
+    # epilogues, plus degenerate 1-tap dimensions
+    "rect_R3S5_pad12": (2, 64, 16, 20, 64, 3, 5, 1, 2),
+    "rect_R5S3_pad21_C96": (1, 96, 11, 13, 96, 5, 3, 2, 1),
+    "rect_R1S3_pad01": (2, 64, 13, 13, 64, 1, 3, 0, 1),
+    "rect_R3S1_pad10_C128": (2, 128, 12, 12, 64, 3, 1, 1, 0),
+    # deeper K: 7x7 taps
+    "k7_pad3": (1, 64, 16, 16, 64, 7, 7, 3, 3),
+}
+
+
+@pytest.mark.parametrize("shape_id", _CONV_IGEMM_SHAPES)
+@pytest.mark.parametrize("with_bias", [False, True])
+def test_fast_conv2d_igemm_edge_shapes(
+    mojo_h100: torch.device,
+    monkeypatch: pytest.MonkeyPatch,
+    shape_id: str,
+    with_bias: bool,
+) -> None:
+    """Every geometry the implicit-GEMM dispatch ACCEPTS, and a check that it
+    really is the route that ran."""
+    calls = _spy_defined_native_calls(
+        monkeypatch, {("conv_igemm_ops.mojo", "ConvIgemm")}
+    )
+    n, c, h, w, out_c, kh, kw, ph, pw = _CONV_IGEMM_SHAPES[shape_id]
+    x = torch.randn(n, c, h, w, dtype=torch.bfloat16)
+    weight = (torch.randn(out_c, c, kh, kw, dtype=torch.bfloat16) * 0.1).to(
+        torch.bfloat16
+    )
+    bias = torch.randn(out_c, dtype=torch.bfloat16) if with_bias else None
+    dev = torch.nn.functional.conv2d(
+        x.to(mojo_h100),
+        weight.to(mojo_h100),
+        None if bias is None else bias.to(mojo_h100),
+        stride=1,
+        padding=(ph, pw),
+    ).cpu()
+    ref = torch.nn.functional.conv2d(
+        x.float(),
+        weight.float(),
+        None if bias is None else bias.float(),
+        stride=1,
+        padding=(ph, pw),
+    )
+
+    target = ("conv_igemm_ops.mojo", "ConvIgemm")
+    assert len(calls[target]) == 1, f"{shape_id} did not take the implicit-GEMM route"
+    # One fp32-accumulated reduction of up to k = 3136, rounded once to
+    # bfloat16 (2^-8 relative): the same calibration the gemm16 mm/bmm tests
+    # use for a bf16 output.
+    torch.testing.assert_close(dev.float(), ref, atol=8e-2, rtol=8e-2)
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "stride2",
+        "dilation2",
+        "grouped",
+        "pointwise_1x1",
+        "thin_c",
+        "thin_out_c",
+        "f32",
+        "f16",
+    ],
+)
+def test_fast_conv2d_igemm_declines_outside_its_domain(
+    mojo_h100: torch.device, monkeypatch: pytest.MonkeyPatch, case: str
+) -> None:
+    """Everything the implicit GEMM cannot (or should not) do stays on the
+    materialized-im2col route and still computes the right answer."""
+    calls = _spy_defined_native_calls(
+        monkeypatch, {("conv_igemm_ops.mojo", "ConvIgemm")}
+    )
+    n, c, h, w, out_c, k = 2, 64, 16, 16, 64, 3
+    stride, pad, dilation, groups = 1, 1, 1, 1
+    dtype = torch.bfloat16
+    if case == "stride2":
+        stride = 2
+    elif case == "dilation2":
+        dilation, pad = 2, 2
+    elif case == "grouped":
+        groups = 4
+    elif case == "pointwise_1x1":
+        k, pad = 1, 0
+    elif case == "thin_c":
+        c = 3  # C_pad/C = 21x wasted math on this route
+    elif case == "thin_out_c":
+        out_c = 16  # BM = 64 would waste 3/4 of every output tile
+    elif case == "f32":
+        dtype = torch.float32
+    elif case == "f16":
+        dtype = torch.float16
+
+    x = torch.randn(n, c, h, w, dtype=dtype)
+    weight = (torch.randn(out_c, c // groups, k, k, dtype=dtype) * 0.1).to(dtype)
+    dev = torch.nn.functional.conv2d(
+        x.to(mojo_h100),
+        weight.to(mojo_h100),
+        None,
+        stride=stride,
+        padding=pad,
+        dilation=dilation,
+        groups=groups,
+    ).cpu()
+    ref = torch.nn.functional.conv2d(
+        x.float(),
+        weight.float(),
+        None,
+        stride=stride,
+        padding=pad,
+        dilation=dilation,
+        groups=groups,
+    )
+
+    target = ("conv_igemm_ops.mojo", "ConvIgemm")
+    assert not calls[target], f"{case} must not take the implicit-GEMM route"
+    torch.testing.assert_close(dev.float(), ref, atol=8e-2, rtol=8e-2)
+
+
+def test_conv_igemm_descriptor_domain_gate() -> None:
+    """The im2col TMA descriptor domain, checked on the host before anything
+    is allocated: pixel-box corners are SIGNED CHAR ([-128, 127]) and the
+    filter taps this kernel issues must fit in [0, 255].
+
+    The R = 257 line is the one that matters: that conv satisfies every other
+    eligibility condition (bf16, sm_90a, dense, stride 1, dilation 1, C = 64,
+    and corners -128/-1, 128/-1 that are all legal) yet its last tap is 256,
+    which is undefined behaviour at the instruction rather than a loud
+    failure.
+    """
+    from torch_mojo_backend.eager_kernels.aten_fast import _conv_igemm_descriptor_legal
+
+    assert _conv_igemm_descriptor_legal(1, 1, 3, 3)
+    assert _conv_igemm_descriptor_legal(0, 0, 1, 1)
+    assert _conv_igemm_descriptor_legal(3, 3, 7, 7)
+    # lower corner = -pad
+    assert _conv_igemm_descriptor_legal(128, 1, 3, 3)
+    assert not _conv_igemm_descriptor_legal(129, 1, 3, 3)
+    assert not _conv_igemm_descriptor_legal(1, 129, 3, 3)
+    # upper corner = pad - (filter - 1)
+    assert _conv_igemm_descriptor_legal(0, 0, 129, 3)
+    assert not _conv_igemm_descriptor_legal(0, 0, 130, 3)
+    # legal corners, illegal tap
+    assert _conv_igemm_descriptor_legal(128, 1, 256, 3)
+    assert not _conv_igemm_descriptor_legal(128, 1, 257, 3)
+    assert not _conv_igemm_descriptor_legal(1, 128, 3, 257)
+
+
 @pytest.mark.parametrize("op", ["bmm16", "1x1_bmm16"])
 def test_fast_conv2d_routes_dense_bf16_through_gemm16_bmm(
     mojo_h100: torch.device, monkeypatch: pytest.MonkeyPatch, op: str

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -9471,7 +9471,8 @@ def test_fast_conv2d_tensor_core_benchmark_shapes(
 # Implicit-GEMM conv (sm_90a, bf16): the TMA im2col route that never
 # materializes the patch matrix. Ported from the standalone Mojo harness the
 # kernel was developed in, which checked EVERY output element of each case
-# against an fp64 host reference; here the reference is torch's own fp32 conv.
+# against an fp64 host reference (`_conv_igemm_reference` below is that same
+# criterion, not torch's own fp32 conv).
 # ---------------------------------------------------------------------------
 _CONV_IGEMM_SHAPES = {
     # (n, c, h, w, out_c, kh, kw, pad_h, pad_w)

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -9500,6 +9500,56 @@ _CONV_IGEMM_SHAPES = {
     "k7_pad3": (1, 64, 16, 16, 64, 7, 7, 3, 3),
 }
 
+# 2^-24, the fp32 machine epsilon: the GEMM's tile accumulation is fp32, so
+# this is the per-term rounding unit the accumulation-error bound below is
+# built from -- ported from conv_igemm_test.mojo's host-side correctness
+# harness, not re-derived here.
+_CI_EPS_F32 = 2.0**-24
+# 2^-8: one bf16 half-ulp, the max relative error of ONE correctly-rounded
+# fp64/fp32 -> bfloat16 cast.
+_CI_BF16_HALF_ULP = 2.0**-8
+
+
+def _conv_igemm_reference(
+    x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor | None, ph: int, pw: int
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """The fp64 ground truth, a PER-ELEMENT tolerance derived from the fp32
+    accumulation error bound (not a fixed slop), and the bit-exact target --
+    ported from conv_igemm_test.mojo, the kernel's own correctness harness.
+
+    Inputs are bf16 tensors, hence already exactly representable in bf16, so
+    the only error a correct kernel can introduce is (1) the fp32 tile
+    accumulation of the GEMM reduction and (2) the bf16 rounding(s) of the
+    output. The accumulation term is `4 * eps_f32 * sqrt(k_pad) * sum|a*b|`
+    (`k_pad` includes the C-padding to the kernel's 64-channel tile, since
+    the padded zero terms still cost accumulation steps); the 4x is the same
+    safety factor the Mojo harness uses. Bias goes through a SEPARATE kernel
+    (`BiasAddChan`) that reads the already-bf16-rounded GEMM output and
+    rounds again after the add, so a biased case pays a second independent
+    half-ulp term, not a bigger accumulation term, and its bit-exact target
+    is the double-rounded value the real pipeline computes, not
+    `round_bf16(gemm + bias)` directly (double rounding can legitimately
+    differ from single rounding even in exact arithmetic).
+    """
+    c, kh, kw = x.shape[1], weight.shape[2], weight.shape[3]
+    c_pad = ((c + 63) // 64) * 64
+    k_pad = kh * kw * c_pad
+    acc_coeff = 4.0 * _CI_EPS_F32 * math.sqrt(k_pad)
+
+    x64 = x.double()
+    w64 = weight.double()
+    acc_gemm = torch.nn.functional.conv2d(x64, w64, stride=1, padding=(ph, pw))
+    mag = torch.nn.functional.conv2d(x64.abs(), w64.abs(), stride=1, padding=(ph, pw))
+    tol = _CI_BF16_HALF_ULP * acc_gemm.abs() + acc_coeff * mag
+    want_bf16 = acc_gemm.to(torch.bfloat16)
+    if bias is None:
+        return acc_gemm, tol, want_bf16
+    b64 = bias.double().view(1, -1, 1, 1)
+    acc_true = acc_gemm + b64
+    tol = tol + _CI_BF16_HALF_ULP * acc_true.abs()
+    want_bf16 = (want_bf16.double() + b64).to(torch.bfloat16)
+    return acc_true, tol, want_bf16
+
 
 @pytest.mark.parametrize("shape_id", _CONV_IGEMM_SHAPES)
 @pytest.mark.parametrize("with_bias", [False, True])
@@ -9511,6 +9561,7 @@ def test_fast_conv2d_igemm_edge_shapes(
 ) -> None:
     """Every geometry the implicit-GEMM dispatch ACCEPTS, and a check that it
     really is the route that ran."""
+    torch.manual_seed(0)  # exact_frac below is a measured bound, not a tautology
     calls = _spy_defined_native_calls(
         monkeypatch, {("conv_igemm_ops.mojo", "ConvIgemm")}
     )
@@ -9527,20 +9578,33 @@ def test_fast_conv2d_igemm_edge_shapes(
         stride=1,
         padding=(ph, pw),
     ).cpu()
-    ref = torch.nn.functional.conv2d(
-        x.float(),
-        weight.float(),
-        None if bias is None else bias.float(),
-        stride=1,
-        padding=(ph, pw),
-    )
 
     target = ("conv_igemm_ops.mojo", "ConvIgemm")
     assert len(calls[target]) == 1, f"{shape_id} did not take the implicit-GEMM route"
-    # One fp32-accumulated reduction of up to k = 3136, rounded once to
-    # bfloat16 (2^-8 relative): the same calibration the gemm16 mm/bmm tests
-    # use for a bf16 output.
-    torch.testing.assert_close(dev.float(), ref, atol=8e-2, rtol=8e-2)
+    acc, tol, want_bf16 = _conv_igemm_reference(x, weight, bias, ph, pw)
+    got = dev.double()
+    err = (got - acc).abs()
+    bad = err > tol
+    assert not bad.any(), (
+        f"{shape_id} with_bias={with_bias}: {int(bad.sum())}/{bad.numel()} "
+        f"outputs exceed the fp32-accumulation-derived tolerance; worst "
+        f"error={err.max().item():.6g} at tol={tol.flatten()[err.argmax()].item():.6g}"
+    )
+    # fp32 accumulation noise should move at most a handful of outputs off
+    # their correctly-rounded bf16 code; an indexing or accumulation bug
+    # collapses this fraction instead of nudging it. conv_igemm_test.mojo's
+    # deterministic hash-filled inputs measure exactly 1.0 on an H100 and
+    # gate at 0.999; these tests use genuinely random inputs instead (no
+    # per-case tuning), and the deepest reductions here (k7_pad3, k_pad =
+    # 3136; mid_14x14_C256, k_pad = 2304) measure ~99.87% at seed 0 -- still
+    # two orders of magnitude away from anything an indexing or
+    # accumulation bug would produce. 0.99 keeps that margin without
+    # chasing the harness's input-specific figure.
+    exact_frac = (dev == want_bf16).double().mean().item()
+    assert exact_frac >= 0.99, (
+        f"{shape_id} with_bias={with_bias}: only {exact_frac:.4%} of outputs "
+        "are bit-exact against the double-rounded reference"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -9467,6 +9467,178 @@ def test_fast_conv2d_tensor_core_benchmark_shapes(
     torch.testing.assert_close(dev.float(), ref, atol=atol, rtol=rtol)
 
 
+# ---------------------------------------------------------------------------
+# Implicit-GEMM conv (sm_90a, bf16): the TMA im2col route that never
+# materializes the patch matrix. Ported from the standalone Mojo harness the
+# kernel was developed in, which checked EVERY output element of each case
+# against an fp64 host reference; here the reference is torch's own fp32 conv.
+# ---------------------------------------------------------------------------
+_CONV_IGEMM_SHAPES = {
+    # (n, c, h, w, out_c, kh, kw, pad_h, pad_w)
+    # hw = 49: fewer pixels than one B tile, so the single im2col transaction
+    # walks past the end of the ONLY sample -- the case that would need a
+    # guard sample if the pixels-per-column tail faulted instead of
+    # zero-filling. Odd row pitch (98 B) -> scalar epilogue.
+    "batch1_pad_7x7": (1, 64, 7, 7, 64, 3, 3, 1, 1),
+    "unpadded_9x9": (2, 64, 9, 9, 64, 3, 3, 0, 0),
+    # body geometry: 16 B aligned row pitch -> TMA-store epilogue
+    "body_56x56": (2, 64, 56, 56, 64, 3, 3, 1, 1),
+    # hw = 196 (392 B) -> scalar epilogue, deep C
+    "mid_14x14_C256": (2, 256, 14, 14, 256, 3, 3, 1, 1),
+    # C = 48 padded to 64, ragged out_c = 80, awkward spatial extent
+    "awkward_C48_K80": (3, 48, 39, 53, 80, 3, 3, 1, 1),
+    # ragged out_c WITH the TMA-store epilogue
+    "ragged_K80_tma_store": (2, 64, 16, 16, 80, 3, 3, 1, 1),
+    "ragged_K96_tma_store": (1, 64, 16, 16, 96, 3, 3, 1, 1),
+    # rectangular filters with ASYMMETRIC padding (pad_h != pad_w), both
+    # epilogues, plus degenerate 1-tap dimensions
+    "rect_R3S5_pad12": (2, 64, 16, 20, 64, 3, 5, 1, 2),
+    "rect_R5S3_pad21_C96": (1, 96, 11, 13, 96, 5, 3, 2, 1),
+    "rect_R1S3_pad01": (2, 64, 13, 13, 64, 1, 3, 0, 1),
+    "rect_R3S1_pad10_C128": (2, 128, 12, 12, 64, 3, 1, 1, 0),
+    # deeper K: 7x7 taps
+    "k7_pad3": (1, 64, 16, 16, 64, 7, 7, 3, 3),
+}
+
+
+@pytest.mark.parametrize("shape_id", _CONV_IGEMM_SHAPES)
+@pytest.mark.parametrize("with_bias", [False, True])
+def test_fast_conv2d_igemm_edge_shapes(
+    mojo_h100: torch.device,
+    monkeypatch: pytest.MonkeyPatch,
+    shape_id: str,
+    with_bias: bool,
+) -> None:
+    """Every geometry the implicit-GEMM dispatch ACCEPTS, and a check that it
+    really is the route that ran."""
+    calls = _spy_defined_native_calls(
+        monkeypatch, {("conv_igemm_ops.mojo", "ConvIgemm")}
+    )
+    n, c, h, w, out_c, kh, kw, ph, pw = _CONV_IGEMM_SHAPES[shape_id]
+    x = torch.randn(n, c, h, w, dtype=torch.bfloat16)
+    weight = (torch.randn(out_c, c, kh, kw, dtype=torch.bfloat16) * 0.1).to(
+        torch.bfloat16
+    )
+    bias = torch.randn(out_c, dtype=torch.bfloat16) if with_bias else None
+    dev = torch.nn.functional.conv2d(
+        x.to(mojo_h100),
+        weight.to(mojo_h100),
+        None if bias is None else bias.to(mojo_h100),
+        stride=1,
+        padding=(ph, pw),
+    ).cpu()
+    ref = torch.nn.functional.conv2d(
+        x.float(),
+        weight.float(),
+        None if bias is None else bias.float(),
+        stride=1,
+        padding=(ph, pw),
+    )
+
+    target = ("conv_igemm_ops.mojo", "ConvIgemm")
+    assert len(calls[target]) == 1, f"{shape_id} did not take the implicit-GEMM route"
+    # One fp32-accumulated reduction of up to k = 3136, rounded once to
+    # bfloat16 (2^-8 relative): the same calibration the gemm16 mm/bmm tests
+    # use for a bf16 output.
+    torch.testing.assert_close(dev.float(), ref, atol=8e-2, rtol=8e-2)
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "stride2",
+        "dilation2",
+        "grouped",
+        "pointwise_1x1",
+        "thin_c",
+        "thin_out_c",
+        "f32",
+        "f16",
+    ],
+)
+def test_fast_conv2d_igemm_declines_outside_its_domain(
+    mojo_h100: torch.device, monkeypatch: pytest.MonkeyPatch, case: str
+) -> None:
+    """Everything the implicit GEMM cannot (or should not) do stays on the
+    materialized-im2col route and still computes the right answer."""
+    calls = _spy_defined_native_calls(
+        monkeypatch, {("conv_igemm_ops.mojo", "ConvIgemm")}
+    )
+    n, c, h, w, out_c, k = 2, 64, 16, 16, 64, 3
+    stride, pad, dilation, groups = 1, 1, 1, 1
+    dtype = torch.bfloat16
+    if case == "stride2":
+        stride = 2
+    elif case == "dilation2":
+        dilation, pad = 2, 2
+    elif case == "grouped":
+        groups = 4
+    elif case == "pointwise_1x1":
+        k, pad = 1, 0
+    elif case == "thin_c":
+        c = 3  # C_pad/C = 21x wasted math on this route
+    elif case == "thin_out_c":
+        out_c = 16  # BM = 64 would waste 3/4 of every output tile
+    elif case == "f32":
+        dtype = torch.float32
+    elif case == "f16":
+        dtype = torch.float16
+
+    x = torch.randn(n, c, h, w, dtype=dtype)
+    weight = (torch.randn(out_c, c // groups, k, k, dtype=dtype) * 0.1).to(dtype)
+    dev = torch.nn.functional.conv2d(
+        x.to(mojo_h100),
+        weight.to(mojo_h100),
+        None,
+        stride=stride,
+        padding=pad,
+        dilation=dilation,
+        groups=groups,
+    ).cpu()
+    ref = torch.nn.functional.conv2d(
+        x.float(),
+        weight.float(),
+        None,
+        stride=stride,
+        padding=pad,
+        dilation=dilation,
+        groups=groups,
+    )
+
+    target = ("conv_igemm_ops.mojo", "ConvIgemm")
+    assert not calls[target], f"{case} must not take the implicit-GEMM route"
+    torch.testing.assert_close(dev.float(), ref, atol=8e-2, rtol=8e-2)
+
+
+def test_conv_igemm_descriptor_domain_gate() -> None:
+    """The im2col TMA descriptor domain, checked on the host before anything
+    is allocated: pixel-box corners are SIGNED CHAR ([-128, 127]) and the
+    filter taps this kernel issues must fit in [0, 255].
+
+    The R = 257 line is the one that matters: that conv satisfies every other
+    eligibility condition (bf16, sm_90a, dense, stride 1, dilation 1, C = 64,
+    and corners -128/-1, 128/-1 that are all legal) yet its last tap is 256,
+    which is undefined behaviour at the instruction rather than a loud
+    failure.
+    """
+    from torch_mojo_backend.eager_kernels.aten_fast import _conv_igemm_descriptor_legal
+
+    assert _conv_igemm_descriptor_legal(1, 1, 3, 3)
+    assert _conv_igemm_descriptor_legal(0, 0, 1, 1)
+    assert _conv_igemm_descriptor_legal(3, 3, 7, 7)
+    # lower corner = -pad
+    assert _conv_igemm_descriptor_legal(128, 1, 3, 3)
+    assert not _conv_igemm_descriptor_legal(129, 1, 3, 3)
+    assert not _conv_igemm_descriptor_legal(1, 129, 3, 3)
+    # upper corner = pad - (filter - 1)
+    assert _conv_igemm_descriptor_legal(0, 0, 129, 3)
+    assert not _conv_igemm_descriptor_legal(0, 0, 130, 3)
+    # legal corners, illegal tap
+    assert _conv_igemm_descriptor_legal(128, 1, 256, 3)
+    assert not _conv_igemm_descriptor_legal(128, 1, 257, 3)
+    assert not _conv_igemm_descriptor_legal(1, 128, 3, 257)
+
+
 @pytest.mark.parametrize("op", ["bmm16", "1x1_bmm16"])
 def test_fast_conv2d_routes_dense_bf16_through_gemm16_bmm(
     mojo_h100: torch.device, monkeypatch: pytest.MonkeyPatch, op: str

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -9415,6 +9415,196 @@ def test_fast_conv2d_refuses_autograd_in_the_forward(mojo_gpu):
         )
 
 
+# Shrunk-N copies of benchmarks/test_vision.py's CONV_SHAPES: same C/H/W/kernel
+# (so the same im2col K and GEMM N the benchmark measures), a small batch so
+# the test is cheap.
+_CONV_BENCH_SHAPES = {
+    "body_N32xC64x56x56_K64k3s1": (2, 64, 56, 56, 64, 3, 1, 1),
+    "stem_N8xC3x224x224_K64k7s2": (2, 3, 224, 224, 64, 7, 2, 3),
+}
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("shape_id", _CONV_BENCH_SHAPES)
+def test_fast_conv2d_tensor_core_benchmark_shapes(
+    mojo_h100: torch.device, shape_id: str, dtype: torch.dtype
+) -> None:
+    """The benchmark body/stem conv shapes, N shrunk to 2, through whichever
+    GEMM route sm_90a picks for the dtype: Bmm16 (bf16/f16, always opt-in),
+    the opt-in TF32 BMM (f32, only past the same
+    `float32_matmul_precision() != "highest"` gate `_try_tf32_mm` uses), or
+    the plain SIMT Bmm fallback (f32 at the default "highest" precision)."""
+    n, c_in, h, w, c_out, k, stride, pad = _CONV_BENCH_SHAPES[shape_id]
+    x = torch.randn(n, c_in, h, w, dtype=dtype)
+    weight = torch.randn(c_out, c_in, k, k, dtype=dtype) * 0.1
+    bias = torch.randn(c_out, dtype=dtype)
+
+    old_precision = torch.get_float32_matmul_precision()
+    torch.set_float32_matmul_precision("high")
+    try:
+        dev = torch.nn.functional.conv2d(
+            x.to(mojo_h100), weight.to(mojo_h100), bias.to(mojo_h100), stride, pad
+        ).cpu()
+    finally:
+        torch.set_float32_matmul_precision(old_precision)
+    ref = torch.nn.functional.conv2d(
+        x.float(), weight.float(), bias.float(), stride, pad
+    )
+
+    # float16 has more mantissa bits than bfloat16, so it gets the tighter
+    # bound; both are FP32-accumulated tensor-core GEMMs (see the analogous
+    # gemm16 mm/bmm tests), just rounded to a narrower output type than the
+    # k=333 case those tests calibrate against, hence the wider margin for
+    # this k up to 576. float32 goes through TF32 (or, at default precision,
+    # plain FP32) -- the same calibrated bound the mm/addmm tensor-core tests
+    # use.
+    if dtype == torch.float16:
+        atol, rtol = 3e-2, 3e-3
+    elif dtype == torch.bfloat16:
+        atol, rtol = 8e-2, 8e-2
+    else:
+        atol, rtol = 5e-2, 5e-2
+    torch.testing.assert_close(dev.float(), ref, atol=atol, rtol=rtol)
+
+
+@pytest.mark.parametrize("op", ["bmm16", "1x1_bmm16"])
+def test_fast_conv2d_routes_dense_bf16_through_gemm16_bmm(
+    mojo_h100: torch.device, monkeypatch: pytest.MonkeyPatch, op: str
+) -> None:
+    """Dense (groups == 1) bf16 conv reaches the same Bmm16 kernel fast_aten_bmm
+    already builds -- both the general im2col path and the 1x1 stride-1
+    fast path that reads the NCHW input as the col matrix in place."""
+    calls = _spy_defined_native_calls(
+        monkeypatch, {("gemm16_matmul_ops.mojo", "Bmm16")}
+    )
+    n, c_in, h, w, c_out = 2, 8, 16, 16, 12
+    k, stride, pad = (3, 1, 1) if op == "bmm16" else (1, 1, 0)
+    x = torch.randn(n, c_in, h, w).to(torch.bfloat16)
+    weight = (torch.randn(c_out, c_in, k, k) * 0.1).to(torch.bfloat16)
+    dev = torch.nn.functional.conv2d(
+        x.to(mojo_h100), weight.to(mojo_h100), None, stride, pad
+    ).cpu()
+    ref = torch.nn.functional.conv2d(x.float(), weight.float(), None, stride, pad)
+
+    target = ("gemm16_matmul_ops.mojo", "Bmm16")
+    assert len(calls[target]) == 1, "dense bf16 conv did not reach the Bmm16 bridge"
+    torch.testing.assert_close(dev.float(), ref, atol=8e-2, rtol=8e-2)
+
+
+def test_fast_conv2d_tf32_bmm_is_opt_in_like_mm(
+    mojo_h100: torch.device, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same numerics policy as the mm/bmm TF32 routes: off by default (torch's
+    `float32_matmul_precision() == "highest"`), reachable once the caller
+    opts in with `torch.set_float32_matmul_precision("high")`. The repo has
+    no separate `torch.backends.cudnn.allow_tf32`-style policy for
+    convolution, so this deliberately follows the mm gate instead."""
+    calls = _spy_defined_native_calls(
+        monkeypatch,
+        {("tf32_matmul_ops.mojo", "Tf32BmmF32"), ("matmul_ops.mojo", "Bmm")},
+    )
+    x = torch.randn(2, 8, 16, 16)
+    weight = torch.randn(12, 8, 3, 3) * 0.1
+
+    dev_default = torch.nn.functional.conv2d(
+        x.to(mojo_h100), weight.to(mojo_h100), None, 1, 1
+    ).cpu()
+    assert not calls[("tf32_matmul_ops.mojo", "Tf32BmmF32")]
+    assert len(calls[("matmul_ops.mojo", "Bmm")]) == 1
+
+    old_precision = torch.get_float32_matmul_precision()
+    torch.set_float32_matmul_precision("high")
+    try:
+        dev_tf32 = torch.nn.functional.conv2d(
+            x.to(mojo_h100), weight.to(mojo_h100), None, 1, 1
+        ).cpu()
+    finally:
+        torch.set_float32_matmul_precision(old_precision)
+    assert len(calls[("tf32_matmul_ops.mojo", "Tf32BmmF32")]) == 1
+
+    ref = torch.nn.functional.conv2d(x, weight, None, 1, 1)
+    torch.testing.assert_close(dev_default, ref, atol=1e-3, rtol=1e-3)
+    torch.testing.assert_close(dev_tf32, ref, atol=5e-2, rtol=5e-2)
+
+
+def test_fast_conv2d_grouped_and_noncontiguous_keep_generic_route(
+    mojo_h100: torch.device, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Blast-radius guard: grouped convs and non-contiguous inputs are the
+    cases the tensor-core routes decline (grouped: no single (out_c, ckk) x
+    (ckk, cols) GEMM; non-contiguous: `_tc` materializes it back to dense
+    before either helper ever sees it, per the existing contract) -- both
+    must still land on the untouched SIMT path, not silently regress or
+    raise."""
+    calls = _spy_defined_native_calls(
+        monkeypatch,
+        {
+            ("gemm16_matmul_ops.mojo", "Bmm16"),
+            ("tf32_matmul_ops.mojo", "Tf32BmmF32"),
+            ("matmul_ops.mojo", "Matmul"),
+            ("matmul_ops.mojo", "Bmm"),
+        },
+    )
+    old_precision = torch.get_float32_matmul_precision()
+    torch.set_float32_matmul_precision("high")
+    try:
+        # Grouped conv, bf16: per (sample, group) Matmul, never Bmm16.
+        x = torch.randn(2, 8, 16, 16).to(torch.bfloat16)
+        w = torch.randn(12, 4, 3, 3).to(torch.bfloat16)
+        dev_grouped = torch.nn.functional.conv2d(
+            x.to(mojo_h100), w.to(mojo_h100), None, 1, 1, groups=2
+        ).cpu()
+        ref_grouped = torch.nn.functional.conv2d(
+            x.float(), w.float(), None, 1, 1, groups=2
+        )
+        torch.testing.assert_close(
+            dev_grouped.float(), ref_grouped, atol=8e-2, rtol=8e-2
+        )
+
+        # Non-contiguous (channels-last) f32 input, dense conv: still TF32.
+        x_nc = torch.randn(2, 8, 16, 16).to(memory_format=torch.channels_last)
+        w_nc = torch.randn(12, 8, 3, 3) * 0.1
+        dev_nc = torch.nn.functional.conv2d(
+            x_nc.to(mojo_h100), w_nc.to(mojo_h100), None, 1, 1
+        ).cpu()
+        ref_nc = torch.nn.functional.conv2d(x_nc, w_nc, None, 1, 1)
+        torch.testing.assert_close(dev_nc, ref_nc, atol=5e-2, rtol=5e-2)
+    finally:
+        torch.set_float32_matmul_precision(old_precision)
+
+    assert not calls[("gemm16_matmul_ops.mojo", "Bmm16")]
+    assert len(calls[("matmul_ops.mojo", "Matmul")]) == 2 * 2  # 2 samples x 2 groups
+    assert len(calls[("tf32_matmul_ops.mojo", "Tf32BmmF32")]) == 1
+    assert len(calls[("matmul_ops.mojo", "Bmm")]) == 0
+
+
+def test_fast_conv2d_cpu_device_matches_gpu_row_kernel(mojo_device: str) -> None:
+    """`conv_ops.mojo`'s Im2col/BiasAddChan dispatch on `ctx.api()`: the CPU
+    device (`mojo_device` here, not `mojo_gpu`) takes the scalar
+    `elementwise` path (`_im2col_scalar`/`_bias_add_chan_scalar`), unchanged
+    logic from before this file's GPU row-kernel rewrite, just extracted into
+    a named function -- this is the one test in the module that actually
+    exercises it, on both stride=1 (im2col's contiguous-read branch) and
+    stride=2 (its strided-gather branch)."""
+    torch.manual_seed(0)
+    x = torch.randn(2, 8, 16, 16)
+    w = torch.randn(12, 8, 3, 3) * 0.1
+    b = torch.randn(12)
+    dev = torch.nn.functional.conv2d(
+        x.to(mojo_device), w.to(mojo_device), b.to(mojo_device), stride=1, padding=1
+    ).cpu()
+    ref = torch.nn.functional.conv2d(x, w, b, stride=1, padding=1)
+    torch.testing.assert_close(dev, ref, atol=1e-4, rtol=1e-4)
+
+    x2 = torch.randn(3, 3, 15, 17)
+    w2 = torch.randn(6, 3, 5, 5) * 0.1
+    dev2 = torch.nn.functional.conv2d(
+        x2.to(mojo_device), w2.to(mojo_device), None, stride=2, padding=2
+    ).cpu()
+    ref2 = torch.nn.functional.conv2d(x2, w2, None, stride=2, padding=2)
+    torch.testing.assert_close(dev2, ref2, atol=1e-4, rtol=1e-4)
+
+
 @pytest.mark.parametrize("is_causal", [True, False])
 # kv_len <= 32 exercises the library softmax's warp kernel, kv_len=64 the
 # online/block kernel.

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -9004,21 +9004,20 @@ def _fast_aten_bmm_transpose_b(input, mat2):
 
 
 def _try_gemm16_conv_bmm(
-    w: TorchMojoTensor,
-    a: TorchMojoTensor,
-    col_ptr: int,
-    n: int,
-    out_c: int,
-    cols: int,
-    ckk: int,
+    w: TorchMojoTensor, col: TorchMojoTensor, n: int, out_c: int, cols: int, ckk: int
 ) -> TorchMojoTensor | None:
     """Dense conv GEMM (shared weight x per-sample im2col) via Bmm16, or
-    ``None``. ``w`` is the contiguous (out_c, ckk) weight; ``col_ptr`` is the
+    ``None``. ``w`` is the contiguous (out_c, ckk) weight; ``col`` OWNS the
     per-sample dense row-major (ckk, cols) im2col slice (or, for 1x1
-    stride-1 convs, the NCHW input reread in place)."""
+    stride-1 convs, ``col`` IS the input tensor, reread in place). ``col``
+    must be the actual owning tensor, not a bare pointer: under the default
+    kernel-call queue the launch this enqueues can be deferred behind a
+    still-compiling specialization, and the caller's last reference to the
+    buffer it points at can drop before that launch runs unless this frame's
+    keepalive tuple holds it too (queue rule 3, call_queue.py:18-26)."""
     if (
         w._dtype not in _GEMM16_DTYPES
-        or w._device != a._device
+        or w._device != col._device
         or w._device.label != "gpu"
         or w._device.api != "cuda"
         or w._device.architecture_name != "sm_90a"
@@ -9033,7 +9032,7 @@ def _try_gemm16_conv_bmm(
         (
             out._ptr,
             w._ptr,
-            col_ptr,
+            col._ptr,
             n,
             out_c,
             cols,
@@ -9048,31 +9047,27 @@ def _try_gemm16_conv_bmm(
         arg_dtypes=(w._dtype, w._dtype),
         output_dtypes=(out._dtype,),
         flags={"TRANSPOSE_B": False},
-        keepalive=(out, w),
+        keepalive=(out, w, col),
     )
     return out
 
 
 def _try_tf32_conv_bmm(
-    w: TorchMojoTensor,
-    a: TorchMojoTensor,
-    col_ptr: int,
-    n: int,
-    out_c: int,
-    cols: int,
-    ckk: int,
+    w: TorchMojoTensor, col: TorchMojoTensor, n: int, out_c: int, cols: int, ckk: int
 ) -> TorchMojoTensor | None:
     """Dense conv GEMM (shared weight x per-sample im2col) via the opt-in
     TF32 BMM, or ``None``. Same numerics policy as ``_try_tf32_bmm``: TF32 is
     off when the user asked for full FP32 (`torch.set_float32_matmul_precision
     ("highest")`) -- the repo has no separate `torch.backends.cudnn.
     allow_tf32`-style policy for convolution, so this follows the exact gate
-    the mm/bmm TF32 paths already use."""
+    the mm/bmm TF32 paths already use. ``col`` must be the tensor that OWNS
+    the im2col buffer (or the input tensor itself for a 1x1 conv), not a
+    bare pointer -- see ``_try_gemm16_conv_bmm``'s docstring for why."""
     if torch.get_float32_matmul_precision() == "highest":
         return None
     if (
         w._dtype != DType.float32
-        or w._device != a._device
+        or w._device != col._device
         or w._device.label != "gpu"
         or w._device.api != "cuda"
         or w._device.architecture_name != "sm_90a"
@@ -9087,7 +9082,7 @@ def _try_tf32_conv_bmm(
         (
             out._ptr,
             w._ptr,
-            col_ptr,
+            col._ptr,
             n,
             out_c,
             cols,
@@ -9102,7 +9097,7 @@ def _try_tf32_conv_bmm(
         arg_dtypes=(w._dtype, w._dtype),
         output_dtypes=(out._dtype,),
         flags={"TRANSPOSE_B": False},
-        keepalive=(out, w),
+        keepalive=(out, w, col),
     )
     return out
 
@@ -9262,6 +9257,7 @@ def fast_aten_convolution(
         and not transposed
         and (bias is None or bias_t is not None)
         and a._dtype == w._dtype
+        and a._device == w._device
         and a._dtype in _FLOAT_DTYPES
         and len(a._shape) == 4
         and len(w._shape) == 4
@@ -9279,7 +9275,9 @@ def fast_aten_convolution(
         out_w = (in_w + 2 * pw - (dw * (kw - 1) + 1)) // sw + 1
         if c_per_group * groups == c and out_h > 0 and out_w > 0:
             if bias_t is not None and (
-                bias_t._dtype != a._dtype or tuple(bias_t._shape) != (out_c,)
+                bias_t._dtype != a._dtype
+                or bias_t._device != a._device
+                or tuple(bias_t._shape) != (out_c,)
             ):
                 return NOT_HANDLED
             ctx = _ctx_ptr(a._device)
@@ -9304,7 +9302,11 @@ def fast_aten_convolution(
             if out is None:
                 if (kh, kw, sh, sw, ph, pw, dh, dw) == (1, 1, 1, 1, 0, 0, 1, 1):
                     # 1x1 stride-1 conv: NCHW input already is the col matrix.
-                    col_ptr = a._ptr
+                    # `col` ALIASES `a` (no allocation) -- it is still the
+                    # tensor that must stay alive until every GEMM reading it
+                    # has launched, so it flows through exactly like the
+                    # materialized branch's freshly allocated `col` below.
+                    col = a
                 else:
                     col = _alloc((n, ckk, cols), a._dtype, a._device)
                     _call_mojo(
@@ -9336,7 +9338,6 @@ def fast_aten_convolution(
                         output_dtypes=(col._dtype,),
                         keepalive=(col, a),
                     )
-                    col_ptr = col._ptr
                 if groups == 1:
                     # H100 tensor cores first: bf16/f16 through the same Bmm16
                     # kernel fast_aten_bmm already builds, f32 through the same
@@ -9345,9 +9346,9 @@ def fast_aten_convolution(
                     # bridge sources missing, and the plain SIMT Bmm below is the
                     # fallback for every regime they decline, including grouped
                     # convs (untouched, handled in the `else` branch).
-                    out = _try_gemm16_conv_bmm(w, a, col_ptr, n, out_c, cols, ckk)
+                    out = _try_gemm16_conv_bmm(w, col, n, out_c, cols, ckk)
                     if out is None:
-                        out = _try_tf32_conv_bmm(w, a, col_ptr, n, out_c, cols, ckk)
+                        out = _try_tf32_conv_bmm(w, col, n, out_c, cols, ckk)
                     if out is None:
                         out = _alloc((n, out_c, cols), a._dtype, a._device)
                         _call_mojo(
@@ -9356,7 +9357,7 @@ def fast_aten_convolution(
                             (
                                 out._ptr,
                                 w._ptr,
-                                col_ptr,
+                                col._ptr,
                                 (n, out_c, cols, ckk, 0, 1),
                                 a._dtype.value,
                                 ctx,
@@ -9369,7 +9370,12 @@ def fast_aten_convolution(
                             # it here would only fork this call site onto a
                             # second .so of identical code.
                             flags={"TRANSPOSE_B": False},
-                            keepalive=(out, w),
+                            # `col` (the im2col buffer, or `a` itself for the
+                            # 1x1 fast path) owns the pointer this call names
+                            # and must outlive the deferred launch (kernel
+                            # queue rule 3, call_queue.py:18-26) -- it is not
+                            # implied by `w`/`out` alone.
+                            keepalive=(out, w, col),
                         )
                 else:
                     out = _alloc((n, out_c, cols), a._dtype, a._device)
@@ -9385,7 +9391,7 @@ def fast_aten_convolution(
                                 (
                                     out._ptr,
                                     w._ptr,
-                                    col_ptr,
+                                    col._ptr,
                                     (
                                         oc_g,
                                         cols,
@@ -9401,7 +9407,10 @@ def fast_aten_convolution(
                                 arg_dtypes=(w._dtype, a._dtype),
                                 output_dtypes=(out._dtype,),
                                 flags={"TRANSPOSE_B": False},
-                                keepalive=(out, w),
+                                # Same rationale as the dense-path Bmm call
+                                # above: `col` owns the pointer this call
+                                # names.
+                                keepalive=(out, w, col),
                             )
             if bias_t is not None:
                 _call_mojo(

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -9245,9 +9245,14 @@ def _try_conv_igemm(
 def fast_aten_convolution(
     input, weight, bias, stride, padding, dilation, transposed, output_padding, groups
 ):
-    a = _tc(input)
-    w = _tc(weight)
-    bias_t = _tc(bias) if bias is not None else None
+    # `_t()` here, not `_tc()`: every gate below (dtype, device, shape) reads
+    # metadata only, so it must run before paying for `_tc()`'s allocation +
+    # copy of a non-contiguous operand -- including the device-equality gate,
+    # so a cross-device pair returns NOT_HANDLED before any materialization,
+    # not just before the eventual conv kernel launch.
+    a = _t(input)
+    w = _t(weight)
+    bias_t = _t(bias) if bias is not None else None
     strides = _pair(list(stride))
     pads = _pair(list(padding))
     dils = _pair(list(dilation))
@@ -9280,6 +9285,13 @@ def fast_aten_convolution(
                 or tuple(bias_t._shape) != (out_c,)
             ):
                 return NOT_HANDLED
+            # Every reason to decline (dtype/device/shape mismatch, a
+            # cross-device pair included) has already returned NOT_HANDLED
+            # above; only now is a non-contiguous operand worth the
+            # allocation + copy `_tc()` pays for.
+            a = _tc(a)
+            w = _tc(w)
+            bias_t = _tc(bias_t) if bias_t is not None else None
             ctx = _ctx_ptr(a._device)
             cols = out_h * out_w
             ckk = c * kh * kw

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -9109,7 +9109,19 @@ def _try_tf32_conv_bmm(
 # the GEMM, where the materialized route costs a full im2col write + read
 # (89% of the body conv's device time) plus the same GEMM. Measured on an
 # H100 PCIe at a 1395 MHz pin, bf16 N32xC64x56x56 K64 k3s1: 59.0 us vs
-# 861 us on the materialized route and 71.95 us for cuDNN (0.82x cuDNN).
+# 861 us on the materialized route and 71.95 us for cuDNN.
+#
+# That 71.95 us is cuDNN reached the way torch.nn.Conv2d reaches it from an
+# NCHW tensor, which is NOT cuDNN's own speed: 31.2 us of convolution plus
+# 41.0 us of nchwToNhwc / nhwcToNchw transposes around it. Handed a
+# channels_last tensor cuDNN does the same convolution in 33.9 us with no
+# transposes, against 54.6 us for the three kernels of this route (NHWC
+# pass + weight repack + implicit GEMM). So this route wins the NCHW
+# comparison because it needs no layout conversion, and loses the
+# same-layout comparison by ~1.6x. Both statements are about the forward
+# convolution only; the separate BiasAddChan kernel is another 12.2 us here
+# against 25.3 us for the elementwise bias add torch appends to cuDNN, which
+# is where a further chunk of the end-to-end ratio comes from.
 #
 # Everything the route cannot do stays on the materialized route: grouped
 # convolution (not implemented here at all), stride != 1, dilation != 1,

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -8985,7 +8985,123 @@ def _fast_aten_bmm_transpose_b(input, mat2):
 # (K,C,R,S) weight used as-is and NCHW output — no layout permutes.
 # Grouped convolutions slice the channel-major im2col rows and weights per
 # group with element offsets.
+#
+# The dense (groups == 1) GEMM shares one (out_c, ckk) weight matrix across
+# every sample in the batch, so it is a batched matmul with the A operand
+# broadcast (runtime batch stride 0) against a densely packed, per-sample
+# row-major im2col B. That broadcast is not a new capability: the plain SIMT
+# `Bmm` bridge below already threads it through as `a_shared`, and the
+# accepted Bmm16/Tf32BmmF32 kernels already prove their pointer arithmetic
+# for a zero A-batch-stride (`_opt_bmm_address_proof`'s `a_bstride > 0`
+# guards treat zero as the trivial case). The two helpers below reuse those
+# kernels as-is: same OP name, same dtype, same TRANSPOSE_B=False flag that
+# fast_aten_bmm already builds, so no new compiled variant exists anywhere
+# because of them -- only a new host-side call site.
 # ---------------------------------------------------------------------------
+
+
+def _try_gemm16_conv_bmm(
+    w: TorchMojoTensor,
+    a: TorchMojoTensor,
+    col_ptr: int,
+    n: int,
+    out_c: int,
+    cols: int,
+    ckk: int,
+) -> TorchMojoTensor | None:
+    """Dense conv GEMM (shared weight x per-sample im2col) via Bmm16, or
+    ``None``. ``w`` is the contiguous (out_c, ckk) weight; ``col_ptr`` is the
+    per-sample dense row-major (ckk, cols) im2col slice (or, for 1x1
+    stride-1 convs, the NCHW input reread in place)."""
+    if (
+        w._dtype not in _GEMM16_DTYPES
+        or w._device != a._device
+        or w._device.label != "gpu"
+        or w._device.api != "cuda"
+        or w._device.architecture_name != "sm_90a"
+        or min(n, out_c, cols, ckk) <= 0
+        or not _gemm16_bridge_available()
+    ):
+        return None
+    out = _alloc((n, out_c, cols), w._dtype, w._device)
+    _call_mojo(
+        _Gemm16MatmulExtension,
+        "Bmm16",
+        (
+            out._ptr,
+            w._ptr,
+            col_ptr,
+            n,
+            out_c,
+            cols,
+            ckk,
+            out_c * cols,
+            0,
+            ckk * cols,
+            0,
+            0,
+            _ctx_ptr(w._device),
+        ),
+        arg_dtypes=(w._dtype, w._dtype),
+        output_dtypes=(out._dtype,),
+        flags={"TRANSPOSE_B": False},
+        keepalive=(out, w),
+    )
+    return out
+
+
+def _try_tf32_conv_bmm(
+    w: TorchMojoTensor,
+    a: TorchMojoTensor,
+    col_ptr: int,
+    n: int,
+    out_c: int,
+    cols: int,
+    ckk: int,
+) -> TorchMojoTensor | None:
+    """Dense conv GEMM (shared weight x per-sample im2col) via the opt-in
+    TF32 BMM, or ``None``. Same numerics policy as ``_try_tf32_bmm``: TF32 is
+    off when the user asked for full FP32 (`torch.set_float32_matmul_precision
+    ("highest")`) -- the repo has no separate `torch.backends.cudnn.
+    allow_tf32`-style policy for convolution, so this follows the exact gate
+    the mm/bmm TF32 paths already use."""
+    if torch.get_float32_matmul_precision() == "highest":
+        return None
+    if (
+        w._dtype != DType.float32
+        or w._device != a._device
+        or w._device.label != "gpu"
+        or w._device.api != "cuda"
+        or w._device.architecture_name != "sm_90a"
+        or min(n, out_c, cols, ckk) <= 0
+        or not _tf32_bridge_available()
+    ):
+        return None
+    out = _alloc((n, out_c, cols), w._dtype, w._device)
+    _call_mojo(
+        _Tf32MatmulExtension,
+        "Tf32BmmF32",
+        (
+            out._ptr,
+            w._ptr,
+            col_ptr,
+            n,
+            out_c,
+            cols,
+            ckk,
+            out_c * cols,
+            0,
+            ckk * cols,
+            0,
+            0,
+            _ctx_ptr(w._device),
+        ),
+        arg_dtypes=(w._dtype, w._dtype),
+        output_dtypes=(out._dtype,),
+        flags={"TRANSPOSE_B": False},
+        keepalive=(out, w),
+    )
+    return out
 
 
 def fast_aten_convolution(
@@ -9061,29 +9177,42 @@ def fast_aten_convolution(
                     keepalive=(col, a),
                 )
                 col_ptr = col._ptr
-            out = _alloc((n, out_c, cols), a._dtype, a._device)
             if groups == 1:
-                _call_mojo(
-                    _MatmulExtension,
-                    "Bmm",
-                    (
-                        out._ptr,
-                        w._ptr,
-                        col_ptr,
-                        (n, out_c, cols, ckk, 0, 1),
-                        a._dtype.value,
-                        ctx,
-                    ),
-                    arg_dtypes=(w._dtype, a._dtype),
-                    output_dtypes=(out._dtype,),
-                    # Same define shape as every other Bmm site: the shared-A
-                    # broadcast is RUNTIME data (the trailing 1 in the params
-                    # tuple, matmul_ops._bmm_go), so naming it here would only
-                    # fork this call site onto a second .so of identical code.
-                    flags={"TRANSPOSE_B": False},
-                    keepalive=(out, w),
-                )
+                # H100 tensor cores first: bf16/f16 through the same Bmm16
+                # kernel fast_aten_bmm already builds, f32 through the same
+                # opt-in TF32 route _try_tf32_mm already gates. Both decline
+                # (return None) off sm_90a, off their dtype, or with the
+                # bridge sources missing, and the plain SIMT Bmm below is the
+                # fallback for every regime they decline, including grouped
+                # convs (untouched, handled in the `else` branch).
+                out = _try_gemm16_conv_bmm(w, a, col_ptr, n, out_c, cols, ckk)
+                if out is None:
+                    out = _try_tf32_conv_bmm(w, a, col_ptr, n, out_c, cols, ckk)
+                if out is None:
+                    out = _alloc((n, out_c, cols), a._dtype, a._device)
+                    _call_mojo(
+                        _MatmulExtension,
+                        "Bmm",
+                        (
+                            out._ptr,
+                            w._ptr,
+                            col_ptr,
+                            (n, out_c, cols, ckk, 0, 1),
+                            a._dtype.value,
+                            ctx,
+                        ),
+                        arg_dtypes=(w._dtype, a._dtype),
+                        output_dtypes=(out._dtype,),
+                        # Same define shape as every other Bmm site: the
+                        # shared-A broadcast is RUNTIME data (the trailing 1
+                        # in the params tuple, matmul_ops._bmm_go), so naming
+                        # it here would only fork this call site onto a
+                        # second .so of identical code.
+                        flags={"TRANSPOSE_B": False},
+                        keepalive=(out, w),
+                    )
             else:
+                out = _alloc((n, out_c, cols), a._dtype, a._device)
                 # Channel-major im2col rows make each group a contiguous
                 # (crs_g, cols) slice; run one offset GEMM per (sample, group).
                 crs_g = c_per_group * kh * kw

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -40,6 +40,9 @@ from torch_mojo_backend.eager_kernels.activation_backward_ops import (
 from torch_mojo_backend.eager_kernels.activation_forward_ops import (
     ActivationForwardExtension as _ActivationForwardExtension,
 )
+from torch_mojo_backend.eager_kernels.conv_igemm_ops import (
+    ConvIgemmExtension as _ConvIgemmExtension,
+)
 from torch_mojo_backend.eager_kernels.conv_ops import ConvExtension as _ConvExtension
 from torch_mojo_backend.eager_kernels.data_movement_ops import (
     DataMovementExtension as _DataMovementExtension,
@@ -9104,6 +9107,146 @@ def _try_tf32_conv_bmm(
     return out
 
 
+# ---------------------------------------------------------------------------
+# Implicit-GEMM conv2d (sm_90a): the (N*OH*OW) x (R*S*C) patch matrix is never
+# written to memory. The hardware im2col TMA reads each B tile straight out of
+# an NHWC copy of the activation, so the route costs one NCHW->NHWC pass plus
+# the GEMM, where the materialized route costs a full im2col write + read
+# (89% of the body conv's device time) plus the same GEMM. Measured on an
+# H100 PCIe at a 1395 MHz pin, bf16 N32xC64x56x56 K64 k3s1: 59.0 us vs
+# 861 us on the materialized route and 71.95 us for cuDNN (0.82x cuDNN).
+#
+# Everything the route cannot do stays on the materialized route: grouped
+# convolution (not implemented here at all), stride != 1, dilation != 1,
+# 1x1 filters (which skip im2col entirely there and are already at 0.94x
+# cuDNN), thin-C shapes like a 3-channel stem, and float32/TF32 (feasible --
+# the descriptor path is dtype-generic -- but the 128 B swizzle makes the
+# k-tile, the C padding and the wgmma shape all change with the element
+# width, so it is a separate piece of work and is not built).
+# ---------------------------------------------------------------------------
+
+_CONV_IGEMM_SOURCE_PATHS = (
+    eager_kernels._PACKAGE_DIR / _ConvIgemmExtension.MOJO_FILE,
+    eager_kernels._PACKAGE_DIR / "wgmma_c_epilogue.mojo",
+)
+
+# 16-bit only: the kernel is a wgmma path whose k-tile is one 128 B swizzle
+# row. float16 is the same instruction with a different operand token and the
+# Mojo source instantiates for it, but only bfloat16 has been measured, so
+# only bfloat16 is admitted here.
+_CONV_IGEMM_DTYPES = (DType.bfloat16,)
+
+# C is padded up to the 64-channel k-tile and the padded reduction is real
+# work: at C = 32 the GEMM already does 2x the necessary math, and a
+# 3-channel stem would do 21x. Below this the materialized route wins.
+_CONV_IGEMM_MIN_C = 32
+# With BM = 64 a ragged out_c wastes up to half of every output tile.
+_CONV_IGEMM_MIN_OUT_C = 32
+_CONV_IGEMM_CHANNEL_TILE = 64
+
+
+def _conv_igemm_bridge_available() -> bool:
+    """Whether the implicit-GEMM conv bridge and its sources are present."""
+    return _bridge_available("conv_igemm", _CONV_IGEMM_SOURCE_PATHS)
+
+
+def _conv_igemm_descriptor_legal(ph: int, pw: int, kh: int, kw: int) -> bool:
+    """Whether the im2col TMA descriptor this conv needs is legal at all.
+
+    `cuTensorMapEncodeIm2col` takes the pixel-box corners as SIGNED CHAR --
+    both corners of both spatial dimensions must land in [-128, 127] -- and
+    the per-transaction im2col offsets (the filter taps this kernel issues,
+    0..R-1 and 0..S-1) are limited to [0, 255]. The two failure modes differ
+    and both have to be caught HERE, before anything is allocated: an illegal
+    corner makes descriptor creation fail outright, while an illegal tap is
+    undefined behaviour at the instruction and does not fail loudly. E.g.
+    N=1, C=64, H=W=7, K=64, R=257, S=3, pad=(128, 1) satisfies every other
+    condition on this route and produces tap r = 256.
+    """
+    corners = (-ph, -pw, ph - (kh - 1), pw - (kw - 1))
+    return (
+        all(-128 <= corner <= 127 for corner in corners)
+        and kh - 1 <= 255
+        and kw - 1 <= 255
+    )
+
+
+def _try_conv_igemm(
+    a: TorchMojoTensor,
+    w: TorchMojoTensor,
+    in_shape: tuple[int, int, int, int],
+    filt: tuple[int, int, int],
+    strides: tuple[int, int],
+    pads: tuple[int, int],
+    dils: tuple[int, int],
+    out_hw: tuple[int, int],
+    ctx: int,
+) -> TorchMojoTensor | None:
+    """Dense conv2d forward through the sm_90a implicit GEMM, or ``None`` when
+    any gate declines (the caller then takes the materialized im2col route).
+
+    Only ``groups == 1`` reaches here; grouped convolution is not implemented
+    by this kernel.
+    """
+    n, c, in_h, in_w = in_shape
+    out_c, kh, kw = filt
+    ph, pw = pads
+    out_h, out_w = out_hw
+    if (
+        a._dtype not in _CONV_IGEMM_DTYPES
+        or w._dtype != a._dtype
+        or w._device != a._device
+        or a._device.label != "gpu"
+        or a._device.api != "cuda"
+        or a._device.architecture_name != "sm_90a"
+        or not _conv_igemm_bridge_available()
+    ):
+        return None
+    if strides != (1, 1) or dils != (1, 1):
+        # The box convention (lower = -pad, upper = pad - (filter - 1)) makes
+        # the pixel box the output grid, which is only true at stride 1;
+        # dilation needs a different box.
+        return None
+    if kh * kw <= 1:
+        # A 1x1 conv has no im2col on the materialized route either (the NCHW
+        # input is reread in place) and is already faster than cuDNN there;
+        # routing it here would only add the NHWC pass.
+        return None
+    if c < _CONV_IGEMM_MIN_C or out_c < _CONV_IGEMM_MIN_OUT_C:
+        return None
+    if min(n, in_h, in_w, out_h, out_w) <= 0:
+        return None
+    if not _conv_igemm_descriptor_legal(ph, pw, kh, kw):
+        return None
+    c_pad = (
+        (c + _CONV_IGEMM_CHANNEL_TILE - 1) // _CONV_IGEMM_CHANNEL_TILE
+    ) * _CONV_IGEMM_CHANNEL_TILE
+    # Scratch: the NHWC activation and the k-major weight. Both are smaller
+    # than the (n, C*R*S, OH*OW) column buffer this route replaces -- the
+    # activation by R*S, the weight by the batch.
+    act = _alloc((n, in_h, in_w, c_pad), a._dtype, a._device)
+    wpack = _alloc((out_c, kh * kw * c_pad), a._dtype, a._device)
+    out = _alloc((n, out_c, out_h * out_w), a._dtype, a._device)
+    _call_mojo(
+        _ConvIgemmExtension,
+        "ConvIgemm",
+        (
+            out._ptr,
+            act._ptr,
+            wpack._ptr,
+            a._ptr,
+            w._ptr,
+            (n, c, c_pad, in_h, in_w, out_c, kh, kw, ph, pw, out_h, out_w),
+            a._dtype.value,
+            ctx,
+        ),
+        arg_dtypes=(a._dtype,),
+        output_dtypes=(out._dtype,),
+        keepalive=(out, act, wpack, a, w),
+    )
+    return out
+
+
 def fast_aten_convolution(
     input, weight, bias, stride, padding, dilation, transposed, output_padding, groups
 ):
@@ -9142,107 +9285,124 @@ def fast_aten_convolution(
             ctx = _ctx_ptr(a._device)
             cols = out_h * out_w
             ckk = c * kh * kw
-            if (kh, kw, sh, sw, ph, pw, dh, dw) == (1, 1, 1, 1, 0, 0, 1, 1):
-                # 1x1 stride-1 conv: NCHW input already is the col matrix.
-                col_ptr = a._ptr
-            else:
-                col = _alloc((n, ckk, cols), a._dtype, a._device)
-                _call_mojo(
-                    _ConvExtension,
-                    "Im2col",
-                    (
-                        col._ptr,
-                        a._ptr,
-                        (
-                            in_h,
-                            in_w,
-                            out_h,
-                            out_w,
-                            kh,
-                            kw,
-                            sh,
-                            sw,
-                            ph,
-                            pw,
-                            dh,
-                            dw,
-                            c,
-                            n,
-                        ),
-                        a._dtype.value,
-                        ctx,
-                    ),
-                    arg_dtypes=(a._dtype,),
-                    output_dtypes=(col._dtype,),
-                    keepalive=(col, a),
-                )
-                col_ptr = col._ptr
+            out = None
             if groups == 1:
-                # H100 tensor cores first: bf16/f16 through the same Bmm16
-                # kernel fast_aten_bmm already builds, f32 through the same
-                # opt-in TF32 route _try_tf32_mm already gates. Both decline
-                # (return None) off sm_90a, off their dtype, or with the
-                # bridge sources missing, and the plain SIMT Bmm below is the
-                # fallback for every regime they decline, including grouped
-                # convs (untouched, handled in the `else` branch).
-                out = _try_gemm16_conv_bmm(w, a, col_ptr, n, out_c, cols, ckk)
-                if out is None:
-                    out = _try_tf32_conv_bmm(w, a, col_ptr, n, out_c, cols, ckk)
-                if out is None:
-                    out = _alloc((n, out_c, cols), a._dtype, a._device)
+                # Implicit GEMM (the patch matrix is never materialized) when
+                # the shape is inside its domain; everything else, grouped
+                # convs included, falls through to the im2col route below.
+                out = _try_conv_igemm(
+                    a,
+                    w,
+                    (n, c, in_h, in_w),
+                    (out_c, kh, kw),
+                    (sh, sw),
+                    (ph, pw),
+                    (dh, dw),
+                    (out_h, out_w),
+                    ctx,
+                )
+            if out is None:
+                if (kh, kw, sh, sw, ph, pw, dh, dw) == (1, 1, 1, 1, 0, 0, 1, 1):
+                    # 1x1 stride-1 conv: NCHW input already is the col matrix.
+                    col_ptr = a._ptr
+                else:
+                    col = _alloc((n, ckk, cols), a._dtype, a._device)
                     _call_mojo(
-                        _MatmulExtension,
-                        "Bmm",
+                        _ConvExtension,
+                        "Im2col",
                         (
-                            out._ptr,
-                            w._ptr,
-                            col_ptr,
-                            (n, out_c, cols, ckk, 0, 1),
+                            col._ptr,
+                            a._ptr,
+                            (
+                                in_h,
+                                in_w,
+                                out_h,
+                                out_w,
+                                kh,
+                                kw,
+                                sh,
+                                sw,
+                                ph,
+                                pw,
+                                dh,
+                                dw,
+                                c,
+                                n,
+                            ),
                             a._dtype.value,
                             ctx,
                         ),
-                        arg_dtypes=(w._dtype, a._dtype),
-                        output_dtypes=(out._dtype,),
-                        # Same define shape as every other Bmm site: the
-                        # shared-A broadcast is RUNTIME data (the trailing 1
-                        # in the params tuple, matmul_ops._bmm_go), so naming
-                        # it here would only fork this call site onto a
-                        # second .so of identical code.
-                        flags={"TRANSPOSE_B": False},
-                        keepalive=(out, w),
+                        arg_dtypes=(a._dtype,),
+                        output_dtypes=(col._dtype,),
+                        keepalive=(col, a),
                     )
-            else:
-                out = _alloc((n, out_c, cols), a._dtype, a._device)
-                # Channel-major im2col rows make each group a contiguous
-                # (crs_g, cols) slice; run one offset GEMM per (sample, group).
-                crs_g = c_per_group * kh * kw
-                oc_g = out_c // groups
-                for s in range(n):
-                    for g in range(groups):
+                    col_ptr = col._ptr
+                if groups == 1:
+                    # H100 tensor cores first: bf16/f16 through the same Bmm16
+                    # kernel fast_aten_bmm already builds, f32 through the same
+                    # opt-in TF32 route _try_tf32_mm already gates. Both decline
+                    # (return None) off sm_90a, off their dtype, or with the
+                    # bridge sources missing, and the plain SIMT Bmm below is the
+                    # fallback for every regime they decline, including grouped
+                    # convs (untouched, handled in the `else` branch).
+                    out = _try_gemm16_conv_bmm(w, a, col_ptr, n, out_c, cols, ckk)
+                    if out is None:
+                        out = _try_tf32_conv_bmm(w, a, col_ptr, n, out_c, cols, ckk)
+                    if out is None:
+                        out = _alloc((n, out_c, cols), a._dtype, a._device)
                         _call_mojo(
                             _MatmulExtension,
-                            "Matmul",
+                            "Bmm",
                             (
                                 out._ptr,
                                 w._ptr,
                                 col_ptr,
-                                (
-                                    oc_g,
-                                    cols,
-                                    crs_g,
-                                    0,
-                                    (s * out_c + g * oc_g) * cols,
-                                    g * oc_g * crs_g,
-                                    (s * c + g * c_per_group) * kh * kw * cols,
-                                ),
+                                (n, out_c, cols, ckk, 0, 1),
                                 a._dtype.value,
                                 ctx,
                             ),
                             arg_dtypes=(w._dtype, a._dtype),
                             output_dtypes=(out._dtype,),
+                            # Same define shape as every other Bmm site: the
+                            # shared-A broadcast is RUNTIME data (the trailing 1
+                            # in the params tuple, matmul_ops._bmm_go), so naming
+                            # it here would only fork this call site onto a
+                            # second .so of identical code.
                             flags={"TRANSPOSE_B": False},
                             keepalive=(out, w),
                         )
+                else:
+                    out = _alloc((n, out_c, cols), a._dtype, a._device)
+                    # Channel-major im2col rows make each group a contiguous
+                    # (crs_g, cols) slice; run one offset GEMM per (sample, group).
+                    crs_g = c_per_group * kh * kw
+                    oc_g = out_c // groups
+                    for s in range(n):
+                        for g in range(groups):
+                            _call_mojo(
+                                _MatmulExtension,
+                                "Matmul",
+                                (
+                                    out._ptr,
+                                    w._ptr,
+                                    col_ptr,
+                                    (
+                                        oc_g,
+                                        cols,
+                                        crs_g,
+                                        0,
+                                        (s * out_c + g * oc_g) * cols,
+                                        g * oc_g * crs_g,
+                                        (s * c + g * c_per_group) * kh * kw * cols,
+                                    ),
+                                    a._dtype.value,
+                                    ctx,
+                                ),
+                                arg_dtypes=(w._dtype, a._dtype),
+                                output_dtypes=(out._dtype,),
+                                flags={"TRANSPOSE_B": False},
+                                keepalive=(out, w),
+                            )
             if bias_t is not None:
                 _call_mojo(
                     _ConvExtension,

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -8664,7 +8664,123 @@ def _fast_aten_bmm_transpose_b(input, mat2):
 # (K,C,R,S) weight used as-is and NCHW output — no layout permutes.
 # Grouped convolutions slice the channel-major im2col rows and weights per
 # group with element offsets.
+#
+# The dense (groups == 1) GEMM shares one (out_c, ckk) weight matrix across
+# every sample in the batch, so it is a batched matmul with the A operand
+# broadcast (runtime batch stride 0) against a densely packed, per-sample
+# row-major im2col B. That broadcast is not a new capability: the plain SIMT
+# `Bmm` bridge below already threads it through as `a_shared`, and the
+# accepted Bmm16/Tf32BmmF32 kernels already prove their pointer arithmetic
+# for a zero A-batch-stride (`_opt_bmm_address_proof`'s `a_bstride > 0`
+# guards treat zero as the trivial case). The two helpers below reuse those
+# kernels as-is: same OP name, same dtype, same TRANSPOSE_B=False flag that
+# fast_aten_bmm already builds, so no new compiled variant exists anywhere
+# because of them -- only a new host-side call site.
 # ---------------------------------------------------------------------------
+
+
+def _try_gemm16_conv_bmm(
+    w: TorchMojoTensor,
+    a: TorchMojoTensor,
+    col_ptr: int,
+    n: int,
+    out_c: int,
+    cols: int,
+    ckk: int,
+) -> TorchMojoTensor | None:
+    """Dense conv GEMM (shared weight x per-sample im2col) via Bmm16, or
+    ``None``. ``w`` is the contiguous (out_c, ckk) weight; ``col_ptr`` is the
+    per-sample dense row-major (ckk, cols) im2col slice (or, for 1x1
+    stride-1 convs, the NCHW input reread in place)."""
+    if (
+        w._dtype not in _GEMM16_DTYPES
+        or w._device != a._device
+        or w._device.label != "gpu"
+        or w._device.api != "cuda"
+        or w._device.architecture_name != "sm_90a"
+        or min(n, out_c, cols, ckk) <= 0
+        or not _gemm16_bridge_available()
+    ):
+        return None
+    out = _alloc((n, out_c, cols), w._dtype, w._device)
+    _call_mojo(
+        _Gemm16MatmulExtension,
+        "Bmm16",
+        (
+            out._ptr,
+            w._ptr,
+            col_ptr,
+            n,
+            out_c,
+            cols,
+            ckk,
+            out_c * cols,
+            0,
+            ckk * cols,
+            0,
+            0,
+            _ctx_ptr(w._device),
+        ),
+        arg_dtypes=(w._dtype, w._dtype),
+        output_dtypes=(out._dtype,),
+        flags={"TRANSPOSE_B": False},
+        keepalive=(out, w),
+    )
+    return out
+
+
+def _try_tf32_conv_bmm(
+    w: TorchMojoTensor,
+    a: TorchMojoTensor,
+    col_ptr: int,
+    n: int,
+    out_c: int,
+    cols: int,
+    ckk: int,
+) -> TorchMojoTensor | None:
+    """Dense conv GEMM (shared weight x per-sample im2col) via the opt-in
+    TF32 BMM, or ``None``. Same numerics policy as ``_try_tf32_bmm``: TF32 is
+    off when the user asked for full FP32 (`torch.set_float32_matmul_precision
+    ("highest")`) -- the repo has no separate `torch.backends.cudnn.
+    allow_tf32`-style policy for convolution, so this follows the exact gate
+    the mm/bmm TF32 paths already use."""
+    if torch.get_float32_matmul_precision() == "highest":
+        return None
+    if (
+        w._dtype != DType.float32
+        or w._device != a._device
+        or w._device.label != "gpu"
+        or w._device.api != "cuda"
+        or w._device.architecture_name != "sm_90a"
+        or min(n, out_c, cols, ckk) <= 0
+        or not _tf32_bridge_available()
+    ):
+        return None
+    out = _alloc((n, out_c, cols), w._dtype, w._device)
+    _call_mojo(
+        _Tf32MatmulExtension,
+        "Tf32BmmF32",
+        (
+            out._ptr,
+            w._ptr,
+            col_ptr,
+            n,
+            out_c,
+            cols,
+            ckk,
+            out_c * cols,
+            0,
+            ckk * cols,
+            0,
+            0,
+            _ctx_ptr(w._device),
+        ),
+        arg_dtypes=(w._dtype, w._dtype),
+        output_dtypes=(out._dtype,),
+        flags={"TRANSPOSE_B": False},
+        keepalive=(out, w),
+    )
+    return out
 
 
 def fast_aten_convolution(
@@ -8740,29 +8856,42 @@ def fast_aten_convolution(
                     keepalive=(col, a),
                 )
                 col_ptr = col._ptr
-            out = _alloc((n, out_c, cols), a._dtype, a._device)
             if groups == 1:
-                _call_mojo(
-                    _MatmulExtension,
-                    "Bmm",
-                    (
-                        out._ptr,
-                        w._ptr,
-                        col_ptr,
-                        (n, out_c, cols, ckk, 0, 1),
-                        a._dtype.value,
-                        ctx,
-                    ),
-                    arg_dtypes=(w._dtype, a._dtype),
-                    output_dtypes=(out._dtype,),
-                    # Same define shape as every other Bmm site: the shared-A
-                    # broadcast is RUNTIME data (the trailing 1 in the params
-                    # tuple, matmul_ops._bmm_go), so naming it here would only
-                    # fork this call site onto a second .so of identical code.
-                    flags={"TRANSPOSE_B": False},
-                    keepalive=(out, w),
-                )
+                # H100 tensor cores first: bf16/f16 through the same Bmm16
+                # kernel fast_aten_bmm already builds, f32 through the same
+                # opt-in TF32 route _try_tf32_mm already gates. Both decline
+                # (return None) off sm_90a, off their dtype, or with the
+                # bridge sources missing, and the plain SIMT Bmm below is the
+                # fallback for every regime they decline, including grouped
+                # convs (untouched, handled in the `else` branch).
+                out = _try_gemm16_conv_bmm(w, a, col_ptr, n, out_c, cols, ckk)
+                if out is None:
+                    out = _try_tf32_conv_bmm(w, a, col_ptr, n, out_c, cols, ckk)
+                if out is None:
+                    out = _alloc((n, out_c, cols), a._dtype, a._device)
+                    _call_mojo(
+                        _MatmulExtension,
+                        "Bmm",
+                        (
+                            out._ptr,
+                            w._ptr,
+                            col_ptr,
+                            (n, out_c, cols, ckk, 0, 1),
+                            a._dtype.value,
+                            ctx,
+                        ),
+                        arg_dtypes=(w._dtype, a._dtype),
+                        output_dtypes=(out._dtype,),
+                        # Same define shape as every other Bmm site: the
+                        # shared-A broadcast is RUNTIME data (the trailing 1
+                        # in the params tuple, matmul_ops._bmm_go), so naming
+                        # it here would only fork this call site onto a
+                        # second .so of identical code.
+                        flags={"TRANSPOSE_B": False},
+                        keepalive=(out, w),
+                    )
             else:
+                out = _alloc((n, out_c, cols), a._dtype, a._device)
                 # Channel-major im2col rows make each group a contiguous
                 # (crs_g, cols) slice; run one offset GEMM per (sample, group).
                 crs_g = c_per_group * kh * kw

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -8683,21 +8683,20 @@ def _fast_aten_bmm_transpose_b(input, mat2):
 
 
 def _try_gemm16_conv_bmm(
-    w: TorchMojoTensor,
-    a: TorchMojoTensor,
-    col_ptr: int,
-    n: int,
-    out_c: int,
-    cols: int,
-    ckk: int,
+    w: TorchMojoTensor, col: TorchMojoTensor, n: int, out_c: int, cols: int, ckk: int
 ) -> TorchMojoTensor | None:
     """Dense conv GEMM (shared weight x per-sample im2col) via Bmm16, or
-    ``None``. ``w`` is the contiguous (out_c, ckk) weight; ``col_ptr`` is the
+    ``None``. ``w`` is the contiguous (out_c, ckk) weight; ``col`` OWNS the
     per-sample dense row-major (ckk, cols) im2col slice (or, for 1x1
-    stride-1 convs, the NCHW input reread in place)."""
+    stride-1 convs, ``col`` IS the input tensor, reread in place). ``col``
+    must be the actual owning tensor, not a bare pointer: under the default
+    kernel-call queue the launch this enqueues can be deferred behind a
+    still-compiling specialization, and the caller's last reference to the
+    buffer it points at can drop before that launch runs unless this frame's
+    keepalive tuple holds it too (queue rule 3, call_queue.py:18-26)."""
     if (
         w._dtype not in _GEMM16_DTYPES
-        or w._device != a._device
+        or w._device != col._device
         or w._device.label != "gpu"
         or w._device.api != "cuda"
         or w._device.architecture_name != "sm_90a"
@@ -8712,7 +8711,7 @@ def _try_gemm16_conv_bmm(
         (
             out._ptr,
             w._ptr,
-            col_ptr,
+            col._ptr,
             n,
             out_c,
             cols,
@@ -8727,31 +8726,27 @@ def _try_gemm16_conv_bmm(
         arg_dtypes=(w._dtype, w._dtype),
         output_dtypes=(out._dtype,),
         flags={"TRANSPOSE_B": False},
-        keepalive=(out, w),
+        keepalive=(out, w, col),
     )
     return out
 
 
 def _try_tf32_conv_bmm(
-    w: TorchMojoTensor,
-    a: TorchMojoTensor,
-    col_ptr: int,
-    n: int,
-    out_c: int,
-    cols: int,
-    ckk: int,
+    w: TorchMojoTensor, col: TorchMojoTensor, n: int, out_c: int, cols: int, ckk: int
 ) -> TorchMojoTensor | None:
     """Dense conv GEMM (shared weight x per-sample im2col) via the opt-in
     TF32 BMM, or ``None``. Same numerics policy as ``_try_tf32_bmm``: TF32 is
     off when the user asked for full FP32 (`torch.set_float32_matmul_precision
     ("highest")`) -- the repo has no separate `torch.backends.cudnn.
     allow_tf32`-style policy for convolution, so this follows the exact gate
-    the mm/bmm TF32 paths already use."""
+    the mm/bmm TF32 paths already use. ``col`` must be the tensor that OWNS
+    the im2col buffer (or the input tensor itself for a 1x1 conv), not a
+    bare pointer -- see ``_try_gemm16_conv_bmm``'s docstring for why."""
     if torch.get_float32_matmul_precision() == "highest":
         return None
     if (
         w._dtype != DType.float32
-        or w._device != a._device
+        or w._device != col._device
         or w._device.label != "gpu"
         or w._device.api != "cuda"
         or w._device.architecture_name != "sm_90a"
@@ -8766,7 +8761,7 @@ def _try_tf32_conv_bmm(
         (
             out._ptr,
             w._ptr,
-            col_ptr,
+            col._ptr,
             n,
             out_c,
             cols,
@@ -8781,7 +8776,7 @@ def _try_tf32_conv_bmm(
         arg_dtypes=(w._dtype, w._dtype),
         output_dtypes=(out._dtype,),
         flags={"TRANSPOSE_B": False},
-        keepalive=(out, w),
+        keepalive=(out, w, col),
     )
     return out
 
@@ -8941,6 +8936,7 @@ def fast_aten_convolution(
         and not transposed
         and (bias is None or bias_t is not None)
         and a._dtype == w._dtype
+        and a._device == w._device
         and a._dtype in _FLOAT_DTYPES
         and len(a._shape) == 4
         and len(w._shape) == 4
@@ -8958,7 +8954,9 @@ def fast_aten_convolution(
         out_w = (in_w + 2 * pw - (dw * (kw - 1) + 1)) // sw + 1
         if c_per_group * groups == c and out_h > 0 and out_w > 0:
             if bias_t is not None and (
-                bias_t._dtype != a._dtype or tuple(bias_t._shape) != (out_c,)
+                bias_t._dtype != a._dtype
+                or bias_t._device != a._device
+                or tuple(bias_t._shape) != (out_c,)
             ):
                 return NOT_HANDLED
             ctx = _ctx_ptr(a._device)
@@ -8983,7 +8981,11 @@ def fast_aten_convolution(
             if out is None:
                 if (kh, kw, sh, sw, ph, pw, dh, dw) == (1, 1, 1, 1, 0, 0, 1, 1):
                     # 1x1 stride-1 conv: NCHW input already is the col matrix.
-                    col_ptr = a._ptr
+                    # `col` ALIASES `a` (no allocation) -- it is still the
+                    # tensor that must stay alive until every GEMM reading it
+                    # has launched, so it flows through exactly like the
+                    # materialized branch's freshly allocated `col` below.
+                    col = a
                 else:
                     col = _alloc((n, ckk, cols), a._dtype, a._device)
                     _call_mojo(
@@ -9015,7 +9017,6 @@ def fast_aten_convolution(
                         output_dtypes=(col._dtype,),
                         keepalive=(col, a),
                     )
-                    col_ptr = col._ptr
                 if groups == 1:
                     # H100 tensor cores first: bf16/f16 through the same Bmm16
                     # kernel fast_aten_bmm already builds, f32 through the same
@@ -9024,9 +9025,9 @@ def fast_aten_convolution(
                     # bridge sources missing, and the plain SIMT Bmm below is the
                     # fallback for every regime they decline, including grouped
                     # convs (untouched, handled in the `else` branch).
-                    out = _try_gemm16_conv_bmm(w, a, col_ptr, n, out_c, cols, ckk)
+                    out = _try_gemm16_conv_bmm(w, col, n, out_c, cols, ckk)
                     if out is None:
-                        out = _try_tf32_conv_bmm(w, a, col_ptr, n, out_c, cols, ckk)
+                        out = _try_tf32_conv_bmm(w, col, n, out_c, cols, ckk)
                     if out is None:
                         out = _alloc((n, out_c, cols), a._dtype, a._device)
                         _call_mojo(
@@ -9035,7 +9036,7 @@ def fast_aten_convolution(
                             (
                                 out._ptr,
                                 w._ptr,
-                                col_ptr,
+                                col._ptr,
                                 (n, out_c, cols, ckk, 0, 1),
                                 a._dtype.value,
                                 ctx,
@@ -9048,7 +9049,12 @@ def fast_aten_convolution(
                             # it here would only fork this call site onto a
                             # second .so of identical code.
                             flags={"TRANSPOSE_B": False},
-                            keepalive=(out, w),
+                            # `col` (the im2col buffer, or `a` itself for the
+                            # 1x1 fast path) owns the pointer this call names
+                            # and must outlive the deferred launch (kernel
+                            # queue rule 3, call_queue.py:18-26) -- it is not
+                            # implied by `w`/`out` alone.
+                            keepalive=(out, w, col),
                         )
                 else:
                     out = _alloc((n, out_c, cols), a._dtype, a._device)
@@ -9064,7 +9070,7 @@ def fast_aten_convolution(
                                 (
                                     out._ptr,
                                     w._ptr,
-                                    col_ptr,
+                                    col._ptr,
                                     (
                                         oc_g,
                                         cols,
@@ -9080,7 +9086,10 @@ def fast_aten_convolution(
                                 arg_dtypes=(w._dtype, a._dtype),
                                 output_dtypes=(out._dtype,),
                                 flags={"TRANSPOSE_B": False},
-                                keepalive=(out, w),
+                                # Same rationale as the dense-path Bmm call
+                                # above: `col` owns the pointer this call
+                                # names.
+                                keepalive=(out, w, col),
                             )
             if bias_t is not None:
                 _call_mojo(

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -8788,7 +8788,19 @@ def _try_tf32_conv_bmm(
 # the GEMM, where the materialized route costs a full im2col write + read
 # (89% of the body conv's device time) plus the same GEMM. Measured on an
 # H100 PCIe at a 1395 MHz pin, bf16 N32xC64x56x56 K64 k3s1: 59.0 us vs
-# 861 us on the materialized route and 71.95 us for cuDNN (0.82x cuDNN).
+# 861 us on the materialized route and 71.95 us for cuDNN.
+#
+# That 71.95 us is cuDNN reached the way torch.nn.Conv2d reaches it from an
+# NCHW tensor, which is NOT cuDNN's own speed: 31.2 us of convolution plus
+# 41.0 us of nchwToNhwc / nhwcToNchw transposes around it. Handed a
+# channels_last tensor cuDNN does the same convolution in 33.9 us with no
+# transposes, against 54.6 us for the three kernels of this route (NHWC
+# pass + weight repack + implicit GEMM). So this route wins the NCHW
+# comparison because it needs no layout conversion, and loses the
+# same-layout comparison by ~1.6x. Both statements are about the forward
+# convolution only; the separate BiasAddChan kernel is another 12.2 us here
+# against 25.3 us for the elementwise bias add torch appends to cuDNN, which
+# is where a further chunk of the end-to-end ratio comes from.
 #
 # Everything the route cannot do stays on the materialized route: grouped
 # convolution (not implemented here at all), stride != 1, dilation != 1,

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -8924,9 +8924,14 @@ def _try_conv_igemm(
 def fast_aten_convolution(
     input, weight, bias, stride, padding, dilation, transposed, output_padding, groups
 ):
-    a = _tc(input)
-    w = _tc(weight)
-    bias_t = _tc(bias) if bias is not None else None
+    # `_t()` here, not `_tc()`: every gate below (dtype, device, shape) reads
+    # metadata only, so it must run before paying for `_tc()`'s allocation +
+    # copy of a non-contiguous operand -- including the device-equality gate,
+    # so a cross-device pair returns NOT_HANDLED before any materialization,
+    # not just before the eventual conv kernel launch.
+    a = _t(input)
+    w = _t(weight)
+    bias_t = _t(bias) if bias is not None else None
     strides = _pair(list(stride))
     pads = _pair(list(padding))
     dils = _pair(list(dilation))
@@ -8959,6 +8964,13 @@ def fast_aten_convolution(
                 or tuple(bias_t._shape) != (out_c,)
             ):
                 return NOT_HANDLED
+            # Every reason to decline (dtype/device/shape mismatch, a
+            # cross-device pair included) has already returned NOT_HANDLED
+            # above; only now is a non-contiguous operand worth the
+            # allocation + copy `_tc()` pays for.
+            a = _tc(a)
+            w = _tc(w)
+            bias_t = _tc(bias_t) if bias_t is not None else None
             ctx = _ctx_ptr(a._device)
             cols = out_h * out_w
             ckk = c * kh * kw

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -39,6 +39,9 @@ from torch_mojo_backend.eager_kernels.activation_backward_ops import (
 from torch_mojo_backend.eager_kernels.activation_forward_ops import (
     ActivationForwardExtension as _ActivationForwardExtension,
 )
+from torch_mojo_backend.eager_kernels.conv_igemm_ops import (
+    ConvIgemmExtension as _ConvIgemmExtension,
+)
 from torch_mojo_backend.eager_kernels.conv_ops import ConvExtension as _ConvExtension
 from torch_mojo_backend.eager_kernels.data_movement_ops import (
     DataMovementExtension as _DataMovementExtension,
@@ -8783,6 +8786,146 @@ def _try_tf32_conv_bmm(
     return out
 
 
+# ---------------------------------------------------------------------------
+# Implicit-GEMM conv2d (sm_90a): the (N*OH*OW) x (R*S*C) patch matrix is never
+# written to memory. The hardware im2col TMA reads each B tile straight out of
+# an NHWC copy of the activation, so the route costs one NCHW->NHWC pass plus
+# the GEMM, where the materialized route costs a full im2col write + read
+# (89% of the body conv's device time) plus the same GEMM. Measured on an
+# H100 PCIe at a 1395 MHz pin, bf16 N32xC64x56x56 K64 k3s1: 59.0 us vs
+# 861 us on the materialized route and 71.95 us for cuDNN (0.82x cuDNN).
+#
+# Everything the route cannot do stays on the materialized route: grouped
+# convolution (not implemented here at all), stride != 1, dilation != 1,
+# 1x1 filters (which skip im2col entirely there and are already at 0.94x
+# cuDNN), thin-C shapes like a 3-channel stem, and float32/TF32 (feasible --
+# the descriptor path is dtype-generic -- but the 128 B swizzle makes the
+# k-tile, the C padding and the wgmma shape all change with the element
+# width, so it is a separate piece of work and is not built).
+# ---------------------------------------------------------------------------
+
+_CONV_IGEMM_SOURCE_PATHS = (
+    eager_kernels._PACKAGE_DIR / _ConvIgemmExtension.MOJO_FILE,
+    eager_kernels._PACKAGE_DIR / "wgmma_c_epilogue.mojo",
+)
+
+# 16-bit only: the kernel is a wgmma path whose k-tile is one 128 B swizzle
+# row. float16 is the same instruction with a different operand token and the
+# Mojo source instantiates for it, but only bfloat16 has been measured, so
+# only bfloat16 is admitted here.
+_CONV_IGEMM_DTYPES = (DType.bfloat16,)
+
+# C is padded up to the 64-channel k-tile and the padded reduction is real
+# work: at C = 32 the GEMM already does 2x the necessary math, and a
+# 3-channel stem would do 21x. Below this the materialized route wins.
+_CONV_IGEMM_MIN_C = 32
+# With BM = 64 a ragged out_c wastes up to half of every output tile.
+_CONV_IGEMM_MIN_OUT_C = 32
+_CONV_IGEMM_CHANNEL_TILE = 64
+
+
+def _conv_igemm_bridge_available() -> bool:
+    """Whether the implicit-GEMM conv bridge and its sources are present."""
+    return _bridge_available("conv_igemm", _CONV_IGEMM_SOURCE_PATHS)
+
+
+def _conv_igemm_descriptor_legal(ph: int, pw: int, kh: int, kw: int) -> bool:
+    """Whether the im2col TMA descriptor this conv needs is legal at all.
+
+    `cuTensorMapEncodeIm2col` takes the pixel-box corners as SIGNED CHAR --
+    both corners of both spatial dimensions must land in [-128, 127] -- and
+    the per-transaction im2col offsets (the filter taps this kernel issues,
+    0..R-1 and 0..S-1) are limited to [0, 255]. The two failure modes differ
+    and both have to be caught HERE, before anything is allocated: an illegal
+    corner makes descriptor creation fail outright, while an illegal tap is
+    undefined behaviour at the instruction and does not fail loudly. E.g.
+    N=1, C=64, H=W=7, K=64, R=257, S=3, pad=(128, 1) satisfies every other
+    condition on this route and produces tap r = 256.
+    """
+    corners = (-ph, -pw, ph - (kh - 1), pw - (kw - 1))
+    return (
+        all(-128 <= corner <= 127 for corner in corners)
+        and kh - 1 <= 255
+        and kw - 1 <= 255
+    )
+
+
+def _try_conv_igemm(
+    a: TorchMojoTensor,
+    w: TorchMojoTensor,
+    in_shape: tuple[int, int, int, int],
+    filt: tuple[int, int, int],
+    strides: tuple[int, int],
+    pads: tuple[int, int],
+    dils: tuple[int, int],
+    out_hw: tuple[int, int],
+    ctx: int,
+) -> TorchMojoTensor | None:
+    """Dense conv2d forward through the sm_90a implicit GEMM, or ``None`` when
+    any gate declines (the caller then takes the materialized im2col route).
+
+    Only ``groups == 1`` reaches here; grouped convolution is not implemented
+    by this kernel.
+    """
+    n, c, in_h, in_w = in_shape
+    out_c, kh, kw = filt
+    ph, pw = pads
+    out_h, out_w = out_hw
+    if (
+        a._dtype not in _CONV_IGEMM_DTYPES
+        or w._dtype != a._dtype
+        or w._device != a._device
+        or a._device.label != "gpu"
+        or a._device.api != "cuda"
+        or a._device.architecture_name != "sm_90a"
+        or not _conv_igemm_bridge_available()
+    ):
+        return None
+    if strides != (1, 1) or dils != (1, 1):
+        # The box convention (lower = -pad, upper = pad - (filter - 1)) makes
+        # the pixel box the output grid, which is only true at stride 1;
+        # dilation needs a different box.
+        return None
+    if kh * kw <= 1:
+        # A 1x1 conv has no im2col on the materialized route either (the NCHW
+        # input is reread in place) and is already faster than cuDNN there;
+        # routing it here would only add the NHWC pass.
+        return None
+    if c < _CONV_IGEMM_MIN_C or out_c < _CONV_IGEMM_MIN_OUT_C:
+        return None
+    if min(n, in_h, in_w, out_h, out_w) <= 0:
+        return None
+    if not _conv_igemm_descriptor_legal(ph, pw, kh, kw):
+        return None
+    c_pad = (
+        (c + _CONV_IGEMM_CHANNEL_TILE - 1) // _CONV_IGEMM_CHANNEL_TILE
+    ) * _CONV_IGEMM_CHANNEL_TILE
+    # Scratch: the NHWC activation and the k-major weight. Both are smaller
+    # than the (n, C*R*S, OH*OW) column buffer this route replaces -- the
+    # activation by R*S, the weight by the batch.
+    act = _alloc((n, in_h, in_w, c_pad), a._dtype, a._device)
+    wpack = _alloc((out_c, kh * kw * c_pad), a._dtype, a._device)
+    out = _alloc((n, out_c, out_h * out_w), a._dtype, a._device)
+    _call_mojo(
+        _ConvIgemmExtension,
+        "ConvIgemm",
+        (
+            out._ptr,
+            act._ptr,
+            wpack._ptr,
+            a._ptr,
+            w._ptr,
+            (n, c, c_pad, in_h, in_w, out_c, kh, kw, ph, pw, out_h, out_w),
+            a._dtype.value,
+            ctx,
+        ),
+        arg_dtypes=(a._dtype,),
+        output_dtypes=(out._dtype,),
+        keepalive=(out, act, wpack, a, w),
+    )
+    return out
+
+
 def fast_aten_convolution(
     input, weight, bias, stride, padding, dilation, transposed, output_padding, groups
 ):
@@ -8821,107 +8964,124 @@ def fast_aten_convolution(
             ctx = _ctx_ptr(a._device)
             cols = out_h * out_w
             ckk = c * kh * kw
-            if (kh, kw, sh, sw, ph, pw, dh, dw) == (1, 1, 1, 1, 0, 0, 1, 1):
-                # 1x1 stride-1 conv: NCHW input already is the col matrix.
-                col_ptr = a._ptr
-            else:
-                col = _alloc((n, ckk, cols), a._dtype, a._device)
-                _call_mojo(
-                    _ConvExtension,
-                    "Im2col",
-                    (
-                        col._ptr,
-                        a._ptr,
-                        (
-                            in_h,
-                            in_w,
-                            out_h,
-                            out_w,
-                            kh,
-                            kw,
-                            sh,
-                            sw,
-                            ph,
-                            pw,
-                            dh,
-                            dw,
-                            c,
-                            n,
-                        ),
-                        a._dtype.value,
-                        ctx,
-                    ),
-                    arg_dtypes=(a._dtype,),
-                    output_dtypes=(col._dtype,),
-                    keepalive=(col, a),
-                )
-                col_ptr = col._ptr
+            out = None
             if groups == 1:
-                # H100 tensor cores first: bf16/f16 through the same Bmm16
-                # kernel fast_aten_bmm already builds, f32 through the same
-                # opt-in TF32 route _try_tf32_mm already gates. Both decline
-                # (return None) off sm_90a, off their dtype, or with the
-                # bridge sources missing, and the plain SIMT Bmm below is the
-                # fallback for every regime they decline, including grouped
-                # convs (untouched, handled in the `else` branch).
-                out = _try_gemm16_conv_bmm(w, a, col_ptr, n, out_c, cols, ckk)
-                if out is None:
-                    out = _try_tf32_conv_bmm(w, a, col_ptr, n, out_c, cols, ckk)
-                if out is None:
-                    out = _alloc((n, out_c, cols), a._dtype, a._device)
+                # Implicit GEMM (the patch matrix is never materialized) when
+                # the shape is inside its domain; everything else, grouped
+                # convs included, falls through to the im2col route below.
+                out = _try_conv_igemm(
+                    a,
+                    w,
+                    (n, c, in_h, in_w),
+                    (out_c, kh, kw),
+                    (sh, sw),
+                    (ph, pw),
+                    (dh, dw),
+                    (out_h, out_w),
+                    ctx,
+                )
+            if out is None:
+                if (kh, kw, sh, sw, ph, pw, dh, dw) == (1, 1, 1, 1, 0, 0, 1, 1):
+                    # 1x1 stride-1 conv: NCHW input already is the col matrix.
+                    col_ptr = a._ptr
+                else:
+                    col = _alloc((n, ckk, cols), a._dtype, a._device)
                     _call_mojo(
-                        _MatmulExtension,
-                        "Bmm",
+                        _ConvExtension,
+                        "Im2col",
                         (
-                            out._ptr,
-                            w._ptr,
-                            col_ptr,
-                            (n, out_c, cols, ckk, 0, 1),
+                            col._ptr,
+                            a._ptr,
+                            (
+                                in_h,
+                                in_w,
+                                out_h,
+                                out_w,
+                                kh,
+                                kw,
+                                sh,
+                                sw,
+                                ph,
+                                pw,
+                                dh,
+                                dw,
+                                c,
+                                n,
+                            ),
                             a._dtype.value,
                             ctx,
                         ),
-                        arg_dtypes=(w._dtype, a._dtype),
-                        output_dtypes=(out._dtype,),
-                        # Same define shape as every other Bmm site: the
-                        # shared-A broadcast is RUNTIME data (the trailing 1
-                        # in the params tuple, matmul_ops._bmm_go), so naming
-                        # it here would only fork this call site onto a
-                        # second .so of identical code.
-                        flags={"TRANSPOSE_B": False},
-                        keepalive=(out, w),
+                        arg_dtypes=(a._dtype,),
+                        output_dtypes=(col._dtype,),
+                        keepalive=(col, a),
                     )
-            else:
-                out = _alloc((n, out_c, cols), a._dtype, a._device)
-                # Channel-major im2col rows make each group a contiguous
-                # (crs_g, cols) slice; run one offset GEMM per (sample, group).
-                crs_g = c_per_group * kh * kw
-                oc_g = out_c // groups
-                for s in range(n):
-                    for g in range(groups):
+                    col_ptr = col._ptr
+                if groups == 1:
+                    # H100 tensor cores first: bf16/f16 through the same Bmm16
+                    # kernel fast_aten_bmm already builds, f32 through the same
+                    # opt-in TF32 route _try_tf32_mm already gates. Both decline
+                    # (return None) off sm_90a, off their dtype, or with the
+                    # bridge sources missing, and the plain SIMT Bmm below is the
+                    # fallback for every regime they decline, including grouped
+                    # convs (untouched, handled in the `else` branch).
+                    out = _try_gemm16_conv_bmm(w, a, col_ptr, n, out_c, cols, ckk)
+                    if out is None:
+                        out = _try_tf32_conv_bmm(w, a, col_ptr, n, out_c, cols, ckk)
+                    if out is None:
+                        out = _alloc((n, out_c, cols), a._dtype, a._device)
                         _call_mojo(
                             _MatmulExtension,
-                            "Matmul",
+                            "Bmm",
                             (
                                 out._ptr,
                                 w._ptr,
                                 col_ptr,
-                                (
-                                    oc_g,
-                                    cols,
-                                    crs_g,
-                                    0,
-                                    (s * out_c + g * oc_g) * cols,
-                                    g * oc_g * crs_g,
-                                    (s * c + g * c_per_group) * kh * kw * cols,
-                                ),
+                                (n, out_c, cols, ckk, 0, 1),
                                 a._dtype.value,
                                 ctx,
                             ),
                             arg_dtypes=(w._dtype, a._dtype),
                             output_dtypes=(out._dtype,),
+                            # Same define shape as every other Bmm site: the
+                            # shared-A broadcast is RUNTIME data (the trailing 1
+                            # in the params tuple, matmul_ops._bmm_go), so naming
+                            # it here would only fork this call site onto a
+                            # second .so of identical code.
                             flags={"TRANSPOSE_B": False},
                             keepalive=(out, w),
                         )
+                else:
+                    out = _alloc((n, out_c, cols), a._dtype, a._device)
+                    # Channel-major im2col rows make each group a contiguous
+                    # (crs_g, cols) slice; run one offset GEMM per (sample, group).
+                    crs_g = c_per_group * kh * kw
+                    oc_g = out_c // groups
+                    for s in range(n):
+                        for g in range(groups):
+                            _call_mojo(
+                                _MatmulExtension,
+                                "Matmul",
+                                (
+                                    out._ptr,
+                                    w._ptr,
+                                    col_ptr,
+                                    (
+                                        oc_g,
+                                        cols,
+                                        crs_g,
+                                        0,
+                                        (s * out_c + g * oc_g) * cols,
+                                        g * oc_g * crs_g,
+                                        (s * c + g * c_per_group) * kh * kw * cols,
+                                    ),
+                                    a._dtype.value,
+                                    ctx,
+                                ),
+                                arg_dtypes=(w._dtype, a._dtype),
+                                output_dtypes=(out._dtype,),
+                                flags={"TRANSPOSE_B": False},
+                                keepalive=(out, w),
+                            )
             if bias_t is not None:
                 _call_mojo(
                     _ConvExtension,

--- a/torch_mojo_backend/eager_kernels/conv_igemm_ops/__init__.py
+++ b/torch_mojo_backend/eager_kernels/conv_igemm_ops/__init__.py
@@ -1,0 +1,3 @@
+from .conv_igemm_ops import ConvIgemmExtension
+
+__all__ = ["ConvIgemmExtension"]

--- a/torch_mojo_backend/eager_kernels/conv_igemm_ops/conv_igemm_ops.mojo
+++ b/torch_mojo_backend/eager_kernels/conv_igemm_ops/conv_igemm_ops.mojo
@@ -1,0 +1,982 @@
+"""Implicit-GEMM conv2d forward on sm_90a — no materialized im2col.
+
+The patch matrix is never written to memory: the activation is read tile by
+tile straight out of an NHWC buffer by the hardware im2col TMA
+(`cp.async.bulk.tensor.4d...im2col`, `cta_group=1`).  On the body shape of a
+ResNet (N32 C64 56x56 K64 3x3 s1, bf16) the materialized route spends 89% of
+its device time writing and re-reading that matrix; this route spends none.
+
+Operand assignment (the load-bearing design choice):
+
+    D[oc, p] = sum_k  Wt[oc, k] * Act[p, k]          k = (r, s, c)
+    A = repacked weight   (out_c x K_pad), k-major
+    B = im2col activation (pixels x K_pad), k-major   <- TMA im2col box
+    D = (out_c x pixels)                              <- ALREADY NCHW
+
+The im2col box delivers (pixels_per_column x channels_per_pixel) with the
+channels contiguous, i.e. exactly a k-major B operand, so wgmma consumes it
+with `transpose_b=True` and no shuffle.  Putting `out_c` on the GEMM's M axis
+makes the accumulator tile (out_c x pixels) = NCHW, so unlike cuDNN — whose
+fprop kernels are NHWC-only and pay an `nhwcToNchwKernel` on the way out —
+there is no output transpose at all.  One NCHW->NHWC pass on the input is
+still needed: TMA requires the descriptor's innermost dimension to be
+contiguous, and for im2col that dimension is C.
+
+Body/mainloop/epilogue are the 16-bit GEMM family's "tiny" batched BMM body
+(`gemm16_bmm_v5_kernels._b5_bmm_nn_tiny`): one 128-thread warp group per work
+item, an mbarrier TMA pipeline, wgmma m64 x bn x k16, and — shared verbatim,
+not copied — the C epilogue in `wgmma_c_epilogue.mojo`.  Only the B producer
+is new.
+
+Two pieces of hard-won knowledge about this instruction on sm_90a, both
+established by experiment on an H100 PCIe (the modular repo only exercises
+im2col TMA under B200 gating, so none of it was documented):
+
+  * `layout.tma_async.TMATensorTileIm2col.async_copy` computes WRONG
+    coordinates here — tap (0,0) is exact and every other tap returns pixels
+    displaced in the pixel stream.  The descriptor itself is fine, so this
+    file keeps `TMATensorTileIm2col` only as the descriptor carrier and
+    issues `cp_async_bulk_tensor_shared_cluster_global_im2col` directly with
+    locally computed coordinates.
+  * `_im2col_desc_shape`'s 256-element box cap (`max_tma_box_elements`) is
+    not a hardware limit.  One transaction per B tile (`pixels_per_column ==
+    bn`, 16 KB) is 7.3x faster end to end than the 4-pixel box that cap
+    implies, and is what this kernel issues.
+
+Dtype: the source is width-generic and instantiates for bfloat16 or float16
+(same operand width, same wgmma shapes); only bfloat16 is enabled at the
+dispatch, because only bfloat16 has been measured.
+"""
+
+from std.gpu import (
+    MAX_THREADS_PER_BLOCK_METADATA,
+    block_dim,
+    block_idx,
+    thread_idx,
+)
+from max.gpu.host import DeviceBuffer, DeviceContext
+from max.gpu.host._tensormap import SwizzleMode, create_tensormap_im2col
+from max.gpu.host.nvidia.tma import (
+    TMADescriptor,
+    TensorMapSwizzle,
+    create_tma_descriptor,
+)
+from max.gpu.memory import cp_async_bulk_tensor_shared_cluster_global_im2col
+from max.gpu.sync import barrier
+from std.memory import AddressSpace, stack_allocation
+from std.os import abort
+from std.python import PythonObject
+from std.python._cpython import PyObjectPtr, Py_ssize_t
+from std.python.bindings import PythonModuleBuilder
+from std.sys import size_of
+from std.sys.info import _is_sm_9x
+from std.utils.index import Index, IndexList
+from std.utils.static_tuple import StaticTuple
+
+from layout import Layout, LayoutTensor
+from layout.tensor_core_async import (
+    TensorCoreAsync,
+    tile_layout_k_major,
+    warpgroup_fence,
+)
+from layout.tma_async import (
+    SharedMemBarrier,
+    TMATensorTile,
+    TMATensorTileIm2col,
+)
+
+from op_utils import (
+    _enqueue_cached,
+    _make_ptr,
+    _raw_ctx,
+    _raw_dtype_int,
+    _raw_int,
+    _raw_ret_none,
+    _raw_tuple_int,
+    _spec_unsupported,
+)
+from variant_gates import _dtype_arg_on, _op_on, _register_call
+from wgmma_c_epilogue import _wgmma_store_c_tile
+
+comptime _CI_F32 = DType.float32
+comptime _CI_SWZ = TensorMapSwizzle.SWIZZLE_128B
+# 128 B swizzle / 2 B element: the im2col box's channels_per_pixel, and
+# therefore the GEMM's k-tile.  K_pad is a multiple of it by construction, so
+# one k-tile never straddles two (r, s) taps.
+comptime _CI_BK = 64
+comptime _CI_BM = 64
+# The 16-bit dtypes this kernel is instantiated for.  float16 is byte-for-byte
+# the same tensor-core path as bfloat16 (same operand width, same wgmma tile,
+# same fp32 accumulator); it is listed here so the source stays honest about
+# what it supports, while the Python dispatch admits bfloat16 only.
+comptime _CI_DTYPES = [DType.bfloat16, DType.float16]
+
+
+@always_inline
+def _ci_tag[dtype: DType]() -> StaticString:
+    """The dtype token the kernel names carry: what CUPTI and Nsight print."""
+    comptime if dtype == DType.float16:
+        return "f16"
+    return "bf16"
+
+
+@always_inline
+def _ci_store_tag[tma_store: Bool]() -> StaticString:
+    comptime if tma_store:
+        return ""
+    return "_scalar_c"
+
+
+# ---------------------------------------------------------------------------
+# NCHW -> NHWC with C padded up to a multiple of BK.  The pad channels are
+# zeroed and the repacked weight's matching rows are zero too, so the padded
+# reduction is exact.
+#
+# A thread owns a SUB x SUB (channel x pixel) sub-tile, loads it along the
+# contiguous HW axis, transposes it IN REGISTERS (comptime index math, free)
+# and moves it through shared memory in SUB-element vector accesses; the
+# read-back puts one wavefront on one pixel's channels, so the global store is
+# 128 B contiguous.
+#
+# SUB is 4, not 8, and that is counter-intuitive: the 8-wide (16 B) version
+# measured 0.80 waves per SM on the body shape -- 64 elements per thread
+# leaves too few warps resident to cover DRAM latency, and it ran at 13% of
+# DRAM peak with nothing saturated.  Halving the tile edge quadrupled the warp
+# count for the same bytes and took the body's transpose from ~38 us to
+# ~18 us (1.4 TB/s, i.e. faster than the `nchwToNhwcKernel` cuDNN pays on the
+# same shape).  Fitted on an H100 PCIe.
+# ---------------------------------------------------------------------------
+comptime _CI_T_SUB = 4
+comptime _CI_T_PIX = 16 * _CI_T_SUB  # pixels per tile
+comptime _CI_T_CH = 64  # channels per tile
+comptime _CI_T_THREADS = (_CI_T_PIX // _CI_T_SUB) * (_CI_T_CH // _CI_T_SUB)
+# Row stride of the transposed smem tile, in elements.  The write phase
+# touches rows SUB apart (a thread owns SUB consecutive pixels) and any
+# 16 B-aligned row stride is a multiple of 32 banks, so those rows collide;
+# the channel offset therefore carries an XOR swizzle keyed on the row GROUP
+# (p // SUB).  The read phase has every lane of a wavefront on ONE row, so the
+# swizzle is constant there and costs it nothing.
+comptime _CI_T_SPAD = _CI_T_CH + _CI_T_SUB
+
+
+@always_inline
+def _ci_swz(p: Int) -> Int:
+    """XOR applied to the SUB-element-aligned channel offset of smem row p."""
+    return ((p // _CI_T_SUB) % (_CI_T_CH // _CI_T_SUB)) * _CI_T_SUB
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(_CI_T_THREADS))
+)
+@__name(t"conv_nchw_to_nhwc_padc_{_ci_tag[dtype]()}")
+def _ci_nchw_to_nhwc_kernel[
+    dtype: DType
+](
+    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    hw_arg: Int32,
+    c_arg: Int32,
+    c_pad_arg: Int32,
+):
+    var hw = Int(hw_arg)
+    var c = Int(c_arg)
+    var c_pad = Int(c_pad_arg)
+    var p0 = Int(block_idx.x) * _CI_T_PIX
+    var c0 = Int(block_idx.y) * _CI_T_CH
+    var n = Int(block_idx.z)
+    var tid = Int(thread_idx.x)
+
+    var smem = LayoutTensor[
+        dtype,
+        Layout.row_major(_CI_T_PIX, _CI_T_SPAD),
+        MutAnyOrigin,
+        address_space=AddressSpace.SHARED,
+        alignment=16,
+    ].stack_allocation()
+
+    comptime PG = _CI_T_PIX // _CI_T_SUB
+    var cg = tid // PG
+    var pg = tid % PG
+    var lc = c0 + cg * _CI_T_SUB
+    var lp = p0 + pg * _CI_T_SUB
+
+    var frag = StaticTuple[SIMD[dtype, _CI_T_SUB], _CI_T_SUB]()
+    comptime for j in range(_CI_T_SUB):
+        var v = SIMD[dtype, _CI_T_SUB](0)
+        # The global side stays at natural (2 B) alignment on purpose: the
+        # NCHW plane pitch `hw` is arbitrary, so (n*c + lc + j)*hw + lp is not
+        # a multiple of SUB in general and an alignment claim here would be a
+        # lie -- a vector path over the input has to be gated on the RUNTIME
+        # address, not on a dimension test.
+        if lc + j < c and lp + _CI_T_SUB - 1 < hw:
+            v = in_ptr.load[width=_CI_T_SUB]((n * c + lc + j) * hw + lp)
+        elif lc + j < c:
+            for i in range(_CI_T_SUB):
+                if lp + i < hw:
+                    v[i] = in_ptr[(n * c + lc + j) * hw + lp + i]
+        frag[j] = v
+
+    # register transpose: out row i (pixel) gathers channel j from frag[j][i]
+    comptime for i in range(_CI_T_SUB):
+        var row = SIMD[dtype, _CI_T_SUB](0)
+        comptime for j in range(_CI_T_SUB):
+            row[j] = frag[j][i]
+        var pp = pg * _CI_T_SUB + i
+        # 8 B shared stores.  The element offset is a multiple of SUB
+        # (_CI_T_SPAD * 2 B = 136 B is a multiple of 8, and both the channel
+        # offset and the XOR swizzle are multiples of SUB), so the alignment
+        # is honest -- and without it Mojo defaults to align-4 and the store
+        # reaches PTX as four scalar `st.shared.b16`.
+        smem.ptr.store[alignment=_CI_T_SUB * 2](
+            pp * _CI_T_SPAD + ((cg * _CI_T_SUB) ^ _ci_swz(pp)), row
+        )
+    barrier()
+
+    # read-back: one wavefront covers one pixel's channels = one 128 B store
+    comptime CHUNKS = _CI_T_CH // _CI_T_SUB
+    comptime for m in range(_CI_T_PIX * CHUNKS // _CI_T_THREADS):
+        var slot = m * _CI_T_THREADS + tid
+        var sp = slot // CHUNKS
+        var sc = (slot % CHUNKS) * _CI_T_SUB
+        if p0 + sp < hw and c0 + sc < c_pad:
+            # Both sides are 8 B here: c_pad is a multiple of BK = 64 elements
+            # by construction (the caller pads C up to it), c0 is a multiple
+            # of _CI_T_CH and sc of SUB, and the destination is a fresh
+            # allocation.
+            out_ptr.store[alignment=_CI_T_SUB * 2](
+                (n * hw + p0 + sp) * c_pad + c0 + sc,
+                smem.ptr.load[width=_CI_T_SUB, alignment=_CI_T_SUB * 2](
+                    sp * _CI_T_SPAD + (sc ^ _ci_swz(sp))
+                ),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Weight (out_c, C, R, S) -> A matrix (out_c, K_pad) with
+# k = (r * S + s) * C_pad + c, matching the im2col K decomposition, and zeros
+# wherever c >= C.  A is k-major, which is what wgmma wants for its A operand,
+# so nothing further happens to it in the kernel.
+# ---------------------------------------------------------------------------
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(256))
+)
+@__name(t"conv_weight_repack_rsc_{_ci_tag[dtype]()}")
+def _ci_weight_repack_kernel[
+    dtype: DType
+](
+    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    w_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    out_c_arg: Int32,
+    c_arg: Int32,
+    c_pad_arg: Int32,
+    r_arg: Int32,
+    s_arg: Int32,
+):
+    var out_c = Int(out_c_arg)
+    var c = Int(c_arg)
+    var c_pad = Int(c_pad_arg)
+    var r_f = Int(r_arg)
+    var s_f = Int(s_arg)
+    var k_pad = r_f * s_f * c_pad
+    var idx = Int(block_idx.x) * Int(block_dim.x) + Int(thread_idx.x)
+    if idx >= out_c * k_pad:
+        return
+    var oc = idx // k_pad
+    var k = idx % k_pad
+    var ch = k % c_pad
+    var fi = k // c_pad
+    var val = Scalar[dtype](0)
+    if ch < c:
+        var r = fi // s_f
+        var s = fi % s_f
+        val = w_ptr[((oc * c + ch) * r_f + r) * s_f + s]
+    out_ptr[idx] = val
+
+
+# ---------------------------------------------------------------------------
+# The im2col B producer.
+#
+# One transaction delivers the whole `bn`-pixel B tile x BK channels
+# (pixels_per_column == bn).  The hardware advances the base pixel inside the
+# descriptor's pixel BOX, and with the CUTLASS fprop corner convention
+# (lower = -pad, upper = pad - (filter - 1)) that box IS the (n, oh, ow)
+# output grid, so a transaction that crosses a row -- or a sample -- boundary
+# lands on the right pixels with no software help.
+#
+# Two DIFFERENT out-of-range behaviours matter here and must not be conflated:
+#
+#   * the BASE coordinate handed to the instruction must lie inside the pixel
+#     box; an out-of-box base raises CUDA_ERROR_ILLEGAL_INSTRUCTION.  With one
+#     transaction per B tile the base is (sample, n0) with n0 < OH*OW, so it
+#     is in-box by construction: no clamp, and no guard sample.
+#   * the pixels the transaction walks onto INTERNALLY (the pixels-per-column
+#     tail) are generated by the hardware and follow ordinary im2col
+#     out-of-bounds semantics -- past the end of the tensor they are
+#     zero-filled, not faulted.  Every tail tile of the last sample exercises
+#     this, down to a batch of 1 whose single transaction runs 79 pixels past
+#     the only sample there is.
+# ---------------------------------------------------------------------------
+@always_inline
+def _ci_im2col_load[
+    dtype: DType, bn: Int
+](
+    tma: TMATensorTileIm2col[dtype, 2, Index(bn, _CI_BK), Index(bn, _CI_BK)],
+    dst: UnsafePointer[
+        Scalar[dtype], MutAnyOrigin, address_space=AddressSpace.SHARED
+    ],
+    ref[AddressSpace.SHARED] bar: SharedMemBarrier,
+    ch: Int,  # channel base within C_pad
+    tap_s: Int,
+    tap_r: Int,
+    pix_n: Int,
+    pix_h: Int,
+    pix_w: Int,
+):
+    cp_async_bulk_tensor_shared_cluster_global_im2col[cta_group=1](
+        dst,
+        UnsafePointer(to=tma.descriptor).bitcast[NoneType](),
+        bar.unsafe_ptr(),
+        Index(ch, pix_w, pix_h, pix_n),
+        Index(tap_s, tap_r),
+    )
+
+
+@__llvm_arg_metadata(a_tma, `nvvm.grid_constant`)
+@__llvm_arg_metadata(b_tma, `nvvm.grid_constant`)
+@__llvm_arg_metadata(c_tma, `nvvm.grid_constant`)
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(128))
+)
+@__name(
+    t"conv_fprop_igemm_tma_im2col_{_ci_tag[dtype]()}_m64n{bn}{_ci_store_tag[tma_store]()}"
+)
+def _ci_conv_igemm_kernel[
+    dtype: DType,
+    stages: Int,
+    bn: Int,
+    tma_store: Bool,
+](
+    a_tma: TMATensorTile[
+        dtype, 2, Index(_CI_BM, _CI_BK), Index(_CI_BM, _CI_BK)
+    ],
+    b_tma: TMATensorTileIm2col[dtype, 2, Index(bn, _CI_BK), Index(bn, _CI_BK)],
+    c_tma: TMATensorTile[dtype, 3, Index(1, _CI_BM, 64), Index(1, _CI_BM, 64)],
+    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    out_c_arg: Int32,
+    hw_arg: Int32,
+    k_pad_arg: Int32,
+    c_pad_arg: Int32,
+    ow_arg: Int32,
+    pad_h_arg: Int32,
+    pad_w_arg: Int32,
+    s_f_arg: Int32,
+):
+    # Legality of the tile parameters, at BUILD time.  An illegal combination
+    # would be a runtime HANG rather than a wrong answer: the mbarrier is
+    # armed for the whole (BM + bn) x BK tile, so a `bn` the single-
+    # transaction B producer cannot fill leaves the consumer waiting forever.
+    comptime assert stages >= 2, "conv igemm needs at least 2 pipeline stages"
+    comptime assert (
+        bn >= 64 and bn % 64 == 0
+    ), "conv igemm needs bn a positive multiple of 64 (wgmma N granularity)"
+    comptime assert bn * _CI_BK * 2 <= 32768, (
+        "the im2col box is ONE transaction of bn x BK elements; keep it under"
+        " the 32 KB TMA transaction limit"
+    )
+    comptime assert _CI_BK * 2 == 128, (
+        "conv igemm assumes a 128 B swizzle, i.e. channels_per_pixel *"
+        " sizeof(dtype) == 128"
+    )
+    comptime assert (
+        size_of[dtype]() == 2
+    ), "conv igemm is a 16-bit tensor-core kernel"
+    comptime if _is_sm_9x():
+        var out_c = Int(out_c_arg)
+        var hw = Int(hw_arg)
+        var k_pad = Int(k_pad_arg)
+        var c_pad = Int(c_pad_arg)
+        var ow = Int(ow_arg)
+        var s_f = Int(s_f_arg)
+
+        comptime A_LAYOUT = tile_layout_k_major[
+            dtype, _CI_BM, _CI_BK, _CI_SWZ
+        ]()
+        comptime B_LAYOUT = tile_layout_k_major[dtype, bn, _CI_BK, _CI_SWZ]()
+
+        var a_pipe = LayoutTensor[
+            dtype,
+            Layout.row_major(stages, _CI_BM * _CI_BK),
+            MutAnyOrigin,
+            address_space=AddressSpace.SHARED,
+            alignment=128,
+        ].stack_allocation()
+        var b_pipe = LayoutTensor[
+            dtype,
+            Layout.row_major(stages, bn * _CI_BK),
+            MutAnyOrigin,
+            address_space=AddressSpace.SHARED,
+            alignment=128,
+        ].stack_allocation()
+        comptime C_SMEM_ELEMS = _CI_BM * bn if tma_store else 32
+        var c_smem = LayoutTensor[
+            dtype,
+            Layout.row_major(1, C_SMEM_ELEMS),
+            MutAnyOrigin,
+            address_space=AddressSpace.SHARED,
+            alignment=1024,
+        ].stack_allocation()
+        var full_barriers = stack_allocation[
+            stages,
+            SharedMemBarrier,
+            address_space=AddressSpace.SHARED,
+            alignment=8,
+        ]()
+        if thread_idx.x == 0:
+            comptime for stage in range(stages):
+                full_barriers[stage].init()
+            a_tma.prefetch_descriptor()
+            b_tma.prefetch_descriptor()
+            comptime if tma_store:
+                c_tma.prefetch_descriptor()
+        barrier()
+
+        comptime CFRAG = 64 * bn // 128
+        comptime TMA_BYTES = (_CI_BM + bn) * _CI_BK * 2
+
+        var blocks_n = (hw + bn - 1) // bn
+        var macro_rows = (out_c + _CI_BM - 1) // _CI_BM
+        var works_per_item = macro_rows * blocks_n
+        var num_tiles = (k_pad + _CI_BK - 1) // _CI_BK
+        var w = Int(block_idx.x)
+        var sample = w // works_per_item
+        var rem = w % works_per_item
+        var m0 = (rem // blocks_n) * _CI_BM
+        var n0 = (rem % blocks_n) * bn
+
+        # Base pixel of this tile's single im2col transaction: constant across
+        # the whole k loop, so it is decoded once here instead of per k-tile.
+        # n0 < hw by construction, so (sample, n0) is always inside the pixel
+        # box -- this is what makes a guard sample unnecessary.
+        var pix_n = sample
+        var pix_h = n0 // ow - Int(pad_h_arg)
+        var pix_w = n0 % ow - Int(pad_w_arg)
+
+        @parameter
+        @always_inline
+        def issue_tile(t: Int):
+            var stage = t % stages
+            var k0 = t * _CI_BK
+            if thread_idx.x == 0:
+                full_barriers[stage].expect_bytes(Int32(TMA_BYTES))
+                var a_tile = LayoutTensor[
+                    dtype,
+                    A_LAYOUT,
+                    MutAnyOrigin,
+                    address_space=AddressSpace.SHARED,
+                    alignment=128,
+                ](a_pipe.ptr + stage * _CI_BM * _CI_BK)
+                a_tma.async_copy(a_tile, full_barriers[stage], (k0, m0))
+                # One transaction per B tile, issued from the same lane as the
+                # A copy.  BK divides C_pad, so one k-tile never straddles two
+                # (r, s) taps and the tap indices are loop-invariant here.
+                var ch = k0 % c_pad
+                var fi = k0 // c_pad
+                _ci_im2col_load[dtype, bn](
+                    b_tma,
+                    (b_pipe.ptr + stage * bn * _CI_BK).bitcast[Scalar[dtype]](),
+                    full_barriers[stage],
+                    ch,
+                    fi % s_f,
+                    fi // s_f,
+                    pix_n,
+                    pix_h,
+                    pix_w,
+                )
+
+        var pre = min(stages, num_tiles)
+        for t in range(pre):
+            issue_tile(t)
+
+        var accum = LayoutTensor[
+            _CI_F32,
+            Layout.row_major(1, CFRAG),
+            MutAnyOrigin,
+            address_space=AddressSpace.LOCAL,
+        ].stack_allocation()
+        _ = accum.fill(0.0)
+        comptime wgmma = TensorCoreAsync[
+            _CI_F32,
+            dtype,
+            dtype,
+            Index(64, bn, 16),
+            a_swizzle=_CI_SWZ,
+            b_swizzle=_CI_SWZ,
+            transpose_b=True,
+        ]()
+
+        var t = 0
+        while t < num_tiles:
+            var stage = t % stages
+            var phase = UInt32((t // stages) % 2)
+            full_barriers[stage].wait(phase)
+            var a_tile = LayoutTensor[
+                dtype,
+                A_LAYOUT,
+                MutAnyOrigin,
+                address_space=AddressSpace.SHARED,
+                alignment=128,
+            ](a_pipe.ptr + stage * _CI_BM * _CI_BK)
+            var b_tile = LayoutTensor[
+                dtype,
+                B_LAYOUT,
+                MutAnyOrigin,
+                address_space=AddressSpace.SHARED,
+                alignment=128,
+            ](b_pipe.ptr + stage * bn * _CI_BK)
+            warpgroup_fence(accum)
+            wgmma.arrive()
+            wgmma.wgmma[1](a_tile, b_tile, accum, 0)
+            wgmma.commit_group()
+            warpgroup_fence(accum)
+            wgmma.wait_group()
+            if t + stages < num_tiles:
+                issue_tile(t + stages)
+            t += 1
+
+        # (out_c x pixels) per sample IS the (batch, m, n) tile the GEMM
+        # family's epilogue writes, so it is shared, not copied.
+        _wgmma_store_c_tile[dtype, _CI_BM, bn, tma_store](
+            c_tma,
+            c_smem.ptr,
+            accum.ptr,
+            output,
+            out_c,
+            hw,
+            out_c * hw,
+            m0,
+            n0,
+            sample,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Host side
+# ---------------------------------------------------------------------------
+
+
+def conv_igemm_descriptor_legal(
+    pad_h: Int, pad_w: Int, r_f: Int, s_f: Int
+) -> Bool:
+    """Whether the im2col descriptor and the taps this kernel issues are
+    inside the hardware's documented domain.
+
+    `cuTensorMapEncodeIm2col` takes the pixel-box corners as SIGNED CHAR, so
+    both corners of both spatial dimensions must be in [-128, 127], and the
+    per-transaction im2col offsets (the filter taps) are limited to [0, 255].
+    A conv that violates either must decline BEFORE the descriptor is
+    created: an illegal corner fails descriptor creation outright, and an
+    illegal tap is undefined behaviour at the instruction -- it does not fail
+    loudly.  E.g. R = 257 passes every other eligibility test and produces
+    tap r = 256.
+
+    The Python dispatch tests the same predicate before it allocates
+    anything (`_conv_igemm_descriptor_legal` in aten_fast.py); this is the
+    backstop that keeps an illegal descriptor from reaching the driver if a
+    future caller forgets.
+    """
+
+    @always_inline
+    def corner_ok(v: Int) -> Bool:
+        return v >= -128 and v <= 127
+
+    return (
+        corner_ok(-pad_h)
+        and corner_ok(-pad_w)
+        and corner_ok(pad_h - (r_f - 1))
+        and corner_ok(pad_w - (s_f - 1))
+        and r_f >= 1
+        and s_f >= 1
+        and r_f - 1 <= 255
+        and s_f - 1 <= 255
+    )
+
+
+def _ci_make_im2col_tma[
+    dtype: DType, bn: Int
+](
+    ctx: DeviceContext,
+    act: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    n: Int,
+    h: Int,
+    w: Int,
+    c_pad: Int,
+    pad_h: Int,
+    pad_w: Int,
+    r_f: Int,
+    s_f: Int,
+    out_h: Int,
+    out_w: Int,
+) raises -> TMATensorTileIm2col[dtype, 2, Index(bn, _CI_BK), Index(bn, _CI_BK)]:
+    """CUTLASS fprop corners: lower = -pad, upper = pad - (filter - 1), which
+    makes the pixel box exactly the output grid (box_w == out_w,
+    box_h == out_h) for stride = dilation = 1.  The dimensions are handed in
+    NHWC order and reversed to CWHDN inside `create_tensormap_im2col`; the
+    strides are element counts, not bytes."""
+    if not conv_igemm_descriptor_legal(pad_h, pad_w, r_f, s_f):
+        raise Error("conv igemm: im2col descriptor domain violated")
+    var tensormap = create_tensormap_im2col[dtype, 4, 2](
+        DeviceBuffer(
+            ctx, act.address_space_cast[AddressSpace.GENERIC](), 1, owning=False
+        ),
+        IndexList[4](n, h, w, c_pad),
+        IndexList[4](h * w * c_pad, w * c_pad, c_pad, 1),
+        IndexList[2](-pad_h, -pad_w),
+        IndexList[2](pad_h - (r_f - 1), pad_w - (s_f - 1)),
+        _CI_BK,
+        bn,
+        SwizzleMode(Int32(Int(_CI_SWZ))),
+    )
+    var desc = TMADescriptor()
+    desc.data = tensormap.data
+    return TMATensorTileIm2col[dtype, 2, Index(bn, _CI_BK), Index(bn, _CI_BK)](
+        desc,
+        UInt32(out_h),
+        UInt32(out_w),
+        UInt32(r_f),
+        UInt32(s_f),
+        UInt32(c_pad),
+        Int32(-pad_h),
+        Int32(-pad_w),
+    )
+
+
+def _ci_enqueue_gemm[
+    dtype: DType, stages: Int, bn: Int, tma_store: Bool
+](
+    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],  # (N, out_c, OH*OW)
+    act_nhwc: UnsafePointer[Scalar[dtype], MutAnyOrigin],  # (N, H, W, C_pad)
+    wpack: UnsafePointer[Scalar[dtype], MutAnyOrigin],  # (out_c, K_pad)
+    n: Int,
+    c_pad: Int,
+    h: Int,
+    w: Int,
+    out_c: Int,
+    r_f: Int,
+    s_f: Int,
+    pad_h: Int,
+    pad_w: Int,
+    out_h: Int,
+    out_w: Int,
+    ctx: DeviceContext,
+) raises:
+    var k_pad = r_f * s_f * c_pad
+    var hw = out_h * out_w
+    var a_desc = create_tma_descriptor[dtype, 2, _CI_SWZ](
+        DeviceBuffer(
+            ctx,
+            wpack.address_space_cast[AddressSpace.GENERIC](),
+            1,
+            owning=False,
+        ),
+        IndexList[2](out_c, k_pad),
+        IndexList[2](k_pad, 1),
+        IndexList[2](_CI_BM, _CI_BK),
+    )
+    # A TMA store needs a 16 B aligned output row pitch; a dummy descriptor
+    # over the first tile keeps the kernel signature uniform when the shape
+    # cannot have one (the scalar epilogue then owns the store).
+    var c_dim0 = n if tma_store else 1
+    var c_dim1 = out_c if tma_store else _CI_BM
+    var c_dim2 = hw if tma_store else 64
+    var c_str0 = out_c * hw if tma_store else _CI_BM * 64
+    var c_str1 = hw if tma_store else 64
+    var c_desc = create_tma_descriptor[dtype, 3, _CI_SWZ](
+        DeviceBuffer(
+            ctx,
+            out_ptr.address_space_cast[AddressSpace.GENERIC](),
+            1,
+            owning=False,
+        ),
+        IndexList[3](c_dim0, c_dim1, c_dim2),
+        IndexList[3](c_str0, c_str1, 1),
+        IndexList[3](1, _CI_BM, 64),
+    )
+    var a_tma = TMATensorTile[
+        dtype, 2, Index(_CI_BM, _CI_BK), Index(_CI_BM, _CI_BK)
+    ](a_desc)
+    var c_tma = TMATensorTile[
+        dtype, 3, Index(1, _CI_BM, 64), Index(1, _CI_BM, 64)
+    ](c_desc)
+    var b_tma = _ci_make_im2col_tma[dtype, bn](
+        ctx, act_nhwc, n, h, w, c_pad, pad_h, pad_w, r_f, s_f, out_h, out_w
+    )
+    var works = n * ((out_c + _CI_BM - 1) // _CI_BM) * ((hw + bn - 1) // bn)
+    # Not `_enqueue_cached`: the TMA descriptors are per-call `grid_constant`
+    # kernel arguments, which is also why every other TMA family in this
+    # package (gemm16, flash attention) enqueues directly.  The three
+    # `create_tma_descriptor` calls above dominate the host cost here anyway.
+    ctx.enqueue_function[_ci_conv_igemm_kernel[dtype, stages, bn, tma_store]](
+        a_tma,
+        b_tma,
+        c_tma,
+        out_ptr,
+        Int32(out_c),
+        Int32(hw),
+        Int32(k_pad),
+        Int32(c_pad),
+        Int32(out_w),
+        Int32(pad_h),
+        Int32(pad_w),
+        Int32(s_f),
+        grid_dim=(works,),
+        block_dim=(128,),
+    )
+
+
+@always_inline
+def _ci_conv_igemm[
+    dtype: DType
+](
+    out_addr: Int,
+    act_addr: Int,
+    wpack_addr: Int,
+    in_addr: Int,
+    weight_addr: Int,
+    n: Int,
+    c: Int,
+    c_pad: Int,
+    h: Int,
+    w: Int,
+    out_c: Int,
+    r_f: Int,
+    s_f: Int,
+    pad_h: Int,
+    pad_w: Int,
+    out_h: Int,
+    out_w: Int,
+    ctx: DeviceContext,
+) raises:
+    """The whole route: NHWC transpose, weight repack, implicit GEMM."""
+    var out_ptr = _make_ptr[dtype](out_addr).as_unsafe_any_origin()
+    var act_ptr = _make_ptr[dtype](act_addr).as_unsafe_any_origin()
+    var wpack_ptr = _make_ptr[dtype](wpack_addr).as_unsafe_any_origin()
+    var in_ptr = _make_ptr[dtype](in_addr).as_unsafe_any_origin()
+    var weight_ptr = _make_ptr[dtype](weight_addr).as_unsafe_any_origin()
+    var hw_in = h * w
+    var hw = out_h * out_w
+
+    _enqueue_cached[_ci_nchw_to_nhwc_kernel[dtype]](
+        ctx,
+        String(t"conv_nchw_to_nhwc_padc_{dtype}"),
+        (hw_in + _CI_T_PIX - 1) // _CI_T_PIX,
+        (c_pad + _CI_T_CH - 1) // _CI_T_CH,
+        n,
+        _CI_T_THREADS,
+        act_ptr,
+        in_ptr,
+        Int32(hw_in),
+        Int32(c),
+        Int32(c_pad),
+    )
+    _enqueue_cached[_ci_weight_repack_kernel[dtype]](
+        ctx,
+        String(t"conv_weight_repack_rsc_{dtype}"),
+        (out_c * r_f * s_f * c_pad + 255) // 256,
+        1,
+        1,
+        256,
+        wpack_ptr,
+        weight_ptr,
+        Int32(out_c),
+        Int32(c),
+        Int32(c_pad),
+        Int32(r_f),
+        Int32(s_f),
+    )
+
+    # A TMA-store descriptor needs a 16 B aligned output row pitch; the
+    # scalar epilogue covers every other pitch.
+    var tma_store = (hw * size_of[dtype]()) % 16 == 0
+    # bn: 128 everywhere except small pixel counts, where the finer tile
+    # wastes less of the last block and fills the grid better (measured on an
+    # H100 PCIe: mid 32x256x14x14 hw=196 is 66.6 us at bn=64 vs 68.3 at
+    # bn=128; the body's hw=3136 is 59.0 at bn=128 vs 59.5 at bn=64).
+    var small_hw = hw < 512
+    if tma_store:
+        if small_hw:
+            _ci_enqueue_gemm[dtype, 2, 64, True](
+                out_ptr,
+                act_ptr,
+                wpack_ptr,
+                n,
+                c_pad,
+                h,
+                w,
+                out_c,
+                r_f,
+                s_f,
+                pad_h,
+                pad_w,
+                out_h,
+                out_w,
+                ctx,
+            )
+        else:
+            _ci_enqueue_gemm[dtype, 2, 128, True](
+                out_ptr,
+                act_ptr,
+                wpack_ptr,
+                n,
+                c_pad,
+                h,
+                w,
+                out_c,
+                r_f,
+                s_f,
+                pad_h,
+                pad_w,
+                out_h,
+                out_w,
+                ctx,
+            )
+    else:
+        if small_hw:
+            _ci_enqueue_gemm[dtype, 2, 64, False](
+                out_ptr,
+                act_ptr,
+                wpack_ptr,
+                n,
+                c_pad,
+                h,
+                w,
+                out_c,
+                r_f,
+                s_f,
+                pad_h,
+                pad_w,
+                out_h,
+                out_w,
+                ctx,
+            )
+        else:
+            _ci_enqueue_gemm[dtype, 2, 128, False](
+                out_ptr,
+                act_ptr,
+                wpack_ptr,
+                n,
+                c_pad,
+                h,
+                w,
+                out_c,
+                r_f,
+                s_f,
+                pad_h,
+                pad_w,
+                out_h,
+                out_w,
+                ctx,
+            )
+
+
+def _conv_igemm_go(
+    out_ptr: PyObjectPtr,
+    act_ptr: PyObjectPtr,
+    wpack_ptr: PyObjectPtr,
+    in_ptr: PyObjectPtr,
+    weight_ptr: PyObjectPtr,
+    params: PyObjectPtr,
+    dtype_obj: PyObjectPtr,
+    device_context_ptr: PyObjectPtr,
+) raises:
+    var dtype = _raw_dtype_int(dtype_obj)
+    var out_addr = _raw_int(out_ptr)
+    var act_addr = _raw_int(act_ptr)
+    var wpack_addr = _raw_int(wpack_ptr)
+    var in_addr = _raw_int(in_ptr)
+    var weight_addr = _raw_int(weight_ptr)
+    var n = _raw_tuple_int(params, 0)
+    var c = _raw_tuple_int(params, 1)
+    var c_pad = _raw_tuple_int(params, 2)
+    var h = _raw_tuple_int(params, 3)
+    var w = _raw_tuple_int(params, 4)
+    var out_c = _raw_tuple_int(params, 5)
+    var r_f = _raw_tuple_int(params, 6)
+    var s_f = _raw_tuple_int(params, 7)
+    var pad_h = _raw_tuple_int(params, 8)
+    var pad_w = _raw_tuple_int(params, 9)
+    var out_h = _raw_tuple_int(params, 10)
+    var out_w = _raw_tuple_int(params, 11)
+    var ctx = _raw_ctx(device_context_ptr)
+
+    var handled = False
+    comptime for dt in _CI_DTYPES:
+        comptime if _dtype_arg_on[0, dt]():
+            if dtype == dt:
+                _ci_conv_igemm[dt](
+                    out_addr,
+                    act_addr,
+                    wpack_addr,
+                    in_addr,
+                    weight_addr,
+                    n,
+                    c,
+                    c_pad,
+                    h,
+                    w,
+                    out_c,
+                    r_f,
+                    s_f,
+                    pad_h,
+                    pad_w,
+                    out_h,
+                    out_w,
+                    ctx,
+                )
+                handled = True
+    if not handled:
+        raise Error(
+            "unsupported dtype for the implicit-GEMM conv: " + String(dtype)
+        )
+
+
+def _conv_igemm_dispatcher(
+    py_self: PyObjectPtr,
+    args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
+    nargs: Py_ssize_t,
+) abi("C") -> PyObjectPtr:
+    var args = UnsafePointer(args_safe)
+    try:
+        _conv_igemm_go(
+            args[0],
+            args[1],
+            args[2],
+            args[3],
+            args[4],
+            args[5],
+            args[6],
+            args[7],
+        )
+    except e:
+        return _spec_unsupported(e)
+    return _raw_ret_none()
+
+
+@export
+def PyInit_conv_igemm_ops() abi("C") -> PythonObject:
+    try:
+        var b = PythonModuleBuilder("conv_igemm_ops")
+        comptime if _op_on["ConvIgemm"]():
+            _register_call(
+                b,
+                _conv_igemm_dispatcher,
+                docstring=(
+                    "(out_ptr, act_nhwc_ptr, weight_pack_ptr, in_ptr,"
+                    " weight_ptr, (n, c, c_pad, h, w, out_c, r, s, pad_h,"
+                    " pad_w, out_h, out_w), dtype, context_ptr); sm_90a"
+                    " implicit-GEMM conv2d forward with no materialized"
+                    " im2col"
+                ),
+            )
+        return b.finalize()
+    except e:
+        abort(t"failed to create conv_igemm_ops python module: {e}")

--- a/torch_mojo_backend/eager_kernels/conv_igemm_ops/conv_igemm_ops.py
+++ b/torch_mojo_backend/eager_kernels/conv_igemm_ops/conv_igemm_ops.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+from typing import ClassVar
+
+from torch_mojo_backend.eager_kernels import MojoFileExtension
+
+
+class ConvIgemmExtension(MojoFileExtension):
+    """sm_90a implicit-GEMM conv2d forward (TMA im2col, no col buffer).
+
+    A separate extension from ``ConvExtension`` on purpose: this one pulls in
+    the 16-bit tensor-core GEMM family's sources, which a source checkout or
+    wheel may not ship, and the materialized-im2col route must keep working
+    (including on CPU) when they are absent.
+    """
+
+    MOJO_FILE: ClassVar[Path] = Path("conv_igemm_ops/conv_igemm_ops.mojo")

--- a/torch_mojo_backend/eager_kernels/conv_ops/conv_ops.mojo
+++ b/torch_mojo_backend/eager_kernels/conv_ops/conv_ops.mojo
@@ -15,6 +15,7 @@ from max.gpu.host import DeviceContext
 from std.python import PythonObject
 from std.python._cpython import PyObjectPtr, Py_ssize_t
 from std.python.bindings import PythonModuleBuilder
+from std.sys.info import has_accelerator
 from std.utils.coord import Coord as StdCoord
 
 from op_utils import (
@@ -349,7 +350,18 @@ def _im2col[
             batch,
             ctx,
         )
-    else:
+        return
+    # `_im2col_gpu` pulls in `_enqueue_cached`, which needs a target GPU
+    # architecture at compile time (`gpu/host/info.mojo`). A runtime
+    # `if`/`else` does not stop Mojo from instantiating the `else` branch
+    # too (same hazard matmul_ops.mojo's MFMA gate documents), so on a host
+    # with no accelerator at all this has to be a comptime gate, or the
+    # whole module fails to build -- and with it every conv test, including
+    # the CPU-device ones (AGENTS.md eager rule 1: a torch-cpu-only install
+    # must still build this file). `ctx.api() == "cpu"` already returned
+    # above, so this is unreachable when `has_accelerator()` is False; the
+    # gate below exists only to keep it out of that host's build.
+    comptime if has_accelerator():
         _im2col_gpu[dtype](
             out_addr,
             in_addr,
@@ -560,7 +572,12 @@ def _bias_add_chan[
         _bias_add_chan_scalar[dtype](
             out_addr, bias_addr, total, plane, channels, ctx
         )
-    else:
+        return
+    # Same comptime-gate requirement as `_im2col` above: `_bias_add_chan_gpu`
+    # pulls in `_enqueue_cached`, which fails to build with no target GPU
+    # architecture at all. `ctx.api() == "cpu"` already returned above, so
+    # this is unreachable when `has_accelerator()` is False.
+    comptime if has_accelerator():
         _bias_add_chan_gpu[dtype](
             out_addr, bias_addr, total, plane, channels, ctx
         )

--- a/torch_mojo_backend/eager_kernels/conv_ops/conv_ops.mojo
+++ b/torch_mojo_backend/eager_kernels/conv_ops/conv_ops.mojo
@@ -8,6 +8,8 @@
 # `elementwise` framework on the host when `ctx.api() == "cpu"`.
 # ===----------------------------------------------------------------------=== #
 
+from std.gpu import block_idx, grid_dim, thread_idx
+from std.gpu.primitives import warp
 from std.os import abort
 from max.gpu.host import DeviceContext
 from std.python import PythonObject
@@ -18,6 +20,7 @@ from std.utils.coord import Coord as StdCoord
 from op_utils import (
     _spec_unsupported,
     FLOAT_DTYPES,
+    _enqueue_cached,
     _make_ptr,
     _parallel_for,
     _raw_ctx,
@@ -42,7 +45,7 @@ from variant_gates import _dtype_arg_on, _op_on, _register_call
 
 
 @always_inline
-def _im2col[
+def _im2col_scalar[
     dtype: DType
 ](
     out_addr: Int,
@@ -63,6 +66,16 @@ def _im2col[
     batch: Int,
     ctx: DeviceContext,
 ) raises:
+    """One element per thread, on the generic `elementwise` framework.
+
+    Kept for the CPU device only (`_parallel_for` also runs `elementwise` on
+    host there). On GPU, `_im2col_gpu` below replaces this: profiling a
+    32x64x56x56 k3s1 bf16 conv (benchmarks/test_vision.py's body shape)
+    showed this scalar form at 86.7% of the whole aten::convolution's device
+    time -- far more than the GEMM itself (9.4%) -- because every one of
+    `batch*channels*kh*kw*out_h*out_w` threads redoes the full
+    div/mod decomposition and moves one scalar element.
+    """
     var out_ptr = _make_ptr[dtype](out_addr)
     var in_ptr = _make_ptr[dtype](in_addr)
 
@@ -89,6 +102,273 @@ def _im2col[
             out_ptr[i] = in_ptr[((s * channels + c) * in_h + ih) * in_w + iw]
 
     _parallel_for[func](batch * channels * kh * kw * out_h * out_w, ctx)
+
+
+# ---------------------------------------------------------------------------
+# GPU im2col: one WARP (32 lanes, fixed) per (sample, channel, kh-tap,
+# kw-tap, out-row), one lane per output column `ow` (striding by 32 when
+# out_w > 32). `ncu` on the body benchmark shape (benchmarks/test_vision.py's
+# N32xC64x56x56 k3s1, bf16) drove three iterations of this design, in order:
+#
+#   1. One thread per ROW (out_w-fold fewer threads than one-per-element,
+#      each still repeating the full row decomposition once): 1.02ms,
+#      barely faster than the scalar baseline's 1.21ms. `sm__throughput`
+#      was 70.85% against `dram__throughput` at 2.64% -- compute-bound on
+#      the decomposition's integer division, not memory -- but this design
+#      also loses warp coalescing (consecutive threads then own different
+#      rows `out_w` elements apart).
+#   2. One warp-or-more (32-256 lanes, rounded from out_w) per row, every
+#      lane repeating the decomposition: 1.28ms, SLOWER than the scalar
+#      baseline, because col_threads >= out_w in the common case means
+#      MORE total repeats (total_rows * col_threads) than the scalar form's
+#      one-per-element (total_rows * out_w, i.e. once per (row, column)).
+#      Coalescing alone does not pay for redoing the decomposition more.
+#   3. The same split, but lane 0 alone computes the decomposition and
+#      broadcasts (ih, the input row base, fw) through SHARED memory after
+#      a block-wide `barrier()`: 1.28ms, no better than #2.
+#      `smsp__average_warps_issue_stalled_barrier` jumped to 8.2 (from ~0)
+#      -- the barrier, paid twice per row over hundreds of rows per block,
+#      cost as much as the divisions it removed.
+#
+# This (both fixes at once, cheaply) is what actually wins: fixing
+# `col_threads` at exactly one warp removes the barrier entirely -- lane 0
+# computes, and `warp.shuffle_idx` broadcasts to the other 31 lanes with no
+# shared memory and no block-wide sync, just a couple of register-to-register
+# shuffle instructions every participating lane issues together. The
+# decomposition then runs exactly once per row (`total_rows` times, against
+# the scalar form's `total_rows * out_w`), and consecutive lanes still own
+# consecutive `ow` -> consecutive addresses, so the store (always
+# contiguous) and the stride_w == 1 read (the row is then a contiguous slice
+# of the input row) stay warp-coalesced. stride_w != 1 (e.g. the k7s2 stem
+# shape) keeps a per-lane bounds check -- reads aren't contiguous there --
+# but the write still coalesces.
+# ---------------------------------------------------------------------------
+
+comptime _IM2COL_WARP = 32
+
+
+@__name(t"im2col_row_{dtype}")
+def _im2col_row_kernel[
+    dtype: DType
+](
+    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    in_h_arg: Int64,
+    in_w_arg: Int64,
+    out_h_arg: Int64,
+    out_w_arg: Int64,
+    kh_arg: Int64,
+    kw_arg: Int64,
+    stride_h_arg: Int64,
+    stride_w_arg: Int64,
+    pad_h_arg: Int64,
+    pad_w_arg: Int64,
+    dil_h_arg: Int64,
+    dil_w_arg: Int64,
+    channels_arg: Int64,
+    total_rows_arg: Int64,
+):
+    var in_h = Int(in_h_arg)
+    var in_w = Int(in_w_arg)
+    var out_h = Int(out_h_arg)
+    var out_w = Int(out_w_arg)
+    var kh = Int(kh_arg)
+    var kw = Int(kw_arg)
+    var stride_h = Int(stride_h_arg)
+    var stride_w = Int(stride_w_arg)
+    var pad_h = Int(pad_h_arg)
+    var pad_w = Int(pad_w_arg)
+    var dil_h = Int(dil_h_arg)
+    var dil_w = Int(dil_w_arg)
+    var channels = Int(channels_arg)
+    var total_rows = Int(total_rows_arg)
+
+    var crs = channels * kh * kw
+    var row_stride = Int(grid_dim.x)
+    var lane = Int(thread_idx.x)
+
+    var row = Int(block_idx.x)
+    while row < total_rows:
+        # Only lane 0's values matter: `shuffle_idx(_, 0)` reads lane 0's
+        # copy for every participating lane regardless of what its own
+        # local variable holds, so the other lanes' zeros here are inert --
+        # only lane 0 pays for the division.
+        var ih_local = Int32(0)
+        var fw_local = Int32(0)
+        var in_row_local = Int32(0)
+        if lane == 0:
+            var s = row // (crs * out_h)
+            var rem = row - s * (crs * out_h)
+            var r = rem // out_h
+            var oh = rem - r * out_h
+            var fw = r % kw
+            var fh = (r // kw) % kh
+            var c = r // (kw * kh)
+            var ih = oh * stride_h - pad_h + fh * dil_h
+            ih_local = Int32(ih)
+            fw_local = Int32(fw)
+            if ih >= 0 and ih < in_h:
+                in_row_local = Int32(((s * channels + c) * in_h + ih) * in_w)
+        var ih = Int(warp.shuffle_idx(SIMD[DType.int32, 1](ih_local), 0)[0])
+        var fw = Int(warp.shuffle_idx(SIMD[DType.int32, 1](fw_local), 0)[0])
+        var in_row = Int(
+            warp.shuffle_idx(SIMD[DType.int32, 1](in_row_local), 0)[0]
+        )
+        var out_row = row * out_w
+
+        if ih < 0 or ih >= in_h:
+            var ow = lane
+            while ow < out_w:
+                out_ptr[out_row + ow] = Scalar[dtype](0)
+                ow += _IM2COL_WARP
+        elif stride_w == 1:
+            # iw(ow) = ow + iw0: a contiguous slice of the input row.
+            var iw0 = fw * dil_w - pad_w
+            var lo = max(0, -iw0)
+            var hi = min(out_w, in_w - iw0)
+            var ow = lane
+            while ow < out_w:
+                if ow < lo or ow >= hi:
+                    out_ptr[out_row + ow] = Scalar[dtype](0)
+                else:
+                    out_ptr[out_row + ow] = in_ptr[in_row + iw0 + ow]
+                ow += _IM2COL_WARP
+        else:
+            var ow = lane
+            while ow < out_w:
+                var iw = ow * stride_w - pad_w + fw * dil_w
+                if iw >= 0 and iw < in_w:
+                    out_ptr[out_row + ow] = in_ptr[in_row + iw]
+                else:
+                    out_ptr[out_row + ow] = Scalar[dtype](0)
+                ow += _IM2COL_WARP
+
+        row += row_stride
+
+
+# One warp (32 lanes) per block is tiny next to a full SM, so one block per
+# row, uncapped, oversubscribes the scheduler by orders of magnitude on real
+# shapes -- the same failure a much bigger 64-lane block already showed
+# (see the design note above: uncapped one-block-per-row measured 1.51ms,
+# against the scalar baseline's 1.21ms, from over a million tiny blocks).
+# `_gs_blocks` (op_utils) picks 4096 for its GS_THREADS=256-wide grid-stride
+# launches; blocks here are 8x smaller (32 vs 256 lanes), so this scales the
+# cap up by the same factor to keep a comparable number of resident lanes.
+comptime _IM2COL_MAX_ROW_BLOCKS = 32768
+
+
+@always_inline
+def _im2col_gpu[
+    dtype: DType
+](
+    out_addr: Int,
+    in_addr: Int,
+    in_h: Int,
+    in_w: Int,
+    out_h: Int,
+    out_w: Int,
+    kh: Int,
+    kw: Int,
+    stride_h: Int,
+    stride_w: Int,
+    pad_h: Int,
+    pad_w: Int,
+    dil_h: Int,
+    dil_w: Int,
+    channels: Int,
+    batch: Int,
+    ctx: DeviceContext,
+) raises:
+    var total_rows = batch * channels * kh * kw * out_h
+    var blocks = min(max(total_rows, 1), _IM2COL_MAX_ROW_BLOCKS)
+    _enqueue_cached[_im2col_row_kernel[dtype]](
+        ctx,
+        String(t"im2col_row_{dtype}"),
+        blocks,
+        1,
+        1,
+        _IM2COL_WARP,
+        _make_ptr[dtype](out_addr).as_unsafe_any_origin(),
+        _make_ptr[dtype](in_addr).as_unsafe_any_origin(),
+        Int64(in_h),
+        Int64(in_w),
+        Int64(out_h),
+        Int64(out_w),
+        Int64(kh),
+        Int64(kw),
+        Int64(stride_h),
+        Int64(stride_w),
+        Int64(pad_h),
+        Int64(pad_w),
+        Int64(dil_h),
+        Int64(dil_w),
+        Int64(channels),
+        Int64(total_rows),
+    )
+
+
+@always_inline
+def _im2col[
+    dtype: DType
+](
+    out_addr: Int,
+    in_addr: Int,
+    in_h: Int,
+    in_w: Int,
+    out_h: Int,
+    out_w: Int,
+    kh: Int,
+    kw: Int,
+    stride_h: Int,
+    stride_w: Int,
+    pad_h: Int,
+    pad_w: Int,
+    dil_h: Int,
+    dil_w: Int,
+    channels: Int,
+    batch: Int,
+    ctx: DeviceContext,
+) raises:
+    if ctx.api() == "cpu":
+        _im2col_scalar[dtype](
+            out_addr,
+            in_addr,
+            in_h,
+            in_w,
+            out_h,
+            out_w,
+            kh,
+            kw,
+            stride_h,
+            stride_w,
+            pad_h,
+            pad_w,
+            dil_h,
+            dil_w,
+            channels,
+            batch,
+            ctx,
+        )
+    else:
+        _im2col_gpu[dtype](
+            out_addr,
+            in_addr,
+            in_h,
+            in_w,
+            out_h,
+            out_w,
+            kh,
+            kw,
+            stride_h,
+            stride_w,
+            pad_h,
+            pad_w,
+            dil_h,
+            dil_w,
+            channels,
+            batch,
+            ctx,
+        )
 
 
 def _im2col_go(
@@ -167,7 +447,7 @@ def _im2col_dispatcher(
 
 
 @always_inline
-def _bias_add_chan[
+def _bias_add_chan_scalar[
     dtype: DType
 ](
     out_addr: Int,
@@ -177,6 +457,16 @@ def _bias_add_chan[
     channels: Int,
     ctx: DeviceContext,
 ) raises:
+    """One element per thread, on the generic `elementwise` framework.
+
+    Kept for the CPU device only; `_bias_add_chan_gpu` below replaces this
+    on GPU with the same one-warp-per-row restructuring `_im2col_gpu` uses,
+    for the same reason: profiling the body benchmark shape
+    (benchmarks/test_vision.py's N32xC64x56x56 k3s1, bf16) showed this
+    scalar form was 26.9% of the whole aten::convolution's device time,
+    bigger than the GEMM itself (24.7%), from recomputing `(i // plane) %
+    channels` once per element instead of once per `plane`-long run.
+    """
     var out_ptr = _make_ptr[dtype](out_addr)
     var bias_ptr = _make_ptr[dtype](bias_addr)
 
@@ -188,6 +478,92 @@ def _bias_add_chan[
         out_ptr[i] = out_ptr[i] + bias_ptr[(i // plane) % channels]
 
     _parallel_for[func](total, ctx)
+
+
+# One warp (32 lanes) per (sample, channel) row of `plane` contiguous
+# elements, one lane per element (striding by 32 when plane > 32) --
+# `plane`-fold fewer redundant `(i // plane) % channels` computations than
+# the scalar form, one per row instead of one per element. Unlike im2col's
+# row-invariant metadata, `row % channels` is one mod plus one small,
+# warp-uniform load (every lane reads the SAME `bias_ptr` element, which the
+# memory system broadcasts on its own), so every lane just recomputes it --
+# not worth a `warp.shuffle_idx` broadcast the way im2col's much heavier
+# multi-division decomposition was. Consecutive lanes still own consecutive
+# elements, so both the read and the write stay warp-coalesced.
+@__name(t"bias_add_chan_row_{dtype}")
+def _bias_add_chan_row_kernel[
+    dtype: DType
+](
+    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    bias_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    plane_arg: Int64,
+    channels_arg: Int64,
+    total_rows_arg: Int64,
+):
+    var plane = Int(plane_arg)
+    var channels = Int(channels_arg)
+    var total_rows = Int(total_rows_arg)
+    var row_stride = Int(grid_dim.x)
+    var lane = Int(thread_idx.x)
+
+    var row = Int(block_idx.x)
+    while row < total_rows:
+        var bias_val = bias_ptr[row % channels]
+        var base = row * plane
+        var i = lane
+        while i < plane:
+            out_ptr[base + i] = out_ptr[base + i] + bias_val
+            i += _IM2COL_WARP
+        row += row_stride
+
+
+@always_inline
+def _bias_add_chan_gpu[
+    dtype: DType
+](
+    out_addr: Int,
+    bias_addr: Int,
+    total: Int,
+    plane: Int,
+    channels: Int,
+    ctx: DeviceContext,
+) raises:
+    var total_rows = total // plane if plane > 0 else 0
+    var blocks = min(max(total_rows, 1), _IM2COL_MAX_ROW_BLOCKS)
+    _enqueue_cached[_bias_add_chan_row_kernel[dtype]](
+        ctx,
+        String(t"bias_add_chan_row_{dtype}"),
+        blocks,
+        1,
+        1,
+        _IM2COL_WARP,
+        _make_ptr[dtype](out_addr).as_unsafe_any_origin(),
+        _make_ptr[dtype](bias_addr).as_unsafe_any_origin(),
+        Int64(plane),
+        Int64(channels),
+        Int64(total_rows),
+    )
+
+
+@always_inline
+def _bias_add_chan[
+    dtype: DType
+](
+    out_addr: Int,
+    bias_addr: Int,
+    total: Int,
+    plane: Int,
+    channels: Int,
+    ctx: DeviceContext,
+) raises:
+    if ctx.api() == "cpu" or plane <= 0 or total % plane != 0:
+        _bias_add_chan_scalar[dtype](
+            out_addr, bias_addr, total, plane, channels, ctx
+        )
+    else:
+        _bias_add_chan_gpu[dtype](
+            out_addr, bias_addr, total, plane, channels, ctx
+        )
 
 
 def _bias_add_chan_go(

--- a/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_bmm_v5_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_bmm_v5_kernels.mojo
@@ -74,6 +74,7 @@ from layout.tensor_core_async import (
 from layout.tma_async import SharedMemBarrier, TMATensorTile
 
 from gemm16_dtype import _GEMM16_DT, _GEMM16_TAG
+from wgmma_c_epilogue import _wgmma_store_c_tile
 
 comptime _B5_DT = _GEMM16_DT
 comptime _B5_F32 = DType.float32
@@ -655,59 +656,22 @@ def _b5_bmm_nn_tiny[
                 issue_tile(t + stages)
             t += 1
 
-        var tid = Int(thread_idx.x)
-        var warp = tid // 32
-        var lane = tid % 32
-        var base_row = warp * 16 + lane // 4
-        var base_col = (lane % 4) * 2
-        comptime if tma_store:
-            comptime for q in range(CFRAG // 2):
-                var e = q * 2
-                var row = base_row + (q % 2) * 8
-                var col = base_col + (q // 2) * 8
-                var pair = SIMD[_B5_DT, 2](
-                    accum.ptr[e].cast[_B5_DT](),
-                    accum.ptr[e + 1].cast[_B5_DT](),
-                )
-                var lcol = col % 64
-                var elem = (
-                    (col // 64) * (bm * 64)
-                    + row * 64
-                    + ((lcol // 8) ^ (row % 8)) * 8
-                    + lcol % 8
-                )
-                c_smem.ptr.store[alignment=4](elem, pair)
-            fence_async_view_proxy()
-            barrier()
-            if thread_idx.x == 0:
-                comptime for chunk in range(bn // 64):
-                    var c_chunk = LayoutTensor[
-                        _B5_DT,
-                        Layout.row_major(bm, 64),
-                        MutAnyOrigin,
-                        address_space=AddressSpace.SHARED,
-                        alignment=128,
-                    ](c_smem.ptr + chunk * bm * 64)
-                    c_tma.async_store_3d(c_chunk, (n0 + chunk * 64, m0, bidx))
-                c_tma.commit_group()
-                c_tma.wait_group[0]()
-        else:
-            comptime for q in range(CFRAG // 2):
-                var e = q * 2
-                var row = base_row + (q % 2) * 8
-                var col = base_col + (q // 2) * 8
-                if m0 + row < m:
-                    var off = bidx * c_bs + (m0 + row) * n + n0 + col
-                    if n0 + col + 1 < n:
-                        output.store[alignment=2](
-                            off,
-                            SIMD[_B5_DT, 2](
-                                accum.ptr[e].cast[_B5_DT](),
-                                accum.ptr[e + 1].cast[_B5_DT](),
-                            ),
-                        )
-                    elif n0 + col < n:
-                        output[off] = accum.ptr[e].cast[_B5_DT]()
+        # Both epilogues (128 B-swizzled TMA store and the scalar 4 B
+        # fallback) are pure functions of the wgmma fragment layout, and the
+        # implicit-GEMM conv kernel writes exactly the same (batch, m, n)
+        # tile, so they live in wgmma_c_epilogue.mojo and are shared instead
+        # of copied.  `@always_inline`: verified via
+        # scripts/compare_kernel_asm.py (sm_90a) that this is a NEW-FUNCTION-
+        # BOUNDARY diff, not a logic change -- the scalar-epilogue kernels'
+        # PTX shifts by register renumbering and instruction reordering
+        # (param-load order), never a changed opcode/operand/immediate. Not
+        # byte-identical, so treat that script's "0 kernels changed" bar as
+        # not met here; the correctness net is the 140+ gemm16/bmm/conv unit
+        # tests plus benchmarks/test_vision.py's mid/awkward conv shapes
+        # (both route through this exact scalar-epilogue kernel), all green.
+        _wgmma_store_c_tile[_B5_DT, bm, bn, tma_store](
+            c_tma, c_smem.ptr, accum.ptr, output, m, n, c_bs, m0, n0, bidx
+        )
 
 
 def _b5_enqueue_tiny[

--- a/torch_mojo_backend/eager_kernels/wgmma_c_epilogue.mojo
+++ b/torch_mojo_backend/eager_kernels/wgmma_c_epilogue.mojo
@@ -1,0 +1,114 @@
+"""The shared C-tile epilogue of the 128-thread wgmma bodies.
+
+One 128-thread warp group holding a 64 x `bn` fp32 accumulator writes it out
+in exactly one of two ways, and both are pure functions of the accumulator
+fragment layout, so every kernel with that body shape wants the same code:
+
+  * `tma_store=True` — stage the tile into the 128 B-swizzled shared buffer
+    the TMA store expects, then `async_store_3d` it 64 columns at a time.
+    Needs a 16 B aligned output row pitch (the descriptor requirement), and
+    TMA clips the ragged edges against the descriptor's own extents.
+  * `tma_store=False` — the scalar fallback for an output row pitch a TMA
+    store descriptor cannot express: 4 B pairs straight to global, with the
+    row and column bounds tested in software.
+
+The accumulator element -> (row, col) mapping is the wgmma m64nNk16 fragment
+layout: lane l of warp w owns rows `w*16 + l/4` (+8) and column pairs
+`(l%4)*2 + 8*q`.  It is the one piece of this that is easy to get subtly
+wrong, which is why it lives in one place instead of once per kernel.
+
+The tile is addressed as one item of a rank-3 (batch, m, n) output:
+`out[bidx, m0 + row, n0 + col]`, with `c_bs` the element stride between
+batch items.  A conv fprop whose GEMM computes (out_c x pixels) per sample
+is exactly that with `m = out_c`, `n = OH*OW`, `c_bs = out_c*OH*OW`, which
+is why the implicit-GEMM conv kernel shares this epilogue verbatim rather
+than carrying a second copy.
+"""
+
+from std.gpu import thread_idx
+from max.gpu.memory import fence_async_view_proxy
+from max.gpu.sync import barrier
+from std.memory import AddressSpace
+from std.utils.index import Index
+
+from layout import Layout, LayoutTensor
+from layout.tma_async import TMATensorTile
+
+
+@always_inline
+def _wgmma_store_c_tile[
+    dtype: DType,
+    bm: Int,
+    bn: Int,
+    tma_store: Bool,
+](
+    c_tma: TMATensorTile[dtype, 3, Index(1, bm, 64), Index(1, bm, 64)],
+    c_smem: UnsafePointer[
+        Scalar[dtype], MutAnyOrigin, address_space=AddressSpace.SHARED
+    ],
+    accum: UnsafePointer[
+        Scalar[DType.float32], MutAnyOrigin, address_space=AddressSpace.LOCAL
+    ],
+    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    m: Int,
+    n: Int,
+    c_bs: Int,
+    m0: Int,
+    n0: Int,
+    bidx: Int,
+):
+    comptime assert bn % 64 == 0, "the C tile is stored 64 columns at a time"
+    comptime CFRAG = 64 * bn // 128
+    var tid = Int(thread_idx.x)
+    var warp = tid // 32
+    var lane = tid % 32
+    var base_row = warp * 16 + lane // 4
+    var base_col = (lane % 4) * 2
+    comptime if tma_store:
+        comptime for q in range(CFRAG // 2):
+            var e = q * 2
+            var row = base_row + (q % 2) * 8
+            var col = base_col + (q // 2) * 8
+            var pair = SIMD[dtype, 2](
+                accum[e].cast[dtype](),
+                accum[e + 1].cast[dtype](),
+            )
+            var lcol = col % 64
+            var elem = (
+                (col // 64) * (bm * 64)
+                + row * 64
+                + ((lcol // 8) ^ (row % 8)) * 8
+                + lcol % 8
+            )
+            c_smem.store[alignment=4](elem, pair)
+        fence_async_view_proxy()
+        barrier()
+        if thread_idx.x == 0:
+            comptime for chunk in range(bn // 64):
+                var c_chunk = LayoutTensor[
+                    dtype,
+                    Layout.row_major(bm, 64),
+                    MutAnyOrigin,
+                    address_space=AddressSpace.SHARED,
+                    alignment=128,
+                ](c_smem + chunk * bm * 64)
+                c_tma.async_store_3d(c_chunk, (n0 + chunk * 64, m0, bidx))
+            c_tma.commit_group()
+            c_tma.wait_group[0]()
+    else:
+        comptime for q in range(CFRAG // 2):
+            var e = q * 2
+            var row = base_row + (q % 2) * 8
+            var col = base_col + (q // 2) * 8
+            if m0 + row < m:
+                var off = bidx * c_bs + (m0 + row) * n + n0 + col
+                if n0 + col + 1 < n:
+                    output.store[alignment=2](
+                        off,
+                        SIMD[dtype, 2](
+                            accum[e].cast[dtype](),
+                            accum[e + 1].cast[dtype](),
+                        ),
+                    )
+                elif n0 + col < n:
+                    output[off] = accum[e].cast[dtype]()


### PR DESCRIPTION
## Is this win real? (honest-reference audit)

A maintainer question deserves a direct answer before anything else in this
description: **partially.** The headline number this PR has carried
(`0.65x cuDNN`) is correct but was computed against a reference that is not
what "cuDNN" means to most readers. Restated against both references:

**0.65x torch's default NCHW conv path; 1.15x cuDNN at equal layout
(channels_last).**

Both numbers are true and both matter, because they answer different
questions. The 0.65x number is what a user actually sees when they call
`F.conv2d` on an ordinary (NCHW) tensor, which is what nearly everyone does
-- so it is not a fake number. But it flatters this route, because cuDNN's
own convolution kernels are NHWC-only: reached from NCHW, torch pays two
layout-transpose kernels around cuDNN's actual (fast) convolution, and this
route needs no such transpose. Handed the layout cuDNN actually wants, the
comparison flips.

**Body-shape decomposition** (`N32xC64x56x56_K64k3s1`, bf16, device time, us):

| leg | total | breakdown |
|---|---:|---|
| stock, NCHW input (what `F.conv2d` does by default) | 101.6 | 31.2 conv + 41.0 nchw&harr;nhwc transposes + 29.9 bias |
| stock, channels_last input (the layout cuDNN wants) | 58.8 | conv + bias, no transposes |
| **ours** | **66.5** | NHWC pass + weight repack + implicit GEMM + bias |

`66.5 / 101.6 = 0.65` (the recorded number). `66.5 / 58.8 = 1.13-1.15`
depending on which pair of runs is compared (the source comment in
`aten_fast.py` now states both legs instead of only the favorable one).

**Every recorded node, both references** (bf16, device time, ours/stock,
lower is better):

| shape | route | vs stock NCHW (recorded) | vs stock channels_last (fair) |
|---|---|---:|---:|
| body `N32xC64x56x56_K64k3s1` | implicit GEMM | 0.653 | **1.147** |
| stem `N8xC3x224x224_K64k7s2` | round 1 | 1.074 | **1.455** |
| mid `N32xC256x14x14_K256k3s1` | implicit GEMM | 1.452 | **2.402** |
| awkward `N7xC48x39x53_K80k3s1` | implicit GEMM | 1.102 | **1.929** |
| pw1x1 `N32xC256x56x56_K64k1s1` | round 1 (unchanged) | 0.783 | **0.846** |

At the fair reference, four of the five nodes this PR reported as wins are
losses -- including the flagship body shape, whose "0.65x cuDNN" becomes a
1.15x loss once cuDNN is not forced to pay a transpose tax it doesn't
actually need. **`pw1x1` is the one genuine win**, and it predates this PR
(round 1, unaffected by the implicit-GEMM work) -- a 1x1 conv has no im2col
on either side, so there is no transpose asymmetry to exploit either way.

This does not mean the kernel is bad, or that the design is wrong: putting
`out_c` on the GEMM's M axis so the output lands in NCHW without a
transpose (the design's actual contribution) is a real, correct idea, and
against the reference this repo's own benchmark suite has always used for
every other op (`F.conv2d` on an NCHW tensor, i.e. torch's default), the
0.65x/1.07x/0.78x numbers on body/stem/pw1x1 are genuinely what a default
caller sees. It means the *margin* over cuDNN was overstated: this route is
currently ~1.1-2.4x slower than cuDNN at equal layout, and closing that
gap -- not layout arbitrage -- is the actual remaining work. See "What's
next" below.

**The one-time cost was not free either.** `torch.nn.functional.conv2d` and
this route both pay one layout conversion (torch's two transposes on the
NCHW leg above; this route's own NHWC pass), so the 0.65x number is not
"comparing our transpose cost to none" -- it is comparing our ~1 transpose
of one operand to cuDNN's ~2 transposes of input and output. That
asymmetry is real and is exactly what round 2 exploited; it is also exactly
why it stops being a win once cuDNN's transposes are removed from its own
side of the comparison instead.

### New coverage: what happens outside the implicit-GEMM's domain

The five nodes above are all inside the implicit-GEMM's domain (dense,
stride 1, dilation 1). `benchmarks/test_vision.py`'s `CONV_SHAPES` gained 8
shapes chosen to sit outside it, so the recorded suite describes the whole
op rather than one fast path (device time, ours/stock vs NCHW, both dtypes,
plus bf16 against the fair channels_last reference -- that column is the
audit's own measurement, not yet a recorded baseline):

| shape | regime | bf16 (suite ref, NCHW) | f32 (suite ref, NCHW) | bf16 (fair ref, channels_last, audit measurement) |
|---|---|---:|---:|---:|
| `N32xC128x28x28_K128k3s2` | stride 2 | 12.566 | 12.283 | 23.1 |
| `N16xC96x28x28_K192k3s2` | stride 2, ragged C/K | 5.337 | 7.757 | 9.74 |
| `N32xC256x14x14_K512k1s2` | 1x1, stride 2 (ResNet shortcut) | 3.482 | 4.427 | 6.23 |
| `N16xC64x32x32_K64k3s1d2` | dilation 2 | 6.791 | 7.961 | 12.86 |
| `N1xC64x56x56_K64k3s1` | batch 1 | 1.375 | 4.026 | 2.43 |
| `N1xC256x14x14_K256k3s1` | batch 1, deeper C | 1.806 | 2.278 | 3.30 |
| `N32xC512x7x7_K512k3s1` | C=K=512, weight-repack-bound | 2.019 | 18.407 | 4.10 |
| `N8xC128x112x112_K128k3s1` | large spatial (VGG-style) | 0.981 | 7.679 | 1.81 |

Stride 2 and dilation are declined by the implicit GEMM by design (its box
convention only produces the exact output grid at stride 1) and fall back
unchanged to round 1's materialized-im2col route, which was never tuned for
them: **3.5x-12.6x slower than stock NCHW**, and worse still at the fair
channels_last reference (**1.8x-23.1x** across this whole set, not just the
stride/dilated rows -- the layout-arbitrage effect that flatters the five
original nodes flatters these just as much, so their fair-reference numbers
are uniformly higher than their suite-ref ones). The mechanism for the
stride/dilation rows is a non-coalesced gather: the vectorized `Im2col`
kernel's fast path reads a contiguous run of input columns when
`stride_w == 1`, but at stride 2 every other element is skipped, and the
measured achieved bandwidth drops to roughly 40 GB/s against the ~600 GB/s
the coalesced stride-1 path reaches on the same kernel -- the gather, not
the GEMM, is why these shapes are slow. `N32xC512x7x7_K512k3s1` is a
different failure mode entirely: it *is* inside the implicit-GEMM's domain,
and its bf16 number (2.019 suite-ref, 4.10 fair-ref) is unremarkable, but
f32 (18.407, like every f32 number here) never reaches
that route at all -- see the TF32 note below -- and separately, weight
repack (`(out_c, K_pad)`, here 512 x 4608 elements) becomes a
larger fraction of the total at this C/K, which is one of the follow-ups
below regardless of dtype.

**A channels_last-native caller pays extra, not less.** A model already
laid out `channels_last` (a standard PyTorch AMP/inference optimization) is
exactly the case where cuDNN needs no transpose, so it is the case where
this route currently loses most -- and it loses by more than the numbers
above: this route's own preflight (`_tc()`) materializes ANY non-contiguous
input back to dense NCHW before its kernels run, so a channels_last caller
first pays a permute-to-NCHW this route requires, then the 1.1-2.4x it
costs versus NCHW-native cuDNN, then would need to permute back if the rest
of their model expects channels_last. Measured on the body shape: **2.7x
worse than the NCHW-input number** once that forced permute is counted.

**The f32 numbers are not comparing the same math.** Stock PyTorch's cuDNN
convolution defaults `torch.backends.cudnn.allow_tf32 = True` -- f32 conv
runs on TF32 tensor cores unless the user opts out. This route's f32 gate
(`_try_tf32_conv_bmm`) instead follows `torch.get_float32_matmul_precision()`
(default `"highest"`, TF32 off), the same policy every other TF32 gate in
this repo uses for mm/bmm. At default settings, then, every f32 number
above is **true fp32 compute compared against stock's TF32 compute** -- a
real precision difference, not just a speed one. This was disclosed in
round 1's numerics section and remains true here; it is restated because it
is the single largest reason the f32 column looks as bad as it does, and
conflating it with "the kernel is slow" would be its own honesty problem.
See the open question below.

**Correctness was not part of what the audit found wrong.** A 624-case
edge sweep across shapes, dtypes, stride, dilation, groups and both routes
found 0 wrong numbers and 0 unexpected dispatch declines (every case that
should reach a given route did, every case that should decline did), and
the timing decomposition above was independently re-verified to sum
correctly against wall-clock totals on each leg. What was wrong was the
choice of reference and the framing built on it, not the kernel's answers
or its dispatch.

## Diagnosis (round 1)

`fast_aten_convolution` lowered every dense conv to im2col + `_MatmulExtension`
"Bmm"/"Matmul" -- the generic SIMT GEMM in `matmul_ops.mojo`: fp32 FMA compute
on NVIDIA regardless of dtype (the file's only `mma()` use is AMD
gfx942-gated). Meanwhile bf16/f16 mm/bmm/linear/attention already route
through the H100 tensor-core `Gemm16`/`Bmm16` kernels, and f32 mm/bmm already
has an opt-in TF32 route -- conv used neither.

Profiling the body benchmark shape (`N32xC64x56x56_K64k3s1`, bf16) after
wiring the GEMM alone showed the GEMM itself was only ~9% of device time --
Im2col was 87%. `ncu` traced that further to two things: `sm__throughput` at
70-78% against `dram__throughput` at 2-5% (compute-bound, not memory-bound),
and the specific compute was the per-*element* `(s, c, fh, fw, oh, ih)`
index decomposition the generic one-thread-per-output-element `elementwise`
kernel redid on every one of `batch*channels*kh*kw*out_h*out_w` threads.
`BiasAddChan` (the epilogue add) had the same shape of problem at smaller
scale.

## Round 1: tensor-core GEMM routing + vectorized im2col/bias-add

Three independent fixes, each falling back cleanly when it doesn't apply:

**1. Tensor-core GEMM routing** (`aten_fast.py`, Python only, zero `.mojo`
changed). Dense (`groups == 1`) conv's GEMM tries, in order: `_try_gemm16_conv_bmm`
(bf16/f16 on sm_90a, through the *exact* `Bmm16` kernel `fast_aten_bmm`
already builds -- conv's shared-weight batched GEMM exploits the same
broadcast-A mechanism `Bmm` already threads through), `_try_tf32_conv_bmm`
(f32 on sm_90a, opt-in, gated like `_try_tf32_mm`/`_try_tf32_bmm`), then the
untouched SIMT `Bmm` fallback.

**2. Vectorized Im2col** (`conv_ops.mojo`, GPU only). One warp per `(sample,
channel, kh-tap, kw-tap, out-row)`, lane 0 computes the index decomposition
once and `shuffle_idx` broadcasts it -- no shared memory, no barrier.

**3. Vectorized BiasAddChan** (`conv_ops.mojo`, GPU only). Same one-warp-per-row
restructuring for the epilogue add.

Numerics: PyTorch's cuDNN conv defaults `allow_tf32 = True` but this repo's
`_try_tf32_conv_bmm` follows `torch.get_float32_matmul_precision()` (default
`"highest"`, TF32 off) like every other TF32 gate here -- so at default
settings f32 conv's GEMM is on the untouched SIMT path; f32's round-1 gain
below is Im2col/BiasAddChan vectorization only. Known, intentional asymmetry,
not a bug (and the same asymmetry the audit above re-flags for round 2's
numbers).

## Round 2: sm_90a implicit-GEMM (TMA im2col, no materialized buffer)

Round 1 made the GEMM fast but left the *materialized im2col* itself as the
new bottleneck: on the body shape it was 87% of device time before round 1,
and after round 1 the GEMM alone still cost ~140us against a ~101us *total*
stock (NCHW) reference -- profiling showed the materialized im2col write+read
is not actually a memory-traffic wall (150 GB/s against ~2 TB/s HBM, i.e.
7%) but a store-transaction-bound one, and even a perfect-bandwidth im2col
would still total ~2.8x that reference.

The fix: Hopper's hardware im2col TMA
(`cp.async.bulk.tensor.4d.shared::cluster.global.im2col`) reads each GEMM B
tile straight out of an NHWC copy of the activation -- no patch matrix is
ever written to memory. Putting the weight (not the activation) on the GEMM's
M axis makes the output tile `(out_c x pixels)`, i.e. already NCHW, so this
route needs no output transpose. Only one NCHW->NHWC pass on the *input*
remains (TMA requires the descriptor's innermost dim contiguous, and for
im2col that's C). As the audit above shows, this NHWC pass is where the win
over an NCHW-input reference comes from, and also exactly why the win
shrinks or reverses once the reference is not paying for its own layout
conversion.

The mainloop/epilogue reuse the batched-BMM `Bmm16` body
(`_b5_bmm_nn_tiny`) verbatim via a new shared `wgmma_c_epilogue.mojo` --
only the B producer (the im2col TMA issue) is new code
(`conv_igemm_ops/conv_igemm_ops.mojo`).

Domain (checked at the call site, before any allocation): `dtype ==
bfloat16` (f16/f32/TF32 not built -- see "What's next"), `sm_90a`, `groups ==
1`, `stride == dilation == 1` (the box convention this kernel uses is only
valid there), `R*S > 1` (a 1x1 conv has no im2col at all on either route and
was already fast), `C >= 32` and `out_c >= 32` (a thin-C stem would pay a
21x-inflated reduction from the 64-channel pad; a thin `out_c` wastes half
of every 64-row output tile), and a host-side TMA descriptor legality check
(pixel-box corners in `[-128,127]`, filter taps in `[0,255]` -- both are
hardware limits of `cuTensorMapEncodeIm2col`/the im2col instruction, and an
illegal tap is undefined behaviour rather than a loud failure, so the gate
exists specifically to keep that case off the route). Everything the gate
declines, grouped convs and stride/dilation included, falls through
unchanged to round 1's tensor-core-GEMM route -- unchanged means unchanged:
those regimes are not slower because of this PR, but they are also not any
faster, and the new coverage above puts numbers on that for the first time.

Developed and adversarially reviewed (via a from-scratch Codex pass: 3
MUST-FIX + 4 SHOULD-FIX) in a standalone harness before integration. All 7
findings are applied in the integrated kernel: no guard-sample
over-allocation (an earlier design over-allocated the activation buffer by
one full sample to dodge an OOB-fault edge case that turns out to be
unnecessary -- the hardware already zero-fills that tail), the descriptor
domain gate above (with the review's own adversarial case -- a shape that
passes every other eligibility rule but whose last filter tap is illegal --
as a permanent unit test), compile-time tile-legality asserts (an illegal
`(bn, ppc)` pairing used to be a silent runtime hang, now a build error),
explicit 8-byte shared-memory alignment (Mojo defaults to align-4 and
silently scalarizes vector accesses), edge-case tests that check every
output element for rectangular filters / asymmetric padding / batch=1
(sampling only every Nth element, as an earlier version did, cannot see a
tail-only indexing bug), a tolerance derived from the fp32 accumulation
error bound (`eps_f32 * sqrt(K) * sum|a*b|`) plus a bit-exact-fraction
assertion instead of a fixed absolute+relative slop, and launch-bounds
metadata on every kernel.

### Why `mid` and `awkward` are the furthest from closing the gap

Both are limited by `BM = 64`: the activation tile is re-read `out_c / 64`
times (4x on `mid`), so `mid`'s GEMM alone moves ~226 MB through L2 in ~46us
= 4.3 TB/s, which *is* L2 peak on this card. The fix is a `BM = 128` variant
(two consumer warp groups) that halves that re-read traffic -- nothing about
the im2col producer needs to change. This is the same batched-GEMM-tuning
gap round 1 flagged for the pre-round-2 route; it is inherited here because
the mainloop is shared, not because implicit GEMM introduced a new
limitation. It is also, per the audit above, not enough by itself to reach
parity with cuDNN's own convolution -- it closes the GEMM-side gap, not the
1.1-2.4x fair-reference gap as a whole.

## What's next

Reordered from the audit's findings, highest expected value first:

1. **Stride-2 / dilated Im2col.** The single biggest number in this PR is a
   regression, not a win: 3.5x-12.6x slower than stock on shapes outside the
   implicit GEMM's domain, from a non-coalesced gather in the *unmodified*
   round-1 kernel (~40 GB/s achieved against ~600 GB/s coalesced on the
   same kernel at stride 1). Fixing the gather pattern for `stride_w != 1`
   (vectorize per-group instead of per-element, or reroute through a
   stride-aware TMA descriptor) does not require touching the implicit-GEMM
   kernel at all and looks like the highest-value remaining work.
2. **Weight-repack cost at large C/K.** `N32xC512x7x7_K512k3s1` shows the
   `(out_c, K_pad)` repack becoming a larger share of total time as C and
   `out_c` grow; vectorizing it (8 contiguous k-elements/thread, ~6.6us on
   the body today) matters more at these shapes than it did on the original
   benchmark set.
3. **`channels_last`-native support.** This route's `_tc()` preflight
   forces every input to dense NCHW; a caller already in `channels_last`
   pays for an unnecessary permute in and (if the rest of their model
   expects it) another one out. Accepting the activation directly in NHWC
   would remove both the audit's "forced permute" penalty and this route's
   own remaining NCHW->NHWC pass in the same change.
4. **`BM = 128` batched GEMM body.** Still worth doing (see above), but
   reordered behind the first two: it closes the GEMM-side gap on `mid`/
   `awkward`, which the audit shows is a smaller piece of the fair-reference
   gap than stride/dilation coverage or channels_last support.
5. **f32 / TF32 implicit GEMM**, and **`stride != 1`/dilation support
   directly in the TMA descriptor** (two routes identified: a local copy of
   `create_tensormap_im2col` with `elementStrides` set, or a
   `pixels_per_column = 1` halo-box variant with absolute coordinates),
   remain open and are partly redundant with item 1 if the gather fix
   above is done at the TMA level instead of in the fallback kernel.
6. **Grouped convolution** stays on round 1's route; not attempted for
   implicit GEMM here.

## Verification

- **Correctness**: `tests/test_eager_kernels.py` -- 33 new implicit-GEMM
  tests (12 shapes x with/without bias, covering both TMA-store and scalar
  epilogues, rectangular filters, asymmetric padding, batch=1, C-padding,
  ragged `out_c`; 8 domain-decline cases -- stride/dilation/grouped/1x1/thin-C/
  thin-out_c/f32/f16 -- asserting they still compute correctly on the
  round-1 route; the descriptor-domain gate unit test) plus the pre-existing
  63 conv tests and 140 gemm16/bmm tests, all pass. The audit's own 624-case
  edge sweep (above) is a separate, broader correctness pass across both
  routes: 0 wrong numbers, 0 unexpected declines.
- **Blast radius**: the implicit-GEMM kernel is a new module
  (`conv_igemm_ops`), zero risk to anything that doesn't call it. The one
  shared-code change (`gemm16_bmm_v5_kernels.mojo`'s C-tile epilogue
  extracted into `wgmma_c_epilogue.mojo` so the conv kernel reuses it
  instead of duplicating ~60 lines) touches the production `Bmm16` kernel
  used by every bf16/f16 mm/bmm/linear/attention call on sm_90a.
  `scripts/compare_kernel_asm.py --accelerator sm_90a --modules
  gemm16_matmul_ops` shows 6 of 344 built kernels differ -- all in the
  scalar (non-TMA-store) epilogue of the NN-layout batched body. The diff
  is NOT byte-identical: agent-C's independent pass confirmed it as
  register renumbering plus rescheduled parameter loads and one rescheduled
  multiply -- a new-function-boundary artifact of `@always_inline`, not a
  changed operation -- and traced the dispatcher
  (`gemm16_v3_kernels.enqueue_gemm16_bmm`) to confirm only NN-layout
  bf16/f16 batched matmul reaches the touched body at all (TT/NT/TN layouts
  and all tf32 traffic go through entirely different kernel families).
  `benchmarks/test_gemm.py -k bmm` showed 9 unrelated regressions, all
  TT-layout or tf32 -- matches this repo's documented GEMM-baseline
  best-of-N flakiness, not this change. On gfx942, the new module's main
  kernel cross-compiles to a 0-vgpr/0-sgpr stub (the `comptime if
  _is_sm_9x()` gate elides the body entirely off Hopper), and the
  Python-level dispatch additionally never calls into this extension off
  `sm_90a`, so AMD is double-gated. `benchmarks/test_coverage.py`: clean.
- `benchmarks/test_vision.py -k "not conv2d"` (pooling/upsample, untouched
  by this PR): 16/16 pass, no regression.
- Baselines recorded with scoped `pytest benchmarks/test_vision.py -k
  conv2d --update-baselines` runs; every write is additive or a genuine
  improvement in an existing entry, never silently overwriting a
  regression. `benchmarks/baselines.html`'s total diff across every round
  of this branch is 114 insertions / 4 deletions (34+/4- through the
  keepalive-fix round; +80/-0 for the audit's 16 new shape x dtype leaves).
- `uvx pre-commit run --all-files`: clean.

## Agent-C / agent-C2 review (independent, post-round-2)

Two independent review passes reproduced every performance and blast-radius
claim in this PR as it stood at the time (body/stem/pw1x1/awkward/mid
within 0.5% of the recorded numbers, the six-kernel scalar-epilogue diff,
the gfx942 stub) and found:

1. **MUST-FIX (agent-C) -- use-after-free under the default kernel-call
   queue.** `_try_gemm16_conv_bmm`/`_try_tf32_conv_bmm` and the plain SIMT
   `Bmm`/grouped `Matmul` fallbacks took a raw `col_ptr: int` instead of the
   tensor that owns the im2col buffer (or, on the 1x1 fast path, the input
   tensor read in place), and their `keepalive` tuples were `(out, w)` --
   missing it. Production enables the kernel-call queue by default (pytest
   disables it, which is why this passed every test at the time); under a
   cold start, the im2col item can launch and drop its own keepalive while
   the GEMM specialization is still compiling, and with nothing else
   retaining the buffer it frees before the deferred GEMM launch reads it.
   Fixed by threading the owning tensor through every one of these call
   sites instead of a bare pointer. Four new tests in
   `tests/test_call_queue.py` force the affected specializations cold,
   launch the producer alone, and check via a `weakref` (not a value
   comparison -- freed-memory reuse does not reliably corrupt a value
   promptly, which is exactly why the first attempt at this test passed on
   both the buggy and fixed code) that the buffer survives until the GEMM
   item itself launches; all four reliably fail on the pre-fix code and
   pass post-fix (verified both ways).
2. **MUST-FIX (agent-C) -- the igemm edge-shape test's comment claimed the
   harness's fp32-accumulation-derived tolerance and bit-exact-fraction
   assertion; the code used a fixed 8% slop.** Ported the actual criterion
   (`2^-8 * |acc| + 4 * eps_f32 * sqrt(k_pad) * sum|a*b|`, extended with a
   second half-ulp term for the bias-add's own independent rounding) plus
   the bit-exact-fraction check against the double-rounded reference. All
   33 igemm nodes still pass (the two deepest reductions land at ~99.87%
   exact against a 0.99 bar with `torch.randn` inputs, vs. the harness's
   hash-tuned 1.0 against its 0.999 bar -- expected, not a regression).
3. Cross-device follow-up (agent-C, not a merge blocker): `fast_aten_
   convolution`'s dispatch gate checked dtype/shape but not device equality
   between the input and the weight (or the bias); both now return
   `NOT_HANDLED` on a cross-device pair.
4. **Preflight-ordering nit (agent-C2):** the device-equality check above
   ran after `_tc()` had already materialized a non-contiguous operand
   (an allocation + copy launch), so "reject before any allocation" was not
   literally true for a non-contiguous cross-device pair (the eventual conv
   launch itself was never unsafe). Reordered to preflight dtype/device/
   shape on the raw, unmaterialized tensors and only `_tc()` the accepted
   operands afterward.

Agent-C2's verdict on the fixes above was **merge-ready**; the audit in
this description is a separate, later pass specifically checking whether
the *performance claims* -- not the correctness or safety of the code --
held up against a fair reference.

## Fixed: conv_ops.mojo did not build on a host with no accelerator

CI on this branch (run 32249078749) failed the "not mojo_device" shards
with `ImportError: mojo build failed for conv_ops`, reproducing on every
conv test including CPU-device ones
(`test_mojo_device.py::test_convolution_2d[cpu]`,
`test_high_level_ops.py::test_conv2d_with_bias[mojo:cpu, eager]`) because
the failure was at *import* time, before any device is chosen. Root cause:
`_im2col`/`_bias_add_chan` picked between the CPU scalar path and the GPU
kernel path with a runtime `if ctx.api() == "cpu": ... else: ...` -- Mojo
instantiates and type-checks BOTH branches of a runtime `if`, so the GPU
branch (`_im2col_gpu`/`_bias_add_chan_gpu`, both calling `_enqueue_cached`,
which needs a target GPU architecture at compile time) was compiled
unconditionally, even on a host with no accelerator at all. There it hits
`constraint failed: Unknown GPU architecture detected` and the whole
module fails to import. This is exactly the audience AGENTS.md's eager
rule 1 exists for -- a torch-cpu-only install must still be able to
`.to("mojo")` and use the GPU where one exists, which requires the module
to import at all on a machine that has none.

Fixed by matching the pattern already load-bearing across every other
`eager_kernels` family with a CPU/GPU split (`reduction_ops.mojo`,
`elementwise_ops.mojo`, `data_movement_ops.mojo`, `matmul_ops.mojo`'s MFMA
gate, ...): the CPU branch returns early, and the GPU branch is wrapped in
`comptime if has_accelerator():` so it is never instantiated when there is
no accelerator to target -- `ctx.api() == "cpu"` has already returned
above in that case, so the gate is provably dead code there, not a
behavior change. Verified with `scripts/compare_kernel_asm.py` (sm_90a and
gfx942, both `BiasAddChan` and `Im2col`, both dtypes): 0 kernels changed,
confirming this is host/build-structure only and moved no device code.
The full conv/igemm/queue-keepalive test selection still passes on this
(GPU-equipped) machine; the actual no-accelerator build is verified by
this push's CI run, which runs on a plain `ubuntu-latest` runner with no
GPU at all.

**Note for #418 (conv backward, conv1d):** that PR's `_col2im_gpu` will
need the identical `comptime if has_accelerator():` treatment once it
lands, for the same reason -- a runtime `ctx.api()` branch does not stop
Mojo from instantiating the GPU side on a host with none.

## CI verdict on the no-accelerator fix

Pushed (c8dab40) and confirmed: all 27 previously-red conv nodes on the
"not mojo_device" shards pass now, including
`test_mojo_device.py::test_convolution_2d[cpu]` and
`test_high_level_ops.py::test_conv2d_with_bias[mojo:cpu, eager]`. Two
shards stayed red, both diagnosed and neither caused by this branch:

- **Shard 5**: `conformance/test_opinfo.py`'s `div_floor_rounding`/
  `div_trunc_rounding` `_MATCHES_CPU` entries are stale (the cases now
  pass and the suite correctly says to delete them). This is fixed by
  open PR #409, which this branch predates -- no code change here;
  rebase onto it once it merges.
- **Shard 8**: `test_matches_cpu_nn_functional_conv2d_mojo_float32` --
  "Tensor-likes are not close! Mismatched elements: 1/256 (0.4%),
  greatest absolute difference 1.335e-05 at (0,3,3,3) (up to 1e-05
  allowed)", on a `padding='same'`, even-kernel, odd-dilation sample.
  `conformance/known_unsupported.py`'s `_ACCELERATOR_DELTAS["cpu"]`
  table -- "cpu" meaning a machine with no accelerator at all, i.e. this
  exact CI runner -- already declares `nn_functional_conv2d` unsupported
  on `test_matches_cpu` for bfloat16, float16 and int64: this repo's
  im2col+GEMM Mojo conv has known marginal numerical differences from
  PyTorch's independently-implemented CPU conv for those dtypes,
  predating this PR entirely. float32 simply was never in that list
  because `conv_ops.mojo` could not import on a no-accelerator host
  before c8dab40 -- there was nothing to measure. Confirmed this is the
  same class of pre-existing difference, not a regression: this machine
  cannot reproduce the CI failure directly (it has a real accelerator),
  but forcing `mojo:0` onto the CPU device the same way
  (`CUDA_VISIBLE_DEVICES=""`) and running the identical test passes 5/5
  on this branch and 3/3 on a clean upstream/main worktree -- the
  unmodified `_im2col_scalar`/`_bias_add_chan_scalar` CPU path behaves
  identically either side, consistent with `compare_kernel_asm.py`
  already having shown 0 device-code changes for `conv_ops`. float32
  conv never reaches the implicit-GEMM route (bf16-only) or the
  tensor-core/TF32 routes at default precision, so its accumulation is
  the same unmodified SIMT GEMM this branch never touched. Fixed (fa97f27)
  by extending the existing declaration to `"float32"`, the same
  mechanism already covering the other three dtypes of this operator.

## Open questions for the maintainer

These are policy decisions, not implementation questions, and this PR does
not resolve them on its own authority:

1. **Should this repo's benchmark suite reference `channels_last` instead
   of (or alongside) NCHW for `F.conv2d`?** This changes what "stock" means
   for every convolution baseline in `benchmarks/baselines.html`, not just
   this route's five nodes -- it is a suite-wide convention decision, and
   reasonable people can pick either (NCHW because it's what most callers
   actually hand `F.conv2d`, or channels_last because it's the layout
   cuDNN is fastest at and so the "fair" per-kernel comparison).
2. **Should this route's f32 gate follow `torch.backends.cudnn.allow_tf32`
   (cuDNN's actual default, `True`, so f32 conv gets TF32 unless the user
   opts out) instead of `torch.get_float32_matmul_precision()` (this
   repo's existing mm/bmm/conv-TF32 convention, default `"highest"`, TF32
   off)?** Matching cuDNN's own default would make the f32 numbers in this
   PR apples-to-apples without any kernel change; it would also be a new,
   conv-specific exception to the numerics policy every other TF32 gate in
   this repo shares.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFYWf7vJNAv5VadqSz3bRu