### PR TITLE
FA4 self-load: pin the refill-after-wait order in the IR (no fence: the ISA says it would be a no-op)

### DIFF
--- a/tests/test_fa4_selfload_ptx_ordering.py
+++ b/tests/test_fa4_selfload_ptx_ordering.py
@@ -1,21 +1,36 @@
-"""PTX ordering regression check for the self-loading FA4 fwd kernel.
+"""PTX *and SASS* ordering regression check for the self-loading FA4 fwd kernel.
 
 ``fa4_fwd_selfload_kernel.mojo`` deleted the empty[] mbarriers a phase-2b
 producer/consumer split used to prove a ring slot's smem read had retired
 before the next TMA refill into that same slot. The substitute proof is
 program order plus ``wgmma.wait_group`` (see the PREFETCH invariant comment
 next to its definition in that file): the refill's `cp.async.bulk.tensor` /
-`mbarrier.arrive.expect_tx` must be textually emitted AFTER the
-`wgmma.wait_group` that proves the slot is free. That is true of today's
-Mojo/LLVM toolchain, but ``wgmma.wait_group`` carries no LLVM memory
-clobber, so nothing stops a *future* toolchain from reordering a refill
-ahead of its wait -- this test is the regression guard for that drift, not
-a check on this PR's own logic (which the soak in
-``test_fa4_selfload_soak.py`` covers at runtime).
+`mbarrier.arrive.expect_tx` must be emitted AFTER the `wgmma.wait_group`
+that proves the slot is free.
+
+That proof has two compilers in it, and this file checks both:
+
+* **LLVM** decides what the emitted PTX order is. The kernel pins it with
+  ``wgmma_wait_group_ordered`` (`wgmma.wait_group.sync.aligned` carrying a
+  `~{memory}` clobber, which the stdlib's `wgmma_wait_group_sync` does
+  not), and ``test_selfload_refills_follow_their_wait_group`` checks the
+  result in the PTX.
+* **ptxas** decides what the SASS order is, and is reached by nothing we
+  can write in Mojo. ``test_selfload_refills_follow_their_wait_group_sass``
+  assembles the PTX and checks that each ``UTMALDG`` refill still sits
+  after a ``WARPGROUP.DEPBAR``. Without it this file would assert a
+  property one compiler down from the one that matters -- the PTX can be
+  in perfect order while the scheduled machine code is not.
+
+Neither test is a check on the kernel's own logic (the soaks in
+``test_fa4_selfload_soak.py`` cover that at runtime); both are guards
+against toolchain drift.
 
 Cross-compiles with ``mojo build --emit asm --target-accelerator sm_90a``
 (needs no GPU, never touches ``/tmp/gpu_lock_0.lock``) the same way
-``scripts/compare_kernel_asm.py`` does, and greps the emitted PTX.
+``scripts/compare_kernel_asm.py`` does, and greps the emitted PTX. The SASS
+leg needs ``ptxas`` and ``nvdisasm`` -- also host-only tools, needing no
+device -- and skips when neither PATH nor the triton wheel provides them.
 
 Builds land in a STABLE directory (``tests/__mojocache__/...``, matching the
 already-gitignored ``__mojocache__/`` pattern), not a fresh temp dir per run:
@@ -30,6 +45,7 @@ shared directory per specialization, which is load-bearing").
 from __future__ import annotations
 
 import re
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -48,9 +64,20 @@ _D128_GUARD_BUILD_DIR = (
     Path(__file__).resolve().parent / "__mojocache__" / "fa4_selfload_d128_guard"
 )
 
+_SASS_BUILD_DIR = (
+    Path(__file__).resolve().parent / "__mojocache__" / "fa4_selfload_sass"
+)
+
 _WAIT_GROUP_RE = re.compile(r"\bwgmma\.wait_group\.sync\.aligned\b")
 _REFILL_COPY_RE = re.compile(r"\bcp\.async\.bulk\.tensor\b.*mbarrier::complete_tx")
 _EXPECT_TX_RE = re.compile(r"\bmbarrier\.arrive\.expect_tx\b")
+
+# SASS spellings on sm_90a: the wgmma wait is WARPGROUP.DEPBAR.LE gsb0, N
+# (the plain DEPBAR.LE SB0 in the epilogue is the TMA *store* wait, a
+# different scoreboard), and a TMA tile load is UTMALDG.
+_SASS_ADDR_RE = re.compile(r"/\*([0-9a-f]{4,})\*/")
+_SASS_WAIT_RE = re.compile(r"\bWARPGROUP\.DEPBAR\b")
+_SASS_TMA_LOAD_RE = re.compile(r"\bUTMALDG\b")
 
 
 def _build_probe_ptx(out_dir: Path) -> str:
@@ -111,24 +138,102 @@ def selfload_ptx() -> str:
     return _build_probe_ptx(_BUILD_DIR)
 
 
