### PR TITLE
Support enable_gqa=True in eager SDPA (grouped-query attention)

### DIFF
--- a/benchmarks/baselines.html
+++ b/benchmarks/baselines.html
@@ -8677,6 +8677,16 @@ document.addEventListener("DOMContentLoaded", boot);
                     "contig": 0.832
                   }
                 },
+                "B1H32KV8S4096D128": {
+                  "layouts": {
+                    "contig": 4.032
+                  }
+                },
+                "B1H8KV1S4096D128": {
+                  "layouts": {
+                    "contig": 0.923
+                  }
+                },
                 "B8H12S1024D64": {
                   "layouts": {
                     "contig": 0.912
@@ -8689,6 +8699,16 @@ document.addEventListener("DOMContentLoaded", boot);
                 "B1H16S4096D128": {
                   "layouts": {
                     "contig": 0.835
+                  }
+                },
+                "B1H32KV8S4096D128": {
+                  "layouts": {
+                    "contig": 3.988
+                  }
+                },
+                "B1H8KV1S4096D128": {
+                  "layouts": {
+                    "contig": 0.929
                   }
                 },
                 "B8H12S1024D64": {

--- a/benchmarks/baselines.html
+++ b/benchmarks/baselines.html
@@ -8639,6 +8639,16 @@ document.addEventListener("DOMContentLoaded", boot);
                     "contig": 0.832
                   }
                 },
+                "B1H32KV8S4096D128": {
+                  "layouts": {
+                    "contig": 4.032
+                  }
+                },
+                "B1H8KV1S4096D128": {
+                  "layouts": {
+                    "contig": 0.923
+                  }
+                },
                 "B8H12S1024D64": {
                   "layouts": {
                     "contig": 0.912
@@ -8651,6 +8661,16 @@ document.addEventListener("DOMContentLoaded", boot);
                 "B1H16S4096D128": {
                   "layouts": {
                     "contig": 0.835
+                  }
+                },
+                "B1H32KV8S4096D128": {
+                  "layouts": {
+                    "contig": 3.988
+                  }
+                },
+                "B1H8KV1S4096D128": {
+                  "layouts": {
+                    "contig": 0.929
                   }
                 },
                 "B8H12S1024D64": {

--- a/benchmarks/test_attention.py
+++ b/benchmarks/test_attention.py
@@ -6,6 +6,11 @@ entry point is pinned — the public F.scaled_dot_product_attention node
 additionally measures whatever backend selection stock PyTorch performs.
 Shapes are (batch, heads, seq, head_dim): a GPT-2-like block and a long
 single-sequence decode-prefill regime.  All cases are causal.
+
+GQA_SHAPES cover the enable_gqa=True regime (see fix/gqa-sdpa-enable-gqa):
+Q and K/V carry different head counts, so they get their own shape dict
+keyed as B{batch}H{q_heads}KV{kv_heads}S{seq}D{head_dim} — the KV token
+in the shape id is what lets a baseline diff show the ratio at a glance.
 """
 
 from __future__ import annotations
@@ -20,6 +25,14 @@ from bench_lib.hw import Hardware
 SHAPES: dict[str, tuple[int, int, int, int]] = {
     "B8H12S1024D64": (8, 12, 1024, 64),
     "B1H16S4096D128": (1, 16, 4096, 128),
+}
+
+# (batch, q_heads, kv_heads, seq, head_dim). Llama-3-8B's own ratio (32:8,
+# head_dim 128) plus an MQA extreme (kv_heads=1) at the same seq/head_dim so
+# the two rows differ only in the ratio being measured.
+GQA_SHAPES: dict[str, tuple[int, int, int, int, int]] = {
+    "B1H32KV8S4096D128": (1, 32, 8, 4096, 128),
+    "B1H8KV1S4096D128": (1, 8, 1, 4096, 128),
 }
 
 COVERS: dict[str, str] = {
@@ -57,6 +70,36 @@ def test_sdpa(
     bench.run(
         lambda: F.scaled_dot_product_attention(*refs, is_causal=True),
         lambda: F.scaled_dot_product_attention(*ours, is_causal=True),
+        flops=flops,
+    )
+
+
+def _qkv_gqa(
+    shape_id: str, dtype_id: str, hw: Hardware, mojo: torch.device
+) -> tuple[list[torch.Tensor], list[torch.Tensor], float]:
+    b, h, kv, s, d = GQA_SHAPES[shape_id]
+    dtype = DTYPES[dtype_id]
+    q_ref, q_our = both(torch.randn(b, h, s, d, dtype=dtype), hw, mojo)
+    k_ref, k_our = both(torch.randn(b, kv, s, d, dtype=dtype), hw, mojo)
+    v_ref, v_our = both(torch.randn(b, kv, s, d, dtype=dtype), hw, mojo)
+    # FLOPs are driven by the query head count: each of the h query heads
+    # still attends over the full (broadcast) K/V, same as the equal-head
+    # case above -- the KV ratio changes memory traffic, not FLOPs.
+    flops = 4.0 * b * h * s * s * d / 2.0  # causal halves the score matrix
+    return [q_ref, k_ref, v_ref], [q_our, k_our, v_our], flops
+
+
+@pytest.mark.parametrize("dtype_id", ("bf16", "f16"))
+@pytest.mark.parametrize("shape_id", GQA_SHAPES)
+@pytest.mark.bench_op("scaled_dot_product_attention")
+def test_sdpa_gqa(
+    shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
+) -> None:
+    """enable_gqa=True: K/V carry fewer heads than Q (see GQA_SHAPES)."""
+    refs, ours, flops = _qkv_gqa(shape_id, dtype_id, hw, mojo_device)
+    bench.run(
+        lambda: F.scaled_dot_product_attention(*refs, is_causal=True, enable_gqa=True),
+        lambda: F.scaled_dot_product_attention(*ours, is_causal=True, enable_gqa=True),
         flops=flops,
     )
 

--- a/benchmarks/test_attention.py
+++ b/benchmarks/test_attention.py
@@ -6,6 +6,11 @@ entry point is pinned — the public F.scaled_dot_product_attention node
 additionally measures whatever backend selection stock PyTorch performs.
 Shapes are (batch, heads, seq, head_dim): a GPT-2-like block and a long
 single-sequence decode-prefill regime.  All cases are causal.
+
+GQA_SHAPES cover the enable_gqa=True regime (see fix/gqa-sdpa-enable-gqa):
+Q and K/V carry different head counts, so they get their own shape dict
+keyed as B{batch}H{q_heads}KV{kv_heads}S{seq}D{head_dim} — the KV token
+in the shape id is what lets a baseline diff show the ratio at a glance.
 """
 
 from __future__ import annotations
@@ -22,6 +27,14 @@ from bench_lib.hw import Hardware
 SHAPES: dict[str, tuple[int, int, int, int]] = {
     "B8H12S1024D64": (8, 12, 1024, 64),
     "B1H16S4096D128": (1, 16, 4096, 128),
+}
+
+# (batch, q_heads, kv_heads, seq, head_dim). Llama-3-8B's own ratio (32:8,
+# head_dim 128) plus an MQA extreme (kv_heads=1) at the same seq/head_dim so
+# the two rows differ only in the ratio being measured.
+GQA_SHAPES: dict[str, tuple[int, int, int, int, int]] = {
+    "B1H32KV8S4096D128": (1, 32, 8, 4096, 128),
+    "B1H8KV1S4096D128": (1, 8, 1, 4096, 128),
 }
 
 COVERS: dict[str, str] = {
@@ -75,6 +88,36 @@ def test_sdpa(
     bench.run(
         lambda: F.scaled_dot_product_attention(*refs, is_causal=True),
         lambda: F.scaled_dot_product_attention(*ours, is_causal=True),
+        flops=flops,
+    )
+
+
+def _qkv_gqa(
+    shape_id: str, dtype_id: str, hw: Hardware, mojo: torch.device
+) -> tuple[list[torch.Tensor], list[torch.Tensor], float]:
+    b, h, kv, s, d = GQA_SHAPES[shape_id]
+    dtype = DTYPES[dtype_id]
+    q_ref, q_our = both(torch.randn(b, h, s, d, dtype=dtype), hw, mojo)
+    k_ref, k_our = both(torch.randn(b, kv, s, d, dtype=dtype), hw, mojo)
+    v_ref, v_our = both(torch.randn(b, kv, s, d, dtype=dtype), hw, mojo)
+    # FLOPs are driven by the query head count: each of the h query heads
+    # still attends over the full (broadcast) K/V, same as the equal-head
+    # case above -- the KV ratio changes memory traffic, not FLOPs.
+    flops = 4.0 * b * h * s * s * d / 2.0  # causal halves the score matrix
+    return [q_ref, k_ref, v_ref], [q_our, k_our, v_our], flops
+
+
+@pytest.mark.parametrize("dtype_id", ("bf16", "f16"))
+@pytest.mark.parametrize("shape_id", GQA_SHAPES)
+@pytest.mark.bench_op("scaled_dot_product_attention")
+def test_sdpa_gqa(
+    shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
+) -> None:
+    """enable_gqa=True: K/V carry fewer heads than Q (see GQA_SHAPES)."""
+    refs, ours, flops = _qkv_gqa(shape_id, dtype_id, hw, mojo_device)
+    bench.run(
+        lambda: F.scaled_dot_product_attention(*refs, is_causal=True, enable_gqa=True),
+        lambda: F.scaled_dot_product_attention(*ours, is_causal=True, enable_gqa=True),
         flops=flops,
     )
 

--- a/benchmarks/test_attention.py
+++ b/benchmarks/test_attention.py
@@ -94,7 +94,11 @@ def test_sdpa(
 
 def _qkv_gqa(
     shape_id: str, dtype_id: str, hw: Hardware, mojo: torch.device
-) -> tuple[list[torch.Tensor], list[torch.Tensor], float]:
+) -> tuple[
+    tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+    tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+    float,
+]:
     b, h, kv, s, d = GQA_SHAPES[shape_id]
     dtype = DTYPES[dtype_id]
     q_ref, q_our = both(torch.randn(b, h, s, d, dtype=dtype), hw, mojo)
@@ -104,7 +108,7 @@ def _qkv_gqa(
     # still attends over the full (broadcast) K/V, same as the equal-head
     # case above -- the KV ratio changes memory traffic, not FLOPs.
     flops = 4.0 * b * h * s * s * d / 2.0  # causal halves the score matrix
-    return [q_ref, k_ref, v_ref], [q_our, k_our, v_our], flops
+    return (q_ref, k_ref, v_ref), (q_our, k_our, v_our), flops
 
 
 @pytest.mark.parametrize("dtype_id", ("bf16", "f16"))

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -9773,6 +9773,501 @@ def test_fast_sdpa_causal_training_backward(mojo_gpu):
         torch.testing.assert_close(actual_grad, expected_grad, atol=2e-2, rtol=2e-2)
 
 
+# ---------------------------------------------------------------------------
+# Grouped-query attention (``enable_gqa=True``).
+#
+# HF transformers' ``sdpa_attention_forward`` stops calling ``repeat_kv``
+# itself and passes ``enable_gqa=True`` whenever there is no padding mask, so
+# this is the shape of every ordinary Llama-3/Mistral/Qwen2/Gemma2 causal step.
+# ``(32, 8)`` is Llama-3-8B's ratio, ``(8, 1)`` is multi-query attention, whose
+# single K/V head is broadcast rather than copied.
+# ---------------------------------------------------------------------------
+
+_GQA_HEAD_COUNTS = ((32, 8), (8, 1))
+_GQA_HEAD_IDS = ["q32kv8", "q8kv1"]
+
+
+def _gqa_host_qkv(
+    q_heads: int,
+    kv_heads: int,
+    dtype: torch.dtype,
+    *,
+    batch: int = 1,
+    q_len: int = 128,
+    kv_len: int = 128,
+    head_dim: int = 64,
+    seed: int = 20260811,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Host-side ``(query, key, value)`` with mismatched head counts."""
+    generator = torch.Generator().manual_seed(seed)
+
+    def make(heads: int, length: int) -> torch.Tensor:
+        return (
+            torch.randn(
+                batch, heads, length, head_dim, generator=generator, dtype=torch.float32
+            )
+            * 0.25
+        ).to(dtype)
+
+    return make(q_heads, q_len), make(kv_heads, kv_len), make(kv_heads, kv_len)
+
+
+def _repeat_kv(tensor: torch.Tensor, q_heads: int) -> torch.Tensor:
+    """HF transformers' ``repeat_kv``, the reference expansion."""
+    batch, kv_heads, length, head_dim = tensor.shape
+    return (
+        tensor[:, :, None]
+        .expand(batch, kv_heads, q_heads // kv_heads, length, head_dim)
+        .reshape(batch, q_heads, length, head_dim)
+    )
+
+
+@pytest.mark.parametrize("is_causal", [True, False], ids=["causal", "full"])
+@pytest.mark.parametrize("head_dim", [64, 128], ids=["d64", "d128"])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "f16"])
+@pytest.mark.parametrize("q_heads,kv_heads", _GQA_HEAD_COUNTS, ids=_GQA_HEAD_IDS)
+def test_fast_sdpa_enable_gqa_forward_matches_reference(
+    mojo_gpu, q_heads, kv_heads, dtype, head_dim, is_causal
+):
+    """``enable_gqa=True`` with fewer K/V heads must compute plain attention.
+
+    head_dim 64 and 128 are the two FA4-eligible regimes, so this also covers
+    a GQA call landing on a fused route after the expansion rather than only
+    on the math decomposition.
+    """
+    query, key, value = _gqa_host_qkv(q_heads, kv_heads, dtype, head_dim=head_dim)
+    reference = torch.nn.functional.scaled_dot_product_attention(
+        query.float(),
+        _repeat_kv(key, q_heads).float(),
+        _repeat_kv(value, q_heads).float(),
+        is_causal=is_causal,
+    )
+    with torch.no_grad():
+        actual = torch.nn.functional.scaled_dot_product_attention(
+            query.to(mojo_gpu),
+            key.to(mojo_gpu),
+            value.to(mojo_gpu),
+            is_causal=is_causal,
+            enable_gqa=True,
+        )
+    assert tuple(actual.shape) == tuple(reference.shape)
+    assert actual.dtype == dtype
+    torch.testing.assert_close(actual.cpu().float(), reference, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.parametrize("q_heads,kv_heads", _GQA_HEAD_COUNTS, ids=_GQA_HEAD_IDS)
+def test_fast_sdpa_enable_gqa_grad_enabled_forward_matches_reference(
+    mojo_gpu, q_heads, kv_heads
+):
+    """Grad mode on with no leaf requiring a gradient stays graph-free.
+
+    fp32 too, so this is the math decomposition rather than the fused route
+    the 16-bit cases above reach.
+    """
+    query, key, value = _gqa_host_qkv(q_heads, kv_heads, torch.float32)
+    reference = torch.nn.functional.scaled_dot_product_attention(
+        query, _repeat_kv(key, q_heads), _repeat_kv(value, q_heads), is_causal=True
+    )
+    actual = torch.nn.functional.scaled_dot_product_attention(
+        query.to(mojo_gpu),
+        key.to(mojo_gpu),
+        value.to(mojo_gpu),
+        is_causal=True,
+        enable_gqa=True,
+    )
+    assert actual.grad_fn is None
+    torch.testing.assert_close(actual.cpu(), reference, atol=2e-3, rtol=2e-3)
+
+
+def test_fast_sdpa_enable_gqa_multi_query_expansion_is_zero_copy(mojo_gpu):
+    """A single K/V head becomes a stride-0 broadcast, never a copy."""
+    from torch_mojo_backend.eager_kernels import aten_fast
+
+    key = torch.randn(2, 1, 8, 16).to(mojo_gpu)
+    expanded = aten_fast._expand_kv_heads_for_gqa(key, 12)
+    assert expanded is not None
+    assert tuple(expanded.shape) == (2, 12, 8, 16)
+    assert expanded._strides[1] == 0
+    assert expanded._ptr == key._ptr
+    assert expanded._holder is key._holder
+    torch.testing.assert_close(expanded.cpu(), _repeat_kv(key.cpu(), 12))
+
+
+def test_fast_sdpa_enable_gqa_expansion_matches_repeat_kv(mojo_gpu):
+    """The materialized expansion repeats each head n_rep times in place."""
+    from torch_mojo_backend.eager_kernels import aten_fast
+
+    host = torch.randn(2, 3, 5, 4)
+    expanded = aten_fast._expand_kv_heads_for_gqa(host.to(mojo_gpu), 12)
+    assert expanded is not None
+    assert expanded._is_contiguous
+    torch.testing.assert_close(expanded.cpu(), _repeat_kv(host, 12))
+
+
+@pytest.mark.parametrize("q_heads,kv_heads", [(6, 4), (2, 3)], ids=["6to4", "2to3"])
+def test_fast_sdpa_enable_gqa_indivisible_head_counts_raise(
+    mojo_gpu, q_heads, kv_heads
+):
+    """A head count the group structure cannot express is declined cleanly."""
+    query, key, value = _gqa_host_qkv(
+        q_heads, kv_heads, torch.float32, q_len=8, kv_len=8
+    )
+    with pytest.raises(NotImplementedError), torch.no_grad():
+        torch.nn.functional.scaled_dot_product_attention(
+            query.to(mojo_gpu), key.to(mojo_gpu), value.to(mojo_gpu), enable_gqa=True
+        )
+
+
+@pytest.mark.parametrize("q_heads,kv_heads", _GQA_HEAD_COUNTS, ids=_GQA_HEAD_IDS)
+def test_fast_sdpa_enable_gqa_masked_forward_matches_reference(
+    mojo_gpu, q_heads, kv_heads
+):
+    """A float bias mask together with ``enable_gqa`` used to decline outright."""
+    query, key, value = _gqa_host_qkv(
+        q_heads, kv_heads, torch.float32, q_len=16, kv_len=24, head_dim=32
+    )
+    generator = torch.Generator().manual_seed(20260812)
+    mask = torch.randn(1, q_heads, 16, 24, generator=generator)
+    reference = torch.nn.functional.scaled_dot_product_attention(
+        query, _repeat_kv(key, q_heads), _repeat_kv(value, q_heads), attn_mask=mask
+    )
+    with torch.no_grad():
+        actual = torch.nn.functional.scaled_dot_product_attention(
+            query.to(mojo_gpu),
+            key.to(mojo_gpu),
+            value.to(mojo_gpu),
+            attn_mask=mask.to(mojo_gpu),
+            enable_gqa=True,
+        )
+    torch.testing.assert_close(actual.cpu(), reference, atol=2e-3, rtol=2e-3)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "f16"])
+def test_fast_sdpa_enable_gqa_strided_qkv_forward_matches_reference(mojo_gpu, dtype):
+    """Q/K/V taken as transposed views of one packed projection, the way a real
+    model hands them over (the layout the FA4 ``_strided_qkv`` ABI exists for).
+
+    The expansion has to read K/V through those strides rather than assume a
+    dense head axis; Q stays a strided view throughout.
+    """
+    batch, seqlen, q_heads, kv_heads, head_dim = 1, 128, 8, 2, 64
+    generator = torch.Generator().manual_seed(20260813)
+    packed = (
+        torch.randn(
+            batch,
+            seqlen,
+            (q_heads + 2 * kv_heads) * head_dim,
+            generator=generator,
+            dtype=torch.float32,
+        )
+        * 0.25
+    ).to(dtype)
+
+    def split(source: torch.Tensor) -> tuple[torch.Tensor, ...]:
+        query_part, key_part, value_part = source.split(
+            [q_heads * head_dim, kv_heads * head_dim, kv_heads * head_dim], dim=2
+        )
+        return tuple(
+            part.view(batch, seqlen, heads, head_dim).transpose(1, 2)
+            for part, heads in (
+                (query_part, q_heads),
+                (key_part, kv_heads),
+                (value_part, kv_heads),
+            )
+        )
+
+    host_query, host_key, host_value = split(packed)
+    reference = torch.nn.functional.scaled_dot_product_attention(
+        host_query.float(),
+        _repeat_kv(host_key, q_heads).float(),
+        _repeat_kv(host_value, q_heads).float(),
+        is_causal=True,
+    )
+    device_query, device_key, device_value = split(packed.to(mojo_gpu))
+    for tensor in (device_query, device_key, device_value):
+        assert not tensor._is_contiguous
+    with torch.no_grad():
+        actual = torch.nn.functional.scaled_dot_product_attention(
+            device_query, device_key, device_value, is_causal=True, enable_gqa=True
+        )
+    torch.testing.assert_close(actual.cpu().float(), reference, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.parametrize("is_causal", [True, False], ids=["causal", "full"])
+@pytest.mark.parametrize("q_heads,kv_heads", _GQA_HEAD_COUNTS, ids=_GQA_HEAD_IDS)
+def test_fast_sdpa_enable_gqa_backward_matches_reference(
+    mojo_gpu, q_heads, kv_heads, is_causal
+):
+    """GQA gradients must land on the ORIGINAL (b, kv_heads, s, d) K and V.
+
+    That is the whole reason the backward-needing route expands with
+    differentiable ops: ``ExpandBackward`` sums each group of query heads back
+    down, so no custom backward code is owed.
+    """
+    query, key, value = _gqa_host_qkv(
+        q_heads, kv_heads, torch.float32, q_len=64, kv_len=64, head_dim=32
+    )
+    grad_output = torch.randn(query.shape, generator=torch.Generator().manual_seed(7))
+
+    reference_inputs = [
+        tensor.detach().clone().requires_grad_() for tensor in (query, key, value)
+    ]
+    reference_output = torch.nn.functional.scaled_dot_product_attention(
+        reference_inputs[0],
+        _repeat_kv(reference_inputs[1], q_heads),
+        _repeat_kv(reference_inputs[2], q_heads),
+        is_causal=is_causal,
+    )
+    reference_output.backward(grad_output)
+
+    mojo_inputs = [
+        tensor.detach().clone().to(mojo_gpu).requires_grad_()
+        for tensor in (query, key, value)
+    ]
+    mojo_output = torch.nn.functional.scaled_dot_product_attention(
+        *mojo_inputs, is_causal=is_causal, enable_gqa=True
+    )
+    assert "Flash" not in type(mojo_output.grad_fn).__name__
+    mojo_output.backward(grad_output.to(mojo_gpu))
+
+    for name, tensor, reference in zip(
+        ("query", "key", "value"), mojo_inputs, reference_inputs, strict=True
+    ):
+        assert tensor.grad is not None, f"{name} gradient was not computed"
+        assert tuple(tensor.grad.shape) == tuple(tensor.shape)
+        torch.testing.assert_close(
+            tensor.grad.cpu(), reference.grad, atol=2e-3, rtol=2e-3
+        )
+
+
+def test_fast_sdpa_enable_gqa_hf_llama_forward(mojo_gpu):
+    """``transformers.integrations.sdpa_attention.sdpa_attention_forward``'s
+    own call shape: no mask, ``is_causal=True``, ``enable_gqa=True``, at
+    Llama-3-8B's 32/8 heads and head_dim 128 -- prefill then one decode step."""
+    q_heads, kv_heads, head_dim = 32, 8, 128
+    for q_len, kv_len in ((256, 256), (1, 257)):
+        query, key, value = _gqa_host_qkv(
+            q_heads,
+            kv_heads,
+            torch.bfloat16,
+            q_len=q_len,
+            kv_len=kv_len,
+            head_dim=head_dim,
+            seed=q_len,
+        )
+        is_causal = q_len > 1
+        reference = torch.nn.functional.scaled_dot_product_attention(
+            query.float(),
+            _repeat_kv(key, q_heads).float(),
+            _repeat_kv(value, q_heads).float(),
+            is_causal=is_causal,
+        )
+        with torch.no_grad():
+            actual = torch.nn.functional.scaled_dot_product_attention(
+                query.to(mojo_gpu),
+                key.to(mojo_gpu),
+                value.to(mojo_gpu),
+                dropout_p=0.0,
+                is_causal=is_causal,
+                enable_gqa=True,
+            )
+        torch.testing.assert_close(
+            actual.cpu().float(), reference, atol=2e-2, rtol=2e-2
+        )
+
+
+def test_fast_sdpa_enable_gqa_inference_expands_without_repeat_kv_copy(
+    mojo_gpu, monkeypatch
+):
+    """A multi-query decode step must not pay for a ``repeat_kv`` copy.
+
+    Without a gradient to track, the expansion happens inside ``aten_fast``,
+    where a single K/V head is a stride-0 broadcast the decode kernel reads
+    through. The differentiable ``repeat_kv`` (whose ``reshape`` materializes)
+    is reserved for the backward-needing routes.
+    """
+    from torch_mojo_backend.mojo_device import mojo_device_autograd
+
+    calls = {"count": 0}
+    original = mojo_device_autograd._expand_gqa_key_value
+
+    def spy(*args: torch.Tensor) -> object:
+        calls["count"] += 1
+        return original(*args)
+
+    monkeypatch.setattr(mojo_device_autograd, "_expand_gqa_key_value", spy)
+
+    q_heads, kv_len, head_dim = 12, 48, 64
+    query, key, value = _gqa_host_qkv(
+        q_heads, 1, torch.float32, q_len=1, kv_len=kv_len, head_dim=head_dim
+    )
+    reference = torch.nn.functional.scaled_dot_product_attention(
+        query, _repeat_kv(key, q_heads), _repeat_kv(value, q_heads)
+    )
+    device_inputs = [tensor.to(mojo_gpu) for tensor in (query, key, value)]
+    with torch.no_grad():
+        gqa = torch.nn.functional.scaled_dot_product_attention(
+            *device_inputs, enable_gqa=True
+        )
+    assert calls["count"] == 0
+    torch.testing.assert_close(gqa.cpu(), reference, atol=2e-3, rtol=2e-3)
+
+    for tensor in device_inputs:
+        tensor.requires_grad_()
+    torch.nn.functional.scaled_dot_product_attention(
+        *device_inputs, enable_gqa=True
+    ).sum().backward()
+    assert calls["count"] == 1
+
+
+def test_fast_sdpa_enable_gqa_math_op_matches_reference(mojo_gpu):
+    """The lower ``aten::_scaled_dot_product_attention_math`` op, which returns
+    the probability matrix alongside the output, declined GQA for the same
+    reason and is fixed by the same expansion."""
+    q_heads, kv_heads = 8, 2
+    query, key, value = _gqa_host_qkv(
+        q_heads, kv_heads, torch.float32, q_len=16, kv_len=16, head_dim=32
+    )
+    reference, reference_probabilities = (
+        torch.ops.aten._scaled_dot_product_attention_math(
+            query, _repeat_kv(key, q_heads), _repeat_kv(value, q_heads), is_causal=True
+        )
+    )
+    with torch.no_grad():
+        actual, probabilities = torch.ops.aten._scaled_dot_product_attention_math(
+            query.to(mojo_gpu),
+            key.to(mojo_gpu),
+            value.to(mojo_gpu),
+            is_causal=True,
+            enable_gqa=True,
+        )
+    torch.testing.assert_close(actual.cpu(), reference, atol=2e-3, rtol=2e-3)
+    torch.testing.assert_close(
+        probabilities.cpu(), reference_probabilities, atol=2e-3, rtol=2e-3
+    )
+
+
+@pytest.mark.parametrize("head_dim", [64, 128], ids=["d64", "d128"])
+def test_fast_sdpa_enable_gqa_reaches_fa4_without_grad(
+    mojo_h100, monkeypatch, head_dim
+):
+    """Once K/V are expanded, a GQA prefill is an ordinary FA4 call.
+
+    The fused kernels decline ``enable_gqa`` outright, so before the expansion
+    a Llama-class causal step could only ever reach the O(n^2) math
+    decomposition. This pins that it now reaches the BHSD-native FA4 route
+    instead -- the reason to expand in the entry point rather than inside the
+    decomposition.
+    """
+    from torch_mojo_backend.eager_flash_attention import load_fa4_ops
+
+    module = load_fa4_ops()
+    name = f"flash_attention_fwd_bf16_d{head_dim}_causal_bhsd"
+    original = getattr(module, name)
+    calls = {"count": 0}
+
+    def spy(*args):
+        calls["count"] += 1
+        return original(*args)
+
+    monkeypatch.setattr(module, name, spy)
+
+    query, key, value = _gqa_host_qkv(
+        32, 8, torch.bfloat16, q_len=128, kv_len=128, head_dim=head_dim
+    )
+    reference = torch.nn.functional.scaled_dot_product_attention(
+        query.float(),
+        _repeat_kv(key, 32).float(),
+        _repeat_kv(value, 32).float(),
+        is_causal=True,
+    )
+    with torch.no_grad():
+        actual = torch.nn.functional.scaled_dot_product_attention(
+            query.to(mojo_h100),
+            key.to(mojo_h100),
+            value.to(mojo_h100),
+            is_causal=True,
+            enable_gqa=True,
+        )
+    actual_host = actual.cpu().float()
+    assert calls["count"] == 1
+    torch.testing.assert_close(actual_host, reference, atol=2e-2, rtol=2e-2)
+
+
+def test_fast_sdpa_enable_gqa_backward_never_uses_native_flash(mojo_h100):
+    """A GQA triple whose EXPANDED form would be FA4-eligible must still not
+    reach the native flash op when a backward is coming.
+
+    Its backward is a native (derivatives.yaml) node, and a decline inside one
+    aborts the process rather than raising, so the expansion is applied only
+    after that dispatch decision. This is the regression test for reordering
+    the two.
+    """
+    q_heads, kv_heads, seqlen, head_dim = 8, 2, 128, 64
+    query, key, value = _gqa_host_qkv(
+        q_heads,
+        kv_heads,
+        torch.bfloat16,
+        q_len=seqlen,
+        kv_len=seqlen,
+        head_dim=head_dim,
+    )
+    grad_output = torch.randn(
+        query.shape, generator=torch.Generator().manual_seed(20260814)
+    ).to(torch.bfloat16)
+
+    reference_inputs = [
+        tensor.float().detach().requires_grad_() for tensor in (query, key, value)
+    ]
+    reference_output = torch.nn.functional.scaled_dot_product_attention(
+        reference_inputs[0],
+        _repeat_kv(reference_inputs[1], q_heads),
+        _repeat_kv(reference_inputs[2], q_heads),
+        is_causal=True,
+    )
+    reference_output.backward(grad_output.float())
+
+    mojo_inputs = [
+        tensor.detach().clone().to(mojo_h100).requires_grad_()
+        for tensor in (query, key, value)
+    ]
+    mojo_output = torch.nn.functional.scaled_dot_product_attention(
+        *mojo_inputs, is_causal=True, enable_gqa=True
+    )
+    assert type(mojo_output.grad_fn).__name__ != (
+        "ScaledDotProductFlashAttentionBackward0"
+    )
+    mojo_output.backward(grad_output.to(mojo_h100))
+
+    torch.testing.assert_close(
+        mojo_output.detach().cpu().float(),
+        reference_output.detach(),
+        atol=2e-2,
+        rtol=2e-2,
+    )
+    for tensor, reference in zip(mojo_inputs, reference_inputs, strict=True):
+        assert tensor.grad is not None
+        assert tuple(tensor.grad.shape) == tuple(tensor.shape)
+        torch.testing.assert_close(
+            tensor.grad.cpu().float(), reference.grad, atol=5e-2, rtol=5e-2
+        )
+
+
+def test_fast_sdpa_equal_head_counts_ignore_enable_gqa(mojo_gpu):
+    """``enable_gqa=True`` with equal head counts is plain attention, and the
+    ordinary ``enable_gqa=False`` call is untouched by the expansion."""
+    query, key, value = _gqa_host_qkv(8, 8, torch.float32, q_len=32, kv_len=32)
+    device_inputs = [tensor.to(mojo_gpu) for tensor in (query, key, value)]
+    with torch.no_grad():
+        plain = torch.nn.functional.scaled_dot_product_attention(
+            *device_inputs, is_causal=True
+        )
+        gqa = torch.nn.functional.scaled_dot_product_attention(
+            *device_inputs, is_causal=True, enable_gqa=True
+        )
+    torch.testing.assert_close(gqa.cpu(), plain.cpu(), atol=0.0, rtol=0.0)
+
+
 @pytest.mark.parametrize(
     (
         "requires",

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -10293,6 +10293,7 @@ def test_fast_sdpa_enable_gqa_grad_enabled_forward_matches_reference(
 def test_fast_sdpa_enable_gqa_multi_query_expansion_is_zero_copy(mojo_gpu):
     """A single K/V head becomes a stride-0 broadcast, never a copy."""
     key = torch.randn(2, 1, 8, 16).to(mojo_gpu)
+    assert isinstance(key, TorchMojoTensor)
     expanded = aten_fast._expand_kv_heads_for_gqa(key, 12)
     assert expanded is not None
     assert tuple(expanded.shape) == (2, 12, 8, 16)
@@ -10392,6 +10393,7 @@ def test_fast_sdpa_enable_gqa_strided_qkv_forward_matches_reference(mojo_gpu, dt
     )
     device_query, device_key, device_value = split(packed.to(mojo_gpu))
     for tensor in (device_query, device_key, device_value):
+        assert isinstance(tensor, TorchMojoTensor)
         assert not tensor._is_contiguous
     with torch.no_grad():
         actual = torch.nn.functional.scaled_dot_product_attention(
@@ -10432,7 +10434,7 @@ def test_fast_sdpa_enable_gqa_backward_matches_reference(
         for tensor in (query, key, value)
     ]
     mojo_output = torch.nn.functional.scaled_dot_product_attention(
-        *mojo_inputs, is_causal=is_causal, enable_gqa=True
+        *mojo_inputs, dropout_p=0.0, is_causal=is_causal, enable_gqa=True
     )
     assert "Flash" not in type(mojo_output.grad_fn).__name__
     mojo_output.backward(grad_output.to(mojo_gpu))
@@ -10512,7 +10514,7 @@ def test_fast_sdpa_enable_gqa_inference_expands_without_repeat_kv_copy(
     device_inputs = [tensor.to(mojo_gpu) for tensor in (query, key, value)]
     with torch.no_grad():
         gqa = torch.nn.functional.scaled_dot_product_attention(
-            *device_inputs, enable_gqa=True
+            *device_inputs, dropout_p=0.0, enable_gqa=True
         )
     assert calls["count"] == 0
     torch.testing.assert_close(gqa.cpu(), reference, atol=2e-3, rtol=2e-3)
@@ -10520,7 +10522,7 @@ def test_fast_sdpa_enable_gqa_inference_expands_without_repeat_kv_copy(
     for tensor in device_inputs:
         tensor.requires_grad_()
     torch.nn.functional.scaled_dot_product_attention(
-        *device_inputs, enable_gqa=True
+        *device_inputs, dropout_p=0.0, enable_gqa=True
     ).sum().backward()
     assert calls["count"] == 1
 
@@ -10635,7 +10637,7 @@ def test_fast_sdpa_enable_gqa_backward_never_uses_native_flash(mojo_h100):
         for tensor in (query, key, value)
     ]
     mojo_output = torch.nn.functional.scaled_dot_product_attention(
-        *mojo_inputs, is_causal=True, enable_gqa=True
+        *mojo_inputs, dropout_p=0.0, is_causal=True, enable_gqa=True
     )
     assert type(mojo_output.grad_fn).__name__ != (
         "ScaledDotProductFlashAttentionBackward0"
@@ -10663,10 +10665,10 @@ def test_fast_sdpa_equal_head_counts_ignore_enable_gqa(mojo_gpu):
     device_inputs = [tensor.to(mojo_gpu) for tensor in (query, key, value)]
     with torch.no_grad():
         plain = torch.nn.functional.scaled_dot_product_attention(
-            *device_inputs, is_causal=True
+            *device_inputs, dropout_p=0.0, is_causal=True
         )
         gqa = torch.nn.functional.scaled_dot_product_attention(
-            *device_inputs, is_causal=True, enable_gqa=True
+            *device_inputs, dropout_p=0.0, is_causal=True, enable_gqa=True
         )
     torch.testing.assert_close(gqa.cpu(), plain.cpu(), atol=0.0, rtol=0.0)
 

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -21,6 +21,7 @@ from torch_mojo_backend import (
 )
 from torch_mojo_backend.eager_flash_attention import load_fa4_ops
 from torch_mojo_backend.eager_kernels import _ctx_ptr, aten_fast
+from torch_mojo_backend.mojo_device import mojo_device_autograd
 from torch_mojo_backend.mojo_device.mojo_device_aten_ops import EAGER_CALL_COUNTERS
 
 pytestmark = pytest.mark.xdist_group(name="group1")
@@ -10181,6 +10182,493 @@ def test_fast_sdpa_causal_training_backward(mojo_gpu):
         actual_grad = tensor.grad.cpu()
         assert torch.isfinite(actual_grad).all(), f"{name} gradient is not finite"
         torch.testing.assert_close(actual_grad, expected_grad, atol=2e-2, rtol=2e-2)
+
+
+# ---------------------------------------------------------------------------
+# Grouped-query attention (``enable_gqa=True``).
+#
+# HF transformers' ``sdpa_attention_forward`` stops calling ``repeat_kv``
+# itself and passes ``enable_gqa=True`` whenever there is no padding mask, so
+# this is the shape of every ordinary Llama-3/Mistral/Qwen2/Gemma2 causal step.
+# ``(32, 8)`` is Llama-3-8B's ratio, ``(8, 1)`` is multi-query attention, whose
+# single K/V head is broadcast rather than copied.
+# ---------------------------------------------------------------------------
+
+_GQA_HEAD_COUNTS = ((32, 8), (8, 1))
+_GQA_HEAD_IDS = ["q32kv8", "q8kv1"]
+
+
+def _gqa_host_qkv(
+    q_heads: int,
+    kv_heads: int,
+    dtype: torch.dtype,
+    *,
+    batch: int = 1,
+    q_len: int = 128,
+    kv_len: int = 128,
+    head_dim: int = 64,
+    seed: int = 20260811,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Host-side ``(query, key, value)`` with mismatched head counts."""
+    generator = torch.Generator().manual_seed(seed)
+
+    def make(heads: int, length: int) -> torch.Tensor:
+        return (
+            torch.randn(
+                batch, heads, length, head_dim, generator=generator, dtype=torch.float32
+            )
+            * 0.25
+        ).to(dtype)
+
+    return make(q_heads, q_len), make(kv_heads, kv_len), make(kv_heads, kv_len)
+
+
+def _repeat_kv(tensor: torch.Tensor, q_heads: int) -> torch.Tensor:
+    """HF transformers' ``repeat_kv``, the reference expansion."""
+    batch, kv_heads, length, head_dim = tensor.shape
+    return (
+        tensor[:, :, None]
+        .expand(batch, kv_heads, q_heads // kv_heads, length, head_dim)
+        .reshape(batch, q_heads, length, head_dim)
+    )
+
+
+@pytest.mark.parametrize("is_causal", [True, False], ids=["causal", "full"])
+@pytest.mark.parametrize("head_dim", [64, 128], ids=["d64", "d128"])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "f16"])
+@pytest.mark.parametrize("q_heads,kv_heads", _GQA_HEAD_COUNTS, ids=_GQA_HEAD_IDS)
+def test_fast_sdpa_enable_gqa_forward_matches_reference(
+    mojo_gpu, q_heads, kv_heads, dtype, head_dim, is_causal
+):
+    """``enable_gqa=True`` with fewer K/V heads must compute plain attention.
+
+    head_dim 64 and 128 are the two FA4-eligible regimes, so this also covers
+    a GQA call landing on a fused route after the expansion rather than only
+    on the math decomposition.
+    """
+    query, key, value = _gqa_host_qkv(q_heads, kv_heads, dtype, head_dim=head_dim)
+    reference = torch.nn.functional.scaled_dot_product_attention(
+        query.float(),
+        _repeat_kv(key, q_heads).float(),
+        _repeat_kv(value, q_heads).float(),
+        is_causal=is_causal,
+    )
+    with torch.no_grad():
+        actual = torch.nn.functional.scaled_dot_product_attention(
+            query.to(mojo_gpu),
+            key.to(mojo_gpu),
+            value.to(mojo_gpu),
+            is_causal=is_causal,
+            enable_gqa=True,
+        )
+    assert tuple(actual.shape) == tuple(reference.shape)
+    assert actual.dtype == dtype
+    torch.testing.assert_close(actual.cpu().float(), reference, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.parametrize("q_heads,kv_heads", _GQA_HEAD_COUNTS, ids=_GQA_HEAD_IDS)
+def test_fast_sdpa_enable_gqa_grad_enabled_forward_matches_reference(
+    mojo_gpu, q_heads, kv_heads
+):
+    """Grad mode on with no leaf requiring a gradient stays graph-free.
+
+    fp32 too, so this is the math decomposition rather than the fused route
+    the 16-bit cases above reach.
+    """
+    query, key, value = _gqa_host_qkv(q_heads, kv_heads, torch.float32)
+    reference = torch.nn.functional.scaled_dot_product_attention(
+        query, _repeat_kv(key, q_heads), _repeat_kv(value, q_heads), is_causal=True
+    )
+    actual = torch.nn.functional.scaled_dot_product_attention(
+        query.to(mojo_gpu),
+        key.to(mojo_gpu),
+        value.to(mojo_gpu),
+        is_causal=True,
+        enable_gqa=True,
+    )
+    assert actual.grad_fn is None
+    torch.testing.assert_close(actual.cpu(), reference, atol=2e-3, rtol=2e-3)
+
+
+def test_fast_sdpa_enable_gqa_multi_query_expansion_is_zero_copy(mojo_gpu):
+    """A single K/V head becomes a stride-0 broadcast, never a copy."""
+    key = torch.randn(2, 1, 8, 16).to(mojo_gpu)
+    expanded = aten_fast._expand_kv_heads_for_gqa(key, 12)
+    assert expanded is not None
+    assert tuple(expanded.shape) == (2, 12, 8, 16)
+    assert expanded._mojo_strides[1] == 0
+    assert expanded._ptr == key._ptr
+    assert expanded._holder is key._holder
+    torch.testing.assert_close(expanded.cpu(), _repeat_kv(key.cpu(), 12))
+
+
+def test_fast_sdpa_enable_gqa_expansion_matches_repeat_kv(mojo_gpu):
+    """The materialized expansion repeats each head n_rep times in place."""
+    host = torch.randn(2, 3, 5, 4)
+    expanded = aten_fast._expand_kv_heads_for_gqa(host.to(mojo_gpu), 12)
+    assert expanded is not None
+    assert expanded._is_contiguous
+    torch.testing.assert_close(expanded.cpu(), _repeat_kv(host, 12))
+
+
+@pytest.mark.parametrize("q_heads,kv_heads", [(6, 4), (2, 3)], ids=["6to4", "2to3"])
+def test_fast_sdpa_enable_gqa_indivisible_head_counts_raise(
+    mojo_gpu, q_heads, kv_heads
+):
+    """A head count the group structure cannot express is declined cleanly."""
+    query, key, value = _gqa_host_qkv(
+        q_heads, kv_heads, torch.float32, q_len=8, kv_len=8
+    )
+    with pytest.raises(NotImplementedError), torch.no_grad():
+        torch.nn.functional.scaled_dot_product_attention(
+            query.to(mojo_gpu), key.to(mojo_gpu), value.to(mojo_gpu), enable_gqa=True
+        )
+
+
+@pytest.mark.parametrize("q_heads,kv_heads", _GQA_HEAD_COUNTS, ids=_GQA_HEAD_IDS)
+def test_fast_sdpa_enable_gqa_masked_forward_matches_reference(
+    mojo_gpu, q_heads, kv_heads
+):
+    """A float bias mask together with ``enable_gqa`` used to decline outright."""
+    query, key, value = _gqa_host_qkv(
+        q_heads, kv_heads, torch.float32, q_len=16, kv_len=24, head_dim=32
+    )
+    generator = torch.Generator().manual_seed(20260812)
+    mask = torch.randn(1, q_heads, 16, 24, generator=generator)
+    reference = torch.nn.functional.scaled_dot_product_attention(
+        query, _repeat_kv(key, q_heads), _repeat_kv(value, q_heads), attn_mask=mask
+    )
+    with torch.no_grad():
+        actual = torch.nn.functional.scaled_dot_product_attention(
+            query.to(mojo_gpu),
+            key.to(mojo_gpu),
+            value.to(mojo_gpu),
+            attn_mask=mask.to(mojo_gpu),
+            enable_gqa=True,
+        )
+    torch.testing.assert_close(actual.cpu(), reference, atol=2e-3, rtol=2e-3)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "f16"])
+def test_fast_sdpa_enable_gqa_strided_qkv_forward_matches_reference(mojo_gpu, dtype):
+    """Q/K/V taken as transposed views of one packed projection, the way a real
+    model hands them over (the layout the FA4 ``_strided_qkv`` ABI exists for).
+
+    The expansion has to read K/V through those strides rather than assume a
+    dense head axis; Q stays a strided view throughout.
+    """
+    batch, seqlen, q_heads, kv_heads, head_dim = 1, 128, 8, 2, 64
+    generator = torch.Generator().manual_seed(20260813)
+    packed = (
+        torch.randn(
+            batch,
+            seqlen,
+            (q_heads + 2 * kv_heads) * head_dim,
+            generator=generator,
+            dtype=torch.float32,
+        )
+        * 0.25
+    ).to(dtype)
+
+    def split(source: torch.Tensor) -> tuple[torch.Tensor, ...]:
+        query_part, key_part, value_part = source.split(
+            [q_heads * head_dim, kv_heads * head_dim, kv_heads * head_dim], dim=2
+        )
+        return tuple(
+            part.view(batch, seqlen, heads, head_dim).transpose(1, 2)
+            for part, heads in (
+                (query_part, q_heads),
+                (key_part, kv_heads),
+                (value_part, kv_heads),
+            )
+        )
+
+    host_query, host_key, host_value = split(packed)
+    reference = torch.nn.functional.scaled_dot_product_attention(
+        host_query.float(),
+        _repeat_kv(host_key, q_heads).float(),
+        _repeat_kv(host_value, q_heads).float(),
+        is_causal=True,
+    )
+    device_query, device_key, device_value = split(packed.to(mojo_gpu))
+    for tensor in (device_query, device_key, device_value):
+        assert not tensor._is_contiguous
+    with torch.no_grad():
+        actual = torch.nn.functional.scaled_dot_product_attention(
+            device_query, device_key, device_value, is_causal=True, enable_gqa=True
+        )
+    torch.testing.assert_close(actual.cpu().float(), reference, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.parametrize("is_causal", [True, False], ids=["causal", "full"])
+@pytest.mark.parametrize("q_heads,kv_heads", _GQA_HEAD_COUNTS, ids=_GQA_HEAD_IDS)
+def test_fast_sdpa_enable_gqa_backward_matches_reference(
+    mojo_gpu, q_heads, kv_heads, is_causal
+):
+    """GQA gradients must land on the ORIGINAL (b, kv_heads, s, d) K and V.
+
+    That is the whole reason the backward-needing route expands with
+    differentiable ops: ``ExpandBackward`` sums each group of query heads back
+    down, so no custom backward code is owed.
+    """
+    query, key, value = _gqa_host_qkv(
+        q_heads, kv_heads, torch.float32, q_len=64, kv_len=64, head_dim=32
+    )
+    grad_output = torch.randn(query.shape, generator=torch.Generator().manual_seed(7))
+
+    reference_inputs = [
+        tensor.detach().clone().requires_grad_() for tensor in (query, key, value)
+    ]
+    reference_output = torch.nn.functional.scaled_dot_product_attention(
+        reference_inputs[0],
+        _repeat_kv(reference_inputs[1], q_heads),
+        _repeat_kv(reference_inputs[2], q_heads),
+        is_causal=is_causal,
+    )
+    reference_output.backward(grad_output)
+
+    mojo_inputs = [
+        tensor.detach().clone().to(mojo_gpu).requires_grad_()
+        for tensor in (query, key, value)
+    ]
+    mojo_output = torch.nn.functional.scaled_dot_product_attention(
+        *mojo_inputs, is_causal=is_causal, enable_gqa=True
+    )
+    assert "Flash" not in type(mojo_output.grad_fn).__name__
+    mojo_output.backward(grad_output.to(mojo_gpu))
+
+    for name, tensor, reference in zip(
+        ("query", "key", "value"), mojo_inputs, reference_inputs, strict=True
+    ):
+        assert tensor.grad is not None, f"{name} gradient was not computed"
+        assert tuple(tensor.grad.shape) == tuple(tensor.shape)
+        torch.testing.assert_close(
+            tensor.grad.cpu(), reference.grad, atol=2e-3, rtol=2e-3
+        )
+
+
+def test_fast_sdpa_enable_gqa_hf_llama_forward(mojo_gpu):
+    """``transformers.integrations.sdpa_attention.sdpa_attention_forward``'s
+    own call shape: no mask, ``is_causal=True``, ``enable_gqa=True``, at
+    Llama-3-8B's 32/8 heads and head_dim 128 -- prefill then one decode step."""
+    q_heads, kv_heads, head_dim = 32, 8, 128
+    for q_len, kv_len in ((256, 256), (1, 257)):
+        query, key, value = _gqa_host_qkv(
+            q_heads,
+            kv_heads,
+            torch.bfloat16,
+            q_len=q_len,
+            kv_len=kv_len,
+            head_dim=head_dim,
+            seed=q_len,
+        )
+        is_causal = q_len > 1
+        reference = torch.nn.functional.scaled_dot_product_attention(
+            query.float(),
+            _repeat_kv(key, q_heads).float(),
+            _repeat_kv(value, q_heads).float(),
+            is_causal=is_causal,
+        )
+        with torch.no_grad():
+            actual = torch.nn.functional.scaled_dot_product_attention(
+                query.to(mojo_gpu),
+                key.to(mojo_gpu),
+                value.to(mojo_gpu),
+                dropout_p=0.0,
+                is_causal=is_causal,
+                enable_gqa=True,
+            )
+        torch.testing.assert_close(
+            actual.cpu().float(), reference, atol=2e-2, rtol=2e-2
+        )
+
+
+def test_fast_sdpa_enable_gqa_inference_expands_without_repeat_kv_copy(
+    mojo_gpu, monkeypatch
+):
+    """A multi-query decode step must not pay for a ``repeat_kv`` copy.
+
+    Without a gradient to track, the expansion happens inside ``aten_fast``,
+    where a single K/V head is a stride-0 broadcast the decode kernel reads
+    through. The differentiable ``repeat_kv`` (whose ``reshape`` materializes)
+    is reserved for the backward-needing routes.
+    """
+    calls = {"count": 0}
+    original = mojo_device_autograd._expand_gqa_key_value
+
+    def spy(*args: torch.Tensor) -> object:
+        calls["count"] += 1
+        return original(*args)
+
+    monkeypatch.setattr(mojo_device_autograd, "_expand_gqa_key_value", spy)
+
+    q_heads, kv_len, head_dim = 12, 48, 64
+    query, key, value = _gqa_host_qkv(
+        q_heads, 1, torch.float32, q_len=1, kv_len=kv_len, head_dim=head_dim
+    )
+    reference = torch.nn.functional.scaled_dot_product_attention(
+        query, _repeat_kv(key, q_heads), _repeat_kv(value, q_heads)
+    )
+    device_inputs = [tensor.to(mojo_gpu) for tensor in (query, key, value)]
+    with torch.no_grad():
+        gqa = torch.nn.functional.scaled_dot_product_attention(
+            *device_inputs, enable_gqa=True
+        )
+    assert calls["count"] == 0
+    torch.testing.assert_close(gqa.cpu(), reference, atol=2e-3, rtol=2e-3)
+
+    for tensor in device_inputs:
+        tensor.requires_grad_()
+    torch.nn.functional.scaled_dot_product_attention(
+        *device_inputs, enable_gqa=True
+    ).sum().backward()
+    assert calls["count"] == 1
+
+
+def test_fast_sdpa_enable_gqa_math_op_matches_reference(mojo_gpu):
+    """The lower ``aten::_scaled_dot_product_attention_math`` op, which returns
+    the probability matrix alongside the output, declined GQA for the same
+    reason and is fixed by the same expansion."""
+    q_heads, kv_heads = 8, 2
+    query, key, value = _gqa_host_qkv(
+        q_heads, kv_heads, torch.float32, q_len=16, kv_len=16, head_dim=32
+    )
+    reference, reference_probabilities = (
+        torch.ops.aten._scaled_dot_product_attention_math(
+            query, _repeat_kv(key, q_heads), _repeat_kv(value, q_heads), is_causal=True
+        )
+    )
+    with torch.no_grad():
+        actual, probabilities = torch.ops.aten._scaled_dot_product_attention_math(
+            query.to(mojo_gpu),
+            key.to(mojo_gpu),
+            value.to(mojo_gpu),
+            is_causal=True,
+            enable_gqa=True,
+        )
+    torch.testing.assert_close(actual.cpu(), reference, atol=2e-3, rtol=2e-3)
+    torch.testing.assert_close(
+        probabilities.cpu(), reference_probabilities, atol=2e-3, rtol=2e-3
+    )
+
+
+@pytest.mark.parametrize("head_dim", [64, 128], ids=["d64", "d128"])
+def test_fast_sdpa_enable_gqa_reaches_fa4_without_grad(
+    mojo_h100, monkeypatch, head_dim
+):
+    """Once K/V are expanded, a GQA prefill is an ordinary FA4 call.
+
+    The fused kernels decline ``enable_gqa`` outright, so before the expansion
+    a Llama-class causal step could only ever reach the O(n^2) math
+    decomposition. This pins that it now reaches the BHSD-native FA4 route
+    instead -- the reason to expand in the entry point rather than inside the
+    decomposition.
+    """
+    module = load_fa4_ops()
+    name = f"flash_attention_fwd_bf16_d{head_dim}_causal_bhsd"
+    original = getattr(module, name)
+    calls = {"count": 0}
+
+    def spy(*args):
+        calls["count"] += 1
+        return original(*args)
+
+    monkeypatch.setattr(module, name, spy)
+
+    query, key, value = _gqa_host_qkv(
+        32, 8, torch.bfloat16, q_len=128, kv_len=128, head_dim=head_dim
+    )
+    reference = torch.nn.functional.scaled_dot_product_attention(
+        query.float(),
+        _repeat_kv(key, 32).float(),
+        _repeat_kv(value, 32).float(),
+        is_causal=True,
+    )
+    with torch.no_grad():
+        actual = torch.nn.functional.scaled_dot_product_attention(
+            query.to(mojo_h100),
+            key.to(mojo_h100),
+            value.to(mojo_h100),
+            is_causal=True,
+            enable_gqa=True,
+        )
+    actual_host = actual.cpu().float()
+    assert calls["count"] == 1
+    torch.testing.assert_close(actual_host, reference, atol=2e-2, rtol=2e-2)
+
+
+def test_fast_sdpa_enable_gqa_backward_never_uses_native_flash(mojo_h100):
+    """A GQA triple whose EXPANDED form would be FA4-eligible must still not
+    reach the native flash op when a backward is coming.
+
+    Its backward is a native (derivatives.yaml) node, and a decline inside one
+    aborts the process rather than raising, so the expansion is applied only
+    after that dispatch decision. This is the regression test for reordering
+    the two.
+    """
+    q_heads, kv_heads, seqlen, head_dim = 8, 2, 128, 64
+    query, key, value = _gqa_host_qkv(
+        q_heads,
+        kv_heads,
+        torch.bfloat16,
+        q_len=seqlen,
+        kv_len=seqlen,
+        head_dim=head_dim,
+    )
+    grad_output = torch.randn(
+        query.shape, generator=torch.Generator().manual_seed(20260814)
+    ).to(torch.bfloat16)
+
+    reference_inputs = [
+        tensor.float().detach().requires_grad_() for tensor in (query, key, value)
+    ]
+    reference_output = torch.nn.functional.scaled_dot_product_attention(
+        reference_inputs[0],
+        _repeat_kv(reference_inputs[1], q_heads),
+        _repeat_kv(reference_inputs[2], q_heads),
+        is_causal=True,
+    )
+    reference_output.backward(grad_output.float())
+
+    mojo_inputs = [
+        tensor.detach().clone().to(mojo_h100).requires_grad_()
+        for tensor in (query, key, value)
+    ]
+    mojo_output = torch.nn.functional.scaled_dot_product_attention(
+        *mojo_inputs, is_causal=True, enable_gqa=True
+    )
+    assert type(mojo_output.grad_fn).__name__ != (
+        "ScaledDotProductFlashAttentionBackward0"
+    )
+    mojo_output.backward(grad_output.to(mojo_h100))
+
+    torch.testing.assert_close(
+        mojo_output.detach().cpu().float(),
+        reference_output.detach(),
+        atol=2e-2,
+        rtol=2e-2,
+    )
+    for tensor, reference in zip(mojo_inputs, reference_inputs, strict=True):
+        assert tensor.grad is not None
+        assert tuple(tensor.grad.shape) == tuple(tensor.shape)
+        torch.testing.assert_close(
+            tensor.grad.cpu().float(), reference.grad, atol=5e-2, rtol=5e-2
+        )
+
+
+def test_fast_sdpa_equal_head_counts_ignore_enable_gqa(mojo_gpu):
+    """``enable_gqa=True`` with equal head counts is plain attention, and the
+    ordinary ``enable_gqa=False`` call is untouched by the expansion."""
+    query, key, value = _gqa_host_qkv(8, 8, torch.float32, q_len=32, kv_len=32)
+    device_inputs = [tensor.to(mojo_gpu) for tensor in (query, key, value)]
+    with torch.no_grad():
+        plain = torch.nn.functional.scaled_dot_product_attention(
+            *device_inputs, is_causal=True
+        )
+        gqa = torch.nn.functional.scaled_dot_product_attention(
+            *device_inputs, is_causal=True, enable_gqa=True
+        )
+    torch.testing.assert_close(gqa.cpu(), plain.cpu(), atol=0.0, rtol=0.0)
 
 
 @pytest.mark.parametrize(

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -7383,6 +7383,71 @@ def _sdpa_math_forward(query, key, value, is_causal, scale):
     return output, probabilities
 
 
+def _expand_kv_heads_for_gqa(
+    tensor: torch.Tensor, q_heads: int
+) -> TorchMojoTensor | None:
+    """A grouped-query K or V ``(b, kv_heads, s, d)`` as ``(b, q_heads, s, d)``.
+
+    ``enable_gqa=True`` lets K and V carry fewer heads than Q: query head ``i``
+    attends to K/V head ``i // n_rep``, with ``n_rep = q_heads // kv_heads``.
+    Expanding the head axis here is exactly HF transformers' ``repeat_kv``, and
+    it lets every route below -- masked, fused, decomposed, decode -- keep its
+    single equal-head indexing rule instead of growing a second one.
+
+    ``kv_heads == 1`` (multi-query attention) is a true zero-copy broadcast: the
+    size-1 head axis simply becomes a stride-0 axis of size ``q_heads``, with no
+    merge to perform, and the decode kernel reads it through that stride. For
+    any other ratio the ``(kv_heads, n_rep)`` merge after a broadcast expand is
+    not expressible as a view -- the merged axis would need stride 0 within a
+    group and ``h_stride`` across groups, which is not one stride -- the same
+    reason ``repeat_kv`` itself materializes, so this materializes too.
+
+    ``None`` means "not a K/V I can expand" (wrong rank, or a head count the
+    group structure cannot express); the caller declines rather than guessing.
+    """
+    t = _t(tensor)
+    if t is None or len(t._shape) != 4:
+        return None
+    kv_heads = t._shape[1]
+    if kv_heads <= 0 or q_heads <= 0 or q_heads % kv_heads != 0:
+        return None
+    if kv_heads == q_heads:
+        return t
+    batch, _, length, head_dim = t._shape
+    batch_stride, head_stride, length_stride, dim_stride = t._strides
+    expanded_shape = (batch, q_heads, length, head_dim)
+    if kv_heads == 1:
+        return _view_of(
+            t, expanded_shape, (batch_stride, 0, length_stride, dim_stride), t._offset
+        )
+    grouped = _view_of(
+        t,
+        (batch, kv_heads, q_heads // kv_heads, length, head_dim),
+        (batch_stride, head_stride, 0, length_stride, dim_stride),
+        t._offset,
+    )
+    dense = grouped._contig()
+    return _view_of(
+        dense,
+        expanded_shape,
+        _row_major_strides(expanded_shape),
+        dense._offset,
+        contiguous=True,
+    )
+
+
+def _sdpa_expanded_gqa_kv(query, key, value):
+    """``(key, value)`` with their head axis grown to the query's, or None."""
+    q = _t(query)
+    if q is None or len(q._shape) != 4:
+        return None
+    expanded_key = _expand_kv_heads_for_gqa(key, q._shape[1])
+    expanded_value = _expand_kv_heads_for_gqa(value, q._shape[1])
+    if expanded_key is None or expanded_value is None:
+        return None
+    return expanded_key, expanded_value
+
+
 def fast_aten__scaled_dot_product_attention_math(
     query,
     key,
@@ -7395,8 +7460,13 @@ def fast_aten__scaled_dot_product_attention_math(
     scale=None,
     enable_gqa=False,
 ):
-    if dropout_p != 0.0 or dropout_mask is not None or enable_gqa:
+    if dropout_p != 0.0 or dropout_mask is not None:
         return NOT_HANDLED
+    if enable_gqa:
+        expanded = _sdpa_expanded_gqa_kv(query, key, value)
+        if expanded is None:
+            return NOT_HANDLED
+        key, value = expanded
     if attn_mask is not None:
         return _sdpa_masked_math_forward(query, key, value, attn_mask, is_causal, scale)
     result = _sdpa_math_forward(query, key, value, is_causal, scale)
@@ -8819,10 +8889,21 @@ def fast_aten_scaled_dot_product_attention(
     scale=None,
     enable_gqa=False,
 ):
+    if enable_gqa:
+        # Grow K/V to Q's head count once, here, and every route below runs its
+        # ordinary equal-head code -- including the fused ones, which decline
+        # ``enable_gqa`` outright and would otherwise be unreachable for the
+        # Llama-class models that pass it.
+        expanded = _sdpa_expanded_gqa_kv(query, key, value)
+        if expanded is None:
+            return NOT_HANDLED
+        key, value = expanded
+        enable_gqa = False
+
     if attn_mask is not None:
         # None of the fused attention kernels take a mask operand, so a masked
         # call goes straight to the decomposed masked forward.
-        if enable_gqa or dropout_p != 0.0:
+        if dropout_p != 0.0:
             return NOT_HANDLED
         result = _sdpa_masked_math_forward(
             query, key, value, attn_mask, is_causal, scale

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -8257,6 +8257,71 @@ def _sdpa_math_forward(
     return output, probabilities
 
 
+def _expand_kv_heads_for_gqa(
+    tensor: torch.Tensor, q_heads: int
+) -> TorchMojoTensor | None:
+    """A grouped-query K or V ``(b, kv_heads, s, d)`` as ``(b, q_heads, s, d)``.
+
+    ``enable_gqa=True`` lets K and V carry fewer heads than Q: query head ``i``
+    attends to K/V head ``i // n_rep``, with ``n_rep = q_heads // kv_heads``.
+    Expanding the head axis here is exactly HF transformers' ``repeat_kv``, and
+    it lets every route below -- masked, fused, decomposed, decode -- keep its
+    single equal-head indexing rule instead of growing a second one.
+
+    ``kv_heads == 1`` (multi-query attention) is a true zero-copy broadcast: the
+    size-1 head axis simply becomes a stride-0 axis of size ``q_heads``, with no
+    merge to perform, and the decode kernel reads it through that stride. For
+    any other ratio the ``(kv_heads, n_rep)`` merge after a broadcast expand is
+    not expressible as a view -- the merged axis would need stride 0 within a
+    group and ``h_stride`` across groups, which is not one stride -- the same
+    reason ``repeat_kv`` itself materializes, so this materializes too.
+
+    ``None`` means "not a K/V I can expand" (wrong rank, or a head count the
+    group structure cannot express); the caller declines rather than guessing.
+    """
+    t = _t(tensor)
+    if t is None or len(t._shape) != 4:
+        return None
+    kv_heads = t._shape[1]
+    if kv_heads <= 0 or q_heads <= 0 or q_heads % kv_heads != 0:
+        return None
+    if kv_heads == q_heads:
+        return t
+    batch, _, length, head_dim = t._shape
+    batch_stride, head_stride, length_stride, dim_stride = t._strides
+    expanded_shape = (batch, q_heads, length, head_dim)
+    if kv_heads == 1:
+        return _view_of(
+            t, expanded_shape, (batch_stride, 0, length_stride, dim_stride), t._offset
+        )
+    grouped = _view_of(
+        t,
+        (batch, kv_heads, q_heads // kv_heads, length, head_dim),
+        (batch_stride, head_stride, 0, length_stride, dim_stride),
+        t._offset,
+    )
+    dense = grouped._contig()
+    return _view_of(
+        dense,
+        expanded_shape,
+        _row_major_strides(expanded_shape),
+        dense._offset,
+        contiguous=True,
+    )
+
+
+def _sdpa_expanded_gqa_kv(query, key, value):
+    """``(key, value)`` with their head axis grown to the query's, or None."""
+    q = _t(query)
+    if q is None or len(q._shape) != 4:
+        return None
+    expanded_key = _expand_kv_heads_for_gqa(key, q._shape[1])
+    expanded_value = _expand_kv_heads_for_gqa(value, q._shape[1])
+    if expanded_key is None or expanded_value is None:
+        return None
+    return expanded_key, expanded_value
+
+
 def fast_aten__scaled_dot_product_attention_math(
     query: torch.Tensor,
     key: torch.Tensor,
@@ -8269,8 +8334,13 @@ def fast_aten__scaled_dot_product_attention_math(
     scale: float | None = None,
     enable_gqa: bool = False,
 ) -> tuple[TorchMojoTensor, TorchMojoTensor] | _NotHandled:
-    if dropout_p != 0.0 or dropout_mask is not None or enable_gqa:
+    if dropout_p != 0.0 or dropout_mask is not None:
         return NOT_HANDLED
+    if enable_gqa:
+        expanded = _sdpa_expanded_gqa_kv(query, key, value)
+        if expanded is None:
+            return NOT_HANDLED
+        key, value = expanded
     if attn_mask is not None:
         return _sdpa_masked_math_forward(query, key, value, attn_mask, is_causal, scale)
     result = _sdpa_math_forward(query, key, value, is_causal, scale)
@@ -9798,10 +9868,21 @@ def fast_aten_scaled_dot_product_attention(
     scale: float | None = None,
     enable_gqa: bool = False,
 ) -> TorchMojoTensor | _NotHandled:
+    if enable_gqa:
+        # Grow K/V to Q's head count once, here, and every route below runs its
+        # ordinary equal-head code -- including the fused ones, which decline
+        # ``enable_gqa`` outright and would otherwise be unreachable for the
+        # Llama-class models that pass it.
+        expanded = _sdpa_expanded_gqa_kv(query, key, value)
+        if expanded is None:
+            return NOT_HANDLED
+        key, value = expanded
+        enable_gqa = False
+
     if attn_mask is not None:
         # None of the fused attention kernels take a mask operand, so a masked
         # call goes straight to the decomposed masked forward.
-        if enable_gqa or dropout_p != 0.0:
+        if dropout_p != 0.0:
             return NOT_HANDLED
         result = _sdpa_masked_math_forward(
             query, key, value, attn_mask, is_causal, scale

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -8288,7 +8288,7 @@ def _expand_kv_heads_for_gqa(
     if kv_heads == q_heads:
         return t
     batch, _, length, head_dim = t._shape
-    batch_stride, head_stride, length_stride, dim_stride = t._strides
+    batch_stride, head_stride, length_stride, dim_stride = t._mojo_strides
     expanded_shape = (batch, q_heads, length, head_dim)
     if kv_heads == 1:
         return _view_of(
@@ -8310,7 +8310,9 @@ def _expand_kv_heads_for_gqa(
     )
 
 
-def _sdpa_expanded_gqa_kv(query, key, value):
+def _sdpa_expanded_gqa_kv(
+    query: torch.Tensor, key: torch.Tensor, value: torch.Tensor
+) -> tuple[TorchMojoTensor, TorchMojoTensor] | None:
     """``(key, value)`` with their head axis grown to the query's, or None."""
     q = _t(query)
     if q is None or len(q._shape) != 4:

--- a/torch_mojo_backend/mojo_device/mojo_device_autograd.py
+++ b/torch_mojo_backend/mojo_device/mojo_device_autograd.py
@@ -562,6 +562,39 @@ class _ScaledDotProductAttentionAutograd(torch.autograd.Function):
         return grad_query, grad_key, grad_value, None, None, None, None, None
 
 
+def _expand_gqa_key_value(
+    query: torch.Tensor, key: torch.Tensor, value: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor] | None:
+    """``(key, value)`` repeated up to the query's head count, differentiably.
+
+    ``enable_gqa=True`` lets K and V carry fewer heads than Q; this is HF
+    transformers' ``repeat_kv``, written with ordinary differentiable ops
+    rather than the raw payload helper in ``aten_fast`` so that PyTorch's own
+    ``ExpandBackward`` sums each group of query heads back down: ``grad_key``
+    and ``grad_value`` then arrive in the leaves' original
+    ``(b, kv_heads, s, d)`` shape with no custom backward code owed here.
+
+    Returns ``None`` when the head counts do not divide.
+    """
+    if query.dim() != 4 or key.dim() != 4 or value.dim() != 4:
+        return None
+    q_heads = query.shape[1]
+    expanded = []
+    for tensor in (key, value):
+        batch, kv_heads, length, head_dim = tensor.shape
+        if kv_heads <= 0 or q_heads <= 0 or q_heads % kv_heads != 0:
+            return None
+        if kv_heads == q_heads:
+            expanded.append(tensor)
+            continue
+        expanded.append(
+            tensor.unsqueeze(2)
+            .expand(batch, kv_heads, q_heads // kv_heads, length, head_dim)
+            .reshape(batch, q_heads, length, head_dim)
+        )
+    return expanded[0], expanded[1]
+
+
 def _scaled_dot_product_attention_autograd(
     query,
     key,
@@ -600,6 +633,28 @@ def _scaled_dot_product_attention_autograd(
         return torch.ops.aten._scaled_dot_product_flash_attention.default(
             query, key, value, dropout_p, is_causal, False, scale=scale
         )[0]
+    # Grouped-query attention is turned into plain attention HERE, and
+    # deliberately not one line earlier: the native flash dispatch above owns a
+    # native (derivatives.yaml-generated) backward, and a decline inside a
+    # native backward node aborts the process instead of raising (the
+    # PrivateUse1 stream guard unwinds through a noexcept Python round-trip --
+    # same hazard ``aten_ops/autograd_preflight.py`` exists for). Its
+    # eligibility gate declines ``enable_gqa`` on the inputs as the caller
+    # passed them, so expanding first would hand it a triple it believes it can
+    # differentiate. Every destination below is a Python ``autograd.Function``,
+    # which is free to decline safely -- and now mostly does not need to.
+    #
+    # Only the backward-needing routes are expanded here, with differentiable
+    # ops. The forward-only route below expands inside ``aten_fast`` instead,
+    # where a single K/V head stays a stride-0 broadcast the decode kernel reads
+    # directly -- no ``repeat_kv`` copy at all on a multi-query decode step.
+    # This runs BEFORE the drain: the expansion queues a copy of its own.
+    if needs_backward and enable_gqa:
+        key, value = _require_handled(
+            _expand_gqa_key_value(query, key, value),
+            "aten::scaled_dot_product_attention with enable_gqa=True",
+        )
+        enable_gqa = False
     # The remaining paths read q/k/v payloads directly through aten_fast,
     # ABOVE __torch_dispatch__ — invisible to the deferred-compile queue —
     # so every still-pending producer must land first (FIFO granularity: the

--- a/torch_mojo_backend/mojo_device/mojo_device_autograd.py
+++ b/torch_mojo_backend/mojo_device/mojo_device_autograd.py
@@ -622,6 +622,39 @@ class _ScaledDotProductAttentionAutograd(torch.autograd.Function):
         return grad_query, grad_key, grad_value, None, None, None, None, None
 
 
+def _expand_gqa_key_value(
+    query: torch.Tensor, key: torch.Tensor, value: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor] | None:
+    """``(key, value)`` repeated up to the query's head count, differentiably.
+
+    ``enable_gqa=True`` lets K and V carry fewer heads than Q; this is HF
+    transformers' ``repeat_kv``, written with ordinary differentiable ops
+    rather than the raw payload helper in ``aten_fast`` so that PyTorch's own
+    ``ExpandBackward`` sums each group of query heads back down: ``grad_key``
+    and ``grad_value`` then arrive in the leaves' original
+    ``(b, kv_heads, s, d)`` shape with no custom backward code owed here.
+
+    Returns ``None`` when the head counts do not divide.
+    """
+    if query.dim() != 4 or key.dim() != 4 or value.dim() != 4:
+        return None
+    q_heads = query.shape[1]
+    expanded = []
+    for tensor in (key, value):
+        batch, kv_heads, length, head_dim = tensor.shape
+        if kv_heads <= 0 or q_heads <= 0 or q_heads % kv_heads != 0:
+            return None
+        if kv_heads == q_heads:
+            expanded.append(tensor)
+            continue
+        expanded.append(
+            tensor.unsqueeze(2)
+            .expand(batch, kv_heads, q_heads // kv_heads, length, head_dim)
+            .reshape(batch, q_heads, length, head_dim)
+        )
+    return expanded[0], expanded[1]
+
+
 def _scaled_dot_product_attention_autograd(
     query: TorchMojoTensor,
     key: TorchMojoTensor,
@@ -660,6 +693,28 @@ def _scaled_dot_product_attention_autograd(
         return torch.ops.aten._scaled_dot_product_flash_attention.default(
             query, key, value, dropout_p, is_causal, False, scale=scale
         )[0]
+    # Grouped-query attention is turned into plain attention HERE, and
+    # deliberately not one line earlier: the native flash dispatch above owns a
+    # native (derivatives.yaml-generated) backward, and a decline inside a
+    # native backward node aborts the process instead of raising (the
+    # PrivateUse1 stream guard unwinds through a noexcept Python round-trip --
+    # same hazard ``aten_ops/autograd_preflight.py`` exists for). Its
+    # eligibility gate declines ``enable_gqa`` on the inputs as the caller
+    # passed them, so expanding first would hand it a triple it believes it can
+    # differentiate. Every destination below is a Python ``autograd.Function``,
+    # which is free to decline safely -- and now mostly does not need to.
+    #
+    # Only the backward-needing routes are expanded here, with differentiable
+    # ops. The forward-only route below expands inside ``aten_fast`` instead,
+    # where a single K/V head stays a stride-0 broadcast the decode kernel reads
+    # directly -- no ``repeat_kv`` copy at all on a multi-query decode step.
+    # This runs BEFORE the drain: the expansion queues a copy of its own.
+    if needs_backward and enable_gqa:
+        key, value = _require_handled(
+            _expand_gqa_key_value(query, key, value),
+            "aten::scaled_dot_product_attention with enable_gqa=True",
+        )
+        enable_gqa = False
     # The remaining paths read q/k/v payloads directly through aten_fast,
     # ABOVE __torch_dispatch__ — invisible to the deferred-compile queue —
     # so every still-pending producer must land first (FIFO granularity: the

--- a/torch_mojo_backend/mojo_device/mojo_device_autograd.py
+++ b/torch_mojo_backend/mojo_device/mojo_device_autograd.py
@@ -10,7 +10,7 @@ values that hooks deliberately unpack onto the host.
 import math
 from collections.abc import Sequence
 from types import ModuleType
-from typing import Protocol, TypeVar, runtime_checkable
+from typing import Protocol, TypeVar, cast, runtime_checkable
 
 import torch
 
@@ -710,9 +710,12 @@ def _scaled_dot_product_attention_autograd(
     # directly -- no ``repeat_kv`` copy at all on a multi-query decode step.
     # This runs BEFORE the drain: the expansion queues a copy of its own.
     if needs_backward and enable_gqa:
-        key, value = _require_handled(
-            _expand_gqa_key_value(query, key, value),
-            "aten::scaled_dot_product_attention with enable_gqa=True",
+        key, value = cast(
+            tuple[TorchMojoTensor, TorchMojoTensor],
+            _require_handled(
+                _expand_gqa_key_value(query, key, value),
+                "aten::scaled_dot_product_attention with enable_gqa=True",
+            ),
         )
         enable_gqa = False
     # The remaining paths read q/k/v payloads directly through aten_fast,


### PR DESCRIPTION
## What was broken

`torch.nn.functional.scaled_dot_product_attention(q, k, v, is_causal=True, enable_gqa=True)` raised `NotImplementedError` on the `mojo` eager device whenever K/V carried fewer heads than Q. Grouped-query attention had **no** eager implementation at all:

- `_fa4_16bit_d64_causal_inputs` and `_fused_fa_inputs` both check `or enable_gqa` and decline outright,
- the masked branch of `fast_aten_scaled_dot_product_attention` declined `enable_gqa` too,
- and its bmm decomposition gate required `tuple(q._shape[:2]) == tuple(k._shape[:2])`, i.e. equal head counts.

## What it unblocks

HF `transformers`' `sdpa_attention_forward` stops calling `repeat_kv` itself and passes `enable_gqa=True` whenever there is no padding `attention_mask` — that is **every ordinary causal forward/generate step** of Llama-3, Mistral, Qwen2, Gemma2 and Phi-3 on the mojo device.

## The fix

Expand K/V's head axis to Q's **once, in the entry points**, then let every existing equal-head route run unchanged — no new kernel, no new shape regime.

- `aten_fast._expand_kv_heads_for_gqa` is `repeat_kv` over `TorchMojoTensor`. `kv_heads == 1` (MQA) is a genuine zero-copy stride-0 broadcast that the decode kernel reads through; other ratios materialize, because the `(kv_heads, n_rep)` merge after a broadcast expand is not expressible as a view — the same reason HF's own `repeat_kv` materializes.
- Expanding in the entry point rather than inside the decomposition means a GQA prefill now reaches **FA4** instead of the O(n²) math path. Measured: a Llama-esque 32/8-head, head_dim 128, causal bf16 call lands on `flash_attention_fwd_bf16_d128_causal_bhsd` (pinned by a test).
- The **backward-needing** route in `mojo_device_autograd` expands with ordinary differentiable ops instead, so PyTorch's own `ExpandBackward` reduces `grad_key`/`grad_value` back to the leaves' `(b, kv_heads, s, d)` shape with no custom backward code. It runs **strictly after** the native-flash dispatch gate: `_scaled_dot_product_flash_attention`'s backward is a native node, and a decline inside a native backward node aborts the process (`std::terminate`) instead of raising, so a GQA triple must never become "eligible" for it by being expanded first. The forward-only route is deliberately left to `aten_fast` so MQA decode keeps its zero-copy broadcast.
- `aten::_scaled_dot_product_attention_math` had the identical decline and gets the identical treatment.

The `torch.compile` backend already handled `enable_gqa` correctly; `aten_functions.py` is unchanged.

## Test evidence

37 new tests in `tests/test_eager_kernels.py`, all passing (H100):

- forward parity vs a CPU fp32 `repeat_kv` reference across 32:8 and 8:1 (MQA) ratios × bf16/f16 × head_dim 64/128 × causal/non-causal (16 cases),
- grad-enabled-but-graph-free fp32 forward (math decomposition), masked (`attn_mask` + GQA, which used to decline), strided Q/K/V taken as transposed views of one packed projection,
- backward parity with grads asserted to land in the **original** `(b, kv_heads, s, d)` shape, causal and non-causal,
- the HF `sdpa_attention_forward` call shape at Llama-3-8B's 32/8 heads, head_dim 128 — prefill and one decode step,
- unit tests that the MQA expansion is zero-copy (same `_ptr`, same holder, stride 0) and that the materialized expansion equals `repeat_kv`,
- route pins: a GQA prefill reaches `flash_attention_fwd_bf16_d{64,128}_causal_bhsd`; a backward-needing GQA call whose *expanded* form would be FA4-eligible does **not** get `ScaledDotProductFlashAttentionBackward0`; a no-grad MQA call never touches the differentiable `repeat_kv`,
- indivisible head counts (6:4, 2:3) still raise `NotImplementedError` cleanly, and `enable_gqa=True` with equal head counts is bit-identical to `enable_gqa=False`.

Regression: `pytest tests/test_eager_kernels.py -k "sdpa or attention or fa4 or flash"` → **164 passed, 4 skipped**; `tests/test_sdpa_host_wiring.py tests/test_fa4_host_wiring.py tests/test_mojo_autocast.py` → **27 passed**; `tests/test_high_level_ops.py -k "sdpa or attention"` → **26 passed**; `benchmarks/test_coverage.py` → 2 passed. `uvx pre-commit run --all-files` clean.

No Mojo kernel was touched, so no cross-architecture assembly check is owed: this is Python-level view/copy composition over already-shipped kernels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Co2wBC1UYzM4y9PEC92Af
