### PR TITLE
Re-record 16 H100 GEMM baselines that were #341 best-of-N artifacts

### DIFF
--- a/benchmarks/baselines.html
+++ b/benchmarks/baselines.html
@@ -5665,7 +5665,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 "S7_768x50304x49152": {
                   "layouts": {
                     "NN": 2.81,
-                    "NT": 3.424,
+                    "NT": 3.142,
                     "TN": 2.246,
                     "TT": 2.555
                   }
@@ -6213,7 +6213,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 "S4_8x1024x1024x8192": {
                   "layouts": {
                     "NN": 3.982,
-                    "NT": 3.682,
+                    "NT": 3.13,
                     "TN": 2.204,
                     "TT": 3.621
                   }
@@ -7239,7 +7239,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 },
                 "S7_768x50304x49152": {
                   "layouts": {
-                    "contig": 3.449
+                    "contig": 3.144
                   }
                 }
               }
@@ -7830,26 +7830,26 @@ document.addEventListener("DOMContentLoaded", boot);
               "shapes": {
                 "S1_4096x4096x4096": {
                   "layouts": {
-                    "NN": 5.165,
+                    "NN": 1.064,
                     "NT": 1.078,
                     "TN": 1.129,
-                    "TT": 4.843
+                    "TT": 1.068
                   }
                 },
                 "S2_8192x2048x2048": {
                   "layouts": {
-                    "NN": 5.168,
+                    "NN": 1.068,
                     "NT": 1.111,
                     "TN": 1.238,
-                    "TT": 4.788
+                    "TT": 1.053
                   }
                 },
                 "S3_2048x8192x2048": {
                   "layouts": {
-                    "NN": 4.912,
+                    "NN": 1.027,
                     "NT": 1.061,
                     "TN": 1.225,
-                    "TT": 4.638
+                    "TT": 1.043
                   }
                 },
                 "S4_1024x1024x8192": {
@@ -7862,10 +7862,10 @@ document.addEventListener("DOMContentLoaded", boot);
                 },
                 "S5_357x789x333": {
                   "layouts": {
-                    "NN": 2.711,
-                    "NT": 2.261,
-                    "TN": 3.266,
-                    "TT": 2.826
+                    "NN": 0.965,
+                    "NT": 0.813,
+                    "TN": 1.097,
+                    "TT": 0.967
                   }
                 },
                 "S6_32768x768x768": {
@@ -7873,15 +7873,15 @@ document.addEventListener("DOMContentLoaded", boot);
                     "NN": 1.055,
                     "NT": 1.151,
                     "TN": 1.071,
-                    "TT": 5.073
+                    "TT": 1.101
                   }
                 },
                 "S7_768x50304x49152": {
                   "layouts": {
-                    "NN": 4.178,
+                    "NN": 1.008,
                     "NT": 1.014,
                     "TN": 1.011,
-                    "TT": 4.05
+                    "TT": 1.017
                   }
                 }
               }

--- a/benchmarks/baselines.html
+++ b/benchmarks/baselines.html
@@ -5665,7 +5665,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 "S7_768x50304x49152": {
                   "layouts": {
                     "NN": 2.81,
-                    "NT": 3.424,
+                    "NT": 3.142,
                     "TN": 2.246,
                     "TT": 2.555
                   }
@@ -6213,7 +6213,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 "S4_8x1024x1024x8192": {
                   "layouts": {
                     "NN": 3.982,
-                    "NT": 3.682,
+                    "NT": 3.13,
                     "TN": 2.204,
                     "TT": 3.621
                   }
@@ -7221,7 +7221,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 },
                 "S7_768x50304x49152": {
                   "layouts": {
-                    "contig": 3.449
+                    "contig": 3.144
                   }
                 }
               }