+def _cuda_host_tool(name: str) -> Path | None:
+    """``ptxas``/``nvdisasm`` from PATH, else from the triton wheel.
+
+    Both are host tools that need no GPU. A CUDA-toolkit install puts them
+    on PATH; a torch install without one still ships them inside triton
+    (``triton/backends/nvidia/bin``), which is where this repo's own venv
+    has them.
+    """
+    found = shutil.which(name)
+    if found is not None:
+        return Path(found)
+    try:
+        import triton
+    except ImportError:
+        return None
+    candidate = (
+        Path(triton.__file__).resolve().parent / "backends" / "nvidia" / "bin" / name
+    )
+    return candidate if candidate.exists() else None
+
+
+@pytest.fixture(scope="module")
+def selfload_sass(selfload_ptx: str) -> str:
+    """The kernel's SASS: ptxas-assembled from the same PTX, then disassembled."""
+    ptxas = _cuda_host_tool("ptxas")
+    nvdisasm = _cuda_host_tool("nvdisasm")
+    if ptxas is None or nvdisasm is None:
+        pytest.skip("ptxas/nvdisasm not found (no CUDA toolkit and no triton wheel)")
+    _SASS_BUILD_DIR.mkdir(parents=True, exist_ok=True)
+    ptx_path = _SASS_BUILD_DIR / "fa4_selfload.ptx"
+    ptx_path.write_text(selfload_ptx)
+    cubin_path = _SASS_BUILD_DIR / "fa4_selfload.cubin"
+    assembled = subprocess.run(
+        [str(ptxas), "-arch=sm_90a", "-O3", str(ptx_path), "-o", str(cubin_path)],
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    assert assembled.returncode == 0, (
+        f"ptxas failed on the self-load kernel PTX:\n"
+        f"{assembled.stderr or assembled.stdout}"
+    )
+    disassembled = subprocess.run(
+        [str(nvdisasm), "-c", str(cubin_path)],
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    assert disassembled.returncode == 0, (
+        f"nvdisasm failed on the self-load kernel cubin:\n"
+        f"{disassembled.stderr or disassembled.stdout}"
+    )
+    return disassembled.stdout
+
+
+def _sass_events(
+    sass: str, pattern: re.Pattern[str], kind: str
+) -> list[tuple[int, str]]:
+    """(instruction address, kind) for every SASS line matching `pattern`.
+
+    Keyed on the address nvdisasm prints in each line's ``/*01a0*/``
+    comment rather than on line order: the listing is grouped into basic
+    blocks, and the address is what actually orders the instructions.
+    """
+    events = []
+    for line in sass.splitlines():
+        if not pattern.search(line):
+            continue
+        address = _SASS_ADDR_RE.search(line)
+        if address is None:
+            continue
+        events.append((int(address.group(1), 16), kind))
+    return events
+
+
 def _line_numbers(pattern: re.Pattern[str], text: str) -> list[int]:
     return [i for i, line in enumerate(text.splitlines()) if pattern.search(line)]
 
 
-def _assert_every_event_follows_a_wait(events: list[tuple[int, str]], event_label: str):
-    """Walk (line_no, kind) events in line order: every 'event_label' kind
-    must have a 'wait' kind since the previous 'event_label' (or since the
-    start of the region, for the first one)."""
+def _assert_every_event_follows_a_wait(
+    events: list[tuple[int, str]], event_label: str
+) -> None:
+    """Walk (position, kind) events in position order: every 'event_label'
+    kind must have a 'wait' kind since the previous 'event_label' (or since
+    the start of the region, for the first one). `position` is a PTX line
+    number or a SASS instruction address depending on the caller."""
     waits_since_last_event = 0
     seen_event = 0
-    for _line_no, kind in sorted(events):
+    for position, kind in sorted(events):
         if kind == "wait":
             waits_since_last_event += 1
         else:
             assert waits_since_last_event >= 1, (
-                f"a {event_label} at line {_line_no} has no preceding"
+                f"a {event_label} at {position} has no preceding"
                 " wgmma.wait_group since the previous one (or region start)"
-                " -- the refill was not textually ordered after the wait"
+                " -- the refill was not ordered after the wait"
                 " that proves its slot is free"
             )
             waits_since_last_event = 0
@@ -171,7 +276,35 @@ def test_selfload_refills_follow_their_wait_group(selfload_ptx: str):
     _assert_every_event_follows_a_wait(expect_events, "mbarrier.arrive.expect_tx")
 
 
-def test_selfload_rejects_d128_at_compile_time():
+def test_selfload_refills_follow_their_wait_group_sass(selfload_sass: str) -> None:
+    """Same ordering, one compiler further down: in ptxas-scheduled SASS.
+
+    The PTX test above constrains LLVM only. ptxas re-schedules that PTX
+    into SASS and is not reachable from Mojo source at all -- no clobber,
+    intrinsic or fence we can write is *addressed* to it -- so the only
+    way to know it kept the refill behind its wait is to look. Every
+    ``UTMALDG`` after the first ``WARPGROUP.DEPBAR`` (i.e. every refill;
+    the prologue's initial fill precedes all waits and is excluded, as in
+    the PTX test) must follow a ``WARPGROUP.DEPBAR``.
+    """
+    waits = _sass_events(selfload_sass, _SASS_WAIT_RE, "wait")
+    loads = _sass_events(selfload_sass, _SASS_TMA_LOAD_RE, "refill")
+    assert len(waits) >= 3, (
+        f"expected at least 3 WARPGROUP.DEPBAR sites in the SASS, found"
+        f" {len(waits)} -- did the disassembly reach the kernel body?"
+    )
+    assert len(loads) >= 6, (
+        f"expected at least 6 UTMALDG sites in the SASS (prologue fill plus"
+        f" refills), found {len(loads)}"
+    )
+    first_wait = waits[0][0]
+    events = waits + [
+        (address, kind) for address, kind in loads if address > first_wait
+    ]
+    _assert_every_event_follows_a_wait(events, "UTMALDG refill")
+
+
+def test_selfload_rejects_d128_at_compile_time() -> None:
     """Scope enforcement, not just documentation: instantiating the
     self-loading kernel at head_dim=128 must fail the BUILD (ported from
     agent A2's review artifact, d128_guard_v7.mojo)."""

--- a/tests/test_fa4_selfload_ptx_ordering.py
+++ b/tests/test_fa4_selfload_ptx_ordering.py
@@ -1,21 +1,36 @@
-"""PTX ordering regression check for the self-loading FA4 fwd kernel.
+"""PTX *and SASS* ordering regression check for the self-loading FA4 fwd kernel.
 
 ``fa4_fwd_selfload_kernel.mojo`` deleted the empty[] mbarriers a phase-2b
 producer/consumer split used to prove a ring slot's smem read had retired
 before the next TMA refill into that same slot. The substitute proof is
 program order plus ``wgmma.wait_group`` (see the PREFETCH invariant comment
 next to its definition in that file): the refill's `cp.async.bulk.tensor` /
-`mbarrier.arrive.expect_tx` must be textually emitted AFTER the
-`wgmma.wait_group` that proves the slot is free. That is true of today's
-Mojo/LLVM toolchain, but ``wgmma.wait_group`` carries no LLVM memory
-clobber, so nothing stops a *future* toolchain from reordering a refill
-ahead of its wait -- this test is the regression guard for that drift, not
-a check on this PR's own logic (which the soak in
-``test_fa4_selfload_soak.py`` covers at runtime).
+`mbarrier.arrive.expect_tx` must be emitted AFTER the `wgmma.wait_group`
+that proves the slot is free.
+
+That proof has two compilers in it, and this file checks both:
+
+* **LLVM** decides what the emitted PTX order is. The kernel pins it with
+  ``wgmma_wait_group_ordered`` (`wgmma.wait_group.sync.aligned` carrying a
+  `~{memory}` clobber, which the stdlib's `wgmma_wait_group_sync` does
+  not), and ``test_selfload_refills_follow_their_wait_group`` checks the
+  result in the PTX.
+* **ptxas** decides what the SASS order is, and is reached by nothing we
+  can write in Mojo. ``test_selfload_refills_follow_their_wait_group_sass``
+  assembles the PTX and checks that each ``UTMALDG`` refill still sits
+  after a ``WARPGROUP.DEPBAR``. Without it this file would assert a
+  property one compiler down from the one that matters -- the PTX can be
+  in perfect order while the scheduled machine code is not.
+
+Neither test is a check on the kernel's own logic (the soaks in
+``test_fa4_selfload_soak.py`` cover that at runtime); both are guards
+against toolchain drift.
 
 Cross-compiles with ``mojo build --emit asm --target-accelerator sm_90a``
 (needs no GPU, never touches ``/tmp/gpu_lock_0.lock``) the same way
-``scripts/compare_kernel_asm.py`` does, and greps the emitted PTX.
+``scripts/compare_kernel_asm.py`` does, and greps the emitted PTX. The SASS
+leg needs ``ptxas`` and ``nvdisasm`` -- also host-only tools, needing no
+device -- and skips when neither PATH nor the triton wheel provides them.
 
 Builds land in a STABLE directory (``tests/__mojocache__/...``, matching the
 already-gitignored ``__mojocache__/`` pattern), not a fresh temp dir per run:
@@ -30,6 +45,7 @@ shared directory per specialization, which is load-bearing").
 from __future__ import annotations
 
 import re
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -48,9 +64,20 @@ _D128_GUARD_BUILD_DIR = (
     Path(__file__).resolve().parent / "__mojocache__" / "fa4_selfload_d128_guard"
 )
 
