### PR TITLE
fix(fa4): round the scaled score before subtracting the rowmax

### DIFF
--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -1,7 +1,11 @@
 """Tests for the Mojo-extension fast path used by mojo eager mode."""
 
+import collections
+import contextlib
+import functools
 import math
 import weakref
+from collections.abc import Iterator
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
@@ -10588,3 +10592,379 @@ def test_fast_sdpa_decode(mojo_gpu, dtype):
     ).cpu()
     ref = torch.nn.functional.scaled_dot_product_attention(q, k, v)
     torch.testing.assert_close(dev, ref, atol=1e-2, rtol=1e-2)
+
+
+# ---------------------------------------------------------------------------
+# FA4 extreme-logit accuracy (2026-08 nanoGPT attention-collapse incident)
+# ---------------------------------------------------------------------------
+#
+# FA4's online softmax formed P as `exp2(fma(s, scale_log2, -rowmax))`: an
+# EXACT product against a ROUNDED row maximum. The winning element's exponent
+# is then off zero by up to half an f32 ulp of |s * scale_log2| -- an envelope
+# that widens with each binade of the scaled logit, so p_max is no longer
+# exactly 1.0 and the 16-bit P-packing error on the dominant entry stops
+# cancelling against the f32 rowsum. Rounding the product on its own first
+# restores the cancellation.
+#
+# The tests below are OUTCOME regressions: they bound the error of saturated
+# rows against a CPU fp64 causal decomposition, so any implementation that
+# reintroduces the mismatch fails regardless of how it is spelled. They do not
+# inspect p_max, and the fixed-seed bounds are empirical thresholds measured on
+# both trees (table below), NOT a derived format floor. The kernel-level
+# companion is tests/test_fa4_rounded_product_ptx.py, which checks the emitted
+# PTX of every FA4 instantiation, including the ones no runtime test reaches.
+#
+# Coverage: H100 only (`mojo_h100` skips everything else) -- FA4 eligibility is
+# hard-gated to sm_90a. A flash kernel for another architecture would need its
+# own measurement; nothing here establishes portability.
+#
+# Measured saturated-row rms/peak, stock -> fixed, at the exact shapes and seed
+# used below (`|` separates head_dim 64 | 128; the selfload row is d64 only):
+#
+#   dtype regime     rms stock          rms fixed         peak stock       peak fixed
+#   bf16  healthy    5.58e-4|5.52e-4    5.58e-4|5.52e-4   1.41e-2|1.16e-2  same
+#   bf16  collapsed  1.12e-3|9.34e-4    3.24e-5|3.27e-5   1.56e-2|1.56e-2  5.66e-3|6.48e-3
+#   bf16  selfload   8.72e-4            3.09e-5           1.56e-2          7.82e-3
+#   f16   healthy    9.32e-5|8.96e-5    9.31e-5|8.96e-5   1.72e-3|1.52e-3  same
+#   f16   collapsed  2.49e-4|2.50e-4    4.85e-6|6.28e-6   1.95e-3|2.52e-3  9.64e-4|9.50e-4
+#   f16   selfload   2.45e-4            4.44e-6           3.91e-3          9.55e-4
+#
+# The healthy rows move by less than 0.1% -- the defect is triggered by logit
+# MAGNITUDE, not by saturation, which is why ordinary random-input sweeps never
+# saw it. The collapsed rows are what the bounds separate; the margins are
+# stated next to each bound and are wide on rms, narrow (about 1.4x either
+# side) on peak, which is a single-element statistic.
+_FA4_EXTREME_LOGIT_BOUNDS = {
+    # (dtype, regime): (rms bound, peak bound)
+    # healthy: sanity guards, ~1.4x above the measured value on both trees.
+    (torch.bfloat16, "healthy"): (8e-4, 2e-2),
+    (torch.float16, "healthy"): (1.5e-4, 3e-3),
+    # collapsed: rms 4.6x above fixed / 5.8x below stock (bf16), 4.8x / 8.2x
+    # (f16). peak 1.4x above fixed / 1.4x below stock for both.
+    (torch.bfloat16, "collapsed"): (1.5e-4, 1.1e-2),
+    (torch.float16, "collapsed"): (3e-5, 1.4e-3),
+}
+_FA4_EXTREME_LOGIT_SIGMA = {"healthy": 8.0, "collapsed": 160.0}
+_FA4_EXTREME_LOGIT_SEED = 20260818
+
+
+@functools.cache
+def _fa4_extreme_logit_reference(
+    batch: int, heads: int, seqlen: int, head_dim: int, dtype: torch.dtype, regime: str
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Host Q/K/V plus the fp64 causal-attention output and saturated mask.
+
+    Q/K/V are rounded to the target 16-bit dtype FIRST and the fp64 reference
+    consumes those exact values, so the only error measured is the kernel's.
+    Cached because the same reference serves every layout of a cell.
+    """
+    sigma = _FA4_EXTREME_LOGIT_SIGMA[regime]
+    generator = torch.Generator().manual_seed(_FA4_EXTREME_LOGIT_SEED)
+    shape = (batch, heads, seqlen, head_dim)
+    query = (torch.randn(shape, generator=generator) * sigma).to(dtype)
+    key = (torch.randn(shape, generator=generator) * sigma).to(dtype)
+    value = torch.randn(shape, generator=generator).to(dtype)
+
+    logits = query.double() @ key.double().transpose(-1, -2) / math.sqrt(head_dim)
+    probabilities = (logits + torch.full((seqlen, seqlen), -math.inf).triu(1)).softmax(
+        -1
+    )
+    reference = probabilities @ value.double()
+    saturated = probabilities.max(-1).values > 0.99
+    assert saturated.any(), "no saturated row: the regime this guards is not reached"
+    return query, key, value, reference, saturated
+
+
+def _fa4_place_qkv(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    layout: str,
+    device: str,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Move Q/K/V to `device` in the physical layout that selects one FA4 ABI.
+
+    Each layout reaches a DIFFERENT compiled bridge -- verified by the route
+    assertions in the tests below, not assumed:
+
+    - ``gapped_qkv``: nanoGPT's production layout, one (B, S, 3*H*D) fused
+      buffer with three gapped (B, H, S, D) views -> ``*_strided_qkv``;
+    - ``bshd_view``: (B, H, S, D) logical over a (B, S, H, D)-contiguous
+      buffer. Its BTHD view is contiguous, so the bridge does NOT need the
+      strided ABI -> the dense entry point;
+    - ``bhsd``: public contiguous (B, H, S, D) -> ``*_bhsd``.
+    """
+    if layout == "gapped_qkv":
+        batch, heads, seqlen, head_dim = query.shape
+        width = heads * head_dim
+        fused = torch.cat(
+            [
+                tensor.transpose(1, 2).reshape(batch, seqlen, width)
+                for tensor in (query, key, value)
+            ],
+            dim=2,
+        ).contiguous()
+        parts = fused.to(device).split(width, dim=2)
+        return tuple(
+            part.view(batch, seqlen, heads, head_dim).transpose(1, 2) for part in parts
+        )
+    if layout == "bshd_view":
+        return tuple(
+            tensor.transpose(1, 2).contiguous().to(device).transpose(1, 2)
+            for tensor in (query, key, value)
+        )
+    return tuple(tensor.contiguous().to(device) for tensor in (query, key, value))
+
+
+_FA4_LAYOUT_VARIANT = {"gapped_qkv": "_strided_qkv", "bshd_view": "", "bhsd": "_bhsd"}
+
+
+@contextlib.contextmanager
+def _fa4_route_spy(monkeypatch) -> Iterator[collections.Counter]:
+    """Count calls to every compiled FA4 bridge symbol, by symbol name.
+
+    Without this the accuracy assertions below would pass just as happily if a
+    future eligibility-gate change routed the case to the accurate math
+    decomposition -- a green test that no longer tests FA4 at all.
+    """
+    from torch_mojo_backend.eager_flash_attention import load_fa4_ops
+
+    module = load_fa4_ops()
+    calls: collections.Counter = collections.Counter()
+    for direction in ("fwd", "bwd"):
+        for suffix in ("bf16", "f16"):
+            for head_dim in (64, 128):
+                for variant in ("", "_strided_qkv", "_bhsd"):
+                    name = (
+                        f"flash_attention_{direction}_{suffix}"
+                        f"_d{head_dim}_causal{variant}"
+                    )
+                    original = getattr(module, name, None)
+                    if original is None:
+                        continue
+
+                    def spy(*args, _name=name, _original=original):
+                        calls[_name] += 1
+                        return _original(*args)
+
+                    monkeypatch.setattr(module, name, spy)
+    yield calls
+
+
+def _fa4_saturated_error(
+    output: torch.Tensor, reference: torch.Tensor, saturated: torch.Tensor
+) -> tuple[float, float]:
+    error = output.cpu().double() - reference
+    saturated_error = error[saturated.unsqueeze(-1).expand_as(error)]
+    return (
+        float(saturated_error.pow(2).mean().sqrt()),
+        float(saturated_error.abs().max()),
+    )
+
+
+def _assert_fa4_saturated_bounds(
+    output: torch.Tensor,
+    reference: torch.Tensor,
+    saturated: torch.Tensor,
+    dtype: torch.dtype,
+    regime: str,
+) -> None:
+    rms_bound, peak_bound = _FA4_EXTREME_LOGIT_BOUNDS[dtype, regime]
+    rms, peak = _fa4_saturated_error(output, reference, saturated)
+    assert rms <= rms_bound, (
+        f"saturated-row rms {rms:.3e} exceeds the {regime} bound {rms_bound:.3e}"
+    )
+    assert peak <= peak_bound, (
+        f"saturated-row max error {peak:.3e} exceeds the {regime} bound"
+        f" {peak_bound:.3e}"
+    )
+
+
+@pytest.mark.parametrize("regime", ["healthy", "collapsed"])
+@pytest.mark.parametrize("layout", ["gapped_qkv", "bshd_view", "bhsd"])
+@pytest.mark.parametrize("head_dim", [64, 128], ids=["d64", "d128"])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "f16"])
+def test_fa4_forward_saturated_extreme_logit_accuracy(
+    mojo_h100: str,
+    monkeypatch,
+    dtype: torch.dtype,
+    head_dim: int,
+    layout: str,
+    regime: str,
+) -> None:
+    """Saturated rows stay accurate at extreme LOGIT MAGNITUDE, every route.
+
+    ``collapsed`` is the incident regime (|scaled logit| ~ 2e4): stock FA4
+    measures a saturated-row rms 28-51x the fixed kernel's here. ``healthy``
+    (|scaled logit| ~ 5e1) is unchanged by the fix and guards against paying
+    for the fix in the ordinary regime. See the module-level table above for
+    every measured value and the margin each bound carries.
+
+    S is 1024 at d64 and 512 at d128, which reaches the two instantiated
+    forward reduction branches (d64/tree and d128/linear). The self-loading
+    d64 kernel needs far more parallel work and has its own test below.
+    """
+    batch, heads = 2, 4
+    seqlen = 1024 if head_dim == 64 else 512
+    query, key, value, reference, saturated = _fa4_extreme_logit_reference(
+        batch, heads, seqlen, head_dim, dtype, regime
+    )
+
+    with _fa4_route_spy(monkeypatch) as calls:
+        output = torch.nn.functional.scaled_dot_product_attention(
+            *_fa4_place_qkv(query, key, value, layout, mojo_h100), is_causal=True
+        )
+        output.cpu()
+
+    suffix = _FA4_DTYPE_SUFFIX[dtype]
+    expected = (
+        f"flash_attention_fwd_{suffix}_d{head_dim}_causal{_FA4_LAYOUT_VARIANT[layout]}"
+    )
+    assert calls == {expected: 1}, (
+        f"expected exactly one call to {expected}, got {dict(calls)} -- this"
+        " case no longer runs the FA4 kernel it is meant to guard"
+    )
+    _assert_fa4_saturated_bounds(output, reference, saturated, dtype, regime)
+
+
+@pytest.mark.parametrize("regime", ["healthy", "collapsed"])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "f16"])
+def test_fa4_selfload_forward_saturated_extreme_logit_accuracy(
+    mojo_h100: str, monkeypatch, dtype: torch.dtype, regime: str
+) -> None:
+    """Same guard on the self-loading d64 forward kernel, which owns its own
+    copy of the P expression.
+
+    The bhsd bridge picks between the phase-2b producer/consumer kernel and
+    the self-loading one at RUNTIME, on wave count: it needs
+    ``ceildiv(S, 64) * heads * batch >= _FA4_SELFLOAD_MIN_WAVES * 3 * SM_count``
+    (see ``fa4_ops.mojo``). This shape supplies ``ceildiv(256, 64) * 32 * 8``
+    = 1024 CTAs, which clears the bar for any SM count up to 170 and so covers
+    both the 114-SM PCIe and 132-SM SXM H100. Selecting the bhsd ABI is not
+    the same as selecting this kernel, which is why the shape is sized rather
+    than borrowed.
+    """
+    batch, heads, seqlen, head_dim = 8, 32, 256, 64
+    query, key, value, reference, saturated = _fa4_extreme_logit_reference(
+        batch, heads, seqlen, head_dim, dtype, regime
+    )
+
+    with _fa4_route_spy(monkeypatch) as calls:
+        output = torch.nn.functional.scaled_dot_product_attention(
+            *_fa4_place_qkv(query, key, value, "bhsd", mojo_h100), is_causal=True
+        )
+        output.cpu()
+
+    expected = f"flash_attention_fwd_{_FA4_DTYPE_SUFFIX[dtype]}_d64_causal_bhsd"
+    assert calls == {expected: 1}, f"expected one {expected}, got {dict(calls)}"
+    _assert_fa4_saturated_bounds(output, reference, saturated, dtype, regime)
+
+
+# Gradient rms bounds, keyed by (dtype, regime). Measured stock -> fixed at the
+# shape and seed below (`|` separates head_dim 64 | 128):
+#
+#   dtype regime     dQ stock         dQ fixed        dK stock         dK fixed
+#   bf16  healthy    6.62e-3|7.30e-3  6.70e-3|7.30e-3 6.45e-3|7.07e-3  6.51e-3|7.08e-3
+#   bf16  collapsed  1.75e-1|1.56e-1  1.36e-5|2.05e-5 1.73e-1|1.56e-1  1.30e-5|2.04e-5
+#   f16   healthy    9.13e-4|9.82e-4  8.87e-4|9.62e-4 8.91e-4|9.63e-4  8.67e-4|9.50e-4
+#   f16   collapsed  4.10e-2|4.17e-2  2.11e-5|9.28e-4 3.83e-2|4.12e-2  1.99e-5|8.09e-4
+#
+# dV barely moves (bf16 collapsed 2.43e-3 -> 1.52e-3 at d64, 3.48e-3 -> 3.54e-3
+# at d128): it is the one gradient whose dominant term does not carry the P
+# normalization error, so its bound is a loose sanity guard, not a
+# discriminator. The f16 d128 collapsed cell is the weakest of the set -- 9.3e-4
+# fixed against 4.2e-2 stock -- so its bound is set from that cell.
+_FA4_EXTREME_LOGIT_GRAD_BOUNDS = {
+    # (dtype, regime): (dQ/dK rms bound, dV rms bound)
+    (torch.bfloat16, "healthy"): (1e-2, 6e-3),
+    (torch.float16, "healthy"): (2e-3, 5e-3),
+    # collapsed: bf16 4.9x above fixed / 7600x below stock; f16 5.4x above the
+    # worst fixed cell (d128) / 8.3x below stock.
+    (torch.bfloat16, "collapsed"): (1e-4, 6e-3),
+    (torch.float16, "collapsed"): (5e-3, 5e-3),
+}
+
+
+@pytest.mark.parametrize("regime", ["healthy", "collapsed"])
+@pytest.mark.parametrize("layout", ["gapped_qkv", "bhsd"])
+@pytest.mark.parametrize("head_dim", [64, 128], ids=["d64", "d128"])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "f16"])
+def test_fa4_backward_saturated_extreme_logit_accuracy(
+    mojo_h100: str,
+    monkeypatch,
+    dtype: torch.dtype,
+    head_dim: int,
+    layout: str,
+    regime: str,
+) -> None:
+    """dQ/dK/dV stay accurate at extreme logit magnitude.
+
+    This exercises the fixed forward and the fixed backward as a PAIR, which
+    is the only combination that ships: the backward consumes the forward's
+    LSE and recomputes P from it, so the two must agree on what softmax was
+    computed. It does not isolate the backward edit from the forward one. The
+    backward's own justification is that consistency -- it subtracts a rounded
+    LSE, never a rowmax, so the forward's exact p_max == 1 argument does not
+    apply there.
+
+    The reference is CPU fp64 autograd over an explicit causal-attention
+    decomposition, so no vendor backward kernel is involved.
+
+    ``layout`` picks the two compiled backward ABIs: gapped Q/K/V views reach
+    ``*_strided_qkv``, contiguous BHSD reaches the dense entry (there is no
+    BHSD-native backward). The remaining backward edit lives in the softcap
+    branch, which no exported FA4 entry instantiates -- it is not covered here
+    and is not compiled into any shipping kernel.
+    """
+    batch, heads, seqlen = 1, 2, 512
+    query, key, value, _, saturated = _fa4_extreme_logit_reference(
+        batch, heads, seqlen, head_dim, dtype, regime
+    )
+    generator = torch.Generator().manual_seed(_FA4_EXTREME_LOGIT_SEED + 1)
+    grad_output = torch.randn(batch, heads, seqlen, head_dim, generator=generator).to(
+        dtype
+    )
+
+    expected_inputs = [
+        tensor.double().requires_grad_() for tensor in (query, key, value)
+    ]
+    expected_logits = (
+        expected_inputs[0] @ expected_inputs[1].transpose(-1, -2) / math.sqrt(head_dim)
+    )
+    expected_probabilities = (
+        expected_logits + torch.full((seqlen, seqlen), -math.inf).triu(1)
+    ).softmax(-1)
+    (expected_probabilities @ expected_inputs[2]).backward(grad_output.double())
+
+    actual_inputs = [
+        tensor.requires_grad_()
+        for tensor in _fa4_place_qkv(query, key, value, layout, mojo_h100)
+    ]
+    with _fa4_route_spy(monkeypatch) as calls:
+        output = torch.nn.functional.scaled_dot_product_attention(
+            *actual_inputs, is_causal=True
+        )
+        output.backward(grad_output.to(mojo_h100))
+
+    suffix = _FA4_DTYPE_SUFFIX[dtype]
+    variant = _FA4_LAYOUT_VARIANT[layout]
+    # The backward has no BHSD-native ABI: a contiguous BHSD forward is
+    # followed by the DENSE backward over the materialized BTHD buffers.
+    backward_variant = variant if variant == "_strided_qkv" else ""
+    assert calls == {
+        f"flash_attention_fwd_{suffix}_d{head_dim}_causal{variant}": 1,
+        f"flash_attention_bwd_{suffix}_d{head_dim}_causal{backward_variant}": 1,
+    }, f"unexpected FA4 route selection: {dict(calls)}"
+
+    grad_bound, value_grad_bound = _FA4_EXTREME_LOGIT_GRAD_BOUNDS[dtype, regime]
+    bounds = (grad_bound, grad_bound, value_grad_bound)
+    names = ("dQ", "dK", "dV")
+    for name, bound, actual, expected in zip(
+        names, bounds, actual_inputs, expected_inputs, strict=True
+    ):
+        assert actual.grad is not None
+        error = actual.grad.cpu().double() - expected.grad
+        rms = float(error.pow(2).mean().sqrt())
+        assert rms <= bound, (
+            f"{name} rms {rms:.3e} exceeds the {regime} bound {bound:.3e}"
+        )

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -11159,8 +11159,6 @@ def _fa4_route_spy(
     future eligibility-gate change routed the case to the accurate math
     decomposition -- a green test that no longer tests FA4 at all.
     """
-    from torch_mojo_backend.eager_flash_attention import load_fa4_ops
-
     module = load_fa4_ops()
     calls: collections.Counter[str] = collections.Counter()
     for direction in ("fwd", "bwd"):

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -1,9 +1,11 @@
 """Tests for the Mojo-extension fast path used by mojo eager mode."""
 
+import collections
+import contextlib
 import functools
 import math
 import weakref
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from typing import Protocol, cast
@@ -11013,3 +11015,379 @@ def test_fast_sdpa_decode(mojo_gpu, dtype):
     ).cpu()
     ref = torch.nn.functional.scaled_dot_product_attention(q, k, v)
     torch.testing.assert_close(dev, ref, atol=1e-2, rtol=1e-2)
+
+
+# ---------------------------------------------------------------------------
+# FA4 extreme-logit accuracy (2026-08 nanoGPT attention-collapse incident)
+# ---------------------------------------------------------------------------
+#
+# FA4's online softmax formed P as `exp2(fma(s, scale_log2, -rowmax))`: an
+# EXACT product against a ROUNDED row maximum. The winning element's exponent
+# is then off zero by up to half an f32 ulp of |s * scale_log2| -- an envelope
+# that widens with each binade of the scaled logit, so p_max is no longer
+# exactly 1.0 and the 16-bit P-packing error on the dominant entry stops
+# cancelling against the f32 rowsum. Rounding the product on its own first
+# restores the cancellation.
+#
+# The tests below are OUTCOME regressions: they bound the error of saturated
+# rows against a CPU fp64 causal decomposition, so any implementation that
+# reintroduces the mismatch fails regardless of how it is spelled. They do not
+# inspect p_max, and the fixed-seed bounds are empirical thresholds measured on
+# both trees (table below), NOT a derived format floor. The kernel-level
+# companion is tests/test_fa4_rounded_product_ptx.py, which checks the emitted
+# PTX of every FA4 instantiation, including the ones no runtime test reaches.
+#
+# Coverage: H100 only (`mojo_h100` skips everything else) -- FA4 eligibility is
+# hard-gated to sm_90a. A flash kernel for another architecture would need its
+# own measurement; nothing here establishes portability.
+#
+# Measured saturated-row rms/peak, stock -> fixed, at the exact shapes and seed
+# used below (`|` separates head_dim 64 | 128; the selfload row is d64 only):
+#
+#   dtype regime     rms stock          rms fixed         peak stock       peak fixed
+#   bf16  healthy    5.58e-4|5.52e-4    5.58e-4|5.52e-4   1.41e-2|1.16e-2  same
+#   bf16  collapsed  1.12e-3|9.34e-4    3.24e-5|3.27e-5   1.56e-2|1.56e-2  5.66e-3|6.48e-3
+#   bf16  selfload   8.72e-4            3.09e-5           1.56e-2          7.82e-3
+#   f16   healthy    9.32e-5|8.96e-5    9.31e-5|8.96e-5   1.72e-3|1.52e-3  same
+#   f16   collapsed  2.49e-4|2.50e-4    4.85e-6|6.28e-6   1.95e-3|2.52e-3  9.64e-4|9.50e-4
+#   f16   selfload   2.45e-4            4.44e-6           3.91e-3          9.55e-4
+#
+# The healthy rows move by less than 0.1% -- the defect is triggered by logit
+# MAGNITUDE, not by saturation, which is why ordinary random-input sweeps never
+# saw it. The collapsed rows are what the bounds separate; the margins are
+# stated next to each bound and are wide on rms, narrow (about 1.4x either
+# side) on peak, which is a single-element statistic.
+_FA4_EXTREME_LOGIT_BOUNDS = {
+    # (dtype, regime): (rms bound, peak bound)
+    # healthy: sanity guards, ~1.4x above the measured value on both trees.
+    (torch.bfloat16, "healthy"): (8e-4, 2e-2),
+    (torch.float16, "healthy"): (1.5e-4, 3e-3),
+    # collapsed: rms 4.6x above fixed / 5.8x below stock (bf16), 4.8x / 8.2x
+    # (f16). peak 1.4x above fixed / 1.4x below stock for both.
+    (torch.bfloat16, "collapsed"): (1.5e-4, 1.1e-2),
+    (torch.float16, "collapsed"): (3e-5, 1.4e-3),
+}
+_FA4_EXTREME_LOGIT_SIGMA = {"healthy": 8.0, "collapsed": 160.0}
+_FA4_EXTREME_LOGIT_SEED = 20260818
+
+
+@functools.cache
+def _fa4_extreme_logit_reference(
+    batch: int, heads: int, seqlen: int, head_dim: int, dtype: torch.dtype, regime: str
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Host Q/K/V plus the fp64 causal-attention output and saturated mask.
+
+    Q/K/V are rounded to the target 16-bit dtype FIRST and the fp64 reference
+    consumes those exact values, so the only error measured is the kernel's.
+    Cached because the same reference serves every layout of a cell.
+    """
+    sigma = _FA4_EXTREME_LOGIT_SIGMA[regime]
+    generator = torch.Generator().manual_seed(_FA4_EXTREME_LOGIT_SEED)
+    shape = (batch, heads, seqlen, head_dim)
+    query = (torch.randn(shape, generator=generator) * sigma).to(dtype)
+    key = (torch.randn(shape, generator=generator) * sigma).to(dtype)
+    value = torch.randn(shape, generator=generator).to(dtype)
+
+    logits = query.double() @ key.double().transpose(-1, -2) / math.sqrt(head_dim)
+    probabilities = (logits + torch.full((seqlen, seqlen), -math.inf).triu(1)).softmax(
+        -1
+    )
+    reference = probabilities @ value.double()
+    saturated = probabilities.max(-1).values > 0.99
+    assert saturated.any(), "no saturated row: the regime this guards is not reached"
+    return query, key, value, reference, saturated
+
+
+def _fa4_place_qkv(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    layout: str,
+    device: str,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Move Q/K/V to `device` in the physical layout that selects one FA4 ABI.
+
+    Each layout reaches a DIFFERENT compiled bridge -- verified by the route
+    assertions in the tests below, not assumed:
+
+    - ``gapped_qkv``: nanoGPT's production layout, one (B, S, 3*H*D) fused
+      buffer with three gapped (B, H, S, D) views -> ``*_strided_qkv``;
+    - ``bshd_view``: (B, H, S, D) logical over a (B, S, H, D)-contiguous
+      buffer. Its BTHD view is contiguous, so the bridge does NOT need the
+      strided ABI -> the dense entry point;
+    - ``bhsd``: public contiguous (B, H, S, D) -> ``*_bhsd``.
+    """
+    if layout == "gapped_qkv":
+        batch, heads, seqlen, head_dim = query.shape
+        width = heads * head_dim
+        fused = torch.cat(
+            [
+                tensor.transpose(1, 2).reshape(batch, seqlen, width)
+                for tensor in (query, key, value)
+            ],
+            dim=2,
+        ).contiguous()
+        parts = fused.to(device).split(width, dim=2)
+        return tuple(
+            part.view(batch, seqlen, heads, head_dim).transpose(1, 2) for part in parts
+        )
+    if layout == "bshd_view":
+        return tuple(
+            tensor.transpose(1, 2).contiguous().to(device).transpose(1, 2)
+            for tensor in (query, key, value)
+        )
+    return tuple(tensor.contiguous().to(device) for tensor in (query, key, value))
+
+
+_FA4_LAYOUT_VARIANT = {"gapped_qkv": "_strided_qkv", "bshd_view": "", "bhsd": "_bhsd"}
+
+
+@contextlib.contextmanager
+def _fa4_route_spy(monkeypatch) -> Iterator[collections.Counter]:
+    """Count calls to every compiled FA4 bridge symbol, by symbol name.
+
+    Without this the accuracy assertions below would pass just as happily if a
+    future eligibility-gate change routed the case to the accurate math
+    decomposition -- a green test that no longer tests FA4 at all.
+    """
+    from torch_mojo_backend.eager_flash_attention import load_fa4_ops
+
+    module = load_fa4_ops()
+    calls: collections.Counter = collections.Counter()
+    for direction in ("fwd", "bwd"):
+        for suffix in ("bf16", "f16"):
+            for head_dim in (64, 128):
+                for variant in ("", "_strided_qkv", "_bhsd"):
+                    name = (
+                        f"flash_attention_{direction}_{suffix}"
+                        f"_d{head_dim}_causal{variant}"
+                    )
+                    original = getattr(module, name, None)
+                    if original is None:
+                        continue
+
+                    def spy(*args, _name=name, _original=original):
+                        calls[_name] += 1
+                        return _original(*args)
+
+                    monkeypatch.setattr(module, name, spy)
+    yield calls
+
+
+def _fa4_saturated_error(
+    output: torch.Tensor, reference: torch.Tensor, saturated: torch.Tensor
+) -> tuple[float, float]:
+    error = output.cpu().double() - reference
+    saturated_error = error[saturated.unsqueeze(-1).expand_as(error)]
+    return (
+        float(saturated_error.pow(2).mean().sqrt()),
+        float(saturated_error.abs().max()),
+    )
+
+
+def _assert_fa4_saturated_bounds(
+    output: torch.Tensor,
+    reference: torch.Tensor,
+    saturated: torch.Tensor,
+    dtype: torch.dtype,
+    regime: str,
+) -> None:
+    rms_bound, peak_bound = _FA4_EXTREME_LOGIT_BOUNDS[dtype, regime]
+    rms, peak = _fa4_saturated_error(output, reference, saturated)
+    assert rms <= rms_bound, (
+        f"saturated-row rms {rms:.3e} exceeds the {regime} bound {rms_bound:.3e}"
+    )
+    assert peak <= peak_bound, (
+        f"saturated-row max error {peak:.3e} exceeds the {regime} bound"
+        f" {peak_bound:.3e}"
+    )
+
+
+@pytest.mark.parametrize("regime", ["healthy", "collapsed"])
+@pytest.mark.parametrize("layout", ["gapped_qkv", "bshd_view", "bhsd"])
+@pytest.mark.parametrize("head_dim", [64, 128], ids=["d64", "d128"])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "f16"])
+def test_fa4_forward_saturated_extreme_logit_accuracy(
+    mojo_h100: str,
+    monkeypatch,
+    dtype: torch.dtype,
+    head_dim: int,
+    layout: str,
+    regime: str,
+) -> None:
+    """Saturated rows stay accurate at extreme LOGIT MAGNITUDE, every route.
+
+    ``collapsed`` is the incident regime (|scaled logit| ~ 2e4): stock FA4
+    measures a saturated-row rms 28-51x the fixed kernel's here. ``healthy``
+    (|scaled logit| ~ 5e1) is unchanged by the fix and guards against paying
+    for the fix in the ordinary regime. See the module-level table above for
+    every measured value and the margin each bound carries.
+
+    S is 1024 at d64 and 512 at d128, which reaches the two instantiated
+    forward reduction branches (d64/tree and d128/linear). The self-loading
+    d64 kernel needs far more parallel work and has its own test below.
+    """
+    batch, heads = 2, 4
+    seqlen = 1024 if head_dim == 64 else 512
+    query, key, value, reference, saturated = _fa4_extreme_logit_reference(
+        batch, heads, seqlen, head_dim, dtype, regime
+    )
+
+    with _fa4_route_spy(monkeypatch) as calls:
+        output = torch.nn.functional.scaled_dot_product_attention(
+            *_fa4_place_qkv(query, key, value, layout, mojo_h100), is_causal=True
+        )
+        output.cpu()
+
+    suffix = _FA4_DTYPE_SUFFIX[dtype]
+    expected = (
+        f"flash_attention_fwd_{suffix}_d{head_dim}_causal{_FA4_LAYOUT_VARIANT[layout]}"
+    )
+    assert calls == {expected: 1}, (
+        f"expected exactly one call to {expected}, got {dict(calls)} -- this"
+        " case no longer runs the FA4 kernel it is meant to guard"
+    )
+    _assert_fa4_saturated_bounds(output, reference, saturated, dtype, regime)
+
+
+@pytest.mark.parametrize("regime", ["healthy", "collapsed"])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "f16"])
+def test_fa4_selfload_forward_saturated_extreme_logit_accuracy(
+    mojo_h100: str, monkeypatch, dtype: torch.dtype, regime: str
+) -> None:
+    """Same guard on the self-loading d64 forward kernel, which owns its own
+    copy of the P expression.
+
+    The bhsd bridge picks between the phase-2b producer/consumer kernel and
+    the self-loading one at RUNTIME, on wave count: it needs
+    ``ceildiv(S, 64) * heads * batch >= _FA4_SELFLOAD_MIN_WAVES * 3 * SM_count``
+    (see ``fa4_ops.mojo``). This shape supplies ``ceildiv(256, 64) * 32 * 8``
+    = 1024 CTAs, which clears the bar for any SM count up to 170 and so covers
+    both the 114-SM PCIe and 132-SM SXM H100. Selecting the bhsd ABI is not
+    the same as selecting this kernel, which is why the shape is sized rather
+    than borrowed.
+    """
+    batch, heads, seqlen, head_dim = 8, 32, 256, 64
+    query, key, value, reference, saturated = _fa4_extreme_logit_reference(
+        batch, heads, seqlen, head_dim, dtype, regime
+    )
+
+    with _fa4_route_spy(monkeypatch) as calls:
+        output = torch.nn.functional.scaled_dot_product_attention(
+            *_fa4_place_qkv(query, key, value, "bhsd", mojo_h100), is_causal=True
+        )
+        output.cpu()
+
+    expected = f"flash_attention_fwd_{_FA4_DTYPE_SUFFIX[dtype]}_d64_causal_bhsd"
+    assert calls == {expected: 1}, f"expected one {expected}, got {dict(calls)}"
+    _assert_fa4_saturated_bounds(output, reference, saturated, dtype, regime)
+
+
+# Gradient rms bounds, keyed by (dtype, regime). Measured stock -> fixed at the
+# shape and seed below (`|` separates head_dim 64 | 128):
+#
+#   dtype regime     dQ stock         dQ fixed        dK stock         dK fixed
+#   bf16  healthy    6.62e-3|7.30e-3  6.70e-3|7.30e-3 6.45e-3|7.07e-3  6.51e-3|7.08e-3
+#   bf16  collapsed  1.75e-1|1.56e-1  1.36e-5|2.05e-5 1.73e-1|1.56e-1  1.30e-5|2.04e-5
+#   f16   healthy    9.13e-4|9.82e-4  8.87e-4|9.62e-4 8.91e-4|9.63e-4  8.67e-4|9.50e-4
+#   f16   collapsed  4.10e-2|4.17e-2  2.11e-5|9.28e-4 3.83e-2|4.12e-2  1.99e-5|8.09e-4
+#
+# dV barely moves (bf16 collapsed 2.43e-3 -> 1.52e-3 at d64, 3.48e-3 -> 3.54e-3
+# at d128): it is the one gradient whose dominant term does not carry the P
+# normalization error, so its bound is a loose sanity guard, not a
+# discriminator. The f16 d128 collapsed cell is the weakest of the set -- 9.3e-4
+# fixed against 4.2e-2 stock -- so its bound is set from that cell.
+_FA4_EXTREME_LOGIT_GRAD_BOUNDS = {
+    # (dtype, regime): (dQ/dK rms bound, dV rms bound)
+    (torch.bfloat16, "healthy"): (1e-2, 6e-3),
+    (torch.float16, "healthy"): (2e-3, 5e-3),
+    # collapsed: bf16 4.9x above fixed / 7600x below stock; f16 5.4x above the
+    # worst fixed cell (d128) / 8.3x below stock.
+    (torch.bfloat16, "collapsed"): (1e-4, 6e-3),
+    (torch.float16, "collapsed"): (5e-3, 5e-3),
+}
+
+
+@pytest.mark.parametrize("regime", ["healthy", "collapsed"])
+@pytest.mark.parametrize("layout", ["gapped_qkv", "bhsd"])
+@pytest.mark.parametrize("head_dim", [64, 128], ids=["d64", "d128"])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "f16"])
+def test_fa4_backward_saturated_extreme_logit_accuracy(
+    mojo_h100: str,
+    monkeypatch,
+    dtype: torch.dtype,
+    head_dim: int,
+    layout: str,
+    regime: str,
+) -> None:
+    """dQ/dK/dV stay accurate at extreme logit magnitude.
+
+    This exercises the fixed forward and the fixed backward as a PAIR, which
+    is the only combination that ships: the backward consumes the forward's
+    LSE and recomputes P from it, so the two must agree on what softmax was
+    computed. It does not isolate the backward edit from the forward one. The
+    backward's own justification is that consistency -- it subtracts a rounded
+    LSE, never a rowmax, so the forward's exact p_max == 1 argument does not
+    apply there.
+
+    The reference is CPU fp64 autograd over an explicit causal-attention
+    decomposition, so no vendor backward kernel is involved.
+
+    ``layout`` picks the two compiled backward ABIs: gapped Q/K/V views reach
+    ``*_strided_qkv``, contiguous BHSD reaches the dense entry (there is no
+    BHSD-native backward). The remaining backward edit lives in the softcap
+    branch, which no exported FA4 entry instantiates -- it is not covered here
+    and is not compiled into any shipping kernel.
+    """
+    batch, heads, seqlen = 1, 2, 512
+    query, key, value, _, saturated = _fa4_extreme_logit_reference(
+        batch, heads, seqlen, head_dim, dtype, regime
+    )
+    generator = torch.Generator().manual_seed(_FA4_EXTREME_LOGIT_SEED + 1)
+    grad_output = torch.randn(batch, heads, seqlen, head_dim, generator=generator).to(
+        dtype
+    )
+
+    expected_inputs = [
+        tensor.double().requires_grad_() for tensor in (query, key, value)
+    ]
+    expected_logits = (
+        expected_inputs[0] @ expected_inputs[1].transpose(-1, -2) / math.sqrt(head_dim)
+    )
+    expected_probabilities = (
+        expected_logits + torch.full((seqlen, seqlen), -math.inf).triu(1)
+    ).softmax(-1)
+    (expected_probabilities @ expected_inputs[2]).backward(grad_output.double())
+
+    actual_inputs = [
+        tensor.requires_grad_()
+        for tensor in _fa4_place_qkv(query, key, value, layout, mojo_h100)
+    ]
+    with _fa4_route_spy(monkeypatch) as calls:
+        output = torch.nn.functional.scaled_dot_product_attention(
+            *actual_inputs, is_causal=True
+        )
+        output.backward(grad_output.to(mojo_h100))
+
+    suffix = _FA4_DTYPE_SUFFIX[dtype]
+    variant = _FA4_LAYOUT_VARIANT[layout]
+    # The backward has no BHSD-native ABI: a contiguous BHSD forward is
+    # followed by the DENSE backward over the materialized BTHD buffers.
+    backward_variant = variant if variant == "_strided_qkv" else ""
+    assert calls == {
+        f"flash_attention_fwd_{suffix}_d{head_dim}_causal{variant}": 1,
+        f"flash_attention_bwd_{suffix}_d{head_dim}_causal{backward_variant}": 1,
+    }, f"unexpected FA4 route selection: {dict(calls)}"
+
+    grad_bound, value_grad_bound = _FA4_EXTREME_LOGIT_GRAD_BOUNDS[dtype, regime]
+    bounds = (grad_bound, grad_bound, value_grad_bound)
+    names = ("dQ", "dK", "dV")
+    for name, bound, actual, expected in zip(
+        names, bounds, actual_inputs, expected_inputs, strict=True
+    ):
+        assert actual.grad is not None
+        error = actual.grad.cpu().double() - expected.grad
+        rms = float(error.pow(2).mean().sqrt())
+        assert rms <= bound, (
+            f"{name} rms {rms:.3e} exceeds the {regime} bound {bound:.3e}"
+        )

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -11127,23 +11127,32 @@ def _fa4_place_qkv(
             ],
             dim=2,
         ).contiguous()
-        parts = fused.to(device).split(width, dim=2)
-        return tuple(
-            part.view(batch, seqlen, heads, head_dim).transpose(1, 2) for part in parts
+        q_part, k_part, v_part = fused.to(device).split(width, dim=2)
+        return (
+            q_part.view(batch, seqlen, heads, head_dim).transpose(1, 2),
+            k_part.view(batch, seqlen, heads, head_dim).transpose(1, 2),
+            v_part.view(batch, seqlen, heads, head_dim).transpose(1, 2),
         )
     if layout == "bshd_view":
-        return tuple(
-            tensor.transpose(1, 2).contiguous().to(device).transpose(1, 2)
-            for tensor in (query, key, value)
+        return (
+            query.transpose(1, 2).contiguous().to(device).transpose(1, 2),
+            key.transpose(1, 2).contiguous().to(device).transpose(1, 2),
+            value.transpose(1, 2).contiguous().to(device).transpose(1, 2),
         )
-    return tuple(tensor.contiguous().to(device) for tensor in (query, key, value))
+    return (
+        query.contiguous().to(device),
+        key.contiguous().to(device),
+        value.contiguous().to(device),
+    )
 
 
 _FA4_LAYOUT_VARIANT = {"gapped_qkv": "_strided_qkv", "bshd_view": "", "bhsd": "_bhsd"}
 
 
 @contextlib.contextmanager
-def _fa4_route_spy(monkeypatch) -> Iterator[collections.Counter]:
+def _fa4_route_spy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Iterator[collections.Counter[str]]:
     """Count calls to every compiled FA4 bridge symbol, by symbol name.
 
     Without this the accuracy assertions below would pass just as happily if a
@@ -11153,7 +11162,7 @@ def _fa4_route_spy(monkeypatch) -> Iterator[collections.Counter]:
     from torch_mojo_backend.eager_flash_attention import load_fa4_ops
 
     module = load_fa4_ops()
-    calls: collections.Counter = collections.Counter()
+    calls: collections.Counter[str] = collections.Counter()
     for direction in ("fwd", "bwd"):
         for suffix in ("bf16", "f16"):
             for head_dim in (64, 128):
@@ -11359,10 +11368,11 @@ def test_fa4_backward_saturated_extreme_logit_accuracy(
     ).softmax(-1)
     (expected_probabilities @ expected_inputs[2]).backward(grad_output.double())
 
-    actual_inputs = [
+    actual_query, actual_key, actual_value = (
         tensor.requires_grad_()
         for tensor in _fa4_place_qkv(query, key, value, layout, mojo_h100)
-    ]
+    )
+    actual_inputs = (actual_query, actual_key, actual_value)
     with _fa4_route_spy(monkeypatch) as calls:
         output = torch.nn.functional.scaled_dot_product_attention(
             *actual_inputs, is_causal=True
@@ -11386,6 +11396,7 @@ def test_fa4_backward_saturated_extreme_logit_accuracy(
         names, bounds, actual_inputs, expected_inputs, strict=True
     ):
         assert actual.grad is not None
+        assert expected.grad is not None
         error = actual.grad.cpu().double() - expected.grad
         rms = float(error.pow(2).mean().sqrt())
         assert rms <= bound, (

--- a/tests/test_fa4_rounded_product_ptx.py
+++ b/tests/test_fa4_rounded_product_ptx.py
@@ -1,0 +1,207 @@
+"""Codegen guard: FA4's softmax exponent must not be a fused multiply-add.
+
+FA4's online softmax computes ``P = exp2(<scaled score> - <row statistic>)``.
+The scaled score must be ROUNDED on its own before the subtraction: a single
+``fma(s, scale_log2, -m)`` keeps the product exact while ``m`` is rounded,
+which leaves the winning element's exponent off zero by up to half an f32 ulp
+of ``|s * scale_log2|`` -- an error that widens with the logit magnitude and,
+at the magnitudes of the 2026-08 nanoGPT attention-collapse incident, cost a
+16x saturated-row rms regression against cuda flash. The source therefore
+spells the product as ``s.fma[FastMathFlag.NONE](scale_log2, 0)`` and
+subtracts afterwards.
+
+That spelling is a request, not a guarantee: floating-point contraction is a
+compiler privilege, ``SIMD.fma`` defaults to ``FastMathFlag.CONTRACT``, and
+``s * scale_log2 - m`` written plainly IS contracted straight back into the
+defective single fma by today's toolchain. So the source form alone cannot be
+trusted to survive a toolchain upgrade, and a numerical regression test only
+covers the instantiations it can reach at runtime. This test reads the
+emitted PTX instead and covers EVERY instantiation the module compiles --
+both forward kernels and the backward P-recompute, bf16 and f16, d64 and
+d128 -- by asserting the property directly on the machine code:
+
+    no ``ex2.approx`` input may be produced by an ``fma``.
+
+Cross-compiles with ``mojo build --emit asm --target-accelerator sm_90a``
+(needs no GPU, never touches ``/tmp/gpu_lock_0.lock``), the same way
+``scripts/compare_kernel_asm.py`` and ``test_fa4_selfload_ptx_ordering.py``
+do. Measured against the stock kernels this check is a total discriminator:
+1728 of the 1728 ``ex2`` sites are fma-fed before the fix and 0 after.
+
+Builds land in a STABLE directory (``tests/__mojocache__/...``) for the
+reason spelled out in ``test_fa4_selfload_ptx_ordering.py``: Mojo's transform
+cache replays a kernel's sidecar to the path it was FIRST built at, so a
+fresh temp dir per run goes empty on the second run in a session.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.compare_kernel_asm import build_env, mojo_cli
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_FA4_DIR = _REPO_ROOT / "torch_mojo_backend" / "eager_flash_attention"
+_ENTRY = _FA4_DIR / "fa4_ops.mojo"
+_BUILD_DIR = Path(__file__).resolve().parent / "__mojocache__" / "fa4_rounded_product"
+# Ties the transform-cache entry to THIS checkout's output path; see the
+# ASM_CACHE_BUST comment in _build_fa4_ptx.
+_BUILD_TAG = hashlib.sha256(str(_BUILD_DIR).encode()).hexdigest()[:16]
+
+# `<op> %dst, <args>;` -- enough to attribute each register to its last writer.
+_DEFINITION = re.compile(r"^\s*([a-z0-9.]+)\s+(%[A-Za-z0-9_]+)\s*,\s*(.*);\s*$")
+_EX2 = re.compile(r"ex2\.approx\.ftz\.f32\s+%[A-Za-z0-9_]+\s*,\s*(%[A-Za-z0-9_]+)")
+# The three kernel families that carry a P = exp2(...) expression, keyed by a
+# substring of their sidecar file name. Sidecars are named
+# `<module>_<kernel>_<hash>.ptx` and the kernel half is truncated, so these
+# match on the module name plus whatever survives of the kernel name.
+_P_LOOP_KERNELS = (
+    "fa4_fwd_kernel_fwd_fa4_kernel",
+    "fa4_fwd_selfload_kernel",
+    "fa4_bwd_kernel_bwd_main_kernel",
+)
+
+
+def _build_fa4_ptx() -> list[Path]:
+    """Cross-compile fa4_ops for sm_90a; return its per-kernel PTX sidecars."""
+    try:
+        mojo = mojo_cli()
+    except FileNotFoundError:
+        pytest.skip("mojo compiler not found")
+    _BUILD_DIR.mkdir(parents=True, exist_ok=True)
+    # The directory is stable across runs, so sidecars from an older source
+    # revision would otherwise linger and be scanned as if they were current.
+    for stale in list(_BUILD_DIR.glob("*.ptx")) + list(_BUILD_DIR.glob("*.s")):
+        stale.unlink()
+    result = subprocess.run(
+        [
+            str(mojo),
+            "build",
+            str(_ENTRY),
+            "-I",
+            str(_FA4_DIR),
+            "--emit",
+            "asm",
+            "--target-accelerator",
+            "sm_90a",
+            # Mojo's transform cache keys on source and defines but NOT on the
+            # output path, and services a hit by rewriting the sidecars to the
+            # path the entry was FIRST built at. An identical fa4_ops built
+            # earlier by scripts/compare_kernel_asm.py (into its own --work-dir,
+            # since deleted) therefore makes this build fail with "could not
+            # open offload output file". Nothing reads this define, so it cannot
+            # move the generated code; it only makes the cache entry belong to
+            # this output path, which stays a hit on every later run.
+            "-D",
+            f"ASM_CACHE_BUST={_BUILD_TAG}",
+            "-o",
+            str(_BUILD_DIR / "fa4_ops.s"),
+        ],
+        cwd=str(_REPO_ROOT),
+        env=build_env(),
+        capture_output=True,
+        text=True,
+        timeout=1800,
+    )
+    assert result.returncode == 0, (
+        f"mojo build --emit asm failed for fa4_ops:\n{result.stderr or result.stdout}"
+    )
+    sidecars = sorted(_BUILD_DIR.glob("*.ptx"))
+    assert sidecars, (
+        "mojo build --emit asm produced no .ptx sidecar -- no GPU kernel was"
+        " instantiated, so this check would be vacuous"
+    )
+    return sidecars
+
+
+@pytest.fixture(scope="module")
+def fa4_ptx() -> dict[str, str]:
+    """Every FA4 GPU kernel's PTX, keyed by sidecar file name."""
+    return {path.name: path.read_text() for path in _build_fa4_ptx()}
+
+
+def _classify_exp2_inputs(ptx: str) -> tuple[int, int, int]:
+    """Count ``ex2`` sites by what produced their input.
+
+    Returns ``(fma_fed, rounded_product_fed, other)``:
+
+    - ``fma_fed`` is the defect signature -- ``fma.rn.f32 %d, %s, %c, %negm``
+      feeding ``ex2`` directly, i.e. an exact product against a rounded row
+      statistic;
+    - ``rounded_product_fed`` is the fixed form -- ``sub.f32`` of an
+      ``fma.rn.f32 ..., 0f00000000`` (the correctly rounded product) and the
+      row statistic;
+    - ``other`` is every remaining ``ex2``: the online-rescale
+      ``exp2(old_max - new_max)`` corrections and the masked-row constants,
+      which are subtractions of two already-rounded values and are not part
+      of the P expression.
+    """
+    definitions: dict[str, tuple[str, str]] = {}
+    fma_fed = rounded = other = 0
+    for line in ptx.splitlines():
+        consumed = _EX2.search(line)
+        if consumed is not None:
+            operation, arguments = definitions.get(consumed.group(1), ("", ""))
+            if operation.startswith("fma"):
+                fma_fed += 1
+            elif operation == "sub.f32":
+                minuend = arguments.split(",")[0].strip()
+                producer, producer_arguments = definitions.get(minuend, ("", ""))
+                if producer.startswith("fma") and producer_arguments.rstrip().endswith(
+                    "0f00000000"
+                ):
+                    rounded += 1
+                else:
+                    other += 1
+            else:
+                other += 1
+        defined = _DEFINITION.match(line)
+        if defined is not None:
+            definitions[defined.group(2)] = (defined.group(1), defined.group(3))
+    return fma_fed, rounded, other
+
+
+def test_no_fa4_exp2_input_is_produced_by_an_fma(fa4_ptx: dict[str, str]) -> None:
+    """The defect signature must not appear in any emitted FA4 kernel."""
+    offenders = {
+        name: _classify_exp2_inputs(ptx)[0]
+        for name, ptx in fa4_ptx.items()
+        if _classify_exp2_inputs(ptx)[0]
+    }
+    assert not offenders, (
+        "an FA4 exp2 input is produced directly by an fma, so the scaled"
+        " score is an EXACT product being compared against a ROUNDED row"
+        " statistic -- the extreme-logit defect this fix removed. Either the"
+        " source regressed to fma(s, scale_log2, -m), or the toolchain"
+        " contracted the rounded product back into the subtraction."
+        f" Offending kernels: {offenders}"
+    )
+
+
+def test_every_fa4_p_loop_uses_a_separately_rounded_product(
+    fa4_ptx: dict[str, str],
+) -> None:
+    """The positive half: the rounded-product form is actually present.
+
+    Without this, deleting the whole P loop (or emitting exp2 of something
+    unrelated) would silently satisfy the negative check above.
+    """
+    for kernel in _P_LOOP_KERNELS:
+        sidecars = [name for name in fa4_ptx if kernel in name]
+        assert sidecars, (
+            f"no PTX sidecar for {kernel!r} -- fa4_ops stopped instantiating"
+            " a kernel this guard is supposed to cover, or the sidecar naming"
+            " changed"
+        )
+        for name in sidecars:
+            _, rounded, _ = _classify_exp2_inputs(fa4_ptx[name])
+            assert rounded >= 8, (
+                f"{name} has only {rounded} exp2 site(s) fed by a separately"
+                " rounded product; the P loop of this kernel should have"
+                " dozens, so the guard is not actually watching it"
+            )

--- a/torch_mojo_backend/eager_flash_attention/PROVENANCE.md
+++ b/torch_mojo_backend/eager_flash_attention/PROVENANCE.md
@@ -16,7 +16,15 @@ Original SHA-256 hashes:
 - `bwd_fa4/kernel.mojo`: `6ad8a2880b3af71b0f45e6747680a26c31f4f1117c8c5d3be8b46452ebde2f3e`
 - `bwd_fa4/launch.mojo`: `4f2b5a1f13b7148c2068d7aca45eb1737a97074d77af9dc3928f0911bb31d75e`
 
-The arithmetic kernel bodies are unchanged. Files were flattened and imports
+The arithmetic kernel bodies carry one deliberate deviation from upstream: the
+online-softmax `P = exp2(...)` in the two forward kernels and in the backward
+P-recompute rounds the scaled score on its own before subtracting the rowmax
+(`s.fma[FastMathFlag.NONE](scale_log2, 0) - m`) instead of fusing the two into a single
+`fma(s, scale_log2, -m)`. The fused form leaves the max element's exponent
+slightly non-zero by an amount that grows with logit magnitude; see the comment
+at the P loop in `fa4_fwd_kernel.mojo` and
+`tests/test_eager_kernels.py::test_fa4_forward_saturated_extreme_logit_accuracy`.
+Nothing else in the kernel bodies differs. Files were flattened and imports
 were prefixed so the official Mojo Python importer can resolve them without
 custom include flags. The launcher copies use the backend's existing MAX
 `DeviceContext` and omit the upstream default-context `synchronize()` calls;

--- a/torch_mojo_backend/eager_flash_attention/fa4_bwd_kernel.mojo
+++ b/torch_mojo_backend/eager_flash_attention/fa4_bwd_kernel.mojo
@@ -43,6 +43,7 @@ or finite next-batch garbage, both annihilated by P=dS=0). All
 q/k/v/o/do/dq/dk/dv tensors are contiguous (B, S, H, D) bf16.
 """
 
+from std.builtin.simd import FastMathFlag
 from std.math import exp2, tanh
 from std.math.constants import log2e
 from std.utils.numerics import inf
@@ -922,8 +923,17 @@ def bwd_main_kernel[
                 comptime for ic in range(4):
                     comptime c: Int = cc * 4 + ic
                     comptime j: Int = c & 1
+                    # Rounded product, then subtract the rounded lse,
+                    # kept in step with the live branch below. DORMANT:
+                    # no exported FA4 entry instantiates softcap_on, so
+                    # this expression is never compiled into a shipping
+                    # kernel and no test or PTX guard covers it. It is
+                    # changed only so the two branches cannot drift.
                     s_reg.ptr[c] = exp2(
-                        s_reg.ptr[c].fma(scale_log2, -lp2c[j])
+                        s_reg.ptr[c].fma[FastMathFlag.NONE](
+                            scale_log2, Scalar[accum_type](0)
+                        )
+                        - lp2c[j]
                     )
             comptime for c in range(c_frag_sdp):
                 dp_reg.ptr[c] = s_reg.ptr[c] * dp_reg.ptr[c]
@@ -946,8 +956,23 @@ def bwd_main_kernel[
                             scale_log2, -lp2[j]
                         )
                     else:
+                        # Round the scaled score before subtracting the
+                        # lse, matching the forward (see
+                        # fa4_fwd_kernel.mojo). The justification HERE is
+                        # fwd/bwd CONSISTENCY, not the forward's
+                        # p_max == 1 cancellation: backward subtracts a
+                        # rounded lse, never a rowmax, so no exact
+                        # winner-zero is available either way. The
+                        # forward now defines its softmax over
+                        # RN32(s * scale_log2), so the recompute must
+                        # rebuild P from those same rounded scores or it
+                        # differentiates a different softmax than the one
+                        # whose output and LSE were saved.
                         s_reg.ptr[c] = exp2(
-                            s_reg.ptr[c].fma(scale_log2, -lp2[j])
+                            s_reg.ptr[c].fma[FastMathFlag.NONE](
+                                scale_log2, Scalar[accum_type](0)
+                            )
+                            - lp2[j]
                         )
 
             # dP^T retired (wait 0: nothing else in flight — FA4's

--- a/torch_mojo_backend/eager_flash_attention/fa4_fwd_kernel.mojo
+++ b/torch_mojo_backend/eager_flash_attention/fa4_fwd_kernel.mojo
@@ -23,7 +23,10 @@ single P register buffer keeps the consumer register count near
 FA4's 168/thread; producer deallocates to 24 regs via setmaxnreg.
 
 The exp2 uses the scaled-domain trick: rowmax is kept premultiplied
-by softmax_scale*log2(e) so P = exp2(fma(s, scale_log2, -m)).
+by softmax_scale*log2(e) so P = exp2(round(s*scale_log2) - m). The
+product is rounded on its own instead of being fused with the
+subtraction, so p_max is exactly 1.0 at any logit magnitude; see the
+comment at the P loop.
 
 Grid: (ceildiv(seqlen, BM), nheads, batch). Block: 384 threads.
 
@@ -34,6 +37,7 @@ straight indexwise cast is correct. (With >1 m_mma it would not be:
 the RS wgmma walks fragments k-major, `a_frags[m + k*num_m]`.)
 """
 
+from std.builtin.simd import FastMathFlag
 from std.math import exp2, log, tanh
 from std.math.constants import log2e
 from std.sys import size_of
@@ -820,8 +824,33 @@ def fwd_fa4_kernel[
             comptime for c in range(c_frag_size_qk):
                 comptime row_idx: Int = 1 if (c % 4) >= 2 else 0
                 comptime part: Int = (c // 4) % RED_WAYS
+                # Round the scaled score BEFORE subtracting the rowmax
+                # (which is itself the rounded scaled max): the winning
+                # element's exponent is then exactly zero and p_max is
+                # exactly 1.0, so the 16-bit P-packing error on the
+                # dominant entry cancels against the f32 rowsum instead
+                # of biasing numerator against denominator. A single
+                # fma(s, scale_log2, -rowmax) keeps the product EXACT
+                # while rowmax is rounded, leaving a residual bounded by
+                # half an f32 ulp of |s * scale_log2| -- an envelope
+                # that widens with each binade of the scaled logit
+                # (2026-08 nanoGPT layer-1 attention-collapse incident:
+                # |scaled logit| ~ 7e4, half-ulp ~3.9e-3, i.e. up to
+                # ~0.27% displacement of the dominant probability, and
+                # 16x cuda flash's saturated-row rms).
+                #
+                # The spelling is load bearing. `s * scale_log2 - rowmax`
+                # is contracted straight back into the defective fma;
+                # FastMathFlag.NONE asks for the strict, non-contracted
+                # form. Verified non-contracted on Mojo 1.0.0 (ed45d567)
+                # for sm_90a -- and kept verified by the PTX guard in
+                # tests/test_fa4_rounded_product_ptx.py, which fails if
+                # any FA4 exp2 input is ever produced by an fma again.
                 var p: Scalar[accum_type] = exp2(
-                    s_reg.ptr[c].fma(scale_log2, -rowmax[row_idx])
+                    s_reg.ptr[c].fma[FastMathFlag.NONE](
+                        scale_log2, Scalar[accum_type](0)
+                    )
+                    - rowmax[row_idx]
                 )
                 s_reg.ptr[c] = p
                 part_sum[row_idx * RED_WAYS + part] += p
@@ -839,8 +868,13 @@ def fwd_fa4_kernel[
                 local_sum[i] = Scalar[accum_type](0)
             comptime for c in range(c_frag_size_qk):
                 comptime row_idx: Int = 1 if (c % 4) >= 2 else 0
+                # Rounded product minus the rounded rowmax, so p_max is
+                # exactly 1.0 (rationale at the TREE_REDUCE site above).
                 var p: Scalar[accum_type] = exp2(
-                    s_reg.ptr[c].fma(scale_log2, -rowmax[row_idx])
+                    s_reg.ptr[c].fma[FastMathFlag.NONE](
+                        scale_log2, Scalar[accum_type](0)
+                    )
+                    - rowmax[row_idx]
                 )
                 s_reg.ptr[c] = p
                 local_sum[row_idx] += p

--- a/torch_mojo_backend/eager_flash_attention/fa4_fwd_selfload_kernel.mojo
+++ b/torch_mojo_backend/eager_flash_attention/fa4_fwd_selfload_kernel.mojo
@@ -52,7 +52,10 @@ register buffer keeps the register count near FA4's target; there is no
 producer warpgroup left to deallocate registers for via setmaxnreg.
 
 The exp2 uses the scaled-domain trick: rowmax is kept premultiplied
-by softmax_scale*log2(e) so P = exp2(fma(s, scale_log2, -m)).
+by softmax_scale*log2(e) so P = exp2(round(s*scale_log2) - m). The
+product is rounded on its own instead of being fused with the
+subtraction, so p_max is exactly 1.0 at any logit magnitude; see the
+comment at the P loop.
 
 Grid: (ceildiv(seqlen, BM), nheads, batch). Block: 128 threads.
 
@@ -63,6 +66,7 @@ straight indexwise cast is correct. (With >1 m_mma it would not be:
 the RS wgmma walks fragments k-major, `a_frags[m + k*num_m]`.)
 """
 
+from std.builtin.simd import FastMathFlag
 from std.math import exp2, log, tanh
 from std.math.constants import log2e
 from std.sys import size_of
@@ -868,8 +872,13 @@ def fwd_fa4_selfload_kernel[
             comptime for c in range(c_frag_size_qk):
                 comptime row_idx: Int = 1 if (c % 4) >= 2 else 0
                 comptime part: Int = (c // 4) % RED_WAYS
+                # Rounded product minus the rounded rowmax, so p_max is
+                # exactly 1.0 (see fa4_fwd_kernel.mojo).
                 var p: Scalar[accum_type] = exp2(
-                    s_reg.ptr[c].fma(scale_log2, -rowmax[row_idx])
+                    s_reg.ptr[c].fma[FastMathFlag.NONE](
+                        scale_log2, Scalar[accum_type](0)
+                    )
+                    - rowmax[row_idx]
                 )
                 s_reg.ptr[c] = p
                 part_sum[row_idx * RED_WAYS + part] += p
@@ -887,8 +896,13 @@ def fwd_fa4_selfload_kernel[
                 local_sum[i] = Scalar[accum_type](0)
             comptime for c in range(c_frag_size_qk):
                 comptime row_idx: Int = 1 if (c % 4) >= 2 else 0
+                # Rounded product minus the rounded rowmax, so p_max is
+                # exactly 1.0 (see fa4_fwd_kernel.mojo).
                 var p: Scalar[accum_type] = exp2(
-                    s_reg.ptr[c].fma(scale_log2, -rowmax[row_idx])
+                    s_reg.ptr[c].fma[FastMathFlag.NONE](
+                        scale_log2, Scalar[accum_type](0)
+                    )
+                    - rowmax[row_idx]
                 )
                 s_reg.ptr[c] = p
                 local_sum[row_idx] += p


### PR DESCRIPTION
## The defect

FA4's online softmax formed the probability of every score as

```mojo
P = exp2(fma(s, scale_log2, -rowmax))     # one fused multiply-add
```

The fma keeps `s * scale_log2` **exact**, but `rowmax` is the **rounded**
scaled maximum (`RN32(max_i(s_i) * scale_log2)`). Subtracting a rounded value
from an exact one leaves the winning element's exponent off zero by

```
|x - RN32(x)| <= 0.5 * ulp32(x),   x = s_max * scale_log2
```

so `p_max` is no longer exactly `1.0`. That matters because FA4 packs `P` to
16-bit for the `P@V` WGMMA while accumulating the rowsum in f32: when the
dominant entry is exactly `1.0` it is exactly representable in both, and its
packing error cancels between numerator and denominator. Once it is not, the
normalized dominant coefficient is effectively `bf16(p)/p` instead of one, and
on a saturated row that single term is the output.

The fix computes the correctly rounded product first and subtracts afterwards,
at all six sites (regular forward x2, self-load forward x2, backward
P-recompute x2):

```mojo
P = exp2(s.fma[FastMathFlag.NONE](scale_log2, 0) - rowmax)
```

**Why random-input sweeps never caught it.** The residual is an envelope that
widens with each binade of the *scaled logit*, not with saturation. At healthy
magnitudes (`|x| ~ 2e2`) half an ulp is `7.6e-6` and the error is invisible;
the 2026-08 nanoGPT run drove layer-1 logits to `|x| ~ 7e4`, where half an ulp
is `3.9e-3` and displaces the dominant probability by up to `2 ** 3.9e-3 - 1 =
0.27%`. Every existing accuracy test uses ordinary-magnitude inputs, so the
regime that triggers this is one no sweep visits. It is magnitude-triggered,
not saturation-triggered.

**The spelling is load bearing.** Written plainly as `s * scale_log2 - rowmax`
the compiler contracts it straight back into the defective fma and emits a
bit-identical kernel; `SIMD.fma` itself defaults to `FastMathFlag.CONTRACT`.
The source therefore asks for strict semantics explicitly, and a PTX guard
(below) keeps the request honest instead of trusting it.

## Causal chain, in brief

The defect was localized on a captured H100 nanoGPT-124M state that entered a
sustained gradient-norm ratchet, by faithful 600-step replays from one
ancestral checkpoint:

- **Transplant.** Replacing only `aten::_scaled_dot_product_flash_attention`
  and its backward with the CUDA ops flips the outcome: three CUDA-SDPA arms
  are clean, while the same-environment production arm and a sham arm (same
  interception plumbing, Mojo kernels retained) both ratchet.
- **Bisection.** Mojo forward + CUDA backward ratchets; CUDA forward + Mojo
  backward is clean. A forward transplant replaces output **and** LSE, so this
  establishes that the *forward-returned state* is necessary, not that output
  values alone are.
- **Proof by fix.** Replays with only the forward source expression corrected
  (and one with the full patch) are clean, 4 of 4, against controls that
  ratchet in the same environment. That is what closes the gap the bisection
  leaves.

The claim this PR makes is bounded accordingly: forward-returned state is
necessary for the ratchet in this captured trajectory, and the forward-only
source fix was sufficient in replays. It is not a claim about training runs in
general.

## Accuracy

On the captured cliff-regime tensors, saturated-row error against a CPU fp64
reference:

| kernel | saturated-row rms | saturated-row max |
|---|---|---|
| FA4, stock | 3.441e-4 | 1.574e-2 |
| CUDA flash | 2.068e-5 | 3.794e-3 |
| FA4, fixed | matches CUDA's rms/max to four significant digits | |

"Matches" means exactly that — the two printed saturated-row metrics agree.
All-row rms still differs slightly (9.188e-4 vs 9.187e-4) and no
tensor-equality test exists; this is not a claim of numerical identity with
CUDA.

The committed regression tests measure the same effect on synthetic
extreme-logit inputs across every FA4 route (see the tables in
`tests/test_eager_kernels.py`); the collapsed-regime forward rms improves by
28-51x and dQ/dK rms by 45-12800x depending on dtype and head_dim.

## Regression tests

Two layers, both new.

**Runtime, `tests/test_eager_kernels.py`** — 44 cells over
`{bf16, f16} x {d64, d128} x {gapped_qkv, bshd_view, bhsd} x {healthy,
collapsed}`, plus a self-load-sized forward case and a backward case:

- the reference is a **CPU fp64 causal decomposition**, never a vendor kernel,
  so a future flash implementation for another architecture inherits the guard
  as written;
- Q/K/V are rounded to the target 16-bit dtype *before* the fp64 reference
  consumes them, so only kernel error is measured;
- every cell **asserts its route**: the compiled FA4 bridge symbol it expects
  is spied and required to run exactly once. Without that a future
  eligibility-gate change could route the case to the accurate math
  decomposition and leave a green test that no longer tests FA4;
- the `healthy` half of every parametrization is unchanged by the fix and
  guards against paying for it in the ordinary regime;
- tolerances are **empirical fixed-seed thresholds**, not a derived format
  floor. Every stock/fixed measurement used to pick them is tabulated in the
  source next to the bounds, with the margin each bound carries (wide on rms;
  about 1.4x either side on the peak, which is a single-element statistic);
- **coverage is H100-only** — `mojo_h100` skips everything else and FA4
  eligibility is hard-gated to `sm_90a`. Nothing here establishes portability
  to another architecture.

The backward case checks dQ/dK/dV against CPU fp64 autograd. It exercises the
fixed forward and fixed backward as a **pair**, which is the only combination
that ships (the backward consumes the forward's LSE), and does not isolate the
backward edit. The backward's own justification is consistency rather than the
forward's cancellation argument: it subtracts a rounded LSE, never a rowmax, so
no exact winner-zero exists there either way — but the fixed forward now
defines its softmax over `RN32(s * scale_log2)`, and the recompute must rebuild
P from those same rounded scores or it differentiates a different softmax than
the one whose output and LSE were saved. One of the two backward sites is in
the `softcap_on` branch, which **no exported FA4 entry instantiates**: it is
changed only so the branches cannot drift, is not compiled into any shipping
kernel, and is covered by no test.

**Codegen, `tests/test_fa4_rounded_product_ptx.py`** — cross-compiles
`fa4_ops.mojo` for `sm_90a` (no GPU, never takes the GPU lock) and asserts on
the emitted PTX that **no `ex2.approx` input is produced by an `fma`**, plus
the positive counterpart that the rounded-product form is actually present.
This covers every instantiation the module compiles — both forward kernels and
the live backward P-recompute, bf16 and f16, d64 and d128 — including the ones
no runtime test can reach, and it is what makes the fix robust to a future
toolchain deciding to contract the expression again.

### Red / green

Runtime tests, stock tree (`upstream/main`, tests only):

```
22 failed, 22 passed, 1724 deselected in 8.73s
```

Every failure is a `collapsed` cell; every `healthy` cell passes. Example:

```
E  AssertionError: saturated-row rms 1.123e-03 exceeds the collapsed bound 1.500e-04
E  AssertionError: dQ rms 1.752e-01 exceeds the collapsed bound 1.000e-04
```

Runtime tests, this branch:

```
44 passed, 1726 deselected, 17 warnings in 3.94s
```

PTX guard, stock tree:

```
2 failed
E  AssertionError: an FA4 exp2 input is produced directly by an fma ...
   Offending kernels: {bwd_main_kernel...: 64, ..., fwd_fa4_kernel...: 128, ...,
                       fwd_fa4_selfload_kernel...: 128, ...}
```

PTX guard, this branch:

```
2 passed
```

Across the 16 emitted kernels this is a total discriminator: **1728 of 1728**
`ex2` sites are fma-fed before the fix and **0** after.

## Blast radius

**Assembly.** `scripts/compare_kernel_asm.py`, stock vs this branch:

| kernel dir | accelerator | result |
|---|---|---|
| `eager_flash_attention` | `sm_90a` | **16 of 24 kernels differ** — intended, see below |
| `eager_flash_attention` | `gfx942` | does not build on either side (`failed to run the pass manager for offload functions`): FA4 is Hopper-only (WGMMA/TMA), so it emits no AMD device code at all |
| `eager_flash_attention` | `apple-m4` | same, no Metal device code |
| `eager_kernels` (all 22 modules) | `sm_90a` | **0 of 3848 kernels differ**, across 269 specializations of all 22 modules |

The 16 changed sm_90a kernels are **intended and global**: this is a numerical
change to a shared source, so every bf16/f16, d64/d128, regular/self-load and
backward instantiation is supposed to move. The 8 unchanged ones are the
backward preprocess/convert kernels, which carry no `exp2`. Nothing outside
`eager_flash_attention` changed source at all — the diff touches three `.mojo`
files, all in that directory.

**Dispatch (host code) is unchanged.** No launch geometry, gate threshold or
SM-count-derived constant is touched, so the assembly diff is the whole story
here rather than half of it.

**Direct A/B microbenchmark.** Device time only, torch-profiler kernel events,
process-level ABBA ordering (fixed, stock, stock, fixed x2), core clock pinned
at 1400 MHz. Per-config burst spread was 0.0-1.2%, so these deltas are real:

| config | stock us | fixed us | ratio |
|---|---:|---:|---:|
| fwd bf16 regular d64 | 12.50 | 12.89 | 1.032 |
| fwd bf16 regular d128 | 13.43 | 13.81 | 1.028 |
| fwd bf16 selfload d64 (nanoGPT 8x12x1024) | 59.57 | 60.74 | 1.020 |
| fwd bf16 selfload d64 (8x32x256) | 21.25 | 21.54 | 1.014 |
| fwd bf16 d128 1x16x4096 | 177.84 | 185.62 | 1.044 |
| fwd f16 regular d64 | 12.44 | 12.88 | 1.035 |
| fwd f16 regular d128 | 13.47 | 13.80 | 1.025 |
| fwd f16 selfload d64 (nanoGPT) | 59.78 | 60.90 | 1.019 |
| fwd f16 selfload d64 (8x32x256) | 21.30 | 21.79 | 1.023 |
| fwd f16 d128 1x16x4096 | 181.46 | 188.08 | 1.037 |
| fwd+bwd bf16 d64 | 116.77 | 116.53 | 0.998 |
| fwd+bwd bf16 d128 | 99.34 | 99.46 | 1.001 |
| fwd+bwd f16 d64 | 116.49 | 116.41 | 0.999 |
| fwd+bwd f16 d128 | 99.87 | 99.99 | 1.001 |

So this **does** cost something: the forward is 1.4-4.4% slower, because the
P loop gains one `sub.f32` per element where the old form fused it away. A
forward+backward step is unchanged within noise, the backward being dominated
by its other work. This is a correctness fix and the cost is stated rather
than claimed away.

(A follow-up could recover it: folding `scale_log2` into Q once, before the
QK WGMMA, would remove the per-element multiply entirely and still leave a
correctly rounded score. That is a separate change with its own precision
question, and is not attempted here.)

**Benchmark suite.** `uv run pytest benchmarks/test_attention.py` — **20
passed**. Note what that guarantees: no node regressed more than the checker's
8% dead band versus the recorded baseline. It is not a base-vs-patch
measurement; the table above is.

**Neighbour tests.** `uv run pytest tests/ -k "fa4 or flash or sdpa or
attention"` — **247 passed, 8 skipped, 0 failed** in 82s (the 209 pre-existing nodes plus
the 38 added here).

## Not in this PR

A separate, **pre-existing** wrong answer exists for `S % 128 != 0` with a
strided (non-BHSD) Q/K/V input: saturated-row max error `2.758`, rms `1.006e-1`
on both the stock and fixed trees. It is unaffected by this change and is not
in the FA4 strided kernel: `aten_fast.py:6905-6911` explicitly declines FA4 for
that combination, so what is producing the wrong answer is the **fallback**
that input reaches. It needs a route-spied red test to localize it properly and
is tracked separately. Production `S=1024` and every cell added here use
`S % 128 == 0`, so no test in this PR touches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Co2wBC1UYzM4y9PEC92Af
