### PR TITLE
Track the compile-path softmax silent-gradient escape #401's body overstated as fixed

### DIFF
--- a/tests/test_compile_mojo_device.py
+++ b/tests/test_compile_mojo_device.py
@@ -224,6 +224,63 @@ def test_compile_backward(mojo_device):
     torch.testing.assert_close(w.grad.cpu(), w_cpu.grad, rtol=2e-2, atol=2e-3)
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "aten::softmax.int silently produces no gradient under torch.compile "
+        "on the mojo device -- pre-existing on main, not introduced by PR #401. "
+        "Root cause (confirmed by direct experiment, see PR body): NOT this "
+        "module's own DECOMPOSITION_TABLE.pop(aten.softmax) -- popping only "
+        "changes what aten_functions.py's own map_to sees; re-adding softmax.int "
+        "to DECOMPOSITION_TABLE still leaves the forward graph fed to fw_compiler "
+        "correctly decomposed into aten::_softmax, yet the SAME "
+        "autograd_not_implemented_fallback warning and empty backward still fire. "
+        "AOTAutograd separately runs the traced function through REAL autograd-key "
+        "resolution (to decide whether/how to build a backward node) before its "
+        "own make_fx decomposition pass ever applies our DECOMPOSITION_TABLE; that "
+        "resolution consults the process-wide dispatcher, which the EAGER backend "
+        "(torch_mojo_backend/mojo_device/mojo_device_aten_ops.py's PrivateUse1 "
+        "registration for aten::softmax.int, kept -- and its silent-no-gradient "
+        "failure mode fixed with a forward-time raise -- by PR #401) has already "
+        "told 'has a specific backend kernel, no AutogradPrivateUse1 kernel, do "
+        "not fall back to CompositeImplicitAutograd' -- for the WHOLE PROCESS, "
+        "compile path included. A real fix means the eager registration itself "
+        "exposing a working AutogradPrivateUse1 path (or an equivalent forward-time "
+        "guard reachable from the compile path), which risks the exact silent-"
+        "training PR #401 just closed and needs its own dedicated engagement, not "
+        "a fix folded into this regression test."
+    ),
+)
+def test_compile_softmax_backward_produces_a_gradient(mojo_device):
+    """torch.softmax's gradient must not silently vanish under torch.compile.
+
+    Currently xfail(strict=True): this is a real, tracked bug, not a skip --
+    see the xfail reason above for the root cause and why it needs its own
+    engagement rather than a fix here. PR #401's body claimed the compile path
+    was safe because "AOTAutograd decomposes these backwards"; that claim was
+    inaccurate for softmax specifically (narrowed via a follow-up edit to that
+    PR's description) and this test is what proves it, and will keep proving
+    it (as a hard xfail->fail promotion, since strict=True turns an
+    unexpected pass into a failure) once someone lands the real fix.
+    """
+
+    def fn(x):
+        return torch.softmax(x, -1).square().sum()
+
+    x = torch.randn(2, 5, device=mojo_device, requires_grad=True)
+    loss = torch.compile(fn, backend=mojo_backend, fullgraph=True)(x)
+    loss.backward()
+    assert x.grad is not None, (
+        "torch.softmax's gradient vanished silently under torch.compile "
+        "(no exception, no traceback): aten::softmax.int escaped "
+        "AOTAutograd's decomposition and has no native derivative of its own"
+    )
+
+    x_cpu = x.detach().cpu().requires_grad_(True)
+    fn(x_cpu).backward()
+    torch.testing.assert_close(x.grad.cpu(), x_cpu.grad, rtol=1e-4, atol=1e-4)
+
+
 def test_compile_recompiles_for_cpu_inputs(mojo_device):
     """The same compiled function serves mojo and cpu inputs (device guard)."""
 


### PR DESCRIPTION
## Context

Adversarial review of #401 (Codex) found that its body overstated a safety
claim. #401 fixed `aten::softmax.int` silently returning no gradient in
**eager** mode (a forward-time raise). Its body's honest-tradeoff section
said the compile path was fine because "AOTAutograd decomposes these
backwards" -- that is not true for softmax specifically, and the review
reproduced it:

```python
x = torch.randn(2, 5).to(mojo_cpu).requires_grad_()
fn = lambda z: torch.softmax(z, -1).square().sum()
y = torch.compile(fn, backend=mojo_backend, fullgraph=True)(x)
y.backward()
assert x.grad is not None   # FAILS: x.grad is None, no exception raised
```