+_SASS_BUILD_DIR = (
+    Path(__file__).resolve().parent / "__mojocache__" / "fa4_selfload_sass"
+)
+
 _WAIT_GROUP_RE = re.compile(r"\bwgmma\.wait_group\.sync\.aligned\b")
 _REFILL_COPY_RE = re.compile(r"\bcp\.async\.bulk\.tensor\b.*mbarrier::complete_tx")
 _EXPECT_TX_RE = re.compile(r"\bmbarrier\.arrive\.expect_tx\b")
+
+# SASS spellings on sm_90a: the wgmma wait is WARPGROUP.DEPBAR.LE gsb0, N
+# (the plain DEPBAR.LE SB0 in the epilogue is the TMA *store* wait, a
+# different scoreboard), and a TMA tile load is UTMALDG.
+_SASS_ADDR_RE = re.compile(r"/\*([0-9a-f]{4,})\*/")
+_SASS_WAIT_RE = re.compile(r"\bWARPGROUP\.DEPBAR\b")
+_SASS_TMA_LOAD_RE = re.compile(r"\bUTMALDG\b")
 
 
 def _build_probe_ptx(out_dir: Path) -> str:
@@ -111,6 +138,81 @@ def selfload_ptx() -> str:
     return _build_probe_ptx(_BUILD_DIR)
 
 