@@ -7812,26 +7812,26 @@ document.addEventListener("DOMContentLoaded", boot);
               "shapes": {
                 "S1_4096x4096x4096": {
                   "layouts": {
-                    "NN": 5.165,
+                    "NN": 1.064,
                     "NT": 1.078,
                     "TN": 1.129,
-                    "TT": 4.843
+                    "TT": 1.068
                   }
                 },
                 "S2_8192x2048x2048": {
                   "layouts": {
-                    "NN": 5.168,
+                    "NN": 1.068,
                     "NT": 1.111,
                     "TN": 1.238,
-                    "TT": 4.788
+                    "TT": 1.053
                   }
                 },
                 "S3_2048x8192x2048": {
                   "layouts": {
-                    "NN": 4.912,
+                    "NN": 1.027,
                     "NT": 1.061,
                     "TN": 1.225,
-                    "TT": 4.638
+                    "TT": 1.043
                   }
                 },
                 "S4_1024x1024x8192": {
@@ -7844,10 +7844,10 @@ document.addEventListener("DOMContentLoaded", boot);
                 },
                 "S5_357x789x333": {
                   "layouts": {
-                    "NN": 2.711,
-                    "NT": 2.261,
-                    "TN": 3.266,
-                    "TT": 2.826
+                    "NN": 0.965,
+                    "NT": 0.813,
+                    "TN": 1.097,
+                    "TT": 0.967
                   }
                 },
                 "S6_32768x768x768": {
@@ -7855,15 +7855,15 @@ document.addEventListener("DOMContentLoaded", boot);
                     "NN": 1.055,
                     "NT": 1.151,
                     "TN": 1.071,
-                    "TT": 5.073
+                    "TT": 1.101
                   }
                 },
                 "S7_768x50304x49152": {
                   "layouts": {
-                    "NN": 4.178,
+                    "NN": 1.008,
                     "NT": 1.014,
                     "TN": 1.011,
-                    "TT": 4.05
+                    "TT": 1.017
                   }
                 }
               }


### PR DESCRIPTION
## Why

Standing GEMM-baseline suspicion (`gemm-baselines-are-unreproducible`,
#385) plus a wide H100 band of mm/bmm/addmm/linear/convolution nodes
recorded > 1.5x prompted a full verification pass: is every node above
that threshold a real regression, or another #341 best-of-N recording
artifact like the 16 #385 already fixed?

## What was done

Fresh worktree off `upstream/main`. Every mm/bmm/addmm/linear/convolution
node with recorded ratio > 1.5 (176 total: 172 gemm-family + 4
convolution) was live-remeasured on the same H100, pinned clock, standard
suite. Every apparent improvement was re-measured a second and third
independent time before writing anything, per the #341/#385 lesson that
this suite's stock leg is bimodal on some shapes.

## Result

- **16 entries re-recorded** (this PR): 13 `mm/bf16` entries across
  S1/S2/S3/S5/S6/S7 (NN/TT/TN layouts) were the same best-of-N artifact
  #385 only partially cleaned up (it fixed S4 and S6/S7-TN; these are the
  remaining shapes with the identical signature) — recorded 2.3-5.2x,
  true value is parity (0.81-1.10x). 3 `tf32` entries (addmm S7-NT, bmm
  S4-NT, linear S7) held a smaller but reproducible ~9-15% improvement
  across two independent re-measurements.
- **6 candidates reverted, left untouched**: bmm bf16/f16/tf32 large
  batched NT/TT shapes and addmm tf32 S1-NT looked like >8% improvements
  on a first pass but did not reproduce on a second/third measurement —
  neither draw is more trustworthy than the other, so the pre-existing
  recorded value stays. These need a larger iteration budget in
  `bench_lib/measure.py` before a baseline there can be trusted either
  way.
- **~150 nodes confirmed real**: every tf32 mm/addmm/linear/bmm entry
  across S1-S7, most bf16/f16 bmm entries, and both convolution shapes
  reproduced their recorded ratio within the suite's 8% band on live H100
  hardware. These are genuine regressions, not recording noise, and stay
  open as engagement targets (worst: tf32 GEMM family ~2.0-5.7x, conv
  stem/3x3 bf16 4.7x/24.4x).

No code changes — `benchmarks/baselines.html` only, and
`benchmarks/test_coverage.py` passes (every baseline still maps to a live
test node).

## Test plan

- [x] `uv run pytest benchmarks/test_coverage.py -q` — 2 passed
- [x] All 16 re-recorded nodes independently re-verified holding within
      the 8% band on a subsequent run
- [x] Diffed against the pre-PR baseline commit: exactly 16 keys changed,
      0 removed

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013Co2wBC1UYzM4y9PEC92Af

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Co2wBC1UYzM4y9PEC92Af