This is **pre-existing on `main`** -- #401 did not introduce it -- but #401's
body did not deliver the safety claim it made for the compile path, and this
PR is the requested follow-up: a regression test, an actual root-cause
investigation (not just repeating Codex's hypothesis), and a narrowing of
#401's own body once the real cause was pinned down.

## What I found

Codex's hypothesis was "the registered fused `softmax.int` escapes AOTAutograd's
decomposition... likely the PrivateUse1 op registration hides it from the
decomposition table the same way it did in eager." I tried the direct fix this
implies first: `aten_functions.py`'s `@map_to(aten.softmax)` pops
`aten.softmax.int`/`.Dimname` out of the `DECOMPOSITION_TABLE` passed to
`aot_autograd(..., decompositions=DECOMPOSITION_TABLE)`, so I removed that pop
(keeping `aten_softmax` as a plain, unregistered Python helper still used by
`aten__softmax` and the SDPA math path).

**It did not fix anything**, which is the useful negative result here. With
the pop removed, the forward graph handed to `fw_compiler` is confirmed
correctly decomposed:

```
call_function  _softmax   aten._softmax.default   (primals_1, -1, False)
call_function  pow_1      aten.pow.Tensor_Scalar  (_softmax, 2)
...
```

-- yet `x.grad` is *still* `None`, and the *same* `autograd_not_implemented_fallback`
warning for `aten::softmax` (not `_softmax`) still fires. So the compile
backend's own decomposition table was never the cause; I reverted that change
(not included in this PR's diff).

The real mechanism, confirmed by isolating each variable (plain CPU `aot_function`
works fine; a from-scratch minimal `aot_autograd` backend on a real mojo-device
leaf tensor reproduces the exact same warning even with a fresh, fully-populated
decomposition table): AOTAutograd resolves whether an op needs special autograd
handling by consulting the **real, process-wide PyTorch dispatcher** as part of
building its joint forward+backward graph, *before* its own `make_fx`
decomposition pass ever runs on the result. That dispatcher has a single,
global answer for `aten::softmax.int` on the mojo `PrivateUse1` key, set by the
**eager** backend's own registration in
`torch_mojo_backend/mojo_device/mojo_device_aten_ops.py`: "this backend has a
specific kernel for this op, and no `AutogradPrivateUse1` kernel" -- which tells
the dispatcher not to fall back to `CompositeImplicitAutograd`'s decomposition-based
differentiability. That answer is process-wide, not compile-path-specific, so
it applies during `torch.compile` too, regardless of what `aten_functions.py`'s
own decomposition table says.

This is the exact same dispatch quirk #401 already documented and fixed for
eager mode (`aten_ops/autograd_preflight.py`'s `mojo_device_softmax`) -- it's
just that #401's fix (a forward-time raise) only prevents the *crash-shaped*
failure in eager; it doesn't change the dispatcher-level fact that makes
AOTAutograd's compile-time autograd resolution fail silently instead.

## Why this isn't fixed here

A real fix means either (a) the eager registration exposing a working
`AutogradPrivateUse1` path for `softmax.int` (so the dispatcher has something
better than "fall back to nothing"), or (b) some other guard reachable from
the compile path specifically. Both are real engineering, not a
test-file-sized fix, and (a) in particular risks reopening the exact
silent-training failure #401 just closed in eager mode if done carelessly
(it would need to preserve the fused eager kernel's performance while still
giving autograd something to work with). That's a dedicated follow-up, not
this PR.

## What this PR does

1. Adds `test_compile_softmax_backward_produces_a_gradient` to
   `tests/test_compile_mojo_device.py`, marked `xfail(strict=True)` with the
   root-cause writeup above as its reason. `strict=True` means this stays a
   real, tracked red test: if someone's fix makes it start passing, the suite
   fails until the `xfail` marker is removed, rather than the fix going
   unnoticed.
2. Narrows #401's own body via the GitHub API so the historical record is
   accurate: the "silent training beats an error, and we traded one for the
   other" claim is now scoped to eager execution, with a pointer to this PR
   for the compile-path gap.

## Test evidence

- `tests/test_compile_mojo_device.py -k "softmax_backward and cpu"` and
  `-k "softmax_backward and gpu"`: `1 xfailed` each, confirming the test
  fails exactly the way described (not an error, not an unexpected pass).
- Full file: `tests/test_compile_mojo_device.py` -- `44 passed, 2 xfailed`
  (H100), no regressions in the other 44 compile-backend tests.
- `uvx pre-commit run --all-files`: clean.

No kernel was touched (pure test + doc-of-record change), so no
cross-architecture check is owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Co2wBC1UYzM4y9PEC92Af
