### PR TITLE
Fix div rounding_mode: bf16 scalar precision, int div-by-zero, out dtype

### DIFF
--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -295,6 +295,83 @@ def test_fast_div_trunc_mode_narrow_float_boundary(mojo_device, dtype):
     torch.testing.assert_close(result, torch.div(x, y, rounding_mode="trunc"))
 
 
+def test_fast_div_trunc_mode_scalar_divisor_uses_fp32_precision(mojo_device):
+    """Regression test (adversarial review, wave A): torch's bf16/fp16
+    trunc kernel takes a SEPARATE fp32-upcast fast path whenever the
+    divisor is a scalar (CPU's `is_scalar(2)`, CUDA's `is_cpu_scalar(2)`),
+    unlike its native-precision tensor/tensor path (pinned by
+    test_fast_div_trunc_mode_narrow_float_boundary above). A prior version
+    of BOP_TRUNCDIV applied the tensor/tensor rule unconditionally and
+    returned 6.0 for this exact case; stock returns 5.0 for both a raw
+    Python-scalar divisor and a one-element TENSOR divisor."""
+    x = torch.tensor([-6.3125], dtype=torch.bfloat16)
+    expected = torch.div(x, -1.0547, rounding_mode="trunc")
+    assert expected.item() == 5.0  # sanity: this is what stock actually does
+
+    scalar_result = torch.div(x.to(mojo_device), -1.0547, rounding_mode="trunc").cpu()
+    torch.testing.assert_close(scalar_result, expected)
+
+    one_elem = torch.tensor([-1.0547], dtype=torch.bfloat16)
+    one_elem_expected = torch.div(x, one_elem, rounding_mode="trunc")
+    one_elem_result = torch.div(
+        x.to(mojo_device), one_elem.to(mojo_device), rounding_mode="trunc"
+    ).cpu()
+    torch.testing.assert_close(one_elem_result, one_elem_expected)
+
+
+def test_fast_div_int_div_by_zero_raises_on_cpu():
+    """Regression test (adversarial review, wave A): integer floor/trunc
+    div-by-zero used to return a deterministic-but-meaningless value
+    (`a // 0` reads as 0 via Mojo's own zero-guard, and the old trunc
+    correction step then perturbed that to 1 for negative numerators) with
+    no raise anywhere. Stock CPU raises `RuntimeError: ZeroDivisionError`;
+    this device's CPU dispatch tier now scans the divisor host-side (real,
+    already-addressable memory on this tier) and raises before launching,
+    matching stock CPU exactly."""
+    cpu_device = f"mojo:{len(get_accelerators()) - 1}"
+    x = torch.tensor([1, -1], dtype=torch.int32)
+    y = torch.tensor([0, 0], dtype=torch.int32)
+    with pytest.raises(RuntimeError, match="ZeroDivisionError"):
+        torch.div(x.to(cpu_device), y.to(cpu_device), rounding_mode="floor")
+    with pytest.raises(RuntimeError, match="ZeroDivisionError"):
+        torch.div(x.to(cpu_device), y.to(cpu_device), rounding_mode="trunc")
+
+
+def test_fast_div_int_div_by_zero_is_a_documented_sentinel_on_gpu(mojo_gpu):
+    """GPU dispatch cannot cheaply raise from device code (see the CPU-only
+    check in `_binary_bcast`), so it returns a documented sentinel instead:
+    0, uniformly, for both floor and trunc (not stock CUDA's own
+    platform-specific sentinel, which this device does not attempt to
+    reproduce -- see BOP_TRUNCDIV's b==0 handling in logic_ops.mojo). This
+    pins that the sentinel is at least CONSISTENT (floor and trunc used to
+    disagree: trunc's now-removed sign-correction step turned 0 into 1 for
+    a negative numerator) rather than an unreviewed accident."""
+    x = torch.tensor([1, -1], dtype=torch.int32).to(mojo_gpu)
+    y = torch.tensor([0, 0], dtype=torch.int32).to(mojo_gpu)
+    zero = torch.tensor([0, 0], dtype=torch.int32)
+    torch.testing.assert_close(torch.div(x, y, rounding_mode="floor").cpu(), zero)
+    torch.testing.assert_close(torch.div(x, y, rounding_mode="trunc").cpu(), zero)
+
+
+def test_fast_div_out_mode_cross_category_dtype(mojo_device):
+    """Regression test (adversarial review, wave A): `div.out_mode`'s
+    "safe_cast" dtype policy accepts any torch-legal (result, out) pair
+    (`torch.can_cast`), but the fast CastSpec kernel family deliberately
+    excludes float64 (see `_CAST_DTYPES`). int32 inputs with a float64 `out`
+    used to raise `NotImplementedError: mojo spec cast into: unsupported
+    dtype pair` even though stock succeeds; `_copy_into_tensor` now falls
+    back to a host round-trip through real torch's own cast for dtype pairs
+    outside `_CAST_DTYPES`."""
+    x = torch.tensor([7, -7], dtype=torch.int32)
+    y = torch.tensor([2, 2], dtype=torch.int32)
+    expected = torch.empty(2, dtype=torch.float64)
+    torch.div(x, y, rounding_mode="trunc", out=expected)
+
+    out = torch.empty(2, dtype=torch.float64, device=mojo_device)
+    torch.div(x.to(mojo_device), y.to(mojo_device), rounding_mode="trunc", out=out)
+    torch.testing.assert_close(out.cpu(), expected)
+
+
 @pytest.mark.parametrize("shape", [(0,), (1,), (7,), (0, 5)])
 def test_edge_case_shapes(mojo_device, shape):
     x = torch.randn(*shape)

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -363,6 +363,83 @@ def test_fast_div_trunc_mode_narrow_float_boundary(mojo_device, dtype):
     torch.testing.assert_close(result, torch.div(x, y, rounding_mode="trunc"))
 
 
