### PR TITLE
Add gather / index_select / scatter_add / index_put to eager mode

### DIFF
--- a/benchmarks/baselines.html
+++ b/benchmarks/baselines.html
@@ -4916,6 +4916,38 @@ document.addEventListener("DOMContentLoaded", boot);
             }
           }
         },
+        "_index_put_impl_": {
+          "dtypes": {
+            "bf16": {
+              "shapes": {
+                "R_262144x64_S65536_acc": {
+                  "layouts": {
+                    "contig": 0.899
+                  }
+                },
+                "R_262144x64_S65536_set": {
+                  "layouts": {
+                    "contig": 3.041
+                  }
+                }
+              }
+            },
+            "f32": {
+              "shapes": {
+                "R_262144x64_S65536_acc": {
+                  "layouts": {
+                    "contig": 0.837
+                  }
+                },
+                "R_262144x64_S65536_set": {
+                  "layouts": {
+                    "contig": 2.957
+                  }
+                }
+              }
+            }
+          }
+        },
         "_log_softmax": {
           "dtypes": {
             "bf16": {
@@ -6812,6 +6844,38 @@ document.addEventListener("DOMContentLoaded", boot);
             }
           }
         },
+        "gather": {
+          "dtypes": {
+            "bf16": {
+              "shapes": {
+                "R_262144x64_D1": {
+                  "layouts": {
+                    "contig": 2.677
+                  }
+                },
+                "R_4096x4096_D0": {
+                  "layouts": {
+                    "contig": 1.126
+                  }
+                }
+              }
+            },
+            "f32": {
+              "shapes": {
+                "R_262144x64_D1": {
+                  "layouts": {
+                    "contig": 2.163
+                  }
+                },
+                "R_4096x4096_D0": {
+                  "layouts": {
+                    "contig": 1.073
+                  }
+                }
+              }
+            }
+          }
+        },
         "ge": {
           "dtypes": {
             "f32": {
@@ -6954,6 +7018,70 @@ document.addEventListener("DOMContentLoaded", boot);
                 "R_262144x64_I1048576": {
                   "layouts": {
                     "contig": 0.522
+                  }
+                }
+              }
+            }
+          }
+        },
+        "index_add": {
+          "dtypes": {
+            "bf16": {
+              "shapes": {
+                "R_262144x64_S1048576_D0": {
+                  "layouts": {
+                    "contig": 1.476
+                  }
+                },
+                "R_4096x4096_S8192_D1": {
+                  "layouts": {
+                    "contig": 2.338
+                  }
+                }
+              }
+            },
+            "f32": {
+              "shapes": {
+                "R_262144x64_S1048576_D0": {
+                  "layouts": {
+                    "contig": 1.517
+                  }
+                },
+                "R_4096x4096_S8192_D1": {
+                  "layouts": {
+                    "contig": 1.013
+                  }
+                }
+              }
+            }
+          }
+        },
+        "index_select": {
+          "dtypes": {
+            "bf16": {
+              "shapes": {
+                "R_262144x64_S1048576_D0": {
+                  "layouts": {
+                    "contig": 0.487
+                  }
+                },
+                "R_4096x4096_S8192_D1": {
+                  "layouts": {
+                    "contig": 4.298
+                  }
+                }
+              }
+            },
+            "f32": {
+              "shapes": {
+                "R_262144x64_S1048576_D0": {
+                  "layouts": {
+                    "contig": 0.52
+                  }
+                },
+                "R_4096x4096_S8192_D1": {
+                  "layouts": {
+                    "contig": 2.855
                   }
                 }
               }
@@ -8758,6 +8886,38 @@ document.addEventListener("DOMContentLoaded", boot);
                 "R_262144x64_S65536": {
                   "layouts": {
                     "contig": 1.183
+                  }
+                }
+              }
+            }
+          }
+        },
+        "scatter_add": {
+          "dtypes": {
+            "bf16": {
+              "shapes": {
+                "R_262144x64_D1": {
+                  "layouts": {
+                    "contig": 2.247
+                  }
+                },
+                "R_4096x4096_D0": {
+                  "layouts": {
+                    "contig": 1.247
+                  }
+                }
+              }
+            },
+            "f32": {
+              "shapes": {
+                "R_262144x64_D1": {
+                  "layouts": {
+                    "contig": 1.508
+                  }
+                },
+                "R_4096x4096_D0": {
+                  "layouts": {
+                    "contig": 1.048
                   }
                 }
               }

--- a/benchmarks/test_embedding.py
+++ b/benchmarks/test_embedding.py
@@ -35,17 +35,68 @@ SELECT_SCATTER_SHAPES: dict[str, tuple[int, int, int]] = {
     "S32x2048x1024": (32, 2048, 1024),
     "S8x357x789": (8, 357, 789),
 }
+# (rows, cols, dim).  WHICH dim is indexed is THE regime axis of the
+# dim-indexed family, not just a parameter: indexing the inner dim keeps every
+# thread's read inside one row (and, for scatter_add, concentrates the atomics
+# on `cols` slots per row), while indexing the outer dim spreads both across
+# the whole allocation.  No awkward-length shape here, unlike the rest of this
+# suite: these kernels move ONE element per thread with no vector path at all,
+# so a length that is not a multiple of a vector width is not a distinct
+# regime for them -- it is the only regime they have.
+DIM_INDEX_SHAPES: dict[str, tuple[int, int, int]] = {
+    "R_262144x64_D1": (262144, 64, 1),
+    "R_4096x4096_D0": (4096, 4096, 0),
+}
+# (rows, row_width, scattered_rows, accumulate).  `accumulate` is a REGIME of
+# index_put -- plain scattered stores vs atomic adds, two different kernels --
+# so it is folded into the shape token rather than parametrized separately: a
+# baseline key is (op, dtype, shape, layout) and nothing else, so two nodes
+# sharing a shape token would overwrite each other's entry and the suite would
+# flap between them on every run.
+PUT_SHAPES: dict[str, tuple[int, int, int, bool]] = {
+    "R_262144x64_S65536_set": (262144, 64, 65536, False),
+    "R_262144x64_S65536_acc": (262144, 64, 65536, True),
+}
+# (rows, cols, selected, dim).  dim 0 is the row-gather fast path (the
+# GatherRows kernel index.Tensor already uses); dim 1 is the general strided
+# kernel, where each selected element is `rows` separate short reads.
+SELECT_SHAPES: dict[str, tuple[int, int, int, int]] = {
+    "R_262144x64_S1048576_D0": (262144, 64, 1048576, 0),
+    "R_4096x4096_S8192_D1": (4096, 4096, 8192, 1),
+}
 
 COVERS: dict[str, str] = {
+    "aten::_index_put_impl_": "test_index_put",
     "aten::embedding": "test_embedding",
     "aten::embedding_dense_backward": "test_embedding_backward",
+    "aten::gather": "test_gather",
     "aten::index.Tensor": "test_index",
+    "aten::index_add": "test_index_add",
+    "aten::index_select": "test_index_select",
     "aten::scatter.src": "test_scatter_src",
     "aten::scatter.value": "test_scatter_value",
+    "aten::scatter_add": "test_scatter_add",
     "aten::select_scatter": "test_select_scatter",
 }
 
-SKIPPED: dict[str, str] = {}
+_SAME_KERNEL_OUT = (
+    "out= overload of a benchmarked functional op: the same single kernel "
+    "launch, writing a caller-supplied destination instead of an allocated "
+    "one (no extra copy, unlike the _register_out wrappers)"
+)
+_SAME_KERNEL_INPLACE = (
+    "in-place overload of a benchmarked functional op: the same single kernel "
+    "launch, minus the clone of self"
+)
+
+SKIPPED: dict[str, str] = {
+    "aten::gather.out": _SAME_KERNEL_OUT,
+    "aten::index_add.out": _SAME_KERNEL_OUT,
+    "aten::index_add_": _SAME_KERNEL_INPLACE,
+    "aten::index_select.out": _SAME_KERNEL_OUT,
+    "aten::scatter_add.out": _SAME_KERNEL_OUT,
+    "aten::scatter_add_": _SAME_KERNEL_INPLACE,
+}
 
 
 @pytest.mark.parametrize("dtype_id", ("bf16", "f32"))
@@ -142,6 +193,107 @@ def test_scatter_value(
         lambda: ref["base"].scatter(0, ref["index"], 1.0),
         lambda: our["base"].scatter(0, our["index"], 1.0),
         flops=float(ref["base"].numel()),
+    )
+
+
+@pytest.mark.parametrize("dtype_id", ("bf16", "f32"))
+@pytest.mark.parametrize("shape_id", DIM_INDEX_SHAPES)
+def test_gather(
+    shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
+) -> None:
+    rows, cols, dim = DIM_INDEX_SHAPES[shape_id]
+    x_ref, x_our = both(
+        torch.randn(rows, cols, dtype=DTYPES[dtype_id]), hw, mojo_device
+    )
+    idx_ref, idx_our = both(
+        torch.randint(0, (rows, cols)[dim], (rows, cols)), hw, mojo_device
+    )
+    bench.run(
+        lambda: torch.gather(x_ref, dim, idx_ref),
+        lambda: torch.gather(x_our, dim, idx_our),
+        flops=float(rows * cols),
+    )
+
+
+@pytest.mark.parametrize("dtype_id", ("bf16", "f32"))
+@pytest.mark.parametrize("shape_id", SELECT_SHAPES)
+def test_index_select(
+    shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
+) -> None:
+    rows, cols, selected, dim = SELECT_SHAPES[shape_id]
+    x_ref, x_our = both(
+        torch.randn(rows, cols, dtype=DTYPES[dtype_id]), hw, mojo_device
+    )
+    idx_ref, idx_our = both(
+        torch.randint(0, (rows, cols)[dim], (selected,)), hw, mojo_device
+    )
+    bench.run(
+        lambda: torch.index_select(x_ref, dim, idx_ref),
+        lambda: torch.index_select(x_our, dim, idx_our),
+        flops=float(selected * (cols if dim == 0 else rows)),
+    )
+
+
+@pytest.mark.parametrize("dtype_id", ("bf16", "f32"))
+@pytest.mark.parametrize("shape_id", DIM_INDEX_SHAPES)
+def test_scatter_add(
+    shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
+) -> None:
+    """Indices are drawn uniformly over the indexed extent, so collisions are
+    the norm — for D1 (64 columns, 262144 rows) every row's 64 writes land in
+    64 slots. Both legs accumulate with atomics, so the ratio is a comparison
+    of two atomic schemes, not of atomics against a sorted reduction."""
+    rows, cols, dim = DIM_INDEX_SHAPES[shape_id]
+    dtype = DTYPES[dtype_id]
+    x_ref, x_our = both(torch.randn(rows, cols, dtype=dtype), hw, mojo_device)
+    src_ref, src_our = both(torch.randn(rows, cols, dtype=dtype), hw, mojo_device)
+    idx_ref, idx_our = both(
+        torch.randint(0, (rows, cols)[dim], (rows, cols)), hw, mojo_device
+    )
+    bench.run(
+        lambda: torch.scatter_add(x_ref, dim, idx_ref, src_ref),
+        lambda: torch.scatter_add(x_our, dim, idx_our, src_our),
+        flops=float(rows * cols),
+    )
+
+
+@pytest.mark.parametrize("dtype_id", ("bf16", "f32"))
+@pytest.mark.parametrize("shape_id", SELECT_SHAPES)
+def test_index_add(
+    shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
+) -> None:
+    """index_add is index_select's mirror image (and its backward): the same
+    broadcast index, the same geometry, writes instead of reads."""
+    rows, cols, selected, dim = SELECT_SHAPES[shape_id]
+    dtype = DTYPES[dtype_id]
+    x_ref, x_our = both(torch.randn(rows, cols, dtype=dtype), hw, mojo_device)
+    source_shape = (selected, cols) if dim == 0 else (rows, selected)
+    s_ref, s_our = both(torch.randn(source_shape, dtype=dtype), hw, mojo_device)
+    idx_ref, idx_our = both(
+        torch.randint(0, (rows, cols)[dim], (selected,)), hw, mojo_device
+    )
+    bench.run(
+        lambda: torch.index_add(x_ref, dim, idx_ref, s_ref),
+        lambda: torch.index_add(x_our, dim, idx_our, s_our),
+        flops=float(selected * (cols if dim == 0 else rows)),
+    )
+
+
+@pytest.mark.parametrize("dtype_id", ("bf16", "f32"))
+@pytest.mark.parametrize("shape_id", PUT_SHAPES)
+@pytest.mark.bench_op("_index_put_impl_")
+def test_index_put(
+    shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
+) -> None:
+    rows, width, scattered, accumulate = PUT_SHAPES[shape_id]
+    dtype = DTYPES[dtype_id]
+    x_ref, x_our = both(torch.randn(rows, width, dtype=dtype), hw, mojo_device)
+    v_ref, v_our = both(torch.randn(scattered, width, dtype=dtype), hw, mojo_device)
+    idx_ref, idx_our = both(torch.randint(0, rows, (scattered,)), hw, mojo_device)
+    bench.run(
+        lambda: torch.index_put(x_ref, [idx_ref], v_ref, accumulate),
+        lambda: torch.index_put(x_our, [idx_our], v_our, accumulate),
+        flops=float(scattered * width),
     )
 
 

--- a/conformance/known_unsupported.py
+++ b/conformance/known_unsupported.py
@@ -531,7 +531,6 @@ _MATCHES_CPU: dict[str, tuple[str, ...]] = {
     "sum_to_size": ("float32", "bfloat16", "float16", "int64", "bool"),
     "svd": ("float32",),
     "take": ("float32", "bfloat16", "float16", "int64", "bool"),
-    "take_along_dim": ("float32", "bfloat16", "float16", "int64", "bool"),
     "tan": ("int64", "bool"),
     "tanh": ("int64", "bool"),
     "tensordot": ("float32", "bfloat16", "float16", "int64"),

--- a/conformance/known_unsupported.py
+++ b/conformance/known_unsupported.py
@@ -533,7 +533,6 @@ _MATCHES_CPU: dict[str, tuple[str, ...]] = {
     "sum_to_size": ("float32", "bfloat16", "float16", "int64", "bool"),
     "svd": ("float32",),
     "take": ("float32", "bfloat16", "float16", "int64", "bool"),
-    "take_along_dim": ("float32", "bfloat16", "float16", "int64", "bool"),
     "tan": ("int64", "bool"),
     "tanh": ("int64", "bool"),
     "tensordot": ("float32", "bfloat16", "float16", "int64"),

--- a/docs/optimization_backlog.md
+++ b/docs/optimization_backlog.md
@@ -834,6 +834,13 @@ temporary** — **DONE** (`NormSpec`)
   broadcast index shape and per-dim index pointers as runtime data (rank ≤ 8,
   the descriptor style `CopyStrided` already uses), plus the boolean-mask case
   routed through `nonzero` + gather.
+* **Still open, but narrower than when this was written.** `aten::gather`,
+  `index_select`, `scatter_add`, `index_add` and `_index_put_impl_` now exist on
+  two kernels alongside `GatherRows` (`GatherDim` reads, `ScatterAddDim`
+  accumulates), so single-axis indexing along ANY dim is covered in both
+  directions, and `x[mask] = scalar` reaches `masked_fill_`. What is left of D5
+  is `aten::index`/`index_put` with SEVERAL index tensors, or one on a non-zero
+  axis, and a boolean mask whose write is not a scalar fill.
 * **Expected win.** N/A (coverage).
 * **How to measure it.** `tests/test_aten_functions.py` with parametrized index
   patterns.

--- a/tests/test_aten_functions.py
+++ b/tests/test_aten_functions.py
@@ -2005,6 +2005,280 @@ def test_aten_isin_all_match(conf: Conf):
     check_outputs(fn, conf, [elements, test_elements])
 
 
+# ---------------------------------------------------------------------------
+# The dim-indexed family: gather / index_select / scatter_add / index_add /
+# index_put.  All of them are the same two kernels over an index space
+# described by strides (GatherDim reads, ScatterDim[+add] writes), so the
+# axes worth parametrizing are the ones that change that description: the
+# rank, WHICH dim is indexed (0 has a dedicated row fast path, the last is
+# the contiguous-inner regime, a negative dim exercises normalization), the
+# payload dtype, and whether the operands are contiguous.
+# ---------------------------------------------------------------------------
+
+_INDEX_DTYPES = [torch.float32, torch.bfloat16, torch.int64]
+
+
+def _index_payload(shape: tuple[int, ...], dtype: torch.dtype) -> torch.Tensor:
+    """A tensor of `dtype` holding exactly representable values: bfloat16 has
+    8 mantissa bits, so a scatter_add of random floats would fail on rounding
+    rather than on anything this family of ops does."""
+    numel = math.prod(shape)
+    values = torch.arange(numel, dtype=torch.int64) % 17 - 8
+    return values.reshape(shape).to(dtype)
+
+
+@pytest.mark.parametrize("dtype", _INDEX_DTYPES)
+@pytest.mark.parametrize(
+    ("shape", "dim"),
+    [((6, 5), 0), ((6, 5), 1), ((6, 5), -1), ((3, 4, 5), 1), ((2, 3, 4, 5), 2)],
+)
+def test_aten_gather(
+    conf: Conf,
+    dtype: torch.dtype,
+    shape: tuple[int, ...],
+    dim: int,
+    call_checker: CallChecker,
+):
+    call_checker.register(aten_functions.aten_gather)
+
+    def fn(x, index):
+        return aten.gather(x, dim, index)
+
+    x = _index_payload(shape, dtype)
+    # `index.size(d) <= self.size(d)` is legal for gather on EVERY dim, not
+    # only the indexed one, and the output is shaped like the INDEX — so a
+    # kernel that walked `self`'s shape, or took the output's strides from
+    # `self`, is wrong here while an equal-shaped index would hide it.
+    index_shape = [3 if d == dim else max(1, s - 1) for d, s in enumerate(shape)]
+    index = torch.randint(0, shape[dim], index_shape, dtype=torch.int64)
+    check_outputs(fn, conf, [x, index])
+
+
+def test_aten_gather_strided_input(conf: Conf, call_checker: CallChecker):
+    """A transposed (non-contiguous) `self`: the kernel reads it through its
+    real strides instead of materializing a copy first."""
+    call_checker.register(aten_functions.aten_gather)
+
+    def fn(x, index):
+        return aten.gather(x.transpose(0, 1), 1, index)
+
+    x = torch.randn(7, 5)
+    index = torch.randint(0, 7, (5, 7), dtype=torch.int64)
+    check_outputs(fn, conf, [x, index])
+
+
+def test_aten_take_along_dim(conf: Conf, call_checker: CallChecker):
+    """`take_along_dim` is a composite that lowers straight to gather — and,
+    unlike gather itself, it DOES define negative indices (it normalizes them
+    with `remainder` before calling gather)."""
+    call_checker.register(aten_functions.aten_gather)
+
+    def fn(x, index):
+        return torch.take_along_dim(x, index, dim=1)
+
+    x = torch.randn(4, 6)
+    index = torch.tensor([[0, -1, 2], [-2, 1, 0], [3, 3, -6], [5, 0, 1]])
+    check_outputs(fn, conf, [x, index])
+
+
+@pytest.mark.parametrize("dtype", _INDEX_DTYPES)
+@pytest.mark.parametrize(
+    ("shape", "dim"),
+    [((6, 5), 0), ((6, 5), 1), ((6, 5), -1), ((3, 4, 5), 1), ((2, 3, 4, 5, 2), 2)],
+)
+def test_aten_index_select(
+    conf: Conf,
+    dtype: torch.dtype,
+    shape: tuple[int, ...],
+    dim: int,
+    call_checker: CallChecker,
+):
+    call_checker.register(aten_functions.aten_index_select)
+
+    def fn(x, index):
+        return aten.index_select(x, dim, index)
+
+    x = _index_payload(shape, dtype)
+    # Duplicated and out-of-order indices, and a length that differs from the
+    # indexed extent (index_select is the one op in the family whose output is
+    # shaped like neither input).
+    index = torch.tensor([2, 0, 2, 1, 0, 1, 2], dtype=torch.int64)
+    check_outputs(fn, conf, [x, index])
+
+
+def test_aten_index_select_int32_index(conf: Conf, call_checker: CallChecker):
+    """index_select accepts an int32 index; gather/scatter_add do not."""
+    call_checker.register(aten_functions.aten_index_select)
+
+    def fn(x, index):
+        return aten.index_select(x, 0, index)
+
+    x = torch.randn(5, 3)
+    index = torch.tensor([4, 0, 2], dtype=torch.int32)
+    check_outputs(fn, conf, [x, index])
+
+
+def test_aten_index_select_strided_input(conf: Conf, call_checker: CallChecker):
+    call_checker.register(aten_functions.aten_index_select)
+
+    def fn(x, index):
+        return aten.index_select(x.transpose(0, 1), 1, index)
+
+    x = torch.randn(6, 4)
+    index = torch.tensor([5, 5, 1, 0], dtype=torch.int64)
+    check_outputs(fn, conf, [x, index])
+
+
+@pytest.mark.parametrize("dtype", _INDEX_DTYPES)
+@pytest.mark.parametrize(
+    ("shape", "dim"), [((6, 5), 0), ((6, 5), 1), ((6, 5), -1), ((3, 4, 5), 1)]
+)
+def test_aten_scatter_add(
+    conf: Conf,
+    dtype: torch.dtype,
+    shape: tuple[int, ...],
+    dim: int,
+    call_checker: CallChecker,
+):
+    """Every index here is duplicated many times over: the whole point of
+    scatter_add is that colliding writes SUM instead of clobbering, and a test
+    with unique indices would pass against a plain scatter."""
+    call_checker.register(aten_functions.aten_scatter_add)
+
+    def fn(x, index, src):
+        return aten.scatter_add(x, dim, index, src)
+
+    x = _index_payload(shape, dtype)
+    index = torch.zeros(shape, dtype=torch.int64)
+    index.narrow(dim % len(shape), 1, shape[dim] - 1).fill_(1)
+    src = _index_payload(shape, dtype)
+    check_outputs(fn, conf, [x, index, src])
+
+
+def test_aten_scatter_add_inplace(conf: Conf, call_checker: CallChecker):
+    """`scatter_add_` and `scatter_add` both route through
+    `aten::scatter_add.out`; in the in-place one the out= tensor IS self, so
+    the "start from a copy of self" step must be a no-op rather than a copy of
+    an already-scattered buffer."""
+    call_checker.register(aten_functions.aten_scatter_add)
+
+    def fn(x, index, src):
+        out = x.clone()
+        out.scatter_add_(1, index, src)
+        return out
+
+    x = _index_payload((4, 6), torch.float32)
+    index = torch.randint(0, 6, (4, 6), dtype=torch.int64)
+    src = _index_payload((4, 6), torch.float32)
+    check_outputs(fn, conf, [x, index, src])
+
+
+@pytest.mark.parametrize("dtype", _INDEX_DTYPES)
+@pytest.mark.parametrize(("shape", "dim"), [((6, 5), 0), ((6, 5), 1), ((3, 4, 5), 1)])
+def test_aten_index_add(
+    conf: Conf,
+    dtype: torch.dtype,
+    shape: tuple[int, ...],
+    dim: int,
+    call_checker: CallChecker,
+):
+    """index_add is scatter_add with a broadcast index, and it is also what
+    autograd calls for index_select's backward — an unimplemented backward on
+    this device aborts the process instead of raising, so it stops being
+    optional the moment index_select exists."""
+    call_checker.register(aten_functions.aten_index_add)
+
+    def fn(x, index, source):
+        return aten.index_add(x, dim, index, source)
+
+    x = _index_payload(shape, dtype)
+    index = torch.tensor([0, 0, 1, 0], dtype=torch.int64)
+    source_shape = list(shape)
+    source_shape[dim] = 4
+    source = _index_payload(tuple(source_shape), dtype)
+    check_outputs(fn, conf, [x, index, source])
+
+
+@pytest.mark.parametrize("accumulate", [False, True])
+@pytest.mark.parametrize("dtype", _INDEX_DTYPES)
+def test_aten_index_put(
+    conf: Conf, dtype: torch.dtype, accumulate: bool, call_checker: CallChecker
+):
+    """`x[idx] = v` / `x[idx] += v`. With `accumulate=False` the indices are
+    unique on purpose: torch leaves the winner of colliding writes undefined
+    on an accelerator, so a duplicate there would be testing nothing."""
+    call_checker.register(aten_functions.aten_index_put)
+
+    def fn(x, index, values):
+        return aten.index_put(x, [index], values, accumulate)
+
+    x = _index_payload((6, 4), dtype)
+    index = torch.tensor(
+        [3, 0, 3, 1] if accumulate else [3, 0, 5, 1], dtype=torch.int64
+    )
+    values = _index_payload((4, 4), dtype)
+    check_outputs(fn, conf, [x, index, values])
+
+
+def test_aten_index_put_negative_indices(conf: Conf, call_checker: CallChecker):
+    """Advanced indexing — unlike gather/index_select/scatter_add — DOES
+    define negative indices, and wraps them python-style."""
+    call_checker.register(aten_functions.aten_index_put)
+
+    def fn(x, index, values):
+        return aten.index_put(x, [index], values, False)
+
+    x = torch.randn(5, 3)
+    index = torch.tensor([-1, -5, 2], dtype=torch.int64)
+    values = torch.randn(3, 3)
+    check_outputs(fn, conf, [x, index, values])
+
+
+def test_aten_index_put_broadcast_values(conf: Conf, call_checker: CallChecker):
+    call_checker.register(aten_functions.aten_index_put)
+
+    def fn(x, index, values):
+        return aten.index_put(x, [index], values, False)
+
+    x = torch.randn(5, 3)
+    index = torch.tensor([1, 4], dtype=torch.int64)
+    values = torch.randn(3)  # broadcast over the indexed rows
+    check_outputs(fn, conf, [x, index, values])
+
+
+def test_aten_index_put_bool_mask_scalar(conf: Conf):
+    """`x[mask] = scalar` does NOT reach a bool-mask index_put kernel: torch's
+    own `_index_put_impl_` re-routes exactly this shape to `masked_fill_`
+    (canDispatchToMaskedFill), and so does the mojo one — which is why no
+    index_put implementation is asserted here."""
+
+    def fn(x):
+        out = x.clone()
+        out[x > 0] = -1.0
+        return out
+
+    check_outputs(fn, conf, [torch.randn(4, 5)])
+
+
+def test_aten_index_put_bool_row_mask_scalar(conf: Conf):
+    """A mask that covers only the LEADING dim, on a SQUARE tensor.
+
+    A mask index selects leading dims, but broadcasting is right-aligned, so
+    routing a shape-(4,) mask straight into masked_fill_ on a (4, 4) tensor
+    fills the wrong axis — and only a square tensor exposes it, because any
+    other shape raises instead of answering wrongly.
+    """
+
+    def fn(x, keep):
+        out = x.clone()
+        out[keep] = 0.0
+        return out
+
+    x = torch.arange(16, dtype=torch.float32).reshape(4, 4)
+    keep = torch.tensor([True, False, False, True])
+    check_outputs(fn, conf, [x, keep])
+
+
 def test_aten_isin_none_match(conf: Conf):
     """Test aten.isin when no elements are in test_elements"""
 

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -1083,37 +1083,74 @@ def test_autograd_preflight_refuses_relu_inplace_in_the_forward(mojo_gpu):
         torch.relu_(non_leaf)
 
 
-def test_autograd_preflight_refuses_advanced_indexing_in_the_forward(mojo_gpu):
-    """`index.Tensor`'s backward scatters through `_index_put_impl_`."""
+@pytest.mark.parametrize("index_shape", [(2,), (3, 2)], ids=["1d", "2d"])
+def test_advanced_indexing_with_an_integer_index_is_differentiable(
+    mojo_gpu, index_shape
+):
+    """`index.Tensor`'s backward scatters through `_index_put_impl_`, which
+    exists now, so this must NOT be refused -- it used to be.
+
+    The 2-D index is the case worth a node of its own: the grad handed to the
+    backward is a stride-0 expansion whose leading index dims have no view at
+    the rank the scatter walks, so a `values` reshape (rather than folding
+    those dims into one stride) declines and aborts the engine.
+    """
     host_input, device_input = _preflight_input((4, 5), mojo_gpu)
-    index = torch.tensor([0, 2], device=mojo_gpu)
-    torch.testing.assert_close(device_input[index].cpu(), host_input[[0, 2]])
+    host_index = torch.arange(math.prod(index_shape)).reshape(index_shape) % 4
+    index = host_index.to(mojo_gpu)
+
+    host_leaf = host_input.clone().requires_grad_()
+    host_leaf[host_index].sum().backward()
+    device_input.requires_grad_()
+    device_input[index].sum().backward()
+
+    torch.testing.assert_close(device_input.grad.cpu(), host_leaf.grad)
+
+
+def test_advanced_indexing_with_a_boolean_mask_is_refused_in_the_forward(mojo_gpu):
+    """A mask's accumulating index_put has no kernel (the written element count
+    is data dependent), so this one still has to be refused from the forward
+    rather than aborting the engine."""
+    host_input, device_input = _preflight_input((4, 5), mojo_gpu)
+    mask = (torch.arange(4) % 2 == 0).to(mojo_gpu)
+    torch.testing.assert_close(
+        device_input[mask].cpu(), host_input[torch.arange(4) % 2 == 0]
+    )
     device_input.requires_grad_()
     with pytest.raises(NotImplementedError, match="aten::_index_put_impl_"):
-        device_input[index]
+        device_input[mask]
 
 
-def test_autograd_preflight_refuses_scatter_src_only_for_the_src_gradient(mojo_gpu):
-    """Only `src`'s gradient needs `gather`; a self-only call still runs.
+def test_scatter_src_is_differentiable_in_both_operands(mojo_gpu):
+    """`src`'s gradient is `grad.gather(dim, index)`, which exists now.
 
-    The `self` gradient is a scatter of zeros, which this backend can run, so
-    preflighting on "any operand requires grad" would refuse a working call.
+    This op used to be preflighted so that a `src`-requiring-grad call was
+    refused from the forward; with `aten::gather` implemented both gradients
+    run, and refusing either would reject a working call.
     """
     host_input, device_input = _preflight_input((4, 5), mojo_gpu)
     host_src, device_src = _preflight_input((4, 1), mojo_gpu, seed=7)
-    index = torch.zeros(4, 1, dtype=torch.long, device=mojo_gpu)
+    host_index = torch.zeros(4, 1, dtype=torch.long)
+    index = host_index.to(mojo_gpu)
 
-    expected = host_input.scatter(1, torch.zeros(4, 1, dtype=torch.long), host_src)
+    expected = host_input.scatter(1, host_index, host_src)
     torch.testing.assert_close(
         device_input.scatter(1, index, device_src).cpu(), expected
     )
-    # self-only: still allowed, and the node it records is runnable.
-    device_input.requires_grad_()
-    device_input.scatter(1, index, device_src).sum().backward()
-    assert device_input.grad is not None
 
-    with pytest.raises(NotImplementedError, match="aten::gather"):
-        device_input.detach().scatter(1, index, device_src.requires_grad_())
+    for want_self, want_src in ((True, False), (False, True), (True, True)):
+        host_a = host_input.clone().requires_grad_(want_self)
+        host_b = host_src.clone().requires_grad_(want_src)
+        host_a.scatter(1, host_index, host_b).sum().backward()
+
+        device_a = device_input.detach().clone().requires_grad_(want_self)
+        device_b = device_src.detach().clone().requires_grad_(want_src)
+        device_a.scatter(1, index, device_b).sum().backward()
+
+        if want_self:
+            torch.testing.assert_close(device_a.grad.cpu(), host_a.grad)
+        if want_src:
+            torch.testing.assert_close(device_b.grad.cpu(), host_b.grad)
 
 
 def test_autograd_preflight_refuses_efficient_attention_in_the_forward(mojo_gpu):

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -1055,37 +1055,74 @@ def test_autograd_preflight_refuses_relu_inplace_in_the_forward(mojo_gpu):
         torch.relu_(non_leaf)
 
 
-def test_autograd_preflight_refuses_advanced_indexing_in_the_forward(mojo_gpu):
-    """`index.Tensor`'s backward scatters through `_index_put_impl_`."""
+@pytest.mark.parametrize("index_shape", [(2,), (3, 2)], ids=["1d", "2d"])
+def test_advanced_indexing_with_an_integer_index_is_differentiable(
+    mojo_gpu, index_shape
+):
+    """`index.Tensor`'s backward scatters through `_index_put_impl_`, which
+    exists now, so this must NOT be refused -- it used to be.
+
+    The 2-D index is the case worth a node of its own: the grad handed to the
+    backward is a stride-0 expansion whose leading index dims have no view at
+    the rank the scatter walks, so a `values` reshape (rather than folding
+    those dims into one stride) declines and aborts the engine.
+    """
     host_input, device_input = _preflight_input((4, 5), mojo_gpu)
-    index = torch.tensor([0, 2], device=mojo_gpu)
-    torch.testing.assert_close(device_input[index].cpu(), host_input[[0, 2]])
+    host_index = torch.arange(math.prod(index_shape)).reshape(index_shape) % 4
+    index = host_index.to(mojo_gpu)
+
+    host_leaf = host_input.clone().requires_grad_()
+    host_leaf[host_index].sum().backward()
+    device_input.requires_grad_()
+    device_input[index].sum().backward()
+
+    torch.testing.assert_close(device_input.grad.cpu(), host_leaf.grad)
+
+
+def test_advanced_indexing_with_a_boolean_mask_is_refused_in_the_forward(mojo_gpu):
+    """A mask's accumulating index_put has no kernel (the written element count
+    is data dependent), so this one still has to be refused from the forward
+    rather than aborting the engine."""
+    host_input, device_input = _preflight_input((4, 5), mojo_gpu)
+    mask = (torch.arange(4) % 2 == 0).to(mojo_gpu)
+    torch.testing.assert_close(
+        device_input[mask].cpu(), host_input[torch.arange(4) % 2 == 0]
+    )
     device_input.requires_grad_()
     with pytest.raises(NotImplementedError, match="aten::_index_put_impl_"):
-        device_input[index]
+        device_input[mask]
 
 
-def test_autograd_preflight_refuses_scatter_src_only_for_the_src_gradient(mojo_gpu):
-    """Only `src`'s gradient needs `gather`; a self-only call still runs.
+def test_scatter_src_is_differentiable_in_both_operands(mojo_gpu):
+    """`src`'s gradient is `grad.gather(dim, index)`, which exists now.
 
-    The `self` gradient is a scatter of zeros, which this backend can run, so
-    preflighting on "any operand requires grad" would refuse a working call.
+    This op used to be preflighted so that a `src`-requiring-grad call was
+    refused from the forward; with `aten::gather` implemented both gradients
+    run, and refusing either would reject a working call.
     """
     host_input, device_input = _preflight_input((4, 5), mojo_gpu)
     host_src, device_src = _preflight_input((4, 1), mojo_gpu, seed=7)
-    index = torch.zeros(4, 1, dtype=torch.long, device=mojo_gpu)
+    host_index = torch.zeros(4, 1, dtype=torch.long)
+    index = host_index.to(mojo_gpu)
 
-    expected = host_input.scatter(1, torch.zeros(4, 1, dtype=torch.long), host_src)
+    expected = host_input.scatter(1, host_index, host_src)
     torch.testing.assert_close(
         device_input.scatter(1, index, device_src).cpu(), expected
     )
-    # self-only: still allowed, and the node it records is runnable.
-    device_input.requires_grad_()
-    device_input.scatter(1, index, device_src).sum().backward()
-    assert device_input.grad is not None
 
-    with pytest.raises(NotImplementedError, match="aten::gather"):
-        device_input.detach().scatter(1, index, device_src.requires_grad_())
+    for want_self, want_src in ((True, False), (False, True), (True, True)):
+        host_a = host_input.clone().requires_grad_(want_self)
+        host_b = host_src.clone().requires_grad_(want_src)
+        host_a.scatter(1, host_index, host_b).sum().backward()
+
+        device_a = device_input.detach().clone().requires_grad_(want_self)
+        device_b = device_src.detach().clone().requires_grad_(want_src)
+        device_a.scatter(1, index, device_b).sum().backward()
+
+        if want_self:
+            torch.testing.assert_close(device_a.grad.cpu(), host_a.grad)
+        if want_src:
+            torch.testing.assert_close(device_b.grad.cpu(), host_b.grad)
 
 
 def test_autograd_preflight_refuses_efficient_attention_in_the_forward(mojo_gpu):

--- a/torch_mojo_backend/aten_functions.py
+++ b/torch_mojo_backend/aten_functions.py
@@ -2230,6 +2230,44 @@ def aten_full_like(
 
 
 # gather(Tensor self, int dim, Tensor index, *, bool sparse_grad=False) -> Tensor
+@map_to(aten.gather)
+def aten_gather(
+    input: MaxTensor, dim: int, index: MaxTensor, sparse_grad: bool = False
+) -> MaxTensor:
+    """``out[i][j][k] = input[i][index[i][j][k]][k]`` for ``dim=1``, etc.
+
+    ``F.gather`` is numpy.take — it selects whole slices along one axis — NOT
+    torch.gather, so the full coordinate of every output element is built and
+    fed to ``gather_nd``. ``sparse_grad`` only picks the layout of the
+    gradient, which autograd builds separately, so the forward ignores it
+    exactly as ATen's does.
+    """
+    return F.gather_nd(input, _dim_coords(input, dim, index), batch_dims=0)
+
+
+def _dim_coords(input: MaxTensor, dim: int, index: MaxTensor) -> MaxTensor:
+    """The ``index.shape + [rank]`` coordinate tensor of a torch-style
+    gather/scatter along ``dim``.
+
+    Every axis contributes its own coordinate — an iota broadcast along that
+    axis — except ``dim``, which contributes ``index``. This is the bridge
+    between torch's elementwise gather/scatter index convention and MAX's
+    ``gather_nd``/``scatter_nd`` coordinate-vector convention, and is shared
+    by ``aten_gather`` and ``aten_scatter_add``: their index semantics are
+    identical, only the direction of the copy differs.
+    """
+    rank = len(input.shape)
+    dim = dim % rank
+    coords = []
+    for axis in range(rank):
+        if axis == dim:
+            coords.append(index)
+            continue
+        iota = F.arange(0, index.shape[axis], 1, dtype=index.dtype, device=index.device)
+        axis_shape = [StaticDim(1)] * rank
+        axis_shape[axis] = index.shape[axis]
+        coords.append(F.broadcast_to(F.reshape(iota, axis_shape), index.shape))
+    return F.stack(coords, axis=-1)
 
 
 # ge.Scalar(Tensor self, Scalar other) -> Tensor
@@ -2387,8 +2425,75 @@ def broadcast_shape(shapes):
     return out
 
 
+# index_add(Tensor self, int dim, Tensor index, Tensor source, *, Scalar alpha=1) -> Tensor
+@map_to(aten.index_add)
+def aten_index_add(
+    input: MaxTensor, dim: int, index: MaxTensor, source: MaxTensor, alpha: Scalar = 1
+) -> MaxTensor:
+    """``out = input.clone(); out.index_add_(dim, index, source)``.
+
+    index_add IS scatter_add with a 1-D index broadcast across every other
+    axis, so it broadcasts the index to `source`'s shape and reuses
+    `aten_scatter_add` rather than repeating the coordinate construction.
+    It is also what autograd calls for index_select's backward.
+    """
+    if alpha != 1:
+        source = source * alpha
+    axis_shape = [StaticDim(1)] * len(source.shape)
+    axis_shape[dim % len(source.shape)] = index.shape[0]
+    index = F.broadcast_to(F.reshape(index, axis_shape), source.shape)
+    return aten_scatter_add(input, dim, index, source)
+
+
 # index_put(Tensor self, Tensor?[] indices, Tensor values, bool accumulate=False) -> Tensor
+@map_to(aten.index_put)
+def aten_index_put(
+    input: MaxTensor,
+    indices: list[MaxTensor | None],
+    values: MaxTensor,
+    accumulate: bool = False,
+) -> MaxTensor:
+    """``out = input.clone(); out[indices] = values`` (``+=`` when
+    ``accumulate``) — the write mirror of ``aten_index``.
+
+    Only a single index tensor on axis 0 is served, the same regime the eager
+    fast path covers; anything else (a boolean mask, several index tensors, an
+    index on a later axis) raises rather than silently computing the wrong
+    thing. The MAX primitives are the ``_nd`` scatters and not the axis-based
+    ``F.scatter``/``F.scatter_add``, because those have no GPU kernel and
+    would insert a silent host round trip per call.
+    """
+    non_none = [(axis, idx) for axis, idx in enumerate(indices) if idx is not None]
+    if len(non_none) != 1 or non_none[0][0] != 0:
+        raise NotImplementedError(
+            "aten.index_put only supports a single index tensor on dim 0, got "
+            f"{[idx is not None for idx in indices]}"
+        )
+    index = non_none[0][1]
+    if index.dtype == DType.bool:
+        raise NotImplementedError(
+            "aten.index_put with a boolean mask is not supported yet (the "
+            "number of written elements is data dependent)"
+        )
+    if len(index.shape) != 1:
+        raise NotImplementedError(
+            f"aten.index_put needs a 1-D index tensor, got rank {len(index.shape)}"
+        )
+    # scatter_nd's updates carry the trailing (unindexed) axes of `input`:
+    # indices [rows, 1] pairs with updates [rows, *input.shape[1:]].
+    updates = F.broadcast_to(values, [index.shape[0]] + list(input.shape[1:]))
+    scatter = F.scatter_nd_add if accumulate else F.scatter_nd
+    return scatter(input, updates, F.unsqueeze(index, -1))
+
+
 # index_select(Tensor self, int dim, Tensor index) -> Tensor
+@map_to(aten.index_select)
+def aten_index_select(input: MaxTensor, dim: int, index: MaxTensor) -> MaxTensor:
+    """``F.gather`` is exactly index_select: numpy.take semantics, with the
+    indexed axis replaced by the (1-D) index's shape."""
+    return F.gather(input, index, axis=dim)
+
+
 # isinf(Tensor self) -> Tensor
 
 
@@ -3305,6 +3410,25 @@ def aten_scatter_value(
 
 
 # scatter_add(Tensor self, int dim, Tensor index, Tensor src) -> Tensor
+@map_to(aten.scatter_add)
+def aten_scatter_add(
+    input: MaxTensor, dim: int, index: MaxTensor, src: MaxTensor
+) -> MaxTensor:
+    """``out = input.clone(); out[i][index[i][j][k]][k] += src[i][j][k]`` for
+    ``dim=1``, etc. — the accumulating twin of ``aten_scatter_src``, and the
+    backward of ``aten_gather``.
+
+    Deliberately NOT `F.scatter_add`, whose semantics match but which has no
+    GPU kernel: its wrapper transfers input/updates/indices to the host and
+    the result back on every call. The `_nd` form keeps the GPU kernel in the
+    loop, at the cost of materializing the coordinate tensor `_dim_coords`
+    builds (shared with `aten_gather`).
+    """
+    coords = _dim_coords(input, dim, index)
+    rank = len(input.shape)
+    return F.scatter_nd_add(input, F.reshape(src, [-1]), F.reshape(coords, [-1, rank]))
+
+
 # scatter_reduce.two(Tensor self, int dim, Tensor index, Tensor src, str reduce, *, bool include_self=True) -> Tensor
 
 

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -4319,6 +4319,16 @@ _SCATTER_DTYPES = _FLOAT_DTYPES + (
     DType.bool,
 )
 
+# What ScatterAddDim can serve. It reduces with `Atomic.fetch_add`, and there
+# is no sub-32-bit atomic read-modify-write on the GPU targets, so the narrow
+# integer dtypes (and bool) are declined HERE rather than reaching the
+# compiler as an unsatisfiable specialization -- the Mojo dtype ladder
+# instantiates whatever DTYPE_ARG_0 names, with no list of its own to gate on.
+_SCATTER_ADD_DTYPES = _FLOAT_DTYPES + (DType.float64, DType.int32, DType.int64)
+
+# The rank Gather/ScatterDim pad their index space to.
+_DIM_INDEX_RANK = 4
+
 
 def _try_stack_scalars(
     tensors: Sequence[torch.Tensor], dim: int
@@ -4574,6 +4584,556 @@ def fast_aten_index(input, indices):
     return NOT_HANDLED
 
 
+# ---------------------------------------------------------------------------
+# The dim-indexed family: gather / index_select / scatter_add / index_add /
+# index_put.  All five are the SAME two Mojo kernels over a rank-<=4 index
+# space described by explicit strides (GatherDim reads, ScatterDim[+add]
+# writes); what distinguishes them is only which stride vector is real and
+# which is a broadcast:
+#
+#   gather        dims = index.shape,  index strides real
+#   index_select  dims = out.shape,    index strides 0 except along `dim`
+#   scatter_add   dims = index.shape,  index strides real, atomic add
+#   index_add     dims = source.shape, index strides 0 except along `dim`
+#   index_put     dims = values.shape, dim 0, index strides (1, 0, ...)
+#
+# INDEX BOUNDS ARE NOT CHECKED, matching torch: its CPU kernels raise before
+# launching, but the CUDA kernels only device-assert (ScatterGatherKernel.cu,
+# Indexing.cu), so an out-of-range index is undefined on an accelerator there
+# too.  NEGATIVE indices are undefined for gather/index_select/scatter_add/
+# index_add for the same reason -- torch never wraps them there.  They ARE
+# wrapped for index_put, which is advanced indexing and does define them; the
+# wrap reuses the `remainder` kernel on the index, exactly as torch's own
+# `wrapIndexOnce` does.
+# ---------------------------------------------------------------------------
+
+
+def _dim_launch_params(dims, out_strides, src_strides, idx_strides, dim):
+    """The 17-int parameter tuple Gather/ScatterDim take: the index-space
+    dims and three stride vectors, each left-padded to rank 4 (dims with 1,
+    strides with 0), plus the padded position of the indexed dim."""
+    pad = _DIM_INDEX_RANK - len(dims)
+    return (
+        tuple([1] * pad + list(dims))
+        + tuple([0] * pad + list(out_strides))
+        + tuple([0] * pad + list(src_strides))
+        + tuple([0] * pad + list(idx_strides))
+        + (dim + pad,)
+    )
+
+
+def _launch_gather_dim(out, src, idx, geometry):
+    """`geometry` is (dims, out_strides, src_strides, idx_strides, dim) over
+    the index space -- passed explicitly rather than read off the tensors so
+    a contiguous operand can be re-described at a lower rank (see
+    `_collapse3`) without minting a view object for it."""
+    _call_mojo(
+        _DataMovementExtension,
+        "GatherDim",
+        (
+            out._ptr,
+            src._ptr,
+            idx._ptr,
+            _dim_launch_params(*geometry),
+            idx._dtype.value,
+            out._itemsize,
+            _ctx_ptr(src._device),
+        ),
+        arg_dtypes=(src._dtype, idx._dtype),
+        output_dtypes=(out._dtype,),
+        keepalive=(out, src, idx),
+    )
+
+
+def _launch_scatter_add_dim(out, src, idx, geometry):
+    _call_mojo(
+        _DataMovementExtension,
+        "ScatterAddDim",
+        (
+            out._ptr,
+            idx._ptr,
+            src._ptr,
+            _dim_launch_params(*geometry),
+            out._dtype.value,
+            _ctx_ptr(out._device),
+        ),
+        arg_dtypes=(out._dtype, idx._dtype, src._dtype),
+        output_dtypes=(out._dtype,),
+        keepalive=(out, src, idx),
+    )
+
+
+def _collapse3(shape, dim):
+    """`(outer, shape[dim], inner)`: the rank-3 form of a CONTIGUOUS operand
+    around its indexed dim.
+
+    A broadcast-index op (index_select / index_add) touches only the `dim`
+    coordinate, so every other dim can be folded into one leading and one
+    trailing extent. That lifts the kernels' rank-4 cap for contiguous
+    operands of any rank and costs one div/mod less per element than the
+    padded rank-4 form.
+    """
+    return math.prod(shape[:dim]), shape[dim], math.prod(shape[dim + 1 :])
+
+
+def _int64_index(index):
+    """`index` as a contiguous int64 tensor, or None.
+
+    The ScatterDim family carries one comptime index dtype (int64) rather
+    than the width ladder GatherDim/GatherRows have, so an int32 index --
+    which torch accepts for index_select/index_add/index_put -- is widened
+    here instead of doubling the number of compiled variants.
+    """
+    idx = _t(index)
+    if idx is None:
+        return None
+    if idx._dtype == DType.int64:
+        return _tc(idx)
+    if idx._dtype == DType.int32:
+        return _tc(_cast_tensor(_tc(idx), DType.int64))
+    return None
+
+
+def _dim_op_dest(out, shape, dtype, device):
+    """`(destination, out)` for an optional `out=` argument.
+
+    `destination` is what the kernel writes; when it is not `out` itself the
+    caller copies it in afterwards. `(None, None)` means `out` cannot serve.
+    Every input must already be validated before this runs: it resizes `out`,
+    so a route that declines afterwards would leave a half-applied out=.
+    """
+    shape = tuple(shape)
+    if out is None:
+        return _alloc(shape, dtype, device), None
+    dst = _t(out)
+    if dst is None or dst._dtype != dtype or dst._device != device:
+        return None, None
+    if tuple(dst._shape) != shape:
+        _resize_payload(dst, shape)
+        return dst, dst
+    if dst._is_contiguous:
+        return dst, dst
+    # A correctly-shaped strided view keeps its storage and takes one
+    # ordered copy after the kernel.
+    return _alloc(shape, dtype, device), dst
+
+
+def _dim_op_finish(dest, out):
+    if out is None:
+        return dest
+    if dest is not out:
+        _copy_into(out, dest)
+    return out
+
+
+def _index_space_fits(idx_shape, shape, skip_dim=None):
+    """torch's gather/scatter shape rule: `index.size(d) <= other.size(d)`
+    for every dim, optionally skipping the indexed one. Enforced because a
+    backend kernel registered at this level replaces the structured meta
+    function that would otherwise have checked it -- and reading past a
+    smaller operand is an out-of-bounds access, not a wrong answer."""
+    return all(
+        i <= s for d, (i, s) in enumerate(zip(idx_shape, shape)) if d != skip_dim
+    )
+
+
+def fast_aten_gather(input, dim, index, sparse_grad=False, *, out=None):
+    t = _t(input)
+    idx = _t(index)
+    if t is None or idx is None or not isinstance(dim, int):
+        return NOT_HANDLED
+    if idx._device != t._device or idx._dtype not in _INT_SCALAR_DTYPES:
+        return NOT_HANDLED
+    if t._dtype not in _COPYABLE_DTYPES:
+        return NOT_HANDLED
+    rank = len(t._shape)
+    if rank == 0 or rank > _DIM_INDEX_RANK or len(idx._shape) != rank:
+        return NOT_HANDLED
+    if not -rank <= dim < rank:
+        return NOT_HANDLED
+    dim %= rank
+    if not _index_space_fits(idx._shape, t._shape, dim):
+        return NOT_HANDLED
+
+    dest, out_t = _dim_op_dest(out, idx._shape, t._dtype, t._device)
+    if dest is None:
+        return NOT_HANDLED
+    if dest._numel > 0:
+        _launch_gather_dim(
+            dest, t, idx, (idx._shape, dest._mojo_strides, t._mojo_strides, idx._mojo_strides, dim)
+        )
+    return _dim_op_finish(dest, out_t)
+
+
+def fast_aten_index_select(input, dim, index, *, out=None):
+    t = _t(input)
+    idx = _t(index)
+    if t is None or idx is None or not isinstance(dim, int):
+        return NOT_HANDLED
+    if idx._device != t._device or idx._dtype not in _INT_SCALAR_DTYPES:
+        return NOT_HANDLED
+    if t._dtype not in _COPYABLE_DTYPES or len(idx._shape) > 1:
+        return NOT_HANDLED
+    rank = len(t._shape)
+    if rank == 0 or not -rank <= dim < rank:
+        return NOT_HANDLED
+    dim %= rank
+    # A contiguous input collapses to a rank-3 (outer, n, inner) problem
+    # whatever its rank; a strided one needs its real strides and so is
+    # capped at the kernels' rank.
+    if not t._is_contiguous and rank > _DIM_INDEX_RANK:
+        return NOT_HANDLED
+
+    n = idx._numel
+    shape = list(t._shape)
+    shape[dim] = n
+    dest, out_t = _dim_op_dest(out, shape, t._dtype, t._device)
+    if dest is None:
+        return NOT_HANDLED
+    if dest._numel > 0:
+        idx_c = _tc(idx)
+        idx_stride = idx_c._mojo_strides[0] if idx_c._shape else 0
+        # `dest` is always contiguous here: `_dim_op_dest` either allocated
+        # it or resized `out` (which resets it to contiguous strides), and a
+        # correctly-shaped strided `out` got scratch instead.
+        if dim == 0 and t._is_contiguous:
+            # Whole rows along dim 0: the existing GatherRows kernel, one
+            # div/mod per element instead of three.
+            _call_mojo(
+                _DataMovementExtension,
+                "GatherRows",
+                (
+                    dest._ptr,
+                    t._ptr,
+                    idx_c._ptr,
+                    idx_c._dtype.value,
+                    n,
+                    math.prod(t._shape[1:]),
+                    t._shape[0],
+                    dest._itemsize,
+                    _ctx_ptr(t._device),
+                ),
+                arg_dtypes=(t._dtype, idx_c._dtype),
+                output_dtypes=(dest._dtype,),
+                keepalive=(dest, t, idx_c),
+            )
+        elif t._is_contiguous:
+            outer, size_dim, inner = _collapse3(t._shape, dim)
+            _launch_gather_dim(
+                dest,
+                t,
+                idx_c,
+                (
+                    (outer, n, inner),
+                    (n * inner, inner, 1),
+                    (size_dim * inner, inner, 1),
+                    (0, idx_stride, 0),
+                    1,
+                ),
+            )
+        else:
+            idx_strides = [0] * rank
+            idx_strides[dim] = idx_stride
+            _launch_gather_dim(
+                dest, t, idx_c, (shape, dest._mojo_strides, t._mojo_strides, idx_strides, dim)
+            )
+    return _dim_op_finish(dest, out_t)
+
+
+def _scatter_add_dest(input, out):
+    """`(dest, out_t)` for a scatter-add-shaped op: the destination starts as
+    a copy of `self`, since `out = self.clone(); out[...] += src`. `out is
+    self` (the in-place `scatter_add_`/`index_add_` overloads) needs no copy
+    at all."""
+    a = _t(input)
+    dest, out_t = _dim_op_dest(out, a._shape, a._dtype, a._device)
+    if dest is None:
+        return None, None
+    if dest is not a:
+        _copy_into(dest, a)
+    return dest, out_t
+
+
+def fast_aten_scatter_add(input, dim, index, src, *, out=None):
+    a = _t(input)
+    s = _t(src)
+    idx = _t(index)
+    if a is None or s is None or idx is None or not isinstance(dim, int):
+        return NOT_HANDLED
+    if idx._device != a._device or s._device != a._device:
+        return NOT_HANDLED
+    if idx._dtype != DType.int64 or s._dtype != a._dtype:
+        return NOT_HANDLED
+    if a._dtype not in _SCATTER_ADD_DTYPES:
+        return NOT_HANDLED
+    if a._dtype == DType.float64 and a._device.api == "metal":
+        return NOT_HANDLED
+    rank = len(a._shape)
+    if rank == 0 or rank > _DIM_INDEX_RANK or not -rank <= dim < rank:
+        return NOT_HANDLED
+    if len(idx._shape) != rank or len(s._shape) != rank:
+        return NOT_HANDLED
+    dim %= rank
+    if not _index_space_fits(idx._shape, a._shape, dim):
+        return NOT_HANDLED
+    if not _index_space_fits(idx._shape, s._shape):
+        return NOT_HANDLED
+
+    dest, out_t = _scatter_add_dest(input, out)
+    if dest is None:
+        return NOT_HANDLED
+    if idx._numel > 0:
+        _launch_scatter_add_dim(
+            dest, s, idx, (idx._shape, dest._mojo_strides, s._mojo_strides, idx._mojo_strides, dim)
+        )
+    return _dim_op_finish(dest, out_t)
+
+
+def fast_aten_scatter_add_(input, dim, index, src):
+    """`scatter_add_`: the out= destination IS self, so no clone happens."""
+    return fast_aten_scatter_add(input, dim, index, src, out=input)
+
+
+def fast_aten_index_add(input, dim, index, source, alpha=1, *, out=None):
+    a = _t(input)
+    if a is None or not isinstance(dim, int):
+        return NOT_HANDLED
+    # alpha scales `source`; an extra elementwise pass for it would be a
+    # different op's kernel, so only the default is served here.
+    if not isinstance(alpha, int | float) or isinstance(alpha, bool) or alpha != 1:
+        return NOT_HANDLED
+    idx = _int64_index(index)
+    src = _t(source)
+    if idx is None or src is None or len(idx._shape) > 1:
+        return NOT_HANDLED
+    if idx._device != a._device or src._device != a._device:
+        return NOT_HANDLED
+    if src._dtype != a._dtype or a._dtype not in _SCATTER_ADD_DTYPES:
+        return NOT_HANDLED
+    if a._dtype == DType.float64 and a._device.api == "metal":
+        return NOT_HANDLED
+    rank = len(a._shape)
+    if rank == 0 or not -rank <= dim < rank:
+        return NOT_HANDLED
+    dim %= rank
+    n = idx._numel
+    expected = list(a._shape)
+    expected[dim] = n
+    if list(src._shape) != expected:
+        return NOT_HANDLED
+    src_c = _tc(src)
+
+    dest, out_t = _scatter_add_dest(input, out)
+    if dest is None:
+        return NOT_HANDLED
+    if n > 0 and src_c._numel > 0:
+        # Both operands are contiguous by construction here -- `_tc` for the
+        # source, `_dim_op_dest` for the destination -- so the rank-3 collapse
+        # always applies and there is no rank cap on this op.
+        outer, size_dim, inner = _collapse3(a._shape, dim)
+        _launch_scatter_add_dim(
+            dest,
+            src_c,
+            idx,
+            (
+                (outer, n, inner),
+                (size_dim * inner, inner, 1),
+                (n * inner, inner, 1),
+                (0, idx._mojo_strides[0] if idx._shape else 0, 0),
+                1,
+            ),
+        )
+    return _dim_op_finish(dest, out_t)
+
+
+def fast_aten_index_add_(input, dim, index, source, alpha=1):
+    """`index_add_`: the out= destination IS self, so no clone happens."""
+    return fast_aten_index_add(input, dim, index, source, alpha, out=input)
+
+
+def _mask_over_leading_dims(mask, shape):
+    """An index mask reshaped so masked_fill's broadcast means what advanced
+    indexing means, or None.
+
+    A mask index covers `self`'s LEADING dims, while broadcasting is
+    right-aligned: a shape-(4,) mask on a (4, 5) tensor selects rows, but
+    `masked_fill_` would try to broadcast it across the 5 columns -- an error
+    when 4 != 5, and silently the WRONG axis when they happen to be equal.
+    Appending the missing trailing 1s (zero-copy: a mask index is contiguous
+    or it is not ours) makes the two conventions agree.
+    """
+    m = _tc(mask)
+    if m is None or len(m._shape) > len(shape):
+        return None
+    if any(a != b for a, b in zip(m._shape, shape)):
+        return None
+    if len(m._shape) == len(shape):
+        return m
+    padded = fast_aten_view(m, tuple(m._shape) + (1,) * (len(shape) - len(m._shape)))
+    return None if padded is NOT_HANDLED else padded
+
+
+def _fold_leading_strides(t, k):
+    """`t`'s element strides with its first `k` dims folded into one axis, or
+    None when they do not fold.
+
+    They fold when their extents and strides describe a single run
+    (`stride[d] == stride[d+1] * shape[d+1]`), which covers both of the cases
+    that reach it: a contiguous buffer, and a fully broadcast one whose
+    strides are all 0. `k == 0` (a 0-d index) prepends a stride for the
+    length-1 row axis the kernel still walks.
+    """
+    if k == 0:
+        return [0] + list(t._mojo_strides)
+    for d in range(k - 1):
+        if t._mojo_strides[d] != t._mojo_strides[d + 1] * t._shape[d + 1]:
+            return None
+    return [t._mojo_strides[k - 1]] + list(t._mojo_strides[k:])
+
+
+def fast_aten_index_put(input, indices, values, accumulate=False, unsafe=False):
+    """Registered for `aten::_index_put_impl_`, which `x[idx] = v` /
+    `x[mask] = v` and `index_put`/`index_put_` all funnel into (those two are
+    CompositeExplicitAutograd wrappers over this one). Named after the concept
+    rather than that overload so it pairs with `aten_functions.aten_index_put`.
+
+    Writes into `input` and returns it. Only a single index tensor on dim 0
+    is served -- of ANY rank, matching what `fast_aten_index` reads, so that
+    `x[idx2d]` is differentiable and not just readable; multi-tensor advanced
+    indexing declines. Duplicate indices with `accumulate=False`
+    race, and torch leaves the winner undefined there too.
+
+    KNOWN GAP, not this function's: on a mojo device that is not the current
+    one, the `accumulate=False` BACKWARD declines and, being inside the
+    autograd engine, aborts the process. Its derivative formula is
+    `grad.index_put(indices, zeros_like(values), false)`, and that
+    `zeros_like` is allocated by ATen on the CURRENT device rather than on
+    `values`' device -- the PrivateUse1 device guard is a no-op here, so the
+    values tensor arrives on a different device than self and there is
+    nothing to do but decline. Every C++ derivative formula that allocates
+    without naming a device has the same problem; the fix belongs in the
+    device guard, not here.
+    """
+    a = _t(input)
+    if a is None or not isinstance(indices, list | tuple):
+        return NOT_HANDLED
+    non_none = [(i, x) for i, x in enumerate(indices) if x is not None]
+    if len(non_none) != 1 or non_none[0][0] != 0:
+        return NOT_HANDLED
+    raw = _t(non_none[0][1])
+    if raw is None or raw._device != a._device:
+        return NOT_HANDLED
+
+    if raw._dtype == DType.bool:
+        # `x[mask] = scalar`, the one boolean-mask form whose output shape is
+        # not data dependent: torch's own `_index_put_impl_` re-routes exactly
+        # it to masked_fill_ (canDispatchToMaskedFill), and so does this.
+        # Anything else needs the mask's true-count, i.e. a host sync.
+        if accumulate:
+            return NOT_HANDLED
+        value = values
+        if isinstance(value, torch.Tensor):
+            if value.numel() != 1:
+                return NOT_HANDLED
+            if not isinstance(value, TorchMojoTensor):
+                # A python scalar assignment arrives as a 1-element CPU tensor
+                # (python_variable_indexing.cpp builds it there); reading it
+                # back costs no device sync.
+                value = value.item()
+        elif not isinstance(value, int | float | bool):
+            return NOT_HANDLED
+        mask = _mask_over_leading_dims(raw, a._shape)
+        if mask is None:
+            return NOT_HANDLED
+        return (
+            input
+            if fast_aten_masked_fill_(input, mask, value) is not None
+            else NOT_HANDLED
+        )
+
+    if raw._dtype not in _INT_SCALAR_DTYPES:
+        return NOT_HANDLED
+    v = _t(values)
+    if v is None or v._device != a._device or v._dtype != a._dtype:
+        return NOT_HANDLED
+    dtypes = _SCATTER_ADD_DTYPES if accumulate else _SCATTER_DTYPES
+    if a._dtype not in dtypes:
+        return NOT_HANDLED
+    # Metal has no float64 at all, in either scatter kernel; decline instead of
+    # letting `_parallel_for_dt`'s guard raise from inside the launch.
+    if a._dtype == DType.float64 and a._device.api == "metal":
+        return NOT_HANDLED
+    rank = len(a._shape)
+    if rank == 0 or rank > _DIM_INDEX_RANK:
+        return NOT_HANDLED
+    n = raw._numel
+    dims = (n,) + tuple(a._shape[1:])
+    if n == 0 or a._numel == 0:
+        return input
+    # `values` is written over the index space `index.shape + self.shape[1:]`,
+    # which the kernel walks as the flattened `(n,) + self.shape[1:]`. Two
+    # shapes arrive here: exactly that subspace (what `aten::index.Tensor`'s
+    # backward hands back, and it is often a STRIDE-0 expansion of a scalar,
+    # so it has no view at the lower rank -- fold its leading dims into one
+    # stride instead), or something smaller that broadcasts.
+    put_shape = tuple(raw._shape) + tuple(a._shape[1:])
+    if tuple(v._shape) == put_shape:
+        src_strides = _fold_leading_strides(v, len(raw._shape))
+        if src_strides is None:
+            return NOT_HANDLED
+    elif tuple(v._shape) == dims:
+        src_strides = list(v._mojo_strides)
+    else:
+        expanded = fast_aten_expand(v, dims)
+        if expanded is NOT_HANDLED:
+            return NOT_HANDLED
+        v = expanded
+        src_strides = list(v._mojo_strides)
+
+    # Advanced indexing DOES define negative indices; `remainder` by the
+    # indexed extent is how torch's own wrapIndexOnce normalizes them.
+    idx = _int64_index(raw)
+    if idx is None:
+        return NOT_HANDLED
+    # One row per index ELEMENT, whatever the index's rank: flatten it so the
+    # kernel walks it with a single stride (zero-copy, `_int64_index` already
+    # made it contiguous).
+    if len(idx._shape) != 1:
+        idx = fast_aten_view(idx, (n,))
+        if idx is NOT_HANDLED:
+            return NOT_HANDLED
+    wrapped = fast_aten_remainder(idx, a._shape[0])
+    if wrapped is NOT_HANDLED:
+        return NOT_HANDLED
+    idx = _tc(wrapped)
+
+    idx_strides = [0] * rank
+    idx_strides[0] = idx._mojo_strides[0] if idx._shape else 0
+    geometry = (dims, a._mojo_strides, src_strides, idx_strides, 0)
+    if accumulate:
+        _launch_scatter_add_dim(a, v, idx, geometry)
+    else:
+        _call_mojo(
+            _DataMovementExtension,
+            "ScatterDim",
+            (
+                a._ptr,
+                idx._ptr,
+                v._ptr,
+                _dim_launch_params(*geometry),
+                0,
+                0.0,
+                a._dtype.value,
+                _ctx_ptr(a._device),
+            ),
+            arg_dtypes=(a._dtype, idx._dtype, v._dtype),
+            output_dtypes=(a._dtype,),
+            flags={"VALUE_MODE": False},
+            keepalive=(a, v, idx),
+        )
+    return input
+
+
 def _fast_scatter(input, dim, index, src, value):
     a = _t(input)
     idx = _t(index)
@@ -4598,7 +5158,7 @@ def _fast_scatter(input, dim, index, src, value):
     is_value = 0
     value_f = 0.0
     src_ptr = out._ptr  # unused in value mode; a valid pointer for the kernel
-    src_strides4 = [0, 0, 0, 0]
+    src_strides = [0] * rank
     if src is not None:
         s = _tc(src)
         if (
@@ -4609,7 +5169,7 @@ def _fast_scatter(input, dim, index, src, value):
         ):
             return NOT_HANDLED
         src_ptr = s._ptr
-        src_strides4 = [0] * (4 - rank) + list(_row_major_strides(s._shape))
+        src_strides = _row_major_strides(s._shape)
     else:
         if isinstance(value, bool):
             value = int(value)
@@ -4621,16 +5181,8 @@ def _fast_scatter(input, dim, index, src, value):
         else:
             value_f = float(value)
 
-    dims4 = [1] * (4 - rank) + list(idx_c._shape)
-    out_strides4 = [0] * (4 - rank) + list(out._mojo_strides)
-    idx_strides4 = [0] * (4 - rank) + list(idx_c._mojo_strides)
-    dim_padded = dim + (4 - rank)
-    params = (
-        tuple(dims4)
-        + tuple(out_strides4)
-        + tuple(src_strides4)
-        + tuple(idx_strides4)
-        + (dim_padded,)
+    params = _dim_launch_params(
+        idx_c._shape, out._mojo_strides, src_strides, idx_c._mojo_strides, dim
     )
     if idx_c._numel > 0:
         _call_mojo(

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -4286,6 +4286,16 @@ _SCATTER_DTYPES = _FLOAT_DTYPES + (
     DType.bool,
 )
 
+# What ScatterAddDim can serve. It reduces with `Atomic.fetch_add`, and there
+# is no sub-32-bit atomic read-modify-write on the GPU targets, so the narrow
+# integer dtypes (and bool) are declined HERE rather than reaching the
+# compiler as an unsatisfiable specialization -- the Mojo dtype ladder
+# instantiates whatever DTYPE_ARG_0 names, with no list of its own to gate on.
+_SCATTER_ADD_DTYPES = _FLOAT_DTYPES + (DType.float64, DType.int32, DType.int64)
+
+# The rank Gather/ScatterDim pad their index space to.
+_DIM_INDEX_RANK = 4
+
 
 def _try_stack_scalars(
     tensors: Sequence[torch.Tensor], dim: int
@@ -4541,6 +4551,556 @@ def fast_aten_index(input, indices):
     return NOT_HANDLED
 
 
+# ---------------------------------------------------------------------------
+# The dim-indexed family: gather / index_select / scatter_add / index_add /
+# index_put.  All five are the SAME two Mojo kernels over a rank-<=4 index
+# space described by explicit strides (GatherDim reads, ScatterDim[+add]
+# writes); what distinguishes them is only which stride vector is real and
+# which is a broadcast:
+#
+#   gather        dims = index.shape,  index strides real
+#   index_select  dims = out.shape,    index strides 0 except along `dim`
+#   scatter_add   dims = index.shape,  index strides real, atomic add
+#   index_add     dims = source.shape, index strides 0 except along `dim`
+#   index_put     dims = values.shape, dim 0, index strides (1, 0, ...)
+#
+# INDEX BOUNDS ARE NOT CHECKED, matching torch: its CPU kernels raise before
+# launching, but the CUDA kernels only device-assert (ScatterGatherKernel.cu,
+# Indexing.cu), so an out-of-range index is undefined on an accelerator there
+# too.  NEGATIVE indices are undefined for gather/index_select/scatter_add/
+# index_add for the same reason -- torch never wraps them there.  They ARE
+# wrapped for index_put, which is advanced indexing and does define them; the
+# wrap reuses the `remainder` kernel on the index, exactly as torch's own
+# `wrapIndexOnce` does.
+# ---------------------------------------------------------------------------
+
+
+def _dim_launch_params(dims, out_strides, src_strides, idx_strides, dim):
+    """The 17-int parameter tuple Gather/ScatterDim take: the index-space
+    dims and three stride vectors, each left-padded to rank 4 (dims with 1,
+    strides with 0), plus the padded position of the indexed dim."""
+    pad = _DIM_INDEX_RANK - len(dims)
+    return (
+        tuple([1] * pad + list(dims))
+        + tuple([0] * pad + list(out_strides))
+        + tuple([0] * pad + list(src_strides))
+        + tuple([0] * pad + list(idx_strides))
+        + (dim + pad,)
+    )
+
+
+def _launch_gather_dim(out, src, idx, geometry):
+    """`geometry` is (dims, out_strides, src_strides, idx_strides, dim) over
+    the index space -- passed explicitly rather than read off the tensors so
+    a contiguous operand can be re-described at a lower rank (see
+    `_collapse3`) without minting a view object for it."""
+    _call_mojo(
+        _DataMovementExtension,
+        "GatherDim",
+        (
+            out._ptr,
+            src._ptr,
+            idx._ptr,
+            _dim_launch_params(*geometry),
+            idx._dtype.value,
+            out._itemsize,
+            _ctx_ptr(src._device),
+        ),
+        arg_dtypes=(src._dtype, idx._dtype),
+        output_dtypes=(out._dtype,),
+        keepalive=(out, src, idx),
+    )
+
+
+def _launch_scatter_add_dim(out, src, idx, geometry):
+    _call_mojo(
+        _DataMovementExtension,
+        "ScatterAddDim",
+        (
+            out._ptr,
+            idx._ptr,
+            src._ptr,
+            _dim_launch_params(*geometry),
+            out._dtype.value,
+            _ctx_ptr(out._device),
+        ),
+        arg_dtypes=(out._dtype, idx._dtype, src._dtype),
+        output_dtypes=(out._dtype,),
+        keepalive=(out, src, idx),
+    )
+
+
+def _collapse3(shape, dim):
+    """`(outer, shape[dim], inner)`: the rank-3 form of a CONTIGUOUS operand
+    around its indexed dim.
+
+    A broadcast-index op (index_select / index_add) touches only the `dim`
+    coordinate, so every other dim can be folded into one leading and one
+    trailing extent. That lifts the kernels' rank-4 cap for contiguous
+    operands of any rank and costs one div/mod less per element than the
+    padded rank-4 form.
+    """
+    return math.prod(shape[:dim]), shape[dim], math.prod(shape[dim + 1 :])
+
+
+def _int64_index(index):
+    """`index` as a contiguous int64 tensor, or None.
+
+    The ScatterDim family carries one comptime index dtype (int64) rather
+    than the width ladder GatherDim/GatherRows have, so an int32 index --
+    which torch accepts for index_select/index_add/index_put -- is widened
+    here instead of doubling the number of compiled variants.
+    """
+    idx = _t(index)
+    if idx is None:
+        return None
+    if idx._dtype == DType.int64:
+        return _tc(idx)
+    if idx._dtype == DType.int32:
+        return _tc(_cast_tensor(_tc(idx), DType.int64))
+    return None
+
+
+def _dim_op_dest(out, shape, dtype, device):
+    """`(destination, out)` for an optional `out=` argument.
+
+    `destination` is what the kernel writes; when it is not `out` itself the
+    caller copies it in afterwards. `(None, None)` means `out` cannot serve.
+    Every input must already be validated before this runs: it resizes `out`,
+    so a route that declines afterwards would leave a half-applied out=.
+    """
+    shape = tuple(shape)
+    if out is None:
+        return _alloc(shape, dtype, device), None
+    dst = _t(out)
+    if dst is None or dst._dtype != dtype or dst._device != device:
+        return None, None
+    if tuple(dst._shape) != shape:
+        _resize_payload(dst, shape)
+        return dst, dst
+    if dst._is_contiguous:
+        return dst, dst
+    # A correctly-shaped strided view keeps its storage and takes one
+    # ordered copy after the kernel.
+    return _alloc(shape, dtype, device), dst
+
+
+def _dim_op_finish(dest, out):
+    if out is None:
+        return dest
+    if dest is not out:
+        _copy_into(out, dest)
+    return out
+
+
+def _index_space_fits(idx_shape, shape, skip_dim=None):
+    """torch's gather/scatter shape rule: `index.size(d) <= other.size(d)`
+    for every dim, optionally skipping the indexed one. Enforced because a
+    backend kernel registered at this level replaces the structured meta
+    function that would otherwise have checked it -- and reading past a
+    smaller operand is an out-of-bounds access, not a wrong answer."""
+    return all(
+        i <= s for d, (i, s) in enumerate(zip(idx_shape, shape)) if d != skip_dim
+    )
+
+
+def fast_aten_gather(input, dim, index, sparse_grad=False, *, out=None):
+    t = _t(input)
+    idx = _t(index)
+    if t is None or idx is None or not isinstance(dim, int):
+        return NOT_HANDLED
+    if idx._device != t._device or idx._dtype not in _INT_SCALAR_DTYPES:
+        return NOT_HANDLED
+    if t._dtype not in _COPYABLE_DTYPES:
+        return NOT_HANDLED
+    rank = len(t._shape)
+    if rank == 0 or rank > _DIM_INDEX_RANK or len(idx._shape) != rank:
+        return NOT_HANDLED
+    if not -rank <= dim < rank:
+        return NOT_HANDLED
+    dim %= rank
+    if not _index_space_fits(idx._shape, t._shape, dim):
+        return NOT_HANDLED
+
+    dest, out_t = _dim_op_dest(out, idx._shape, t._dtype, t._device)
+    if dest is None:
+        return NOT_HANDLED
+    if dest._numel > 0:
+        _launch_gather_dim(
+            dest, t, idx, (idx._shape, dest._strides, t._strides, idx._strides, dim)
+        )
+    return _dim_op_finish(dest, out_t)
+
+
+def fast_aten_index_select(input, dim, index, *, out=None):
+    t = _t(input)
+    idx = _t(index)
+    if t is None or idx is None or not isinstance(dim, int):
+        return NOT_HANDLED
+    if idx._device != t._device or idx._dtype not in _INT_SCALAR_DTYPES:
+        return NOT_HANDLED
+    if t._dtype not in _COPYABLE_DTYPES or len(idx._shape) > 1:
+        return NOT_HANDLED
+    rank = len(t._shape)
+    if rank == 0 or not -rank <= dim < rank:
+        return NOT_HANDLED
+    dim %= rank
+    # A contiguous input collapses to a rank-3 (outer, n, inner) problem
+    # whatever its rank; a strided one needs its real strides and so is
+    # capped at the kernels' rank.
+    if not t._is_contiguous and rank > _DIM_INDEX_RANK:
+        return NOT_HANDLED
+
+    n = idx._numel
+    shape = list(t._shape)
+    shape[dim] = n
+    dest, out_t = _dim_op_dest(out, shape, t._dtype, t._device)
+    if dest is None:
+        return NOT_HANDLED
+    if dest._numel > 0:
+        idx_c = _tc(idx)
+        idx_stride = idx_c._strides[0] if idx_c._shape else 0
+        # `dest` is always contiguous here: `_dim_op_dest` either allocated
+        # it or resized `out` (which resets it to contiguous strides), and a
+        # correctly-shaped strided `out` got scratch instead.
+        if dim == 0 and t._is_contiguous:
+            # Whole rows along dim 0: the existing GatherRows kernel, one
+            # div/mod per element instead of three.
+            _call_mojo(
+                _DataMovementExtension,
+                "GatherRows",
+                (
+                    dest._ptr,
+                    t._ptr,
+                    idx_c._ptr,
+                    idx_c._dtype.value,
+                    n,
+                    math.prod(t._shape[1:]),
+                    t._shape[0],
+                    dest._itemsize,
+                    _ctx_ptr(t._device),
+                ),
+                arg_dtypes=(t._dtype, idx_c._dtype),
+                output_dtypes=(dest._dtype,),
+                keepalive=(dest, t, idx_c),
+            )
+        elif t._is_contiguous:
+            outer, size_dim, inner = _collapse3(t._shape, dim)
+            _launch_gather_dim(
+                dest,
+                t,
+                idx_c,
+                (
+                    (outer, n, inner),
+                    (n * inner, inner, 1),
+                    (size_dim * inner, inner, 1),
+                    (0, idx_stride, 0),
+                    1,
+                ),
+            )
+        else:
+            idx_strides = [0] * rank
+            idx_strides[dim] = idx_stride
+            _launch_gather_dim(
+                dest, t, idx_c, (shape, dest._strides, t._strides, idx_strides, dim)
+            )
+    return _dim_op_finish(dest, out_t)
+
+
+def _scatter_add_dest(input, out):
+    """`(dest, out_t)` for a scatter-add-shaped op: the destination starts as
+    a copy of `self`, since `out = self.clone(); out[...] += src`. `out is
+    self` (the in-place `scatter_add_`/`index_add_` overloads) needs no copy
+    at all."""
+    a = _t(input)
+    dest, out_t = _dim_op_dest(out, a._shape, a._dtype, a._device)
+    if dest is None:
+        return None, None
+    if dest is not a:
+        _copy_into(dest, a)
+    return dest, out_t
+
+
+def fast_aten_scatter_add(input, dim, index, src, *, out=None):
+    a = _t(input)
+    s = _t(src)
+    idx = _t(index)
+    if a is None or s is None or idx is None or not isinstance(dim, int):
+        return NOT_HANDLED
+    if idx._device != a._device or s._device != a._device:
+        return NOT_HANDLED
+    if idx._dtype != DType.int64 or s._dtype != a._dtype:
+        return NOT_HANDLED
+    if a._dtype not in _SCATTER_ADD_DTYPES:
+        return NOT_HANDLED
+    if a._dtype == DType.float64 and a._device.api == "metal":
+        return NOT_HANDLED
+    rank = len(a._shape)
+    if rank == 0 or rank > _DIM_INDEX_RANK or not -rank <= dim < rank:
+        return NOT_HANDLED
+    if len(idx._shape) != rank or len(s._shape) != rank:
+        return NOT_HANDLED
+    dim %= rank
+    if not _index_space_fits(idx._shape, a._shape, dim):
+        return NOT_HANDLED
+    if not _index_space_fits(idx._shape, s._shape):
+        return NOT_HANDLED
+
+    dest, out_t = _scatter_add_dest(input, out)
+    if dest is None:
+        return NOT_HANDLED
+    if idx._numel > 0:
+        _launch_scatter_add_dim(
+            dest, s, idx, (idx._shape, dest._strides, s._strides, idx._strides, dim)
+        )
+    return _dim_op_finish(dest, out_t)
+
+
+def fast_aten_scatter_add_(input, dim, index, src):
+    """`scatter_add_`: the out= destination IS self, so no clone happens."""
+    return fast_aten_scatter_add(input, dim, index, src, out=input)
+
+
+def fast_aten_index_add(input, dim, index, source, alpha=1, *, out=None):
+    a = _t(input)
+    if a is None or not isinstance(dim, int):
+        return NOT_HANDLED
+    # alpha scales `source`; an extra elementwise pass for it would be a
+    # different op's kernel, so only the default is served here.
+    if not isinstance(alpha, int | float) or isinstance(alpha, bool) or alpha != 1:
+        return NOT_HANDLED
+    idx = _int64_index(index)
+    src = _t(source)
+    if idx is None or src is None or len(idx._shape) > 1:
+        return NOT_HANDLED
+    if idx._device != a._device or src._device != a._device:
+        return NOT_HANDLED
+    if src._dtype != a._dtype or a._dtype not in _SCATTER_ADD_DTYPES:
+        return NOT_HANDLED
+    if a._dtype == DType.float64 and a._device.api == "metal":
+        return NOT_HANDLED
+    rank = len(a._shape)
+    if rank == 0 or not -rank <= dim < rank:
+        return NOT_HANDLED
+    dim %= rank
+    n = idx._numel
+    expected = list(a._shape)
+    expected[dim] = n
+    if list(src._shape) != expected:
+        return NOT_HANDLED
+    src_c = _tc(src)
+
+    dest, out_t = _scatter_add_dest(input, out)
+    if dest is None:
+        return NOT_HANDLED
+    if n > 0 and src_c._numel > 0:
+        # Both operands are contiguous by construction here -- `_tc` for the
+        # source, `_dim_op_dest` for the destination -- so the rank-3 collapse
+        # always applies and there is no rank cap on this op.
+        outer, size_dim, inner = _collapse3(a._shape, dim)
+        _launch_scatter_add_dim(
+            dest,
+            src_c,
+            idx,
+            (
+                (outer, n, inner),
+                (size_dim * inner, inner, 1),
+                (n * inner, inner, 1),
+                (0, idx._strides[0] if idx._shape else 0, 0),
+                1,
+            ),
+        )
+    return _dim_op_finish(dest, out_t)
+
+
+def fast_aten_index_add_(input, dim, index, source, alpha=1):
+    """`index_add_`: the out= destination IS self, so no clone happens."""
+    return fast_aten_index_add(input, dim, index, source, alpha, out=input)
+
+
+def _mask_over_leading_dims(mask, shape):
+    """An index mask reshaped so masked_fill's broadcast means what advanced
+    indexing means, or None.
+
+    A mask index covers `self`'s LEADING dims, while broadcasting is
+    right-aligned: a shape-(4,) mask on a (4, 5) tensor selects rows, but
+    `masked_fill_` would try to broadcast it across the 5 columns -- an error
+    when 4 != 5, and silently the WRONG axis when they happen to be equal.
+    Appending the missing trailing 1s (zero-copy: a mask index is contiguous
+    or it is not ours) makes the two conventions agree.
+    """
+    m = _tc(mask)
+    if m is None or len(m._shape) > len(shape):
+        return None
+    if any(a != b for a, b in zip(m._shape, shape)):
+        return None
+    if len(m._shape) == len(shape):
+        return m
+    padded = fast_aten_view(m, tuple(m._shape) + (1,) * (len(shape) - len(m._shape)))
+    return None if padded is NOT_HANDLED else padded
+
+
+def _fold_leading_strides(t, k):
+    """`t`'s element strides with its first `k` dims folded into one axis, or
+    None when they do not fold.
+
+    They fold when their extents and strides describe a single run
+    (`stride[d] == stride[d+1] * shape[d+1]`), which covers both of the cases
+    that reach it: a contiguous buffer, and a fully broadcast one whose
+    strides are all 0. `k == 0` (a 0-d index) prepends a stride for the
+    length-1 row axis the kernel still walks.
+    """
+    if k == 0:
+        return [0] + list(t._strides)
+    for d in range(k - 1):
+        if t._strides[d] != t._strides[d + 1] * t._shape[d + 1]:
+            return None
+    return [t._strides[k - 1]] + list(t._strides[k:])
+
+
+def fast_aten_index_put(input, indices, values, accumulate=False, unsafe=False):
+    """Registered for `aten::_index_put_impl_`, which `x[idx] = v` /
+    `x[mask] = v` and `index_put`/`index_put_` all funnel into (those two are
+    CompositeExplicitAutograd wrappers over this one). Named after the concept
+    rather than that overload so it pairs with `aten_functions.aten_index_put`.
+
+    Writes into `input` and returns it. Only a single index tensor on dim 0
+    is served -- of ANY rank, matching what `fast_aten_index` reads, so that
+    `x[idx2d]` is differentiable and not just readable; multi-tensor advanced
+    indexing declines. Duplicate indices with `accumulate=False`
+    race, and torch leaves the winner undefined there too.
+
+    KNOWN GAP, not this function's: on a mojo device that is not the current
+    one, the `accumulate=False` BACKWARD declines and, being inside the
+    autograd engine, aborts the process. Its derivative formula is
+    `grad.index_put(indices, zeros_like(values), false)`, and that
+    `zeros_like` is allocated by ATen on the CURRENT device rather than on
+    `values`' device -- the PrivateUse1 device guard is a no-op here, so the
+    values tensor arrives on a different device than self and there is
+    nothing to do but decline. Every C++ derivative formula that allocates
+    without naming a device has the same problem; the fix belongs in the
+    device guard, not here.
+    """
+    a = _t(input)
+    if a is None or not isinstance(indices, list | tuple):
+        return NOT_HANDLED
+    non_none = [(i, x) for i, x in enumerate(indices) if x is not None]
+    if len(non_none) != 1 or non_none[0][0] != 0:
+        return NOT_HANDLED
+    raw = _t(non_none[0][1])
+    if raw is None or raw._device != a._device:
+        return NOT_HANDLED
+
+    if raw._dtype == DType.bool:
+        # `x[mask] = scalar`, the one boolean-mask form whose output shape is
+        # not data dependent: torch's own `_index_put_impl_` re-routes exactly
+        # it to masked_fill_ (canDispatchToMaskedFill), and so does this.
+        # Anything else needs the mask's true-count, i.e. a host sync.
+        if accumulate:
+            return NOT_HANDLED
+        value = values
+        if isinstance(value, torch.Tensor):
+            if value.numel() != 1:
+                return NOT_HANDLED
+            if not isinstance(value, TorchMojoTensor):
+                # A python scalar assignment arrives as a 1-element CPU tensor
+                # (python_variable_indexing.cpp builds it there); reading it
+                # back costs no device sync.
+                value = value.item()
+        elif not isinstance(value, int | float | bool):
+            return NOT_HANDLED
+        mask = _mask_over_leading_dims(raw, a._shape)
+        if mask is None:
+            return NOT_HANDLED
+        return (
+            input
+            if fast_aten_masked_fill_(input, mask, value) is not None
+            else NOT_HANDLED
+        )
+
+    if raw._dtype not in _INT_SCALAR_DTYPES:
+        return NOT_HANDLED
+    v = _t(values)
+    if v is None or v._device != a._device or v._dtype != a._dtype:
+        return NOT_HANDLED
+    dtypes = _SCATTER_ADD_DTYPES if accumulate else _SCATTER_DTYPES
+    if a._dtype not in dtypes:
+        return NOT_HANDLED
+    # Metal has no float64 at all, in either scatter kernel; decline instead of
+    # letting `_parallel_for_dt`'s guard raise from inside the launch.
+    if a._dtype == DType.float64 and a._device.api == "metal":
+        return NOT_HANDLED
+    rank = len(a._shape)
+    if rank == 0 or rank > _DIM_INDEX_RANK:
+        return NOT_HANDLED
+    n = raw._numel
+    dims = (n,) + tuple(a._shape[1:])
+    if n == 0 or a._numel == 0:
+        return input
+    # `values` is written over the index space `index.shape + self.shape[1:]`,
+    # which the kernel walks as the flattened `(n,) + self.shape[1:]`. Two
+    # shapes arrive here: exactly that subspace (what `aten::index.Tensor`'s
+    # backward hands back, and it is often a STRIDE-0 expansion of a scalar,
+    # so it has no view at the lower rank -- fold its leading dims into one
+    # stride instead), or something smaller that broadcasts.
+    put_shape = tuple(raw._shape) + tuple(a._shape[1:])
+    if tuple(v._shape) == put_shape:
+        src_strides = _fold_leading_strides(v, len(raw._shape))
+        if src_strides is None:
+            return NOT_HANDLED
+    elif tuple(v._shape) == dims:
+        src_strides = list(v._strides)
+    else:
+        expanded = fast_aten_expand(v, dims)
+        if expanded is NOT_HANDLED:
+            return NOT_HANDLED
+        v = expanded
+        src_strides = list(v._strides)
+
+    # Advanced indexing DOES define negative indices; `remainder` by the
+    # indexed extent is how torch's own wrapIndexOnce normalizes them.
+    idx = _int64_index(raw)
+    if idx is None:
+        return NOT_HANDLED
+    # One row per index ELEMENT, whatever the index's rank: flatten it so the
+    # kernel walks it with a single stride (zero-copy, `_int64_index` already
+    # made it contiguous).
+    if len(idx._shape) != 1:
+        idx = fast_aten_view(idx, (n,))
+        if idx is NOT_HANDLED:
+            return NOT_HANDLED
+    wrapped = fast_aten_remainder(idx, a._shape[0])
+    if wrapped is NOT_HANDLED:
+        return NOT_HANDLED
+    idx = _tc(wrapped)
+
+    idx_strides = [0] * rank
+    idx_strides[0] = idx._strides[0] if idx._shape else 0
+    geometry = (dims, a._strides, src_strides, idx_strides, 0)
+    if accumulate:
+        _launch_scatter_add_dim(a, v, idx, geometry)
+    else:
+        _call_mojo(
+            _DataMovementExtension,
+            "ScatterDim",
+            (
+                a._ptr,
+                idx._ptr,
+                v._ptr,
+                _dim_launch_params(*geometry),
+                0,
+                0.0,
+                a._dtype.value,
+                _ctx_ptr(a._device),
+            ),
+            arg_dtypes=(a._dtype, idx._dtype, v._dtype),
+            output_dtypes=(a._dtype,),
+            flags={"VALUE_MODE": False},
+            keepalive=(a, v, idx),
+        )
+    return input
+
+
 def _fast_scatter(input, dim, index, src, value):
     a = _t(input)
     idx = _t(index)
@@ -4565,7 +5125,7 @@ def _fast_scatter(input, dim, index, src, value):
     is_value = 0
     value_f = 0.0
     src_ptr = out._ptr  # unused in value mode; a valid pointer for the kernel
-    src_strides4 = [0, 0, 0, 0]
+    src_strides = [0] * rank
     if src is not None:
         s = _tc(src)
         if (
@@ -4576,7 +5136,7 @@ def _fast_scatter(input, dim, index, src, value):
         ):
             return NOT_HANDLED
         src_ptr = s._ptr
-        src_strides4 = [0] * (4 - rank) + list(_row_major_strides(s._shape))
+        src_strides = _row_major_strides(s._shape)
     else:
         if isinstance(value, bool):
             value = int(value)
@@ -4588,16 +5148,8 @@ def _fast_scatter(input, dim, index, src, value):
         else:
             value_f = float(value)
 
-    dims4 = [1] * (4 - rank) + list(idx_c._shape)
-    out_strides4 = [0] * (4 - rank) + list(out._strides)
-    idx_strides4 = [0] * (4 - rank) + list(idx_c._strides)
-    dim_padded = dim + (4 - rank)
-    params = (
-        tuple(dims4)
-        + tuple(out_strides4)
-        + tuple(src_strides4)
-        + tuple(idx_strides4)
-        + (dim_padded,)
+    params = _dim_launch_params(
+        idx_c._shape, out._strides, src_strides, idx_c._strides, dim
     )
     if idx_c._numel > 0:
         _call_mojo(

--- a/torch_mojo_backend/eager_kernels/data_movement_ops/data_movement_ops.mojo
+++ b/torch_mojo_backend/eager_kernels/data_movement_ops/data_movement_ops.mojo
@@ -14,6 +14,7 @@
 # `_raw_dtype_int`.
 # ===----------------------------------------------------------------------=== #
 
+from std.atomic import Atomic, Ordering
 from std.os import abort
 from std.builtin.device_passable import DevicePassable, DeviceTypeEncoder
 from std.collections import InlineArray
@@ -22,6 +23,7 @@ from std.math import ceildiv
 from max.gpu.host import DeviceContext
 from std.python import PythonObject
 from std.python.bindings import PythonModuleBuilder
+from std.sys import is_amd_gpu, is_nvidia_gpu
 from std.sys.info import has_accelerator, has_apple_gpu_accelerator, size_of
 from std.utils.coord import Coord
 
@@ -3113,6 +3115,307 @@ def _gather_rows_go(
 
 
 # ---------------------------------------------------------------------------
+# GatherDim: out[coord] = in[coord with coord[dim] := index[coord]], the read
+# mirror of ScatterDim below, over a rank-<=4 index space described by
+# explicit strides (padded to rank 4 with leading 0/1). Serves
+#   * aten::gather      -- dims = index.shape, real index strides
+#   * aten::index_select -- dims = out.shape, index strides 0 everywhere but
+#     `dim` (a 1-D index broadcast across the untouched coordinates), which is
+#     why one kernel covers both and no separate index_select body exists.
+# Element-size dispatch for the payload (a pure copy), int32/int64 for the
+# index. NEGATIVE INDICES ARE NOT WRAPPED and nothing is bounds checked, which
+# is torch's own contract for these two ops: CPU raises before launching,
+# CUDA's ScatterGatherKernel.cu only device-asserts, so a negative index is
+# undefined there too. (aten::index.Tensor / aten::index_put_ do wrap; those
+# route through GatherRows / a `remainder` on the index instead.)
+# ---------------------------------------------------------------------------
+
+
+@always_inline
+def _gather_dim[
+    dtype: DType, idx_dtype: DType
+](
+    out_addr: Int,
+    in_addr: Int,
+    index_addr: Int,
+    d0: Int,
+    d1: Int,
+    d2: Int,
+    d3: Int,
+    os0: Int,
+    os1: Int,
+    os2: Int,
+    os3: Int,
+    ss0: Int,
+    ss1: Int,
+    ss2: Int,
+    ss3: Int,
+    xs0: Int,
+    xs1: Int,
+    xs2: Int,
+    xs3: Int,
+    dim_padded: Int,
+    ctx: DeviceContext,
+) raises:
+    var out_ptr = _make_ptr[dtype](out_addr)
+    var in_ptr = _make_ptr[dtype](in_addr)
+    var index_ptr = _make_ptr[idx_dtype](index_addr)
+    var total = d0 * d1 * d2 * d3
+
+    @always_inline
+    @parameter
+    @__copy_capture(out_ptr, in_ptr, index_ptr)
+    def func[width: Int, alignment: Int = 1](coord: Coord):
+        var i = Int(coord[0].value())
+        var i3 = i % d3
+        var rest = i // d3
+        var i2 = rest % d2
+        rest = rest // d2
+        var i1 = rest % d1
+        var i0 = rest // d1
+        var source = Int(index_ptr[i0 * xs0 + i1 * xs1 + i2 * xs2 + i3 * xs3])
+        var in_off = i0 * ss0 + i1 * ss1 + i2 * ss2 + i3 * ss3
+        # Replace the coordinate along `dim_padded` with the gather source.
+        if dim_padded == 0:
+            in_off += (source - i0) * ss0
+        elif dim_padded == 1:
+            in_off += (source - i1) * ss1
+        elif dim_padded == 2:
+            in_off += (source - i2) * ss2
+        else:
+            in_off += (source - i3) * ss3
+        out_ptr[i0 * os0 + i1 * os1 + i2 * os2 + i3 * os3] = in_ptr[in_off]
+
+    _parallel_for[func](total, ctx)
+
+
+@always_inline
+def _gather_dim_idx[
+    idx_dtype: DType
+](
+    out_addr: Int,
+    in_addr: Int,
+    index_addr: Int,
+    d0: Int,
+    d1: Int,
+    d2: Int,
+    d3: Int,
+    os0: Int,
+    os1: Int,
+    os2: Int,
+    os3: Int,
+    ss0: Int,
+    ss1: Int,
+    ss2: Int,
+    ss3: Int,
+    xs0: Int,
+    xs1: Int,
+    xs2: Int,
+    xs3: Int,
+    dim_padded: Int,
+    itemsize: Int,
+    ctx: DeviceContext,
+) raises:
+    comptime if _dtype_arg_width_on[0, 32]():
+        if itemsize != 4:
+            raise Error("gather_dim specialization/itemsize mismatch")
+        _gather_dim[DType.uint32, idx_dtype](
+            out_addr,
+            in_addr,
+            index_addr,
+            d0,
+            d1,
+            d2,
+            d3,
+            os0,
+            os1,
+            os2,
+            os3,
+            ss0,
+            ss1,
+            ss2,
+            ss3,
+            xs0,
+            xs1,
+            xs2,
+            xs3,
+            dim_padded,
+            ctx,
+        )
+    elif _dtype_arg_width_on[0, 16]():
+        if itemsize != 2:
+            raise Error("gather_dim specialization/itemsize mismatch")
+        _gather_dim[DType.uint16, idx_dtype](
+            out_addr,
+            in_addr,
+            index_addr,
+            d0,
+            d1,
+            d2,
+            d3,
+            os0,
+            os1,
+            os2,
+            os3,
+            ss0,
+            ss1,
+            ss2,
+            ss3,
+            xs0,
+            xs1,
+            xs2,
+            xs3,
+            dim_padded,
+            ctx,
+        )
+    elif _dtype_arg_width_on[0, 64]():
+        if itemsize != 8:
+            raise Error("gather_dim specialization/itemsize mismatch")
+        _gather_dim[DType.uint64, idx_dtype](
+            out_addr,
+            in_addr,
+            index_addr,
+            d0,
+            d1,
+            d2,
+            d3,
+            os0,
+            os1,
+            os2,
+            os3,
+            ss0,
+            ss1,
+            ss2,
+            ss3,
+            xs0,
+            xs1,
+            xs2,
+            xs3,
+            dim_padded,
+            ctx,
+        )
+    elif _dtype_arg_width_on[0, 8]():
+        if itemsize != 1:
+            raise Error("gather_dim specialization/itemsize mismatch")
+        _gather_dim[DType.uint8, idx_dtype](
+            out_addr,
+            in_addr,
+            index_addr,
+            d0,
+            d1,
+            d2,
+            d3,
+            os0,
+            os1,
+            os2,
+            os3,
+            ss0,
+            ss1,
+            ss2,
+            ss3,
+            xs0,
+            xs1,
+            xs2,
+            xs3,
+            dim_padded,
+            ctx,
+        )
+    else:
+        raise Error("GatherDim: unsupported element size ", itemsize)
+
+
+def _gather_dim_go(
+    out_ptr: PyObjectPtr,
+    in_ptr: PyObjectPtr,
+    index_ptr: PyObjectPtr,
+    params: PyObjectPtr,  # (d0..d3, os0..os3, ss0..ss3, xs0..xs3, dim_padded)
+    idx_dtype_o: PyObjectPtr,
+    itemsize_o: PyObjectPtr,
+    ctx_ptr: PyObjectPtr,
+) raises:
+    var out_addr = _raw_int(out_ptr)
+    var in_addr = _raw_int(in_ptr)
+    var index_addr = _raw_int(index_ptr)
+    var d0 = _raw_tuple_int(params, 0)
+    var d1 = _raw_tuple_int(params, 1)
+    var d2 = _raw_tuple_int(params, 2)
+    var d3 = _raw_tuple_int(params, 3)
+    var os0 = _raw_tuple_int(params, 4)
+    var os1 = _raw_tuple_int(params, 5)
+    var os2 = _raw_tuple_int(params, 6)
+    var os3 = _raw_tuple_int(params, 7)
+    var ss0 = _raw_tuple_int(params, 8)
+    var ss1 = _raw_tuple_int(params, 9)
+    var ss2 = _raw_tuple_int(params, 10)
+    var ss3 = _raw_tuple_int(params, 11)
+    var xs0 = _raw_tuple_int(params, 12)
+    var xs1 = _raw_tuple_int(params, 13)
+    var xs2 = _raw_tuple_int(params, 14)
+    var xs3 = _raw_tuple_int(params, 15)
+    var dim_padded = _raw_tuple_int(params, 16)
+    var idx_dtype = _raw_dtype_int(idx_dtype_o)
+    var itemsize = _raw_int(itemsize_o)
+    var ctx = _raw_ctx(ctx_ptr)
+
+    comptime if _dtype_arg_on[1, DType.int64]():
+        if idx_dtype != DType.int64:
+            raise Error("gather_dim specialization/index dtype mismatch")
+        _gather_dim_idx[DType.int64](
+            out_addr,
+            in_addr,
+            index_addr,
+            d0,
+            d1,
+            d2,
+            d3,
+            os0,
+            os1,
+            os2,
+            os3,
+            ss0,
+            ss1,
+            ss2,
+            ss3,
+            xs0,
+            xs1,
+            xs2,
+            xs3,
+            dim_padded,
+            itemsize,
+            ctx,
+        )
+    elif _dtype_arg_on[1, DType.int32]():
+        if idx_dtype != DType.int32:
+            raise Error("gather_dim specialization/index dtype mismatch")
+        _gather_dim_idx[DType.int32](
+            out_addr,
+            in_addr,
+            index_addr,
+            d0,
+            d1,
+            d2,
+            d3,
+            os0,
+            os1,
+            os2,
+            os3,
+            ss0,
+            ss1,
+            ss2,
+            ss3,
+            xs0,
+            xs1,
+            xs2,
+            xs3,
+            dim_padded,
+            itemsize,
+            ctx,
+        )
+    else:
+        raise Error("GatherDim: unsupported index dtype ", idx_dtype)
+
+
+# ---------------------------------------------------------------------------
 # ScatterDim: out[coord with coord[dim] := index[coord]] = src[coord] (or a
 # scalar value). Implements aten::scatter.src / aten::scatter.value over a
 # rank-<=4 index space; `out` is a contiguous clone of self, `index` is
@@ -3255,6 +3558,187 @@ def _scatter_dim_go(
                 handled = True
     if not handled:
         raise Error("ScatterDim: unsupported dtype ", dtype)
+
+
+# ---------------------------------------------------------------------------
+# ScatterAddDim: out[coord with coord[dim] := index[coord]] += src[coord] over
+# the same rank-<=4 index space and stride convention as ScatterDim above,
+# reducing with a relaxed device-scope atomic add. Serves
+#   * aten::scatter_add   -- real index strides
+#   * aten::index_add     -- index strides 0 everywhere but `dim`
+#   * aten::index_put(accumulate=True) -- dim 0, index strides (1, 0, ...)
+# Which dtypes may be asked for is decided on the PYTHON side
+# (`_SCATTER_ADD_DTYPES` in aten_fast.py): `Atomic.fetch_add` has no lowering
+# for sub-32-bit integers on the GPU targets, so int8/int16/uint8/bool are
+# declined before a build is requested rather than reaching the compiler as an
+# unsatisfiable specialization.
+#
+# This is deliberately NOT ScatterDim parametrized on the reduction, which is
+# what it looks like it should be. Every way of writing that -- a
+# `comptime if` around the value/src branch, one inside each arm of it, an
+# `@always_inline` store helper called from both -- moved the REDUCE=0
+# assembly (2 to 4 of ScatterDim's 4 sm_90a kernels changed, +/-3 predicates
+# and +/-25 b64 registers), while a bare unused comptime parameter on
+# `_scatter_dim` changed nothing. Metaprogramming that rewrites the existing
+# kernel's code is not a refactor, so the reduction lives here instead. The
+# duplication is smaller than it looks: scatter_add has no scalar-value
+# overload, so this body has no `is_value` branch and no `value` argument.
+#
+# Match torch: no bounds checking, and the accumulation order of colliding
+# writes is unspecified -- torch's own CUDA scatter_add is atomic too
+# (ScatterGatherKernel.cu's ReduceAdd calls fastAtomicAdd), so neither
+# implementation is bitwise reproducible for float dtypes.
+# `torch.use_deterministic_algorithms(True)` is not honored: torch switches to
+# a sort-based reduction there and this does not.
+#
+# The deterministic alternative, if it is ever wanted: a scatter along `dim`
+# can only collide between entries that agree on every coordinate EXCEPT
+# `dim` (the index replaces that one coordinate and no other), so giving one
+# thread a whole `dim`-column and accumulating it serially is race-free with
+# no atomics at all, for every dtype and every backend. The catch is
+# parallelism -- the thread count becomes total/dims[dim], which is 64 threads
+# for a (65536, 64) index scattered along dim 0 -- so it would have to be a
+# second kernel chosen by a runtime dispatch, not a replacement for this one.
+# ---------------------------------------------------------------------------
+
+
+@always_inline
+def _atomic_scope() -> StaticString:
+    # Device-scope atomics skip system-scope ordering cost on the discrete
+    # targets; every other accelerator keeps the portable default scope.
+    # (embedding_backward_kernels.mojo has an f32-only twin of this with an
+    # extra sm_90 `red.v4.f32` vector path; this one is scalar and generic over
+    # the dtype, so they are deliberately not shared.)
+    comptime if is_nvidia_gpu():
+        return "device"
+    elif is_amd_gpu():
+        return "agent"
+    else:
+        return ""
+
+
+@always_inline
+def _scatter_add_dim[
+    dtype: DType
+](
+    out_addr: Int,
+    index_addr: Int,
+    src_addr: Int,
+    d0: Int,
+    d1: Int,
+    d2: Int,
+    d3: Int,
+    os0: Int,
+    os1: Int,
+    os2: Int,
+    os3: Int,
+    ss0: Int,
+    ss1: Int,
+    ss2: Int,
+    ss3: Int,
+    xs0: Int,
+    xs1: Int,
+    xs2: Int,
+    xs3: Int,
+    dim_padded: Int,
+    ctx: DeviceContext,
+) raises:
+    var out_ptr = _make_ptr[dtype](out_addr)
+    var index_ptr = _make_ptr[DType.int64](index_addr)
+    var src_ptr = _make_ptr[dtype](src_addr)
+    var total = d0 * d1 * d2 * d3
+
+    @always_inline
+    @parameter
+    @__copy_capture(out_ptr, index_ptr, src_ptr)
+    def func[width: Int, alignment: Int = 1](coord: Coord):
+        var i = Int(coord[0].value())
+        var i3 = i % d3
+        var rest = i // d3
+        var i2 = rest % d2
+        rest = rest // d2
+        var i1 = rest % d1
+        var i0 = rest // d1
+        var target = Int(index_ptr[i0 * xs0 + i1 * xs1 + i2 * xs2 + i3 * xs3])
+        var out_off = i0 * os0 + i1 * os1 + i2 * os2 + i3 * os3
+        # Replace the coordinate along `dim_padded` with the scatter target.
+        if dim_padded == 0:
+            out_off += (target - i0) * os0
+        elif dim_padded == 1:
+            out_off += (target - i1) * os1
+        elif dim_padded == 2:
+            out_off += (target - i2) * os2
+        else:
+            out_off += (target - i3) * os3
+        # Relaxed ordering is enough: nothing else in the launch reads `out`.
+        _ = Atomic[dtype, scope=_atomic_scope()].fetch_add[
+            ordering=Ordering.RELAXED
+        ](out_ptr + out_off, src_ptr[i0 * ss0 + i1 * ss1 + i2 * ss2 + i3 * ss3])
+
+    _parallel_for_dt[dtype, func](total, ctx)
+
+
+def _scatter_add_dim_go(
+    out_ptr: PyObjectPtr,
+    index_ptr: PyObjectPtr,
+    src_ptr: PyObjectPtr,
+    params: PyObjectPtr,  # (d0..d3, os0..os3, ss0..ss3, xs0..xs3, dim_padded)
+    dtype_o: PyObjectPtr,
+    ctx_ptr: PyObjectPtr,
+) raises:
+    var out_addr = _raw_int(out_ptr)
+    var index_addr = _raw_int(index_ptr)
+    var src_addr = _raw_int(src_ptr)
+    var d0 = _raw_tuple_int(params, 0)
+    var d1 = _raw_tuple_int(params, 1)
+    var d2 = _raw_tuple_int(params, 2)
+    var d3 = _raw_tuple_int(params, 3)
+    var os0 = _raw_tuple_int(params, 4)
+    var os1 = _raw_tuple_int(params, 5)
+    var os2 = _raw_tuple_int(params, 6)
+    var os3 = _raw_tuple_int(params, 7)
+    var ss0 = _raw_tuple_int(params, 8)
+    var ss1 = _raw_tuple_int(params, 9)
+    var ss2 = _raw_tuple_int(params, 10)
+    var ss3 = _raw_tuple_int(params, 11)
+    var xs0 = _raw_tuple_int(params, 12)
+    var xs1 = _raw_tuple_int(params, 13)
+    var xs2 = _raw_tuple_int(params, 14)
+    var xs3 = _raw_tuple_int(params, 15)
+    var dim_padded = _raw_tuple_int(params, 16)
+    var dtype = _raw_dtype_int(dtype_o)
+    var ctx = _raw_ctx(ctx_ptr)
+
+    var handled = False
+    comptime for dt in SCATTER_DTYPES:
+        comptime if _dtype_arg_on[0, dt]():
+            if dtype == dt:
+                _scatter_add_dim[dt](
+                    out_addr,
+                    index_addr,
+                    src_addr,
+                    d0,
+                    d1,
+                    d2,
+                    d3,
+                    os0,
+                    os1,
+                    os2,
+                    os3,
+                    ss0,
+                    ss1,
+                    ss2,
+                    ss3,
+                    xs0,
+                    xs1,
+                    xs2,
+                    xs3,
+                    dim_padded,
+                    ctx,
+                )
+                handled = True
+    if not handled:
+        raise Error("ScatterAddDim: unsupported dtype ", dtype)
 
 
 # ---------------------------------------------------------------------------
@@ -3412,6 +3896,27 @@ def _gather_rows_dispatcher(
     return _raw_ret_none()
 
 
+def _gather_dim_dispatcher(
+    py_self: PyObjectPtr,
+    args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
+    nargs: Py_ssize_t,
+) abi("C") -> PyObjectPtr:
+    var args = UnsafePointer(args_safe)
+    try:
+        _gather_dim_go(
+            args[0],
+            args[1],
+            args[2],
+            args[3],
+            args[4],
+            args[5],
+            args[6],
+        )
+    except e:
+        return _spec_unsupported(e)
+    return _raw_ret_none()
+
+
 def _scatter_dim_dispatcher(
     py_self: PyObjectPtr,
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
@@ -3428,6 +3933,21 @@ def _scatter_dim_dispatcher(
             args[5],
             args[6],
             args[7],
+        )
+    except e:
+        return _spec_unsupported(e)
+    return _raw_ret_none()
+
+
+def _scatter_add_dim_dispatcher(
+    py_self: PyObjectPtr,
+    args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
+    nargs: Py_ssize_t,
+) abi("C") -> PyObjectPtr:
+    var args = UnsafePointer(args_safe)
+    try:
+        _scatter_add_dim_go(
+            args[0], args[1], args[2], args[3], args[4], args[5]
         )
     except e:
         return _spec_unsupported(e)
@@ -3573,6 +4093,16 @@ def PyInit_data_movement_ops() abi("C") -> PythonObject:
                     " int32/int64 idx)"
                 ),
             )
+        comptime if _op_on["GatherDim"]():
+            _register_call(
+                b,
+                _gather_dim_dispatcher,
+                docstring=(
+                    "out[coord] = in[coord with dim := index[coord]]"
+                    " (aten::gather / aten::index_select, rank <= 4;"
+                    " element-size + int32/int64 idx)"
+                ),
+            )
         comptime if _op_on["ScatterDim"]():
             _register_call(
                 b,
@@ -3580,6 +4110,16 @@ def PyInit_data_movement_ops() abi("C") -> PythonObject:
                 docstring=(
                     "out[coord with dim := index[coord]] = src[coord] or value"
                     " (aten::scatter.src/value, rank <= 4; dtype dispatch)"
+                ),
+            )
+        comptime if _op_on["ScatterAddDim"]():
+            _register_call(
+                b,
+                _scatter_add_dim_dispatcher,
+                docstring=(
+                    "out[coord with dim := index[coord]] += src[coord] with"
+                    " relaxed atomics (aten::scatter_add / index_add /"
+                    " index_put accumulate, rank <= 4; dtype dispatch)"
                 ),
             )
         return b.finalize()

--- a/torch_mojo_backend/mojo_device/aten_ops/autograd_preflight.py
+++ b/torch_mojo_backend/mojo_device/aten_ops/autograd_preflight.py
@@ -115,13 +115,6 @@ mojo_device_cumsum = _preflight_unsupported_backward(
     "aten::cumsum", "fast_aten_cumsum", "aten::flip", grad_operands=(0,)
 )
 
-mojo_device_index = _preflight_unsupported_backward(
-    "aten::index.Tensor",
-    "fast_aten_index",
-    "aten::_index_put_impl_",
-    grad_operands=(0,),
-)
-
 mojo_device_max_pool2d_with_indices = _preflight_unsupported_backward(
     "aten::max_pool2d_with_indices",
     "fast_aten_max_pool2d_with_indices",
@@ -131,12 +124,6 @@ mojo_device_max_pool2d_with_indices = _preflight_unsupported_backward(
 
 mojo_device_relu = _preflight_unsupported_backward(
     "aten::relu", "fast_aten_relu", "aten::threshold_backward", grad_operands=(0,)
-)
-
-# Only the `src` gradient goes through `gather`; the `self` gradient is a
-# scatter of zeros, which runs, so a self-only call must not be refused.
-mojo_device_scatter_src = _preflight_unsupported_backward(
-    "aten::scatter.src", "fast_aten_scatter_src", "aten::gather", grad_operands=(3,)
 )
 
 mojo_device_sigmoid = _preflight_unsupported_backward(
@@ -237,6 +224,41 @@ def mojo_device_embedding(
     )
     if result is aten_fast.NOT_HANDLED:
         raise _unsupported("aten::embedding", (weight, indices))
+    return result
+
+
+def mojo_device_index(
+    self: torch.Tensor, indices: Sequence[torch.Tensor | None]
+) -> TorchMojoTensor:
+    """Advanced indexing, refused from the forward only where its backward
+    still cannot run.
+
+    `index.Tensor`'s derivative is
+    `zeros.index_put_(indices, grad, accumulate=True)`, i.e.
+    `aten::_index_put_impl_`. That op EXISTS for an integer index, so ordinary
+    `x[idx]` is differentiable here and a blanket refusal would reject a case
+    that works — this function used to be a table entry that did exactly that,
+    written when the op was missing.
+
+    A BOOLEAN mask is still refused. The forward takes it (through a host
+    bounce, since the number of selected rows is data dependent), but the
+    accumulating `index_put` its backward needs has no kernel for a mask, so
+    without this the engine would abort the process instead of raising.
+    """
+    if any(
+        index is not None and index.dtype in (torch.bool, torch.uint8)
+        for index in indices
+    ):
+        _refuse_unsupported_backward(
+            "aten::index.Tensor with a boolean mask",
+            "aten::_index_put_impl_ with a boolean mask",
+            (self,),
+            _GRAD_OFF_ONLY,
+        )
+    aten_fast = _fast()
+    result = aten_fast.fast_aten_index(self, indices)
+    if result is aten_fast.NOT_HANDLED:
+        raise _unsupported("aten::index.Tensor", (self, *indices))
     return result
 
 

--- a/torch_mojo_backend/mojo_device/mojo_device_aten_ops.py
+++ b/torch_mojo_backend/mojo_device/mojo_device_aten_ops.py
@@ -34,7 +34,6 @@ from .aten_ops.autograd_preflight import (
     mojo_device_native_batch_norm,
     mojo_device_native_group_norm,
     mojo_device_relu,
-    mojo_device_scatter_src,
     mojo_device_sigmoid,
     mojo_device_softmax,
     mojo_device_tanh,
@@ -176,6 +175,7 @@ register_aten_op("aten::_foreach_norm.Scalar")(mojo_device__foreach_norm_scalar)
 register_aten_op("aten::_foreach_sqrt")(mojo_device__foreach_sqrt)
 _register_fast("aten::_fused_adamw_", "fast_aten__fused_adamw")
 _register_fast("aten::_fused_adamw_.tensor_lr", "fast_aten__fused_adamw")
+_register_fast("aten::_index_put_impl_", "fast_aten_index_put")
 _register_fast("aten::_local_scalar_dense", "fast_aten__local_scalar_dense")
 _register_fast("aten::_log_softmax", "fast_aten__log_softmax")
 _register_fast(
@@ -277,6 +277,18 @@ _register_fast("aten::floor_divide.Scalar", "fast_aten_floor_divide")
 _register_fast("aten::floordiv", "fast_aten_floor_divide")
 register_aten_op("aten::full")(mojo_device_full)
 register_aten_op("aten::full_like")(mojo_device_full_like)
+# The functional/in-place overloads of the structured ops in this family are
+# registered ALONGSIDE their `.out` twin on purpose. PyTorch's generated
+# wrapper for a `structured_delegate` op allocates the `out` tensor itself,
+# on the CURRENT device rather than the input's -- the PrivateUse1 device
+# guard is a no-op for us (there is no C++ extension to register a real
+# one), so on a machine with more than one accelerator that wrapper hands
+# `gather.out` an `out` that lives on the wrong device and nothing can
+# recover from it. A backend kernel on the functional overload takes
+# precedence over the wrapper and allocates the output where the inputs
+# are, which is also one allocation and one dispatch less.
+_register_fast("aten::gather", "fast_aten_gather")
+_register_fast("aten::gather.out", "fast_aten_gather")
 _register_fast("aten::ge", "fast_aten_ge")
 _register_fast("aten::ge.Scalar", "fast_aten_ge")
 _register_fast("aten::ge.Tensor", "fast_aten_ge")
@@ -286,6 +298,11 @@ _register_fast("aten::gt", "fast_aten_gt")
 _register_fast("aten::gt.Scalar", "fast_aten_gt")
 _register_fast("aten::gt.Tensor", "fast_aten_gt")
 register_aten_op("aten::index.Tensor")(mojo_device_index)
+_register_fast("aten::index_add", "fast_aten_index_add")
+_register_fast("aten::index_add.out", "fast_aten_index_add")
+_register_fast("aten::index_add_", "fast_aten_index_add_")
+_register_fast("aten::index_select", "fast_aten_index_select")
+_register_fast("aten::index_select.out", "fast_aten_index_select")
 _register_fast("aten::isin.Tensor_Tensor", "fast_aten_isin")
 _register_out("aten::isin.Tensor_Tensor_out", "fast_aten_isin", dtype_policy="exact")
 _register_fast("aten::isnan", "fast_aten_isnan")
@@ -366,8 +383,11 @@ register_aten_op("aten::scalar_tensor")(mojo_device_scalar_tensor)
 _register_fast(
     "aten::scaled_dot_product_attention", "fast_aten_scaled_dot_product_attention"
 )
-register_aten_op("aten::scatter.src")(mojo_device_scatter_src)
+_register_fast("aten::scatter.src", "fast_aten_scatter_src")
 _register_fast("aten::scatter.value", "fast_aten_scatter_value")
+_register_fast("aten::scatter_add", "fast_aten_scatter_add")
+_register_fast("aten::scatter_add.out", "fast_aten_scatter_add")
+_register_fast("aten::scatter_add_", "fast_aten_scatter_add_")
 _register_fast("aten::searchsorted.Scalar", "fast_aten_searchsorted")
 _register_out(
     "aten::searchsorted.Scalar_out", "fast_aten_searchsorted", dtype_policy="exact"

--- a/torch_mojo_backend/mojo_device/mojo_device_aten_ops.py
+++ b/torch_mojo_backend/mojo_device/mojo_device_aten_ops.py
@@ -34,7 +34,6 @@ from .aten_ops.autograd_preflight import (
     mojo_device_native_batch_norm,
     mojo_device_native_group_norm,
     mojo_device_relu,
-    mojo_device_scatter_src,
     mojo_device_sigmoid,
     mojo_device_softmax,
     mojo_device_tanh,
@@ -176,6 +175,7 @@ register_aten_op("aten::_foreach_norm.Scalar")(mojo_device__foreach_norm_scalar)
 register_aten_op("aten::_foreach_sqrt")(mojo_device__foreach_sqrt)
 _register_fast("aten::_fused_adamw_", "fast_aten__fused_adamw")
 _register_fast("aten::_fused_adamw_.tensor_lr", "fast_aten__fused_adamw")
+_register_fast("aten::_index_put_impl_", "fast_aten_index_put")
 _register_fast("aten::_local_scalar_dense", "fast_aten__local_scalar_dense")
 _register_fast("aten::_log_softmax", "fast_aten__log_softmax")
 _register_fast(
@@ -276,6 +276,18 @@ _register_fast("aten::floor_divide.Scalar", "fast_aten_floor_divide")
 _register_fast("aten::floordiv", "fast_aten_floor_divide")
 register_aten_op("aten::full")(mojo_device_full)
 register_aten_op("aten::full_like")(mojo_device_full_like)
+# The functional/in-place overloads of the structured ops in this family are
+# registered ALONGSIDE their `.out` twin on purpose. PyTorch's generated
+# wrapper for a `structured_delegate` op allocates the `out` tensor itself,
+# on the CURRENT device rather than the input's -- the PrivateUse1 device
+# guard is a no-op for us (there is no C++ extension to register a real
+# one), so on a machine with more than one accelerator that wrapper hands
+# `gather.out` an `out` that lives on the wrong device and nothing can
+# recover from it. A backend kernel on the functional overload takes
+# precedence over the wrapper and allocates the output where the inputs
+# are, which is also one allocation and one dispatch less.
+_register_fast("aten::gather", "fast_aten_gather")
+_register_fast("aten::gather.out", "fast_aten_gather")
 _register_fast("aten::ge", "fast_aten_ge")
 _register_fast("aten::ge.Scalar", "fast_aten_ge")
 _register_fast("aten::ge.Tensor", "fast_aten_ge")
@@ -285,6 +297,11 @@ _register_fast("aten::gt", "fast_aten_gt")
 _register_fast("aten::gt.Scalar", "fast_aten_gt")
 _register_fast("aten::gt.Tensor", "fast_aten_gt")
 register_aten_op("aten::index.Tensor")(mojo_device_index)
+_register_fast("aten::index_add", "fast_aten_index_add")
+_register_fast("aten::index_add.out", "fast_aten_index_add")
+_register_fast("aten::index_add_", "fast_aten_index_add_")
+_register_fast("aten::index_select", "fast_aten_index_select")
+_register_fast("aten::index_select.out", "fast_aten_index_select")
 _register_fast("aten::isin.Tensor_Tensor", "fast_aten_isin")
 _register_out("aten::isin.Tensor_Tensor_out", "fast_aten_isin", dtype_policy="exact")
 _register_fast("aten::isnan", "fast_aten_isnan")
@@ -365,8 +382,11 @@ register_aten_op("aten::scalar_tensor")(mojo_device_scalar_tensor)
 _register_fast(
     "aten::scaled_dot_product_attention", "fast_aten_scaled_dot_product_attention"
 )
-register_aten_op("aten::scatter.src")(mojo_device_scatter_src)
+_register_fast("aten::scatter.src", "fast_aten_scatter_src")
 _register_fast("aten::scatter.value", "fast_aten_scatter_value")
+_register_fast("aten::scatter_add", "fast_aten_scatter_add")
+_register_fast("aten::scatter_add.out", "fast_aten_scatter_add")
+_register_fast("aten::scatter_add_", "fast_aten_scatter_add_")
 _register_fast("aten::searchsorted.Scalar", "fast_aten_searchsorted")
 _register_out(
     "aten::searchsorted.Scalar_out", "fast_aten_searchsorted", dtype_policy="exact"


### PR DESCRIPTION
Adds eager-mode (`.to("mojo")`) and torch.compile-backend support for the
index-op family: `gather`, `index_select`, `scatter_add`, `index_put` — plus
`index_add`, which is not optional once `index_select` exists (see *Autograd*
below) — and `take_along_dim`, which is a composite over `gather`.

Every one of them was verified missing first, on a real mojo device:

```
[MISSING] gather              Could not run 'aten::gather.out'
[MISSING] index_select        Could not run 'aten::index_select'
[MISSING] scatter_add         Could not run 'aten::scatter_add.out'
[MISSING] index_put           Could not run 'aten::_index_put_impl_'
[MISSING] index_add           Could not run 'aten::index_add.out'
[MISSING] take_along_dim      Could not run 'aten::gather.out'
```

## Two kernels, not five

All five ops are one index-space walk with different stride vectors, so they
are two new kernels next to the existing `GatherRows`/`ScatterDim` in
`data_movement_ops.mojo` — `GatherDim` reads, `ScatterAddDim` accumulates —
and what distinguishes the ops is only which stride vector is real and which
is a broadcast:

| op | index space | index strides |
|---|---|---|
| `gather` | `index.shape` | real |
| `index_select` | `out.shape` | 0 except along `dim` |
| `scatter_add` | `index.shape` | real, atomic add |
| `index_add` | `source.shape` | 0 except along `dim`, atomic add |
| `index_put` | `values.shape` | dim 0, `(1, 0, ...)` |

`index_select` on dim 0 of a contiguous input reuses the **existing**
`GatherRows` kernel unchanged (one div/mod per element instead of three), and
`index_put(accumulate=False)` reuses the **existing** `ScatterDim`. A
contiguous operand collapses to a rank-3 `(outer, n, inner)` problem whatever
its rank, so `index_select`/`index_add` have no rank cap at all; the strided
routes keep the family's rank-4 cap.

## Semantics matched to torch, deliberately

- **No bounds checking, no negative-index wrap** for
  gather/index_select/scatter_add/index_add. That is torch's own contract:
  its CPU kernels raise before launching, but the CUDA kernels only
  device-assert (`ScatterGatherKernel.cu`, `Indexing.cu`), so an
  out-of-range or negative index is undefined on an accelerator there too.
- **`index_put` DOES wrap negative indices**, because advanced indexing
  defines them. The wrap reuses the `remainder` kernel on the index tensor,
  exactly as ATen's own `wrapIndexOnce` does.
- **`scatter_add` uses atomics and is not bitwise reproducible** for float
  dtypes — neither is torch's, whose default CUDA kernel is
  `ReduceAdd`→`fastAtomicAdd`. `torch.use_deterministic_algorithms(True)` is
  not honored (torch switches to a sort-based reduction there; we do not).
  The deterministic scheme that would work here is written down next to the
  kernel: a scatter along `dim` can only collide between entries agreeing on
  every *other* coordinate, so one thread per `dim`-column is race-free with
  no atomics for every dtype and backend — but it yields only
  `total/dims[dim]` threads (64 for a `(65536, 64)` index on dim 0), so it
  needs a runtime dispatch rather than replacing this kernel.
- **`x[mask] = scalar`** does not reach a bool-mask kernel at all: ATen's own
  `_index_put_impl_` re-routes exactly that shape to `masked_fill_`
  (`canDispatchToMaskedFill`), and so does this. A mask index covers the
  LEADING dims while broadcasting is right-aligned, so the mask is padded
  with trailing 1s first — without that, a shape-`(4,)` mask on a `(4, 4)`
  tensor fills the wrong axis, which only a square tensor exposes
  (`test_aten_index_put_bool_row_mask_scalar`).
- `scatter_add`/`index_add`/`index_put(accumulate=True)` decline
  int8/int16/uint8/bool: there is no sub-32-bit atomic RMW on the GPU
  targets, so those are refused in Python rather than sent to the compiler as
  an unsatisfiable specialization.

## Why the functional overloads are registered next to the `.out` ones

`gather`, `scatter_add` and `index_add` are `structured_delegate` ops, so
registering only `aten::gather.out` looks sufficient. It is not: PyTorch's
generated wrapper allocates the `out` tensor itself on the **current** device
rather than the input's, because the PrivateUse1 device guard is a no-op here
(there is no C++ extension to register a real one). On this box that hands
`gather.out` an `out` on `mojo:0` while the inputs are on `mojo:1`, and
nothing downstream can recover. A backend kernel on the functional overload
takes precedence over the wrapper, allocates the output where the inputs are,
and saves an allocation and a dispatch.

## Autograd

The family's derivative formulas call each other
(`gather`→`scatter_add_`, `index_select`→`index_add_`,
`scatter_add`→`gather`, `index_put`/`index`→`index_put`/`index`), and a raise
from a native backward node on this device is `std::terminate`, not an
exception — so a half-implemented family is worse than none. All eight
forward/backward pairs now run:

```
[ok] gather  [ok] gather_d0  [ok] index_select  [ok] index_select_d1
[ok] scatter_add  [ok] index_add  [ok] index_put  [ok] index_put_acc
```

This also **fixes an existing abort**: `x[idx].sum().backward()`
(`aten::index.Tensor`'s backward, which is
`zeros.index_put_(indices, grad, true)`) killed the process with
`terminate called without an active exception` on `main`, on both devices,
because `_index_put_impl_` did not exist. It now returns a gradient.

One pre-existing gap is documented rather than fixed: on a mojo device that
is not the *current* one, `index_put(accumulate=False)`'s backward still
aborts, because its formula's `zeros_like(values)` is allocated by ATen on
the current device and arrives on the wrong one. Every C++ derivative that
allocates without naming a device has that problem; the fix belongs in the
device guard.

## Verification

- **Unit tests** in `tests/test_aten_functions.py`, parametrized over
  dtype × rank × which dim is indexed (0 has a dedicated fast path, the last
  is the contiguous-inner regime, a negative dim exercises normalization),
  plus strided inputs, int32 indices, duplicate indices for the accumulating
  ops, negative indices for `index_put`, broadcast `values`, and the two
  bool-mask forms.
- **Cross-architecture assembly**, `scripts/compare_kernel_asm.py`, both
  `sm_90a` and `gfx942`: **0 kernels changed, +4 new** on each. The Mojo diff
  is purely additive — no existing line was touched.
  Getting there is worth recording: `ScatterAddDim` started as `ScatterDim`
  parametrized on the reduction, and *every* way of writing that (a
  `comptime if` around the value/src branch, one inside each arm, an
  `@always_inline` store helper called from both) moved the existing kernel's
  assembly by ±3 predicates and ±25 registers, while a bare unused comptime
  parameter changed nothing. Metaprogramming that rewrites the existing
  kernel is not a refactor, so the reduction got its own (leaner — no
  scalar-value overload) body.
- **Conformance** (`conformance/known_unsupported.py` is xfail-strict, so a
  now-passing declared node fails the suite): regenerated for these
  operators. `take_along_dim`'s entry is gone — it passes end to end now.
  The `gather`/`index_select`/`scatter_add`/`index_add`/`index_put` entries
  stay, and the reason is worth knowing: their OpInfo corpora also contain
  0-d samples and rank-5 samples, both of which decline here (rank-0 is a
  small fix; rank > 5 for gather/scatter_add needs a rank-8 kernel, since
  a full-rank index cannot be collapsed). 33 nodes xfail, 0 fail.
- **Benchmarks** in `benchmarks/test_embedding.py` for all five ops, with
  baselines recorded on this H100 (device time only, ABBA-interleaved,
  reproducible to ±0.6% and matching an independent earlier run within 1%);
  `benchmarks/test_coverage.py` passes, so every newly registered overload is
  either benchmarked or carries a written skip reason.

  | op | shape | bf16 | f32 |
  |---|---|---|---|
  | `gather` | 262144×64, dim 1 | 2.70 | 2.19 |
  | `gather` | 4096×4096, dim 0 | 1.13 | 1.08 |
  | `index_select` | 262144×64, 1048576 rows, dim 0 | **0.49** | **0.52** |
  | `index_select` | 4096×4096, 8192, dim 1 | 4.31 | 2.89 |
  | `scatter_add` | 262144×64, dim 1 | 2.28 | 1.52 |
  | `scatter_add` | 4096×4096, dim 0 | 1.25 | 1.05 |
  | `index_add` | 262144×64, 1048576, dim 0 | 1.48 | 1.52 |
  | `index_add` | 4096×4096, 8192, dim 1 | 2.35 | 1.03 |
  | `index_put` accumulate | 262144×64, 65536 rows | **0.90** | **0.84** |
  | `index_put` set | 262144×64, 65536 rows | 3.04 | 2.97 |

  (ratio = ours/stock CUDA device time; lower is better.) This is an
  op-support change, not an optimization one, so these are recorded as
  honest first-implementation baselines rather than tuned numbers — but two
  of them point somewhere specific, and they are the useful part:

  - **The dim-0 routes are at or ahead of stock** (`index_select` 0.49,
    `index_put` accumulate 0.90, `gather`/`scatter_add` dim 0 within 5-25%),
    because those are whole-row moves and the coordinate math amortizes.
  - **The inner-dim routes are 2-4× off**, and the cause is index traffic,
    not payload: at `(4096, 4096)` selecting 8192 columns, every one of the
    33.5M threads reloads its own int64 index element, i.e. 268 MB of index
    reads against 67 MB of payload. Stock's kernel stages indices per block.
    Fixing that is a tiling change, i.e. its own engagement.
  - **`index_put` with `accumulate=False` is 3× off while `accumulate=True`
    is at parity** — and the slow one is the path that reuses the
    PRE-EXISTING `ScatterDim`, while the fast one is the new
    `ScatterAddDim`. A row-granular scatter (the write mirror of
    `GatherRows`, which is what this call actually is) is the obvious next
    step, and it would speed up `aten::scatter.src`/`scatter.value` too.
- **The torch.compile backend** side (`aten_functions.py`) is exercised
  separately, since the `conf` fixture only runs eager: all 12 shapes/ops
  check out against CPU eager through `torch.compile(backend=mojo_backend)`.
  It uses the GPU-capable `_nd` scatters rather than `F.scatter_add`, whose
  wrapper has no GPU kernel and inserts a silent host round trip per call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