+def _cuda_host_tool(name: str) -> Path | None:
+    """``ptxas``/``nvdisasm`` from PATH, else from the triton wheel.
+
+    Both are host tools that need no GPU. A CUDA-toolkit install puts them
+    on PATH; a torch install without one still ships them inside triton
+    (``triton/backends/nvidia/bin``), which is where this repo's own venv
+    has them.
+    """
+    found = shutil.which(name)
+    if found is not None:
+        return Path(found)
+    try:
+        import triton
+    except ImportError:
+        return None
+    candidate = (
+        Path(triton.__file__).resolve().parent / "backends" / "nvidia" / "bin" / name
+    )
+    return candidate if candidate.exists() else None
+
+
+@pytest.fixture(scope="module")
+def selfload_sass(selfload_ptx: str) -> str:
+    """The kernel's SASS: ptxas-assembled from the same PTX, then disassembled."""
+    ptxas = _cuda_host_tool("ptxas")
+    nvdisasm = _cuda_host_tool("nvdisasm")
+    if ptxas is None or nvdisasm is None:
+        pytest.skip("ptxas/nvdisasm not found (no CUDA toolkit and no triton wheel)")
+    _SASS_BUILD_DIR.mkdir(parents=True, exist_ok=True)
+    ptx_path = _SASS_BUILD_DIR / "fa4_selfload.ptx"
+    ptx_path.write_text(selfload_ptx)
+    cubin_path = _SASS_BUILD_DIR / "fa4_selfload.cubin"
+    assembled = subprocess.run(
+        [str(ptxas), "-arch=sm_90a", "-O3", str(ptx_path), "-o", str(cubin_path)],
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    assert assembled.returncode == 0, (
+        f"ptxas failed on the self-load kernel PTX:\n"
+        f"{assembled.stderr or assembled.stdout}"
+    )
+    disassembled = subprocess.run(
+        [str(nvdisasm), "-c", str(cubin_path)],
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    assert disassembled.returncode == 0, (
+        f"nvdisasm failed on the self-load kernel cubin:\n"
+        f"{disassembled.stderr or disassembled.stdout}"
+    )
+    return disassembled.stdout
+
+
+def _sass_events(
+    sass: str, pattern: re.Pattern[str], kind: str
+) -> list[tuple[int, str]]:
+    """(instruction address, kind) for every SASS line matching `pattern`.
+
+    Keyed on the address nvdisasm prints in each line's ``/*01a0*/``
+    comment rather than on line order: the listing is grouped into basic
+    blocks, and the address is what actually orders the instructions.
+    """
+    events = []
+    for line in sass.splitlines():
+        if not pattern.search(line):
+            continue
+        address = _SASS_ADDR_RE.search(line)
+        if address is None:
+            continue
+        events.append((int(address.group(1), 16), kind))
+    return events
+
+
 def _line_numbers(pattern: re.Pattern[str], text: str) -> list[int]:
     return [i for i, line in enumerate(text.splitlines()) if pattern.search(line)]
 
@@ -118,19 +220,20 @@ def _line_numbers(pattern: re.Pattern[str], text: str) -> list[int]:
 def _assert_every_event_follows_a_wait(
     events: list[tuple[int, str]], event_label: str
 ) -> None:
-    """Walk (line_no, kind) events in line order: every 'event_label' kind
-    must have a 'wait' kind since the previous 'event_label' (or since the
-    start of the region, for the first one)."""
+    """Walk (position, kind) events in position order: every 'event_label'
+    kind must have a 'wait' kind since the previous 'event_label' (or since
+    the start of the region, for the first one). `position` is a PTX line
+    number or a SASS instruction address depending on the caller."""
     waits_since_last_event = 0
     seen_event = 0
-    for _line_no, kind in sorted(events):
+    for position, kind in sorted(events):
         if kind == "wait":
             waits_since_last_event += 1
         else:
             assert waits_since_last_event >= 1, (
-                f"a {event_label} at line {_line_no} has no preceding"
+                f"a {event_label} at {position} has no preceding"
                 " wgmma.wait_group since the previous one (or region start)"
-                " -- the refill was not textually ordered after the wait"
+                " -- the refill was not ordered after the wait"
                 " that proves its slot is free"
             )
             waits_since_last_event = 0
@@ -171,6 +274,34 @@ def test_selfload_refills_follow_their_wait_group(selfload_ptx: str) -> None:
         (line, "expect_tx") for line in expect_lines if line > first_wait
     ]
     _assert_every_event_follows_a_wait(expect_events, "mbarrier.arrive.expect_tx")
+
+
+def test_selfload_refills_follow_their_wait_group_sass(selfload_sass: str) -> None:
+    """Same ordering, one compiler further down: in ptxas-scheduled SASS.
+
+    The PTX test above constrains LLVM only. ptxas re-schedules that PTX
+    into SASS and is not reachable from Mojo source at all -- no clobber,
+    intrinsic or fence we can write is *addressed* to it -- so the only
+    way to know it kept the refill behind its wait is to look. Every
+    ``UTMALDG`` after the first ``WARPGROUP.DEPBAR`` (i.e. every refill;
+    the prologue's initial fill precedes all waits and is excluded, as in
+    the PTX test) must follow a ``WARPGROUP.DEPBAR``.
+    """
+    waits = _sass_events(selfload_sass, _SASS_WAIT_RE, "wait")
+    loads = _sass_events(selfload_sass, _SASS_TMA_LOAD_RE, "refill")
+    assert len(waits) >= 3, (
+        f"expected at least 3 WARPGROUP.DEPBAR sites in the SASS, found"
+        f" {len(waits)} -- did the disassembly reach the kernel body?"
+    )
+    assert len(loads) >= 6, (
+        f"expected at least 6 UTMALDG sites in the SASS (prologue fill plus"
+        f" refills), found {len(loads)}"
+    )
+    first_wait = waits[0][0]
+    events = waits + [
+        (address, kind) for address, kind in loads if address > first_wait
+    ]
+    _assert_every_event_follows_a_wait(events, "UTMALDG refill")
 
 
 def test_selfload_rejects_d128_at_compile_time() -> None:

--- a/tests/test_fa4_selfload_ptx_ordering.py
+++ b/tests/test_fa4_selfload_ptx_ordering.py
@@ -150,7 +150,7 @@ def _cuda_host_tool(name: str) -> Path | None:
     if found is not None:
         return Path(found)
     try:
-        import triton
+        import triton  # noqa: PLC0415 -- optional: the CPU-only torch install may lack it
     except ImportError:
         return None
     candidate = (

--- a/tests/test_fa4_selfload_soak.py
+++ b/tests/test_fa4_selfload_soak.py
@@ -41,6 +41,7 @@ from torch.profiler import ProfilerActivity, profile
 
 from scripts.compare_kernel_asm import build_env, mojo_cli
 from torch_mojo_backend import get_accelerators
+from torch_mojo_backend.mojo_device import torch_mojo_device_module
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _PROBE = Path(__file__).resolve().parent / "fa4_selfload_soak_probe.mojo"
@@ -127,7 +128,7 @@ def _device_kernel_names(run: Callable[[], object]) -> set[str]:
     """Names of the device kernels `run` launches, per torch.profiler."""
     with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:
         run()
-        torch.mojo.synchronize()
+        torch_mojo_device_module.synchronize()
     return {
         event.name
         for event in prof.events()

--- a/tests/test_fa4_selfload_soak.py
+++ b/tests/test_fa4_selfload_soak.py
@@ -1,5 +1,8 @@
-"""Race regression soak for the self-loading FA4 fwd kernel (CI-lite).
+"""Race regression soaks for the self-loading FA4 fwd kernel (CI-lite).
 
+Two of them, at two levels:
+
+``test_selfload_soak_no_race`` drives the kernel through its Mojo launcher.
 Ported from agent A's phase-2c harness
 (``/scratch/fa4-fwd-harness-2c/soak_v7.mojo``), shortened to two shapes and
 fewer reps for the permanent suite: bursts of back-to-back self-load kernel
@@ -11,14 +14,30 @@ clock pins) stays in the harness; see ``tests/fa4_selfload_soak_probe.mojo``
 for what this CI-lite variant covers and why (the PREFETCH invariant this
 guards is documented next to its definition in
 ``fa4_fwd_selfload_kernel.mojo``).
+
+``test_selfload_bhsd_production_soak`` drives the SAME kernel through the
+route a user actually reaches: ``F.scaled_dot_product_attention`` on
+contiguous (B, H, S, D) mojo tensors, which is the ONLY way into this
+kernel (``fa4_ops.mojo``'s bhsd entry points, above the wave gate; the
+launcher hardcodes ``bhsd=True``, so a strided/fused-qkv model such as
+nanoGPT never lands here at all and this is the layout that does). It
+proves the route with the profiler instead of assuming it, and it runs
+longer than the Mojo probe because it is cheap: each launch is ~66us on an
+H100, so the whole thing is a few seconds. ``FA4_SELFLOAD_SOAK_REPS`` in
+the environment turns it up for a deliberate stress run.
 """
 
 from __future__ import annotations
 
+import os
 import subprocess
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
+import torch
+import torch.nn.functional as F
+from torch.profiler import ProfilerActivity, profile
 
 from scripts.compare_kernel_asm import build_env, mojo_cli
 from torch_mojo_backend import get_accelerators
@@ -27,9 +46,24 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 _PROBE = Path(__file__).resolve().parent / "fa4_selfload_soak_probe.mojo"
 _FA4_DIR = _REPO_ROOT / "torch_mojo_backend" / "eager_flash_attention"
 
+# (batch, heads, seqlen) at head_dim 64, causal, bf16. Both clear the
+# self-load wave gate (>= 2 waves of 3 CTAs/SM) on every H100 SKU: at 114
+# SMs they are 4.4 and 3.3 waves, at 132 SMs 3.8 and 2.8 -- and the test
+# asserts the route rather than trusting that arithmetic. The second shape
+# is deliberately awkward: 1608 is not a multiple of BM=64, so its last
+# m-tile is partial and the epilogue takes the clamped-store path, and
+# 11 heads is coprime with everything in the scheduler's swizzle.
+_PROD_SHAPES: tuple[tuple[int, int, int], ...] = ((8, 12, 1024), (4, 11, 1608))
+# Launches per burst with NO sync between them: consecutive kernels' CTAs
+# stay co-resident, which is the schedule perturbation the soak is for.
+_PROD_BURST = 8
+_PROD_REPS = int(os.environ.get("FA4_SELFLOAD_SOAK_REPS", "12"))
+# torch.profiler reports the mojo-device kernels under the PrivateUse1
+# backend (same list bench_lib/measure.py uses).
+_DEVICE_EVENT_TYPES = ("DeviceType.CUDA", "DeviceType.PrivateUse1")
 
-@pytest.fixture(scope="module")
-def selfload_soak_binary(tmp_path_factory: pytest.TempPathFactory) -> Path:
+
+def _require_sm90a() -> None:
     accelerators = list(get_accelerators())
     if (
         not accelerators
@@ -37,6 +71,11 @@ def selfload_soak_binary(tmp_path_factory: pytest.TempPathFactory) -> Path:
         or (accelerators[0].architecture_name != "sm_90a")
     ):
         pytest.skip("the self-load FA4 fwd kernel is H100 (sm_90a) only")
+
+
+@pytest.fixture(scope="module")
+def selfload_soak_binary(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    _require_sm90a()
     try:
         mojo = mojo_cli()
     except FileNotFoundError:
@@ -82,3 +121,69 @@ def test_selfload_soak_no_race(selfload_soak_binary: Path):
     output = result.stdout + result.stderr
     assert result.returncode == 0, f"self-load soak failed:\n{output}"
     assert "SOAK PASS" in output, f"self-load soak did not report PASS:\n{output}"
+
+
+def _device_kernel_names(run: Callable[[], object]) -> set[str]:
+    """Names of the device kernels `run` launches, per torch.profiler."""
+    with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:
+        run()
+        torch.mojo.synchronize()
+    return {
+        event.name
+        for event in prof.events()
+        if str(event.device_type) in _DEVICE_EVENT_TYPES
+    }
+
+
+@pytest.mark.parametrize("shape", _PROD_SHAPES, ids=lambda s: "B{}H{}S{}D64".format(*s))
+def test_selfload_bhsd_production_soak(
+    shape: tuple[int, int, int], mojo_gpu: str
+) -> None:
+    """The reachable-in-production path: contiguous BHSD SDPA, soaked.
+
+    Every launch is checked bitwise against the first one (this kernel is
+    deterministic by construction -- no atomics, no split-K -- so a single
+    moved bit IS a race) and, once, against a CPU float32 reference so a
+    corruption that happened to be bitwise-stable would still show.
+    """
+    _require_sm90a()
+    batch, heads, seqlen = shape
+    device = torch.device(mojo_gpu)
+    torch.manual_seed(0xFA4)
+    host = [
+        torch.randn(batch, heads, seqlen, 64, dtype=torch.bfloat16) for _ in range(3)
+    ]
+    q, k, v = (tensor.to(device) for tensor in host)
+    assert q.is_contiguous() and k.is_contiguous() and v.is_contiguous()
+
+    def attend() -> torch.Tensor:
+        return F.scaled_dot_product_attention(q, k, v, is_causal=True)
+
+    # Prove the route instead of assuming the wave gate: this soak is
+    # worthless if the shape quietly dispatched to the phase-2b kernel.
+    kernels = _device_kernel_names(attend)
+    assert any("selfload" in name for name in kernels), (
+        f"the contiguous-BHSD SDPA call did not run the self-load kernel"
+        f" (device kernels seen: {sorted(kernels)}) -- either the wave gate"
+        " in fa4_ops.mojo moved or this shape no longer reaches it"
+    )
+
+    gold = attend().cpu()
+    reference = F.scaled_dot_product_attention(
+        host[0].float(), host[1].float(), host[2].float(), is_causal=True
+    )
+    # bf16 rounding of the output only; the same tolerance the Mojo probe
+    # uses against the phase-2b kernel.
+    assert (gold.float() - reference).abs().max().item() < 0.05
+
+    for rep in range(_PROD_REPS):
+        burst = [attend() for _ in range(_PROD_BURST)]
+        for index, out in enumerate(burst):
+            assert torch.equal(out.cpu(), gold), (
+                f"self-load output moved on rep {rep}, burst slot {index}"
+                f" (shape B{batch} H{heads} S{seqlen} D64): this kernel is"
+                " deterministic, so a differing bit is a race -- most likely"
+                " a TMA refill overtaking the wgmma.wait_group that frees"
+                " its ring slot (see fa4_fwd_selfload_kernel.mojo's PREFETCH"
+                " invariant)"
+            )

--- a/tests/test_fa4_selfload_soak.py
+++ b/tests/test_fa4_selfload_soak.py
@@ -1,5 +1,8 @@
-"""Race regression soak for the self-loading FA4 fwd kernel (CI-lite).
+"""Race regression soaks for the self-loading FA4 fwd kernel (CI-lite).
 
+Two of them, at two levels:
+
+``test_selfload_soak_no_race`` drives the kernel through its Mojo launcher.
 Ported from agent A's phase-2c harness
 (``/scratch/fa4-fwd-harness-2c/soak_v7.mojo``), shortened to two shapes and
 fewer reps for the permanent suite: bursts of back-to-back self-load kernel
@@ -11,14 +14,30 @@ clock pins) stays in the harness; see ``tests/fa4_selfload_soak_probe.mojo``
 for what this CI-lite variant covers and why (the PREFETCH invariant this
 guards is documented next to its definition in
 ``fa4_fwd_selfload_kernel.mojo``).
+
+``test_selfload_bhsd_production_soak`` drives the SAME kernel through the
+route a user actually reaches: ``F.scaled_dot_product_attention`` on
+contiguous (B, H, S, D) mojo tensors, which is the ONLY way into this
+kernel (``fa4_ops.mojo``'s bhsd entry points, above the wave gate; the
+launcher hardcodes ``bhsd=True``, so a strided/fused-qkv model such as
+nanoGPT never lands here at all and this is the layout that does). It
+proves the route with the profiler instead of assuming it, and it runs
+longer than the Mojo probe because it is cheap: each launch is ~66us on an
+H100, so the whole thing is a few seconds. ``FA4_SELFLOAD_SOAK_REPS`` in
+the environment turns it up for a deliberate stress run.
 """
 
 from __future__ import annotations
 
+import os
 import subprocess
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
+import torch
+import torch.nn.functional as F
+from torch.profiler import ProfilerActivity, profile
 
 from scripts.compare_kernel_asm import build_env, mojo_cli
 from torch_mojo_backend import get_accelerators
@@ -27,9 +46,24 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 _PROBE = Path(__file__).resolve().parent / "fa4_selfload_soak_probe.mojo"
 _FA4_DIR = _REPO_ROOT / "torch_mojo_backend" / "eager_flash_attention"
 
+# (batch, heads, seqlen) at head_dim 64, causal, bf16. Both clear the
+# self-load wave gate (>= 2 waves of 3 CTAs/SM) on every H100 SKU: at 114
+# SMs they are 4.4 and 3.3 waves, at 132 SMs 3.8 and 2.8 -- and the test
+# asserts the route rather than trusting that arithmetic. The second shape
+# is deliberately awkward: 1608 is not a multiple of BM=64, so its last
+# m-tile is partial and the epilogue takes the clamped-store path, and
+# 11 heads is coprime with everything in the scheduler's swizzle.
+_PROD_SHAPES: tuple[tuple[int, int, int], ...] = ((8, 12, 1024), (4, 11, 1608))
+# Launches per burst with NO sync between them: consecutive kernels' CTAs
+# stay co-resident, which is the schedule perturbation the soak is for.
+_PROD_BURST = 8
+_PROD_REPS = int(os.environ.get("FA4_SELFLOAD_SOAK_REPS", "12"))
+# torch.profiler reports the mojo-device kernels under the PrivateUse1
+# backend (same list bench_lib/measure.py uses).
+_DEVICE_EVENT_TYPES = ("DeviceType.CUDA", "DeviceType.PrivateUse1")
 
-@pytest.fixture(scope="module")
-def selfload_soak_binary(tmp_path_factory: pytest.TempPathFactory) -> Path:
+
+def _require_sm90a() -> None:
     accelerators = list(get_accelerators())
     if (
         not accelerators
@@ -37,6 +71,11 @@ def selfload_soak_binary(tmp_path_factory: pytest.TempPathFactory) -> Path:
         or (accelerators[0].architecture_name != "sm_90a")
     ):
         pytest.skip("the self-load FA4 fwd kernel is H100 (sm_90a) only")
+
+
+@pytest.fixture(scope="module")
+def selfload_soak_binary(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    _require_sm90a()
     try:
         mojo = mojo_cli()
     except FileNotFoundError:
@@ -82,3 +121,69 @@ def test_selfload_soak_no_race(selfload_soak_binary: Path) -> None:
     output = result.stdout + result.stderr
     assert result.returncode == 0, f"self-load soak failed:\n{output}"
     assert "SOAK PASS" in output, f"self-load soak did not report PASS:\n{output}"
+
+
+def _device_kernel_names(run: Callable[[], object]) -> set[str]:
+    """Names of the device kernels `run` launches, per torch.profiler."""
+    with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:
+        run()
+        torch.mojo.synchronize()
+    return {
+        event.name
+        for event in prof.events()
+        if str(event.device_type) in _DEVICE_EVENT_TYPES
+    }
+
+
+@pytest.mark.parametrize("shape", _PROD_SHAPES, ids=lambda s: "B{}H{}S{}D64".format(*s))
+def test_selfload_bhsd_production_soak(
+    shape: tuple[int, int, int], mojo_gpu: str
+) -> None:
+    """The reachable-in-production path: contiguous BHSD SDPA, soaked.
+
+    Every launch is checked bitwise against the first one (this kernel is
+    deterministic by construction -- no atomics, no split-K -- so a single
+    moved bit IS a race) and, once, against a CPU float32 reference so a
+    corruption that happened to be bitwise-stable would still show.
+    """
+    _require_sm90a()
+    batch, heads, seqlen = shape
+    device = torch.device(mojo_gpu)
+    torch.manual_seed(0xFA4)
+    host = [
+        torch.randn(batch, heads, seqlen, 64, dtype=torch.bfloat16) for _ in range(3)
+    ]
+    q, k, v = (tensor.to(device) for tensor in host)
+    assert q.is_contiguous() and k.is_contiguous() and v.is_contiguous()
+
+    def attend() -> torch.Tensor:
+        return F.scaled_dot_product_attention(q, k, v, is_causal=True)
+
+    # Prove the route instead of assuming the wave gate: this soak is
+    # worthless if the shape quietly dispatched to the phase-2b kernel.
+    kernels = _device_kernel_names(attend)
+    assert any("selfload" in name for name in kernels), (
+        f"the contiguous-BHSD SDPA call did not run the self-load kernel"
+        f" (device kernels seen: {sorted(kernels)}) -- either the wave gate"
+        " in fa4_ops.mojo moved or this shape no longer reaches it"
+    )
+
+    gold = attend().cpu()
+    reference = F.scaled_dot_product_attention(
+        host[0].float(), host[1].float(), host[2].float(), is_causal=True
+    )
+    # bf16 rounding of the output only; the same tolerance the Mojo probe
+    # uses against the phase-2b kernel.
+    assert (gold.float() - reference).abs().max().item() < 0.05
+
+    for rep in range(_PROD_REPS):
+        burst = [attend() for _ in range(_PROD_BURST)]
+        for index, out in enumerate(burst):
+            assert torch.equal(out.cpu(), gold), (
+                f"self-load output moved on rep {rep}, burst slot {index}"
+                f" (shape B{batch} H{heads} S{seqlen} D64): this kernel is"
+                " deterministic, so a differing bit is a race -- most likely"
+                " a TMA refill overtaking the wgmma.wait_group that frees"
+                " its ring slot (see fa4_fwd_selfload_kernel.mojo's PREFETCH"
+                " invariant)"
+            )

--- a/torch_mojo_backend/eager_flash_attention/fa4_fwd_selfload_kernel.mojo
+++ b/torch_mojo_backend/eager_flash_attention/fa4_fwd_selfload_kernel.mojo
@@ -65,7 +65,7 @@ the RS wgmma walks fragments k-major, `a_frags[m + k*num_m]`.)
 
 from std.math import exp2, log, tanh
 from std.math.constants import log2e
-from std.sys import size_of
+from std.sys import inlined_assembly, size_of
 from std.utils.index import StaticTuple, IndexList
 
 from max.gpu.sync import barrier
@@ -103,6 +103,67 @@ from fa4_fwd_selfload_common import (
 
 comptime WGMMA_M: Int = 64
 comptime WGMMA_K: Int = 16
+
+
+@always_inline
+def wgmma_wait_group_ordered[group: Int = 0]():
+    """`wgmma.wait_group.sync.aligned` that is also a COMPILER ordering point.
+
+    Identical PTX to the stdlib's `wgmma_wait_group_sync` (same one
+    instruction, zero extra cost) with one addition: `~{memory}` in the
+    constraint string, so LLVM is told the wait may read and write memory
+    and may not move memory operations across it.
+
+    Why this kernel needs that and the stdlib call does not suffice.
+    This kernel has no empty[] mbarriers: the proof that a ring slot's
+    reader has retired before the TMA refills that slot is
+    `wgmma.wait_group` plus PROGRAM ORDER (see the PREFETCH invariant
+    comment in the kernel body). The PTX ISA backs that proof:
+
+      * "The wgmma.mma_async operations are performed in the asynchronous
+        proxy (or async proxy)" (PTX ISA 9.7.16.4), and TMA
+        (`cp.async.bulk.tensor`) writes are async-proxy too -- so this is
+        an async->async write-after-read, NOT a proxy crossing.
+        `fence.proxy.async` (what `fence_async_view_proxy()` emits) is
+        defined only "between the async proxy and the generic proxy"
+        (9.7.14.4), so it is the wrong instrument here and would order
+        nothing: it is deliberately NOT used at the refill sites.
+      * "Once the wgmma-group completes, all the wgmma.mma_async
+        operations have been performed and completed" (9.7.16) -- the
+        reads are done when the wait returns.
+      * "These asynchronous operations are ordered after prior
+        instructions in the same thread" (8.9.1.1, and cp.async.bulk is
+        not among the exceptions) -- the refill cannot start before the
+        wait that precedes it.
+
+    Every link in that chain is a statement about the order the two
+    instructions appear in, which is exactly the property the compiler is
+    free to change: the stdlib's `wgmma_wait_group_sync` is
+    `inlined_assembly[..., constraints="n"]` (max/mojo/max/gpu/compute/
+    mma.mojo), i.e. `has_side_effect=True` but NO memory clobber, and so
+    is the TMA copy asm it must stay ordered against
+    (`cp_async_bulk_tensor_shared_cluster_global`, max/mojo/max/gpu/
+    memory/memory.mojo). Today both are side-effecting asm and LLVM keeps
+    side-effecting asm in relative order, which is why the emitted PTX is
+    correct -- but that is a property of the current toolchain, not a
+    contract it owes us. The clobber makes it a contract, for free, and
+    it is the same idiom the modular repo itself documents as a "hard
+    reordering barrier" (has_side_effect=True + `~{memory}`, see
+    max/kernels/src/nn/attention/gpu/amd_structured/mha_prefill_v2.mojo).
+
+    ptxas is the other half and cannot be reached from here: it is
+    covered by asserting the SASS (not just the PTX) in
+    tests/test_fa4_selfload_ptx_ordering.py.
+
+    Parameters:
+        group: Number of most recent wgmma-groups allowed to stay pending.
+    """
+    inlined_assembly[
+        "wgmma.wait_group.sync.aligned $0;",
+        NoneType,
+        constraints="n,~{memory}",
+        has_side_effect=True,
+    ](group)
 
 
 @__llvm_metadata(
@@ -195,16 +256,23 @@ def fwd_fa4_selfload_kernel[
     # sites' `it + PREFETCH` / `pf < kv_trips` offsets to match) breaks
     # the slot arithmetic silently: the refill would target a slot a
     # DIFFERENT in-flight tile still owns, which is a write-after-read
-    # race with no barrier left to catch it -- Mojo's `wgmma.wait_group`
-    # is not annotated with an LLVM memory clobber, so nothing but this
-    # invariant (and the PTX-ordering regression test that checks it,
-    # tests/test_fa4_selfload_ptx_ordering.py) stops a future toolchain
-    # from reordering a refill's `cp.async.bulk.tensor` ahead of the
-    # `wgmma.wait_group` that proves the slot is free. Failure mode if
-    # violated: silent corruption (wrong output, no error, no crash) --
-    # see tests/test_fa4_selfload_soak.py, ported from the phase-2c
-    # harness's soak_v7.mojo, which stresses exactly this window with
-    # back-to-back launches and no inter-launch sync.
+    # race with no barrier left to catch it. Failure mode if violated:
+    # silent corruption (wrong output, no error, no crash) -- see
+    # tests/test_fa4_selfload_soak.py, ported from the phase-2c harness's
+    # soak_v7.mojo, which stresses exactly this window with back-to-back
+    # launches and no inter-launch sync.
+    #
+    # The other half of the proof is that the refill really is EMITTED
+    # after the wait. That is a program-order property, so it is the
+    # compiler's to break, and the stdlib's `wgmma.wait_group` asm
+    # declares no memory clobber; the refill-gating waits below therefore
+    # go through `wgmma_wait_group_ordered` (same single instruction,
+    # plus `~{memory}`) instead -- see its docstring for the PTX ISA
+    # chain this pins down, and why a `fence.proxy.async` is NOT the
+    # instrument (async->async write-after-read: that fence is defined
+    # only across the generic/async boundary). The regression guards are
+    # tests/test_fa4_selfload_ptx_ordering.py, which checks the emitted
+    # PTX *and* the ptxas-scheduled SASS, and the soak above.
     #
     # The "consumer refills its own slot after its own retirement proof"
     # pattern is the same one warp-specialized GEMM mainloops use for
@@ -225,6 +293,21 @@ def fwd_fa4_selfload_kernel[
     # say anything about a paired smem consumer/producer schedule being
     # safe, so those three call sites (not the ISA text alone) are what
     # back the claim that this pattern is correct.
+    #
+    # READ THOSE THREE PRECEDENTS CAREFULLY, because all three ALSO have
+    # an mbarrier release/acquire pair where this kernel has nothing, and
+    # that difference looks alarming until you see what the pair is for.
+    # In every one of them the thread that refills the slot is in a
+    # DIFFERENT warp from the threads whose wgmma read it, so the arrive/
+    # wait pair is how the refilling thread LEARNS the read retired; the
+    # proof that it retired is `wgmma.wait_group` on the consumer side,
+    # exactly as here (CUTLASS says so at the call site: "Wait on the
+    # GMMA barrier for K_PIPE_MMAS (or fewer) outstanding to ensure
+    # smem_pipe_write is consumed"). This CTA is ONE warpgroup: the
+    # thread that refills is one of the threads that waited, so there is
+    # no second party to inform and the pair would carry no information.
+    # What it would carry is ordering, and that comes instead from the
+    # PTX ISA chain in `wgmma_wait_group_ordered`'s docstring.
     comptime PREFETCH: Int = STAGES // 2
     comptime accum_type: DType = DType.float32
     comptime swizzle: TensorMapSwizzle = TensorMapSwizzle.SWIZZLE_128B
@@ -917,7 +1000,10 @@ def fwd_fa4_selfload_kernel[
         q_smem, k_tile(0), s_reg, wg
     )
     wgmma_qk.commit_group()
-    wgmma_qk.wait_group()
+    # Refill-gating wait: `wgmma_wait_group_ordered`, not the stdlib's
+    # `wgmma_qk.wait_group()`, so the refill below cannot be moved above
+    # it (see the helper's docstring).
+    wgmma_wait_group_ordered()
     warpgroup_fence(s_reg)
     # K(0)'s slot (0) is free: refill it with K(PREFETCH). 2*PREFETCH
     # == STAGES, so that tile's slot IS slot 0 (see the PREFETCH
@@ -1003,7 +1089,8 @@ def fwd_fa4_selfload_kernel[
             )
 
         # QK(n+1) retired (PV(n) still running on the tensor core).
-        wgmma_qk.wait_group[1]()
+        # Refill-gating wait -- memory-clobbering variant (see the helper).
+        wgmma_wait_group_ordered[1]()
         warpgroup_fence(s_reg)
         # QK(it+1) has retired for the whole warpgroup -> K(it+1)'s slot
         # is free for the tile PREFETCH trips later (same slot; see the
@@ -1042,7 +1129,8 @@ def fwd_fa4_selfload_kernel[
         softmax_block(loop_diag, loop_lead)
 
         # PV(n) retired: p_reg and o_reg are safe to touch.
-        wgmma_pv.wait_group[0]()
+        # Refill-gating wait -- memory-clobbering variant (see the helper).
+        wgmma_wait_group_ordered[0]()
         warpgroup_fence(o_reg)
         if thread_idx.x == 0:
             var v_next: Int = it + PREFETCH
@@ -1070,7 +1158,15 @@ def fwd_fa4_selfload_kernel[
     wgmma_pv.arrive()
     pv_gemm(v_slot)
     wgmma_pv.commit_group()
-    wgmma_pv.wait_group[0]()
+    # Same memory-clobbering wait: what follows is not a TMA refill but the
+    # O epilogue staging its c-frags into the DEAD Q tile -- plain
+    # (generic-proxy) shared-memory stores into the exact smem the QK
+    # wgmmas were reading. Same write-after-read shape, same reliance on
+    # "the wait retired the readers, and the stores come after it in
+    # program order", and plain stores are freer to move than the refill's
+    # side-effecting asm is, so this site wants the clobber at least as
+    # much as the three above.
+    wgmma_wait_group_ordered[0]()
     warpgroup_fence(o_reg)
 
     # ---- Normalize (reciprocal; one div per row) and store.


### PR DESCRIPTION
An adversarial review of the self-loading FA4 forward kernel (from an unrelated training-divergence investigation) cleared its ring/phase/ABA/warp-skew logic — issue-set == wait-set for kv_trips 1..8, exact phase parity, no in-flight TMA at CTA exit on small-kv_trips tails, `SCHED_BAR` comptime-dead at NWG=1 — and found one open question. This PR answers it, and hardens the one thing that was genuinely unpinned.

## The gap as reported

`fa4_fwd_selfload_kernel.mojo` deleted the `empty[]` mbarriers of the phase-2b producer/consumer split. The substitute proof that a ring slot's readers retired before the TMA refills that same slot is `wgmma.wait_group` plus program order, at two sites:

| wait | refill |
| --- | --- |
| `:1005` `wgmma_qk.wait_group[1]()` | `:1010-1013` `issue_k(k_next, k_slot)` |
| `:1045` `wgmma_pv.wait_group[0]()` | `:1047-1050` `issue_v(v_next, v_slot)` |

(plus the prologue's `wait_group()` → `issue_k(PREFETCH, 0)`).

Between them sits only same-thread program order. The intervening `warpgroup_fence(s_reg)` / `warpgroup_fence(o_reg)` is not the missing piece: it is a **register** dependency fence on the accumulator (`wgmma.fence`), not a memory fence. All three precedents the design was justified against — CUTLASS `sm90_mma_tma_gmma_ss.hpp`, FlashAttention-3's mainloop, MAX's own SM90 GEMM mainloop — have an mbarrier release/acquire pair at that transition and this kernel has nothing.

Compounding it: `wgmma_wait_group_sync` (`/root/modular/max/mojo/max/gpu/compute/mma.mojo:620`) is

```mojo
inlined_assembly["wgmma.wait_group.sync.aligned $0;", NoneType, constraints="n"](group)
```

— `has_side_effect=True` by default but **no `~{memory}` clobber**, so the existing PTX-ordering regression test can pass while saying nothing about what ptxas does at SASS level.

## What the ISA says (and why no fence is added)

Quoting the PTX ISA (v9.3):

* **9.7.16.4:** "The wgmma.mma_async operations are performed in the asynchronous proxy (or async proxy)." TMA writes are async-proxy as well, so the hazard here is **async → async** write-after-read, not a proxy crossing.
* **9.7.14.4:** for `fence.proxy.async`, "the memory ordering is established between the async proxy and the generic proxy." There is no statement anywhere that it orders async against async.

So `fence.proxy.async.shared::cta` — what `fence_async_view_proxy()` emits, and the instruction the brief suspected — is defined for exactly the pair we do not have. Inserting it at the refill sites would be a no-op with respect to this hazard, at the price of two extra `FENCE.VIEW.ASYNC.S` in the inner loop. **This PR deliberately does not add it.** (The kernel's existing `fence_async_view_proxy()` in the epilogue is correct and untouched: there it fences generic-proxy stores before an async-proxy TMA *store* reads them — the direction the instruction is for.)

What does hold:

* **9.7.16:** "Once the wgmma-group completes, all the wgmma.mma_async operations have been performed and completed" — the reads are done when the wait returns, and wgmma-groups are per-warpgroup with `.sync.aligned` covering all 128 threads.
* **8.9.1.1:** asynchronous operations "are ordered after prior instructions in the same thread (except in the case of wgmma.mma_async)" — `cp.async.bulk` is not among the exceptions, so the refill cannot be initiated before the wait that precedes it.

**And the three precedents do not contradict this.** In all three, the thread that refills is in a different warp from the threads whose wgmma read the slot, so the mbarrier pair is how the refiller *learns* the read retired; the proof that it retired is the same `wgmma.wait_group` we use. CUTLASS says so at the call site (`sm90_mma_tma_gmma_ss.hpp:493-505`):

```cpp
/// Wait on the GMMA barrier for K_PIPE_MMAS (or fewer) outstanding to ensure smem_pipe_write is consumed
warpgroup_wait<K_PIPE_MMAS>();
warpgroup_fence_operand(accum);
pipeline.consumer_release(smem_pipe_release);  // UNLOCK wr stage, done _computing_ on it
...
if (warp_idx == 0 && lane_predicate == 1 && (k_tile_count_tma > 0) ) {
  pipeline.producer_acquire(smem_pipe_write);  // LOCK wr stage, for _writing_
```

FA3 is the same shape (`warpgroup_wait<0>(); pipeline_k.consumer_release(...)`), and MAX's SM90 mainloop reduces to `wgmma_op.wait_group()` followed by `stage.arrive()` on the empty mbarrier. A grep of the whole modular repo finds **no** proxy fence between a wgmma wait and a subsequent TMA load into the same buffer, anywhere — consistent with the async-proxy reading above.

This CTA is one warpgroup: the thread that refills is one of the threads that waited. There is no second party to inform, so re-adding the mbarrier pair would carry no information — only ordering, which the ISA chain above already provides.

## What actually needed fixing

Every link in that chain is a statement about the order the two instructions **appear in**, which is precisely the property a compiler is free to change — and neither side declares memory effects: the stdlib wait is `constraints="n"`, and `cp_async_bulk_tensor_shared_cluster_global` (the TMA copy, `max/mojo/max/gpu/memory/memory.mojo`) is likewise side-effecting asm with no clobber. Today LLVM keeps side-effecting asm in relative order, which is why the emitted PTX is correct. That is a property of this toolchain, not a contract it owes us.

The refill-gating waits now go through a local `wgmma_wait_group_ordered[N]()` — the same single instruction plus `~{memory}` — which makes it a contract. It is the idiom the modular repo itself documents as a "hard reordering barrier" (`mha_prefill_v2.mojo:180-183`).

The epilogue wait takes it too: what follows there is not a refill but the O staging writing its c-frags into the **dead Q tile** — plain generic-proxy smem stores into the exact memory the QK wgmmas were reading. Same write-after-read shape, and plain stores are freer to move than the refill's side-effecting asm is.

`ptxas` is the other half and is reachable from no Mojo construct; it is covered by the test below instead.

## Cost: zero, verified byte-for-byte

The change adds no instruction. All **24** FA4 kernels (fwd phase-2b at every specialization, bwd, and the self-load kernel) cross-compile to **byte-identical sm_90a PTX** before and after (mangling hash masked; the self-load kernel is identical including its hash). A marker build proved the comparison is live: adding one instruction to the same asm string changes the PTX as expected.

`benchmarks/test_attention.py` was run anyway — all 20 nodes pass, every D64 case inside the ±8% dead band, so no baseline moves and `baselines.html` is untouched:

| case (B8H12S1024D64) | baseline | measured |
| --- | --- | --- |
| `scaled_dot_product_attention` bf16 / f16 | 0.912 / 0.915 | 0.914 / 0.913 |
| `_scaled_dot_product_flash_attention` bf16 / f16 | 0.558 / 0.553 | 0.555 / 0.555 |
| `_scaled_dot_product_efficient_attention` bf16 / f16 | 0.308 / 0.310 | 0.309 / 0.306 |
| `_scaled_dot_product_attention_math` bf16 / f32 | 0.171 / 0.757 | 0.171 / 0.761 |
| `_scaled_dot_product_flash_attention_backward` bf16 / f16 | 0.716 / 0.764 | 0.755 / 0.757 |

(All ±0.3% measurement uncertainty. The backward is forward-independent and untouched; its +5.4% bf16 reading is baseline noise inside the dead band.)

`amdgpu:gfx942` cross-builds the FA4 extension identically before and after — the same instantiation failures at the same sites (FA4 is Hopper-only and never built for AMD).

## Why no failure was ever observed, and who is exposed

2048-launch soaks at three clock regimes were bit-clean, and today's emitted code is correct at both levels — I checked the SASS directly: `WARPGROUP.DEPBAR` then `UTMALDG`, at all three refill sites. So this is hardening, not a bug fix.

Exposure, if a future toolchain did reorder: silent corruption (wrong output, no error, no crash) for **any model producing genuinely contiguous (B,H,S,D) q/k/v at head_dim 64, causal, with ≥2 self-load waves** — the common case for architectures with separate q/k/v projections. Unaffected: models whose q/k/v are non-contiguous views of a fused projection (nanoGPT and most GPT-2-style `c_attn`), which never reach this kernel at all.

## Tests

* **`test_selfload_refills_follow_their_wait_group_sass`** (new). The existing test asserted PTX order, which constrains LLVM only. The new one assembles that same PTX with `ptxas` and disassembles it with `nvdisasm` (both host-only tools that need no GPU; skipped when neither PATH nor the triton wheel provides them) and asserts every `UTMALDG` after the first `WARPGROUP.DEPBAR` follows a `WARPGROUP.DEPBAR`, keyed on instruction addresses rather than listing order. Both checks are mutation-tested: deleting one `wgmma.wait_group` from the PTX makes each of them fail.
* **`test_selfload_bhsd_production_soak`** (new). The existing Mojo soak drives the launcher directly; this one drives the route a user reaches — `F.scaled_dot_product_attention` on contiguous BHSD mojo tensors, the only way into this kernel (the launcher hardcodes `bhsd=True`, so the strided route never lands here). It **proves** the route with the profiler instead of trusting the wave gate, then runs bursts of launches with no inter-launch sync and checks every output bitwise against the first plus once against a CPU float32 reference. Two shapes, one deliberately awkward (S=1608 → partial tail tile, 11 heads). ~13s; `FA4_SELFLOAD_SOAK_REPS` turns it up.

Green: `tests/test_fa4_host_wiring.py`, `tests/test_sdpa_host_wiring.py`, `tests/test_fa4_selfload_*.py` (30 passed) and `-k "attention or sdpa or flash"` across `test_eager_kernels/test_aten_functions/test_high_level_ops` (120 passed, 8 skipped). `uvx pre-commit run --all-files` clean.

## Upstream note for Modular

The missing `~{memory}` on `wgmma_wait_group_sync` (and on the `cp.async.bulk.tensor` asm in `gpu/memory/memory.mojo`) is a stdlib issue, not ours — every Hopper kernel that relies on a wgmma wait to retire a shared-memory reader inherits it. Worth reporting upstream; the local wrapper is the fix we can ship today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TFYWf7vJNAv5VadqSz3bRu