+def test_fast_div_trunc_mode_scalar_divisor_uses_fp32_precision(mojo_device):
+    """Regression test (adversarial review, wave A): torch's bf16/fp16
+    trunc kernel takes a SEPARATE fp32-upcast fast path whenever the
+    divisor is a scalar (CPU's `is_scalar(2)`, CUDA's `is_cpu_scalar(2)`),
+    unlike its native-precision tensor/tensor path (pinned by
+    test_fast_div_trunc_mode_narrow_float_boundary above). A prior version
+    of BOP_TRUNCDIV applied the tensor/tensor rule unconditionally and
+    returned 6.0 for this exact case; stock returns 5.0 for both a raw
+    Python-scalar divisor and a one-element TENSOR divisor."""
+    x = torch.tensor([-6.3125], dtype=torch.bfloat16)
+    expected = torch.div(x, -1.0547, rounding_mode="trunc")
+    assert expected.item() == 5.0  # sanity: this is what stock actually does
+
+    scalar_result = torch.div(x.to(mojo_device), -1.0547, rounding_mode="trunc").cpu()
+    torch.testing.assert_close(scalar_result, expected)
+
+    one_elem = torch.tensor([-1.0547], dtype=torch.bfloat16)
+    one_elem_expected = torch.div(x, one_elem, rounding_mode="trunc")
+    one_elem_result = torch.div(
+        x.to(mojo_device), one_elem.to(mojo_device), rounding_mode="trunc"
+    ).cpu()
+    torch.testing.assert_close(one_elem_result, one_elem_expected)
+
+
+def test_fast_div_int_div_by_zero_raises_on_cpu():
+    """Regression test (adversarial review, wave A): integer floor/trunc
+    div-by-zero used to return a deterministic-but-meaningless value
+    (`a // 0` reads as 0 via Mojo's own zero-guard, and the old trunc
+    correction step then perturbed that to 1 for negative numerators) with
+    no raise anywhere. Stock CPU raises `RuntimeError: ZeroDivisionError`;
+    this device's CPU dispatch tier now scans the divisor host-side (real,
+    already-addressable memory on this tier) and raises before launching,
+    matching stock CPU exactly."""
+    cpu_device = f"mojo:{len(get_accelerators()) - 1}"
+    x = torch.tensor([1, -1], dtype=torch.int32)
+    y = torch.tensor([0, 0], dtype=torch.int32)
+    with pytest.raises(RuntimeError, match="ZeroDivisionError"):
+        torch.div(x.to(cpu_device), y.to(cpu_device), rounding_mode="floor")
+    with pytest.raises(RuntimeError, match="ZeroDivisionError"):
+        torch.div(x.to(cpu_device), y.to(cpu_device), rounding_mode="trunc")
+
+
+def test_fast_div_int_div_by_zero_is_a_documented_sentinel_on_gpu(mojo_gpu):
+    """GPU dispatch cannot cheaply raise from device code (see the CPU-only
+    check in `_binary_bcast`), so it returns a documented sentinel instead:
+    0, uniformly, for both floor and trunc (not stock CUDA's own
+    platform-specific sentinel, which this device does not attempt to
+    reproduce -- see BOP_TRUNCDIV's b==0 handling in logic_ops.mojo). This
+    pins that the sentinel is at least CONSISTENT (floor and trunc used to
+    disagree: trunc's now-removed sign-correction step turned 0 into 1 for
+    a negative numerator) rather than an unreviewed accident."""
+    x = torch.tensor([1, -1], dtype=torch.int32).to(mojo_gpu)
+    y = torch.tensor([0, 0], dtype=torch.int32).to(mojo_gpu)
+    zero = torch.tensor([0, 0], dtype=torch.int32)
+    torch.testing.assert_close(torch.div(x, y, rounding_mode="floor").cpu(), zero)
+    torch.testing.assert_close(torch.div(x, y, rounding_mode="trunc").cpu(), zero)
+
+
+def test_fast_div_out_mode_cross_category_dtype(mojo_device):
+    """Regression test (adversarial review, wave A): `div.out_mode`'s
+    "safe_cast" dtype policy accepts any torch-legal (result, out) pair
+    (`torch.can_cast`), but the fast CastSpec kernel family deliberately
+    excludes float64 (see `_CAST_DTYPES`). int32 inputs with a float64 `out`
+    used to raise `NotImplementedError: mojo spec cast into: unsupported
+    dtype pair` even though stock succeeds; `_copy_into_tensor` now falls
+    back to a host round-trip through real torch's own cast for dtype pairs
+    outside `_CAST_DTYPES`."""
+    x = torch.tensor([7, -7], dtype=torch.int32)
+    y = torch.tensor([2, 2], dtype=torch.int32)
+    expected = torch.empty(2, dtype=torch.float64)
+    torch.div(x, y, rounding_mode="trunc", out=expected)
+
+    out = torch.empty(2, dtype=torch.float64, device=mojo_device)
+    torch.div(x.to(mojo_device), y.to(mojo_device), rounding_mode="trunc", out=out)
+    torch.testing.assert_close(out.cpu(), expected)
+
+
 @pytest.mark.parametrize("shape", [(0,), (1,), (7,), (0, 5)])
 def test_edge_case_shapes(mojo_device, shape):
     x = torch.randn(*shape)

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -2011,16 +2011,28 @@ def _try_spec_reduce(
 
 
 def _raise_if_device_oom(exc: BaseException) -> None:
-    """Keep TensorSpec fallbacks from disguising allocator exhaustion.
+    """Keep TensorSpec fallbacks from disguising a handful of REAL errors.
 
     Mojo TensorSpec dispatch reports both unsupported metadata and runtime
-    launch/allocation failures as ``NotImplementedError``. Unsupported
-    metadata should retain the classic fallback, but retrying after a device
-    OOM only replaces the useful allocator error with a misleading
-    ``aten::<op> is not supported`` message.
+    launch/allocation/data failures as ``NotImplementedError``. Unsupported
+    metadata should retain the classic fallback (return ``None`` so the
+    caller declines), but a few conditions are not "this input combination
+    isn't supported" at all and must propagate instead of being disguised as
+    a generic ``aten::<op> is not supported`` decline:
+
+    - Device OOM: retrying after allocator exhaustion only replaces the
+      useful allocator error with that misleading message.
+    - Integer floor/trunc division by zero: `_binary_bcast`'s CPU dispatch
+      tier (logic_ops.mojo) scans the divisor host-side and raises
+      ``Error("ZeroDivisionError")`` rather than silently returning the
+      documented sentinel the (non-raising) GPU tiers use -- matching
+      stock CPU's own ``RuntimeError: ZeroDivisionError`` means re-raising
+      that here, not letting the generic decline path swallow it.
     """
     if eager_kernels.is_device_oom(exc):
         raise torch.OutOfMemoryError(str(exc)) from exc
+    if "ZeroDivisionError" in str(exc):
+        raise RuntimeError("ZeroDivisionError") from exc
 
 
 # A queued launch fails inside `call_queue.drain()`, far from the `_call_mojo`
@@ -2677,11 +2689,54 @@ def fast_aten_mul_(input, other):
 _DIV_ROUNDING_MODE_SPECS = {"floor": "FloorDivSpec", "trunc": "TruncDivSpec"}
 
 
+def _is_div_other_scalar_like(other: object) -> bool:
+    """Whether `other` is a scalar for torch's div-by-a-scalar fp32 fast
+    path: a raw Python number, or a tensor with exactly one element (any
+    rank, including 0-dim) -- both count as `TensorIteratorBase::is_scalar`
+    in torch's own CPU/CUDA kernels."""
+    if isinstance(other, int | float) and not isinstance(other, bool):
+        return True
+    t = _t(other)
+    return t is not None and t._numel == 1
+
+
 def fast_aten_div(input, other, *, rounding_mode=None):
     if rounding_mode is not None:
         spec_name = _DIV_ROUNDING_MODE_SPECS.get(rounding_mode)
         if spec_name is None:
             return NOT_HANDLED
+        a = _t(input)
+        if (
+            rounding_mode == "trunc"
+            and a is not None
+            and a._dtype in (DType.float16, DType.bfloat16)
+            and _is_div_other_scalar_like(other)
+        ):
+            # BOP_TRUNCDIV intentionally computes at the operands' own
+            # (narrow) precision for ordinary tensor/tensor calls, matching
+            # torch's tensor/tensor trunc kernel exactly (see the comment on
+            # BOP_TRUNCDIV in logic_ops.mojo). But torch's kernels take a
+            # SEPARATE, fp32-upcast fast path whenever the divisor is a
+            # scalar (CPU's `is_scalar(2)`, CUDA's `is_cpu_scalar(2)`) --
+            # e.g. `torch.div(bf16_tensor, -1.0547, rounding_mode="trunc")`
+            # divides at fp32, not bf16. A raw Python scalar reaches this
+            # function unrounded (see `_try_spec_binary`'s scalar-embed
+            # path), so casting `input` to fp32 BEFORE calling
+            # `_try_spec_binary` embeds the scalar straight into fp32
+            # storage -- no bf16 rounding of the divisor at all, matching
+            # (and for a raw Python float, exceeding) torch's own
+            # cast-the-original-value-to-opmath_t precision. A one-element
+            # TENSOR divisor is already whatever dtype it was created at, so
+            # upcasting it to fp32 here recovers no precision that wasn't
+            # already lost, same as torch's own `scalar_value<accscalar_t>`
+            # read of an already-narrow stored value.
+            other_t = _t(other)
+            lhs = _cast_tensor(a, DType.float32)
+            rhs = _cast_tensor(other_t, DType.float32) if other_t is not None else other
+            result = _try_spec_binary(spec_name, lhs, rhs)
+            if result is None:
+                return NOT_HANDLED
+            return _cast_tensor(result, a._dtype)
         result = _try_spec_binary(spec_name, input, other)
         return result if result is not None else NOT_HANDLED
     a = _t(input)

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -2109,16 +2109,28 @@ def _try_spec_reduce(
 
 
 def _raise_if_device_oom(exc: BaseException):
-    """Keep TensorSpec fallbacks from disguising allocator exhaustion.
+    """Keep TensorSpec fallbacks from disguising a handful of REAL errors.
 
     Mojo TensorSpec dispatch reports both unsupported metadata and runtime
-    launch/allocation failures as ``NotImplementedError``. Unsupported
-    metadata should retain the classic fallback, but retrying after a device
-    OOM only replaces the useful allocator error with a misleading
-    ``aten::<op> is not supported`` message.
+    launch/allocation/data failures as ``NotImplementedError``. Unsupported
+    metadata should retain the classic fallback (return ``None`` so the
+    caller declines), but a few conditions are not "this input combination
+    isn't supported" at all and must propagate instead of being disguised as
+    a generic ``aten::<op> is not supported`` decline:
+
+    - Device OOM: retrying after allocator exhaustion only replaces the
+      useful allocator error with that misleading message.
+    - Integer floor/trunc division by zero: `_binary_bcast`'s CPU dispatch
+      tier (logic_ops.mojo) scans the divisor host-side and raises
+      ``Error("ZeroDivisionError")`` rather than silently returning the
+      documented sentinel the (non-raising) GPU tiers use -- matching
+      stock CPU's own ``RuntimeError: ZeroDivisionError`` means re-raising
+      that here, not letting the generic decline path swallow it.
     """
     if eager_kernels.is_device_oom(exc):
         raise torch.OutOfMemoryError(str(exc)) from exc
+    if "ZeroDivisionError" in str(exc):
+        raise RuntimeError("ZeroDivisionError") from exc
 
 
 # A queued launch fails inside `call_queue.drain()`, far from the `_call_mojo`
@@ -2807,6 +2819,17 @@ def fast_aten_mul_(input: torch.Tensor, other: object) -> torch.Tensor | None:
 _DIV_ROUNDING_MODE_SPECS = {"floor": "FloorDivSpec", "trunc": "TruncDivSpec"}
 
 
+def _is_div_other_scalar_like(other: object) -> bool:
+    """Whether `other` is a scalar for torch's div-by-a-scalar fp32 fast
+    path: a raw Python number, or a tensor with exactly one element (any
+    rank, including 0-dim) -- both count as `TensorIteratorBase::is_scalar`
+    in torch's own CPU/CUDA kernels."""
+    if isinstance(other, int | float) and not isinstance(other, bool):
+        return True
+    t = _t(other)
+    return t is not None and t._numel == 1
+
+
 def fast_aten_div(
     input: torch.Tensor, other: object, *, rounding_mode: str | None = None
 ) -> TorchMojoTensor | _NotHandled:
@@ -2814,6 +2837,38 @@ def fast_aten_div(
         spec_name = _DIV_ROUNDING_MODE_SPECS.get(rounding_mode)
         if spec_name is None:
             return NOT_HANDLED
+        a = _t(input)
+        if (
+            rounding_mode == "trunc"
+            and a is not None
+            and a._dtype in (DType.float16, DType.bfloat16)
+            and _is_div_other_scalar_like(other)
+        ):
+            # BOP_TRUNCDIV intentionally computes at the operands' own
+            # (narrow) precision for ordinary tensor/tensor calls, matching
+            # torch's tensor/tensor trunc kernel exactly (see the comment on
+            # BOP_TRUNCDIV in logic_ops.mojo). But torch's kernels take a
+            # SEPARATE, fp32-upcast fast path whenever the divisor is a
+            # scalar (CPU's `is_scalar(2)`, CUDA's `is_cpu_scalar(2)`) --
+            # e.g. `torch.div(bf16_tensor, -1.0547, rounding_mode="trunc")`
+            # divides at fp32, not bf16. A raw Python scalar reaches this
+            # function unrounded (see `_try_spec_binary`'s scalar-embed
+            # path), so casting `input` to fp32 BEFORE calling
+            # `_try_spec_binary` embeds the scalar straight into fp32
+            # storage -- no bf16 rounding of the divisor at all, matching
+            # (and for a raw Python float, exceeding) torch's own
+            # cast-the-original-value-to-opmath_t precision. A one-element
+            # TENSOR divisor is already whatever dtype it was created at, so
+            # upcasting it to fp32 here recovers no precision that wasn't
+            # already lost, same as torch's own `scalar_value<accscalar_t>`
+            # read of an already-narrow stored value.
+            other_t = _t(other)
+            lhs = _cast_tensor(a, DType.float32)
+            rhs = _cast_tensor(other_t, DType.float32) if other_t is not None else other
+            result = _try_spec_binary(spec_name, lhs, rhs)
+            if result is None:
+                return NOT_HANDLED
+            return _cast_tensor(result, a._dtype)
         result = _try_spec_binary(spec_name, input, other)
         return result if result is not None else NOT_HANDLED
     a = _t(input)

--- a/torch_mojo_backend/eager_kernels/logic_ops/logic_ops.mojo
+++ b/torch_mojo_backend/eager_kernels/logic_ops/logic_ops.mojo
@@ -371,20 +371,28 @@ def _bin_vec_op[
             # (away from zero), trunc rounds toward zero.
             comptime if dtype.is_floating_point():
                 # UNLIKE BOP_FLOORDIV, deliberately NOT widened to fp32 for
-                # bf16/fp16: torch's own tensor-tensor trunc kernel
+                # bf16/fp16 HERE: torch's own tensor-tensor trunc kernel
                 # (`div_trunc_kernel` in aten/src/ATen/native/cpu/
-                # BinaryOpsKernel.cpp) computes `std::trunc(a / b)` at the
-                # operand's OWN precision for the general tensor/tensor case
-                # -- only its separate is-scalar fast path upcasts to
-                # opmath_t, and that fast path is not reachable from here
-                # (a Python scalar operand already arrives pre-rounded into
-                # a same-dtype broadcast tensor, see `_scalar_embed`). So
-                # matching torch means reproducing its rounding here too:
-                # verified directly against torch.div(..., rounding_mode=
-                # "trunc") on real bf16 tensors that -6.3125 / -1.0546875
-                # (true quotient ~5.985) rounds to 6.0 in bf16 *before*
-                # truncation, same as torch -- not the fp32-computed 5.0
-                # BOP_FLOORDIV's comment calls "correct".
+                # BinaryOpsKernel.cpp / BinaryDivTruncKernel.cu) computes
+                # `std::trunc(a / b)` at the operand's OWN precision for the
+                # general tensor/tensor case -- only its separate
+                # is-scalar fast path (CPU's `is_scalar(2)`, CUDA's
+                # `is_cpu_scalar(2)`) upcasts to opmath_t. That scalar fast
+                # path IS reachable from a Python call, but it is handled
+                # one level up in Python (`fast_aten_div` in aten_fast.py,
+                # see `_is_div_other_scalar_like`): a scalar/one-element
+                # divisor is cast to fp32 by the CALLER before this kernel
+                # ever runs, so by the time `dtype` is bf16/fp16 HERE, both
+                # operands are guaranteed genuine multi-element tensors and
+                # native precision is correct -- verified directly against
+                # torch.div(..., rounding_mode="trunc") on real bf16
+                # tensors that -6.3125 / -1.0546875 (true quotient ~5.985)
+                # rounds to 6.0 in bf16 *before* truncation for a tensor
+                # divisor, same as torch, but computes the mathematically
+                # exact 5.0 (matching torch's OWN scalar fast path) for a
+                # scalar/one-element divisor -- not the same value BOP_
+                # FLOORDIV's comment calls "correct" for its own (always
+                # fp32) case.
                 return (a / b).__trunc__().cast[out_dtype]()
             else:
                 # Correct Mojo's floor division (`//`, already zero-safe --
@@ -394,11 +402,26 @@ def _bin_vec_op[
                 # from zero than trunc; `r` here has floor's sign
                 # convention (the divisor's sign, or zero) so `r != 0` is
                 # exactly the "inexact" test.
+                #
+                # b == 0: `a // b` already comes back 0 (Mojo's own
+                # `pop.floordiv` zero-guard, same as BOP_FLOORDIV above), and
+                # `not_zero` below forces `needs_adjust` off too, so trunc
+                # matches floor's documented b==0 sentinel: 0, not a raise
+                # (there is no per-element device-side raise) and not
+                # whatever sign-dependent value the correction step would
+                # otherwise produce. See `_binary_bcast`'s CPU-only
+                # zero-divisor check for the platforms that DO raise
+                # (matching stock CPU); this 0 is what every OTHER dispatch
+                # tier (GPU) returns instead, by documented convention, not
+                # accident -- stock CUDA's own int-div-by-zero sentinel is
+                # likewise platform-defined, not something a raise-free
+                # kernel is expected to reproduce bit-for-bit.
                 var q = a // b
                 var r = a - q * b
                 var zero = SIMD[dtype, width](0)
+                var not_zero = b.ne(zero)
                 var opposite_signs = a.lt(zero) ^ b.lt(zero)
-                var needs_adjust = opposite_signs & r.ne(zero)
+                var needs_adjust = opposite_signs & r.ne(zero) & not_zero
                 return needs_adjust.select(q + 1, q).cast[out_dtype]()
         comptime if op_code == BOP_POW:
             # Float only (gated at the launcher); accumulate halves in
@@ -643,6 +666,37 @@ def _binary_bcast[
             var r_ptr = _make_ptr[dtype](r_addr)
 
             if ctx.api() == "cpu":
+                comptime if (
+                    not is_cmp
+                    and (op_code == BOP_FLOORDIV or op_code == BOP_TRUNCDIV)
+                    and not dtype.is_floating_point()
+                ):
+                    # Stock CPU raises for integer div-by-zero
+                    # (`TORCH_CHECK(b != 0, "ZeroDivisionError")` in
+                    # BinaryOpsKernel.cpp); Mojo's `pop.floordiv` has its
+                    # own zero-guard instead (see BOP_FLOORDIV/BOP_TRUNCDIV
+                    # above), silently substituting a documented 0 rather
+                    # than trapping. This CPU dispatch path's divisor
+                    # buffer is real, host-addressable memory -- no device
+                    # sync needed to read it -- so scan it up front and
+                    # raise before doing any work, matching stock's CPU
+                    # behavior exactly instead of returning the
+                    # documented-but-still-wrong 0 sentinel that GPU
+                    # dispatch (which cannot cheaply raise from device
+                    # code, and settles for a plain documented 0 instead)
+                    # returns.
+                    for i in range(total):
+                        var i3 = i % d3
+                        var rest = i // d3
+                        var i2 = rest % d2
+                        rest = rest // d2
+                        var i1 = rest % d1
+                        var i0 = rest // d1
+                        if (
+                            r_ptr[i0 * rs0 + i1 * rs1 + i2 * rs2 + i3 * rs3]
+                            == 0
+                        ):
+                            raise Error("ZeroDivisionError")
 
                 @always_inline
                 @parameter

--- a/torch_mojo_backend/eager_kernels/logic_ops/logic_ops.mojo
+++ b/torch_mojo_backend/eager_kernels/logic_ops/logic_ops.mojo
@@ -337,20 +337,28 @@ def _bin_vec_op[
             # (away from zero), trunc rounds toward zero.
             comptime if dtype.is_floating_point():
                 # UNLIKE BOP_FLOORDIV, deliberately NOT widened to fp32 for
-                # bf16/fp16: torch's own tensor-tensor trunc kernel
+                # bf16/fp16 HERE: torch's own tensor-tensor trunc kernel
                 # (`div_trunc_kernel` in aten/src/ATen/native/cpu/
-                # BinaryOpsKernel.cpp) computes `std::trunc(a / b)` at the
-                # operand's OWN precision for the general tensor/tensor case
-                # -- only its separate is-scalar fast path upcasts to
-                # opmath_t, and that fast path is not reachable from here
-                # (a Python scalar operand already arrives pre-rounded into
-                # a same-dtype broadcast tensor, see `_scalar_embed`). So
-                # matching torch means reproducing its rounding here too:
-                # verified directly against torch.div(..., rounding_mode=
-                # "trunc") on real bf16 tensors that -6.3125 / -1.0546875
-                # (true quotient ~5.985) rounds to 6.0 in bf16 *before*
-                # truncation, same as torch -- not the fp32-computed 5.0
-                # BOP_FLOORDIV's comment calls "correct".
+                # BinaryOpsKernel.cpp / BinaryDivTruncKernel.cu) computes
+                # `std::trunc(a / b)` at the operand's OWN precision for the
+                # general tensor/tensor case -- only its separate
+                # is-scalar fast path (CPU's `is_scalar(2)`, CUDA's
+                # `is_cpu_scalar(2)`) upcasts to opmath_t. That scalar fast
+                # path IS reachable from a Python call, but it is handled
+                # one level up in Python (`fast_aten_div` in aten_fast.py,
+                # see `_is_div_other_scalar_like`): a scalar/one-element
+                # divisor is cast to fp32 by the CALLER before this kernel
+                # ever runs, so by the time `dtype` is bf16/fp16 HERE, both
+                # operands are guaranteed genuine multi-element tensors and
+                # native precision is correct -- verified directly against
+                # torch.div(..., rounding_mode="trunc") on real bf16
+                # tensors that -6.3125 / -1.0546875 (true quotient ~5.985)
+                # rounds to 6.0 in bf16 *before* truncation for a tensor
+                # divisor, same as torch, but computes the mathematically
+                # exact 5.0 (matching torch's OWN scalar fast path) for a
+                # scalar/one-element divisor -- not the same value BOP_
+                # FLOORDIV's comment calls "correct" for its own (always
+                # fp32) case.
                 return (a / b).__trunc__().cast[out_dtype]()
             else:
                 # Correct Mojo's floor division (`//`, already zero-safe --
@@ -360,11 +368,26 @@ def _bin_vec_op[
                 # from zero than trunc; `r` here has floor's sign
                 # convention (the divisor's sign, or zero) so `r != 0` is
                 # exactly the "inexact" test.
+                #
+                # b == 0: `a // b` already comes back 0 (Mojo's own
+                # `pop.floordiv` zero-guard, same as BOP_FLOORDIV above), and
+                # `not_zero` below forces `needs_adjust` off too, so trunc
+                # matches floor's documented b==0 sentinel: 0, not a raise
+                # (there is no per-element device-side raise) and not
+                # whatever sign-dependent value the correction step would
+                # otherwise produce. See `_binary_bcast`'s CPU-only
+                # zero-divisor check for the platforms that DO raise
+                # (matching stock CPU); this 0 is what every OTHER dispatch
+                # tier (GPU) returns instead, by documented convention, not
+                # accident -- stock CUDA's own int-div-by-zero sentinel is
+                # likewise platform-defined, not something a raise-free
+                # kernel is expected to reproduce bit-for-bit.
                 var q = a // b
                 var r = a - q * b
                 var zero = SIMD[dtype, width](0)
+                var not_zero = b.ne(zero)
                 var opposite_signs = a.lt(zero) ^ b.lt(zero)
-                var needs_adjust = opposite_signs & r.ne(zero)
+                var needs_adjust = opposite_signs & r.ne(zero) & not_zero
                 return needs_adjust.select(q + 1, q).cast[out_dtype]()
         comptime if op_code == BOP_POW:
             # Float only (gated at the launcher); accumulate halves in
@@ -609,6 +632,37 @@ def _binary_bcast[
             var r_ptr = _make_ptr[dtype](r_addr)
 
             if ctx.api() == "cpu":
+                comptime if (
+                    not is_cmp
+                    and (op_code == BOP_FLOORDIV or op_code == BOP_TRUNCDIV)
+                    and not dtype.is_floating_point()
+                ):
+                    # Stock CPU raises for integer div-by-zero
+                    # (`TORCH_CHECK(b != 0, "ZeroDivisionError")` in
+                    # BinaryOpsKernel.cpp); Mojo's `pop.floordiv` has its
+                    # own zero-guard instead (see BOP_FLOORDIV/BOP_TRUNCDIV
+                    # above), silently substituting a documented 0 rather
+                    # than trapping. This CPU dispatch path's divisor
+                    # buffer is real, host-addressable memory -- no device
+                    # sync needed to read it -- so scan it up front and
+                    # raise before doing any work, matching stock's CPU
+                    # behavior exactly instead of returning the
+                    # documented-but-still-wrong 0 sentinel that GPU
+                    # dispatch (which cannot cheaply raise from device
+                    # code, and settles for a plain documented 0 instead)
+                    # returns.
+                    for i in range(total):
+                        var i3 = i % d3
+                        var rest = i // d3
+                        var i2 = rest % d2
+                        rest = rest // d2
+                        var i1 = rest % d1
+                        var i0 = rest // d1
+                        if (
+                            r_ptr[i0 * rs0 + i1 * rs1 + i2 * rs2 + i3 * rs3]
+                            == 0
+                        ):
+                            raise Error("ZeroDivisionError")
 
                 @always_inline
                 @parameter

--- a/torch_mojo_backend/mojo_device/aten_ops/support.py
+++ b/torch_mojo_backend/mojo_device/aten_ops/support.py
@@ -136,7 +136,26 @@ def _copy_into_tensor(dst: TorchMojoTensor, src: TorchMojoTensor) -> None:
     """dst[...] = src[...] with dtype cast + broadcast, any strides."""
     aten_fast = _fast()
     if src._dtype != dst._dtype:
-        src = aten_fast._cast_tensor(src, dst._dtype)
+        if (
+            src._dtype in aten_fast._CAST_DTYPES
+            and dst._dtype in aten_fast._CAST_DTYPES
+        ):
+            src = aten_fast._cast_tensor(src, dst._dtype)
+        else:
+            # Neither the fast CastSpec kernel family's dtype list nor this
+            # helper's callers agree with torch's own `can_cast` rules --
+            # an `out=` dtype policy of "safe_cast" (e.g. div.out_mode)
+            # accepts any torch-legal pair (int32 -> float64 is legal), but
+            # _CAST_DTYPES deliberately excludes float64 (and the narrow
+            # ints) from the device cast kernels. Rather than growing that
+            # kernel matrix for a rare `out=` dtype, round-trip through the
+            # host and real torch's own cast, which is correct for any
+            # dtype pair torch supports. This is the same `_to_cpu_tensor`
+            # drain other host-dependent ops already pay (see
+            # deferred_compile.py), just on the tail end of an `out=` copy
+            # instead of a value read.
+            host_cast = src._to_cpu_tensor().to(max_dtype_to_torch_dtype(dst._dtype))
+            src = TorchMojoTensor._from_cpu(host_cast, dst._device)
     if tuple(src._shape) != tuple(dst._shape):
         expanded = aten_fast.fast_aten_expand(src, dst._shape)
         if expanded is aten_fast.NOT_HANDLED:

--- a/torch_mojo_backend/mojo_device/aten_ops/support.py
+++ b/torch_mojo_backend/mojo_device/aten_ops/support.py
@@ -130,7 +130,26 @@ def _copy_into_tensor(dst: TorchMojoTensor, src: TorchMojoTensor):
     """dst[...] = src[...] with dtype cast + broadcast, any strides."""
     aten_fast = _fast()
     if src._dtype != dst._dtype:
-        src = aten_fast._cast_tensor(src, dst._dtype)
+        if (
+            src._dtype in aten_fast._CAST_DTYPES
+            and dst._dtype in aten_fast._CAST_DTYPES
+        ):
+            src = aten_fast._cast_tensor(src, dst._dtype)
+        else:
+            # Neither the fast CastSpec kernel family's dtype list nor this
+            # helper's callers agree with torch's own `can_cast` rules --
+            # an `out=` dtype policy of "safe_cast" (e.g. div.out_mode)
+            # accepts any torch-legal pair (int32 -> float64 is legal), but
+            # _CAST_DTYPES deliberately excludes float64 (and the narrow
+            # ints) from the device cast kernels. Rather than growing that
+            # kernel matrix for a rare `out=` dtype, round-trip through the
+            # host and real torch's own cast, which is correct for any
+            # dtype pair torch supports. This is the same `_to_cpu_tensor`
+            # drain other host-dependent ops already pay (see
+            # deferred_compile.py), just on the tail end of an `out=` copy
+            # instead of a value read.
+            host_cast = src._to_cpu_tensor().to(max_dtype_to_torch_dtype(dst._dtype))
+            src = TorchMojoTensor._from_cpu(host_cast, dst._device)
     if tuple(src._shape) != tuple(dst._shape):
         expanded = aten_fast.fast_aten_expand(src, dst._shape)
         if expanded is aten_fast.NOT_HANDLED:


### PR DESCRIPTION
## Summary

Follow-up to #402 (merged). An adversarial review found three real bugs in
that PR's div rounding_mode support. This PR fixes all three.

### 1. bf16/fp16 scalar trunc division used the wrong precision path

`BOP_TRUNCDIV`'s "compute at native precision for tensor/tensor" rule is
correct (matches torch's own tensor/tensor trunc kernel), but it was being
applied unconditionally — including to a **scalar** divisor. Torch's own
kernels take a separate fp32-upcast fast path whenever the divisor is
scalar-shaped (CPU's `is_scalar(2)`, CUDA's `is_cpu_scalar(2)`), which
includes a genuine one-element tensor, not just a Python number:

```python
torch.div(torch.tensor([-6.3125], dtype=torch.bfloat16), -1.0547, rounding_mode="trunc")
```

Stock returns `[5.0]`; this returned `[6.0]`. Fixed at the Python level
(`fast_aten_div` / new `_is_div_other_scalar_like` helper): a scalar-shaped
divisor now casts both operands to fp32 before the kernel runs and casts
the result back. The already-verified native-precision tensor/tensor path
(multi-element divisor) is untouched.

### 2. Integer division by zero returned garbage, no raise anywhere

`floor` returned `0`; `trunc` returned `0` or `1` depending on the
numerator's sign (a side effect of the sign-correction step). Stock CPU
raises `RuntimeError: ZeroDivisionError`. Fixed per dispatch tier:

- CPU: `_binary_bcast`'s CPU path is real, host-addressable memory — no
  device sync needed to inspect it — so it now scans the divisor up front
  and raises before doing any work. Re-raised in Python as the same
  `RuntimeError`/message stock uses, via `_raise_if_device_oom` (already
  the checkpoint for "this exception must propagate, not decline" — it
  gained a second case).
- GPU: can't cheaply raise from device code, so it keeps a sentinel — now
  a uniform, **documented** `0` for both floor and trunc (matching floor's
  existing zero-guard), instead of trunc's old sign-dependent leftover.
  Not stock CUDA's own sentinel, which this device doesn't attempt to
  reproduce (per-device stock CUDA sentinels are themselves
  platform-specific, not something a raise-free kernel is expected to
  match bit-for-bit).

### 3. `div.out_mode` rejected a legal out= dtype

```python
x = torch.tensor([7, -7], dtype=torch.int32)
y = torch.tensor([2, 2], dtype=torch.int32)
out = torch.empty(2, dtype=torch.float64)
torch.div(x, y, rounding_mode="trunc", out=out)  # stock: succeeds, [3.0, -3.0]
```

raised `NotImplementedError: mojo spec cast into: unsupported dtype pair`
here. `_out_variant`'s `"safe_cast"` policy checks torch's own `can_cast`
rules, which are broader than `_CAST_DTYPES` (the fast CastSpec kernel
family deliberately excludes float64 and the narrow int types). Fixed in
the **shared** `_copy_into_tensor` helper — used by every `_register_out`
op, not just div — so this benefits any other out= variant with the same
latent gap: when either dtype falls outside `_CAST_DTYPES`, round-trip
through the host via real torch's own cast instead of the device kernel.
Correct for any dtype pair torch supports; only this rare case pays the
drain.

## Test plan

All of Codex's exact repros, as regression tests in
`tests/test_eager_kernels.py`, on both `cpu` and `gpu` mojo targets where
applicable:

- [x] `flock /tmp/gpu_lock_0.lock uv run pytest tests/test_eager_kernels.py -k div -v`
      — 50 passed on H100 (includes the 3 new bug-specific tests plus every
      pre-existing div/floor_divide test, unaffected).
- [x] `flock /tmp/gpu_lock_0.lock uv run pytest tests/test_eager_kernels.py -k "cast or oom or floor_divide or remainder or div or addcdiv or addcmul or mean_out or isin or copy_into" -q`
      — 150 passed (sweep of every other path `_copy_into_tensor`/
      `_raise_if_device_oom` touches, since both are shared helpers).
- [x] `uv run pytest tests/test_aten_functions.py -k div -q` — 17 passed
      (`mojo:cpu` eager vs CPU reference; 6 pre-existing, unrelated
      float64 xfails).
- [x] `uvx pre-commit run --all-files` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Co2wBC1UYzM4y9PEC92Af