### PR TITLE
Fix compare_kernel_asm.py: collect() drops instantiations sharing a name

### DIFF
--- a/scripts/compare_kernel_asm.py
+++ b/scripts/compare_kernel_asm.py
@@ -75,6 +75,7 @@ import sys
 import textwrap
 import threading
 import uuid
+from collections import Counter
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
@@ -412,6 +413,104 @@ def print_diff(kernel: str, before: str, after: str) -> None:
     )
 
 
+def residual_bodies(before: list[str], after: list[str]) -> tuple[list[str], list[str]]:
+    """Multiset difference between two instantiation lists sharing one
+    stripped name.
+
+    Identical bodies cancel regardless of position or count: `Counter`
+    subtraction removes exactly as many copies of a body as appear on the
+    other side, so a body present twice on both sides cancels completely,
+    one present three times on one side and once on the other leaves two
+    residual copies, and so on. A positional zip of the two SORTED lists
+    (an earlier, wrong version of this function) instead pairs whichever
+    bodies happen to land at the same sorted index once a multiplicity
+    differs -- e.g. before=[A,B,C], after=[B,C,Z] zips to (A,B) (B,C) (C,Z),
+    reporting three changes for what is really one replacement (A -> Z) --
+    or, when the group only grew or shrank, reports the whole group as
+    changed instead of the true added/removed delta (before=[A,B],
+    after=[A,B,C] zips to (A,A) (B,B), silently dropping C rather than
+    reporting it as new). What's left after cancellation, sorted on each
+    side, is what the caller should treat as a real difference.
+    """
+    before_counter = Counter(before)
+    after_counter = Counter(after)
+    return (
+        sorted((before_counter - after_counter).elements()),
+        sorted((after_counter - before_counter).elements()),
+    )
+
+
+@dataclass(frozen=True)
+class KernelDelta:
+    """One stripped name's multiset delta between before and after.
+
+    `changed`/`added`/`removed` are body counts, not name counts -- see
+    collect()'s docstring for why one name can carry more than one body.
+    `residual_before`/`residual_after` are what's left of each side after
+    identical bodies cancel (sorted); the first `changed` entries of each
+    are a same-length pair-up used for display, any excess on the `after`
+    side is purely new, any excess on the `before` side is purely gone.
+    """
+
+    name: str
+    changed: int
+    added: int
+    removed: int
+    residual_before: list[str]
+    residual_after: list[str]
+
+
+def diff_names(
+    before: dict[str, list[str]], after: dict[str, list[str]]
+) -> list[KernelDelta]:
+    """Per-name multiset deltas for every name present on both sides that
+    genuinely differs.
+
+    A name entirely missing from one side is NOT covered here -- the caller
+    already has a fast, exact path for a whole name being added or removed
+    (see main()); this only concerns names that exist on both sides but
+    whose instantiations differ.
+    """
+    deltas = []
+    for name in sorted(before.keys() & after.keys()):
+        residual_before, residual_after = residual_bodies(before[name], after[name])
+        if not residual_before and not residual_after:
+            continue
+        paired = min(len(residual_before), len(residual_after))
+        deltas.append(
+            KernelDelta(
+                name,
+                changed=paired,
+                added=len(residual_after) - paired,
+                removed=len(residual_before) - paired,
+                residual_before=residual_before,
+                residual_after=residual_after,
+            )
+        )
+    return deltas
+
+
+def print_kernel_delta(label: str, delta: KernelDelta) -> None:
+    """--show-diff detail for one changed name: a header when the
+    instantiation count itself moved, then a unified diff per paired
+    residual (the excess residual on either side has no partner to diff
+    against and is only reflected in the header's added/removed counts).
+    """
+    paired = min(len(delta.residual_before), len(delta.residual_after))
+    if len(delta.residual_before) != len(delta.residual_after):
+        print(
+            f"\n{label}: {delta.changed} replaced, {delta.added} added, "
+            f"{delta.removed} removed (after canceling identical "
+            "instantiations)"
+        )
+    for index in range(paired):
+        print_diff(
+            f"{label}[{index}]",
+            delta.residual_before[index],
+            delta.residual_after[index],
+        )
+
+
 def default_jobs() -> int:
     """Concurrent `mojo build` subprocesses.
 
@@ -742,47 +841,23 @@ def main() -> int:
                 counts["added"] += after_count
                 counts["removed"] += before_count
                 continue
-            # Multiset compare per name: sort each side's instantiations so
-            # order (which depends on mangling-hash sort order, not on
-            # anything meaningful) cannot make an unchanged set of bodies
-            # read as different.
-            changed = sorted(
-                name
-                for name in before.keys() & after.keys()
-                if sorted(before[name]) != sorted(after[name])
-            )
-            # Weight a changed name by the larger side's instantiation count,
-            # so a name whose instantiation count itself changed (an
-            # instantiation added or dropped under an existing name) is not
-            # under-counted relative to added/removed's own file counts.
-            counts["changed"] += sum(
-                max(len(before[name]), len(after[name])) for name in changed
-            )
-            counts["added"] += sum(
+            # Multiset compare per name: identical bodies cancel regardless
+            # of position or count (see residual_bodies()), so a name whose
+            # instantiation count changed reports as added/removed, not as
+            # every member of the group changing, and a single replacement
+            # inside a larger group reports as one change, not the whole
+            # group.
+            deltas = diff_names(before, after)
+            counts["changed"] += sum(delta.changed for delta in deltas)
+            counts["added"] += sum(delta.added for delta in deltas) + sum(
                 len(after[name]) for name in after.keys() - before.keys()
             )
-            counts["removed"] += sum(
+            counts["removed"] += sum(delta.removed for delta in deltas) + sum(
                 len(before[name]) for name in before.keys() - after.keys()
             )
-            changed_names += [f"{variant.label}/{name}" for name in changed]
-            for name in changed if args.show_diff else []:
-                before_asms, after_asms = sorted(before[name]), sorted(after[name])
-                if len(before_asms) != len(after_asms):
-                    print(
-                        f"\n{plan.stem}/{variant.label}/{name}: instantiation "
-                        f"count {len(before_asms)} -> {len(after_asms)} "
-                        "(before/after; sorted bodies below are paired by "
-                        "position up to the shorter side only)"
-                    )
-                for index, (one_before, one_after) in enumerate(
-                    zip(before_asms, after_asms)
-                ):
-                    if one_before != one_after:
-                        print_diff(
-                            f"{plan.stem}/{variant.label}/{name}[{index}]",
-                            one_before,
-                            one_after,
-                        )
+            changed_names += [f"{variant.label}/{delta.name}" for delta in deltas]
+            for delta in deltas if args.show_diff else []:
+                print_kernel_delta(f"{plan.stem}/{variant.label}/{delta.name}", delta)
 
         total_changed += counts["changed"] + counts["added"] + counts["removed"]
         if broken:

--- a/scripts/compare_kernel_asm.py
+++ b/scripts/compare_kernel_asm.py
@@ -367,12 +367,32 @@ def plan_module(
     return ModulePlan(stem, modules, merged, variants, notes)
 
 
-def collect(out_dir: Path) -> dict[str, str]:
-    """Map each kernel's hash-stripped name to its hash-masked assembly."""
-    kernels = {}
+def collect(out_dir: Path) -> dict[str, list[str]]:
+    """Map each kernel's hash-stripped name to every hash-masked assembly
+    sharing that name.
+
+    A stripped name is not unique within one build: several comptime
+    instantiations of one generically-named function (different tile sizes,
+    stage counts, or in this repo's case different `col_a`/`kmaj_b` layout
+    parameters sharing one base symbol) can all reduce to the same name once
+    HASH_RE removes the part of the mangled symbol that told them apart.
+    Keying a plain `dict[str, str]` on that name overwrote every instantiation
+    but the last one `sorted(out_dir.iterdir())` produced -- which one
+    survived depended on mangling-hash sort order, not on anything meaningful
+    -- and then compared whichever survivor "before" happened to keep against
+    whichever survivor "after" happened to keep, which need not be the same
+    instantiation. That produced false "changed" reports on any module with
+    more than one instantiation per base name (confirmed on this repo's bmm
+    module: 10 false changes with the dict, 0 with the multiset below).
+    Collecting every instantiation into a list, compared as a multiset by the
+    caller (order-independent: sort before comparing), fixes this without
+    losing the hash-masking that makes an unrelated rename compare equal.
+    """
+    kernels: dict[str, list[str]] = {}
     for path in sorted(out_dir.iterdir()):
         if path.suffix in SIDECAR_SUFFIXES:
-            kernels[HASH_RE.sub("", path.stem)] = HASH_RE.sub("_HASH", path.read_text())
+            name = HASH_RE.sub("", path.stem)
+            kernels.setdefault(name, []).append(HASH_RE.sub("_HASH", path.read_text()))
     return kernels
 
 
@@ -543,7 +563,7 @@ def build_plans(args: argparse.Namespace) -> list[ModulePlan]:
 
 def build_both_sides(
     args: argparse.Namespace, trees: dict[str, Path], plan: ModulePlan, variant: Variant
-) -> tuple[dict[str, dict[str, str]], dict[str, str]]:
+) -> tuple[dict[str, dict[str, list[str]]], dict[str, str]]:
     """Build one specialization on every side it exists, and read its kernels.
 
     Both sides are built one after the other **into the same directory**, which
@@ -558,7 +578,7 @@ def build_both_sides(
     miss; the sidecars are read into memory and the directory is emptied between
     sides so nothing of the first side can be mistaken for the second's.
     """
-    kernels: dict[str, dict[str, str]] = {}
+    kernels: dict[str, dict[str, list[str]]] = {}
     errors: dict[str, str] = {}
     out_dir = args.work_dir / plan.stem / variant.label
     for side in plan.modules:
@@ -598,11 +618,13 @@ def build_both_sides(
 
 def run_builds(
     args: argparse.Namespace, plans: list[ModulePlan]
-) -> tuple[dict[tuple[str, str, str], dict[str, str]], dict[tuple[str, str, str], str]]:
+) -> tuple[
+    dict[tuple[str, str, str], dict[str, list[str]]], dict[tuple[str, str, str], str]
+]:
     """Build every (module, variant) in parallel; return kernels and errors."""
     trees = {"before": args.before, "after": args.after}
     jobs = [(plan, variant) for plan in plans for variant in plan.variants]
-    kernels: dict[tuple[str, str, str], dict[str, str]] = {}
+    kernels: dict[tuple[str, str, str], dict[str, list[str]]] = {}
     errors: dict[tuple[str, str, str], str] = {}
     lock = threading.Lock()
     done = 0
@@ -618,7 +640,12 @@ def run_builds(
             for side, error in failures.items():
                 errors[(side, plan.stem, variant.label)] = error
             if not args.quiet:
-                counts = [f"{side} {len(found)}" for side, found in built.items()]
+                # Total sidecar count, not the number of distinct names: a
+                # name can carry more than one instantiation (see collect()).
+                counts = [
+                    f"{side} {sum(len(asms) for asms in found.values())}"
+                    for side, found in built.items()
+                ]
                 counts += [f"{side} FAILED" for side in failures]
                 print(
                     f"[{done:>4}/{len(jobs)}] {plan.stem}/{variant.label}"
@@ -700,29 +727,62 @@ def main() -> int:
                 continue
             before = sides.get("before", {})
             after = sides.get("after", {})
-            counts["kernels"] += len(after)
-            total_kernels += len(before) + len(after)
+            # File counts (total sidecars), not name counts: a name can carry
+            # more than one instantiation (see collect()), and every other
+            # count below is a file count too, so these stay comparable.
+            after_count = sum(len(asms) for asms in after.values())
+            before_count = sum(len(asms) for asms in before.values())
+            counts["kernels"] += after_count
+            total_kernels += before_count + after_count
             if not before and not after:
                 empty.append(f"{plan.stem}/{variant.label}")
                 continue
             if "before" not in sides or "after" not in sides:
                 # Added or removed module: every kernel of it is new or gone.
-                counts["added"] += len(after)
-                counts["removed"] += len(before)
+                counts["added"] += after_count
+                counts["removed"] += before_count
                 continue
+            # Multiset compare per name: sort each side's instantiations so
+            # order (which depends on mangling-hash sort order, not on
+            # anything meaningful) cannot make an unchanged set of bodies
+            # read as different.
             changed = sorted(
                 name
                 for name in before.keys() & after.keys()
-                if before[name] != after[name]
+                if sorted(before[name]) != sorted(after[name])
             )
-            counts["changed"] += len(changed)
-            counts["added"] += len(after.keys() - before.keys())
-            counts["removed"] += len(before.keys() - after.keys())
+            # Weight a changed name by the larger side's instantiation count,
+            # so a name whose instantiation count itself changed (an
+            # instantiation added or dropped under an existing name) is not
+            # under-counted relative to added/removed's own file counts.
+            counts["changed"] += sum(
+                max(len(before[name]), len(after[name])) for name in changed
+            )
+            counts["added"] += sum(
+                len(after[name]) for name in after.keys() - before.keys()
+            )
+            counts["removed"] += sum(
+                len(before[name]) for name in before.keys() - after.keys()
+            )
             changed_names += [f"{variant.label}/{name}" for name in changed]
             for name in changed if args.show_diff else []:
-                print_diff(
-                    f"{plan.stem}/{variant.label}/{name}", before[name], after[name]
-                )
+                before_asms, after_asms = sorted(before[name]), sorted(after[name])
+                if len(before_asms) != len(after_asms):
+                    print(
+                        f"\n{plan.stem}/{variant.label}/{name}: instantiation "
+                        f"count {len(before_asms)} -> {len(after_asms)} "
+                        "(before/after; sorted bodies below are paired by "
+                        "position up to the shorter side only)"
+                    )
+                for index, (one_before, one_after) in enumerate(
+                    zip(before_asms, after_asms)
+                ):
+                    if one_before != one_after:
+                        print_diff(
+                            f"{plan.stem}/{variant.label}/{name}[{index}]",
+                            one_before,
+                            one_after,
+                        )
 
         total_changed += counts["changed"] + counts["added"] + counts["removed"]
         if broken:

--- a/scripts/compare_kernel_asm.py
+++ b/scripts/compare_kernel_asm.py
@@ -75,6 +75,7 @@ import sys
 import textwrap
 import threading
 import uuid
+from collections import Counter
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
@@ -417,6 +418,104 @@ def print_diff(kernel: str, before: str, after: str):
     )
 
 
+def residual_bodies(before: list[str], after: list[str]) -> tuple[list[str], list[str]]:
+    """Multiset difference between two instantiation lists sharing one
+    stripped name.
+
+    Identical bodies cancel regardless of position or count: `Counter`
+    subtraction removes exactly as many copies of a body as appear on the
+    other side, so a body present twice on both sides cancels completely,
+    one present three times on one side and once on the other leaves two
+    residual copies, and so on. A positional zip of the two SORTED lists
+    (an earlier, wrong version of this function) instead pairs whichever
+    bodies happen to land at the same sorted index once a multiplicity
+    differs -- e.g. before=[A,B,C], after=[B,C,Z] zips to (A,B) (B,C) (C,Z),
+    reporting three changes for what is really one replacement (A -> Z) --
+    or, when the group only grew or shrank, reports the whole group as
+    changed instead of the true added/removed delta (before=[A,B],
+    after=[A,B,C] zips to (A,A) (B,B), silently dropping C rather than
+    reporting it as new). What's left after cancellation, sorted on each
+    side, is what the caller should treat as a real difference.
+    """
+    before_counter = Counter(before)
+    after_counter = Counter(after)
+    return (
+        sorted((before_counter - after_counter).elements()),
+        sorted((after_counter - before_counter).elements()),
+    )
+
+
+@dataclass(frozen=True)
+class KernelDelta:
+    """One stripped name's multiset delta between before and after.
+
+    `changed`/`added`/`removed` are body counts, not name counts -- see
+    collect()'s docstring for why one name can carry more than one body.
+    `residual_before`/`residual_after` are what's left of each side after
+    identical bodies cancel (sorted); the first `changed` entries of each
+    are a same-length pair-up used for display, any excess on the `after`
+    side is purely new, any excess on the `before` side is purely gone.
+    """
+
+    name: str
+    changed: int
+    added: int
+    removed: int
+    residual_before: list[str]
+    residual_after: list[str]
+
+
+def diff_names(
+    before: dict[str, list[str]], after: dict[str, list[str]]
+) -> list[KernelDelta]:
+    """Per-name multiset deltas for every name present on both sides that
+    genuinely differs.
+
+    A name entirely missing from one side is NOT covered here -- the caller
+    already has a fast, exact path for a whole name being added or removed
+    (see main()); this only concerns names that exist on both sides but
+    whose instantiations differ.
+    """
+    deltas = []
+    for name in sorted(before.keys() & after.keys()):
+        residual_before, residual_after = residual_bodies(before[name], after[name])
+        if not residual_before and not residual_after:
+            continue
+        paired = min(len(residual_before), len(residual_after))
+        deltas.append(
+            KernelDelta(
+                name,
+                changed=paired,
+                added=len(residual_after) - paired,
+                removed=len(residual_before) - paired,
+                residual_before=residual_before,
+                residual_after=residual_after,
+            )
+        )
+    return deltas
+
+
+def print_kernel_delta(label: str, delta: KernelDelta) -> None:
+    """--show-diff detail for one changed name: a header when the
+    instantiation count itself moved, then a unified diff per paired
+    residual (the excess residual on either side has no partner to diff
+    against and is only reflected in the header's added/removed counts).
+    """
+    paired = min(len(delta.residual_before), len(delta.residual_after))
+    if len(delta.residual_before) != len(delta.residual_after):
+        print(
+            f"\n{label}: {delta.changed} replaced, {delta.added} added, "
+            f"{delta.removed} removed (after canceling identical "
+            "instantiations)"
+        )
+    for index in range(paired):
+        print_diff(
+            f"{label}[{index}]",
+            delta.residual_before[index],
+            delta.residual_after[index],
+        )
+
+
 def default_jobs() -> int:
     """Concurrent `mojo build` subprocesses.
 
@@ -747,47 +846,23 @@ def main() -> int:
                 counts["added"] += after_count
                 counts["removed"] += before_count
                 continue
-            # Multiset compare per name: sort each side's instantiations so
-            # order (which depends on mangling-hash sort order, not on
-            # anything meaningful) cannot make an unchanged set of bodies
-            # read as different.
-            changed = sorted(
-                name
-                for name in before.keys() & after.keys()
-                if sorted(before[name]) != sorted(after[name])
-            )
-            # Weight a changed name by the larger side's instantiation count,
-            # so a name whose instantiation count itself changed (an
-            # instantiation added or dropped under an existing name) is not
-            # under-counted relative to added/removed's own file counts.
-            counts["changed"] += sum(
-                max(len(before[name]), len(after[name])) for name in changed
-            )
-            counts["added"] += sum(
+            # Multiset compare per name: identical bodies cancel regardless
+            # of position or count (see residual_bodies()), so a name whose
+            # instantiation count changed reports as added/removed, not as
+            # every member of the group changing, and a single replacement
+            # inside a larger group reports as one change, not the whole
+            # group.
+            deltas = diff_names(before, after)
+            counts["changed"] += sum(delta.changed for delta in deltas)
+            counts["added"] += sum(delta.added for delta in deltas) + sum(
                 len(after[name]) for name in after.keys() - before.keys()
             )
-            counts["removed"] += sum(
+            counts["removed"] += sum(delta.removed for delta in deltas) + sum(
                 len(before[name]) for name in before.keys() - after.keys()
             )
-            changed_names += [f"{variant.label}/{name}" for name in changed]
-            for name in changed if args.show_diff else []:
-                before_asms, after_asms = sorted(before[name]), sorted(after[name])
-                if len(before_asms) != len(after_asms):
-                    print(
-                        f"\n{plan.stem}/{variant.label}/{name}: instantiation "
-                        f"count {len(before_asms)} -> {len(after_asms)} "
-                        "(before/after; sorted bodies below are paired by "
-                        "position up to the shorter side only)"
-                    )
-                for index, (one_before, one_after) in enumerate(
-                    zip(before_asms, after_asms)
-                ):
-                    if one_before != one_after:
-                        print_diff(
-                            f"{plan.stem}/{variant.label}/{name}[{index}]",
-                            one_before,
-                            one_after,
-                        )
+            changed_names += [f"{variant.label}/{delta.name}" for delta in deltas]
+            for delta in deltas if args.show_diff else []:
+                print_kernel_delta(f"{plan.stem}/{variant.label}/{delta.name}", delta)
 
         total_changed += counts["changed"] + counts["added"] + counts["removed"]
         if broken:

--- a/scripts/compare_kernel_asm.py
+++ b/scripts/compare_kernel_asm.py
@@ -372,12 +372,32 @@ def plan_module(
     return ModulePlan(stem, modules, merged, variants, notes)
 
 
-def collect(out_dir: Path) -> dict[str, str]:
-    """Map each kernel's hash-stripped name to its hash-masked assembly."""
-    kernels = {}
+def collect(out_dir: Path) -> dict[str, list[str]]:
+    """Map each kernel's hash-stripped name to every hash-masked assembly
+    sharing that name.
+
+    A stripped name is not unique within one build: several comptime
+    instantiations of one generically-named function (different tile sizes,
+    stage counts, or in this repo's case different `col_a`/`kmaj_b` layout
+    parameters sharing one base symbol) can all reduce to the same name once
+    HASH_RE removes the part of the mangled symbol that told them apart.
+    Keying a plain `dict[str, str]` on that name overwrote every instantiation
+    but the last one `sorted(out_dir.iterdir())` produced -- which one
+    survived depended on mangling-hash sort order, not on anything meaningful
+    -- and then compared whichever survivor "before" happened to keep against
+    whichever survivor "after" happened to keep, which need not be the same
+    instantiation. That produced false "changed" reports on any module with
+    more than one instantiation per base name (confirmed on this repo's bmm
+    module: 10 false changes with the dict, 0 with the multiset below).
+    Collecting every instantiation into a list, compared as a multiset by the
+    caller (order-independent: sort before comparing), fixes this without
+    losing the hash-masking that makes an unrelated rename compare equal.
+    """
+    kernels: dict[str, list[str]] = {}
     for path in sorted(out_dir.iterdir()):
         if path.suffix in SIDECAR_SUFFIXES:
-            kernels[HASH_RE.sub("", path.stem)] = HASH_RE.sub("_HASH", path.read_text())
+            name = HASH_RE.sub("", path.stem)
+            kernels.setdefault(name, []).append(HASH_RE.sub("_HASH", path.read_text()))
     return kernels
 
 
@@ -548,7 +568,7 @@ def build_plans(args: argparse.Namespace) -> list[ModulePlan]:
 
 def build_both_sides(
     args: argparse.Namespace, trees: dict[str, Path], plan: ModulePlan, variant: Variant
-) -> tuple[dict[str, dict[str, str]], dict[str, str]]:
+) -> tuple[dict[str, dict[str, list[str]]], dict[str, str]]:
     """Build one specialization on every side it exists, and read its kernels.
 
     Both sides are built one after the other **into the same directory**, which
@@ -563,7 +583,7 @@ def build_both_sides(
     miss; the sidecars are read into memory and the directory is emptied between
     sides so nothing of the first side can be mistaken for the second's.
     """
-    kernels: dict[str, dict[str, str]] = {}
+    kernels: dict[str, dict[str, list[str]]] = {}
     errors: dict[str, str] = {}
     out_dir = args.work_dir / plan.stem / variant.label
     for side in plan.modules:
@@ -603,11 +623,13 @@ def build_both_sides(
 
 def run_builds(
     args: argparse.Namespace, plans: list[ModulePlan]
-) -> tuple[dict[tuple[str, str, str], dict[str, str]], dict[tuple[str, str, str], str]]:
+) -> tuple[
+    dict[tuple[str, str, str], dict[str, list[str]]], dict[tuple[str, str, str], str]
+]:
     """Build every (module, variant) in parallel; return kernels and errors."""
     trees = {"before": args.before, "after": args.after}
     jobs = [(plan, variant) for plan in plans for variant in plan.variants]
-    kernels: dict[tuple[str, str, str], dict[str, str]] = {}
+    kernels: dict[tuple[str, str, str], dict[str, list[str]]] = {}
     errors: dict[tuple[str, str, str], str] = {}
     lock = threading.Lock()
     done = 0
@@ -623,7 +645,12 @@ def run_builds(
             for side, error in failures.items():
                 errors[(side, plan.stem, variant.label)] = error
             if not args.quiet:
-                counts = [f"{side} {len(found)}" for side, found in built.items()]
+                # Total sidecar count, not the number of distinct names: a
+                # name can carry more than one instantiation (see collect()).
+                counts = [
+                    f"{side} {sum(len(asms) for asms in found.values())}"
+                    for side, found in built.items()
+                ]
                 counts += [f"{side} FAILED" for side in failures]
                 print(
                     f"[{done:>4}/{len(jobs)}] {plan.stem}/{variant.label}"
@@ -705,29 +732,62 @@ def main() -> int:
                 continue
             before = sides.get("before", {})
             after = sides.get("after", {})
-            counts["kernels"] += len(after)
-            total_kernels += len(before) + len(after)
+            # File counts (total sidecars), not name counts: a name can carry
+            # more than one instantiation (see collect()), and every other
+            # count below is a file count too, so these stay comparable.
+            after_count = sum(len(asms) for asms in after.values())
+            before_count = sum(len(asms) for asms in before.values())
+            counts["kernels"] += after_count
+            total_kernels += before_count + after_count
             if not before and not after:
                 empty.append(f"{plan.stem}/{variant.label}")
                 continue
             if "before" not in sides or "after" not in sides:
                 # Added or removed module: every kernel of it is new or gone.
-                counts["added"] += len(after)
-                counts["removed"] += len(before)
+                counts["added"] += after_count
+                counts["removed"] += before_count
                 continue
+            # Multiset compare per name: sort each side's instantiations so
+            # order (which depends on mangling-hash sort order, not on
+            # anything meaningful) cannot make an unchanged set of bodies
+            # read as different.
             changed = sorted(
                 name
                 for name in before.keys() & after.keys()
-                if before[name] != after[name]
+                if sorted(before[name]) != sorted(after[name])
             )
-            counts["changed"] += len(changed)
-            counts["added"] += len(after.keys() - before.keys())
-            counts["removed"] += len(before.keys() - after.keys())
+            # Weight a changed name by the larger side's instantiation count,
+            # so a name whose instantiation count itself changed (an
+            # instantiation added or dropped under an existing name) is not
+            # under-counted relative to added/removed's own file counts.
+            counts["changed"] += sum(
+                max(len(before[name]), len(after[name])) for name in changed
+            )
+            counts["added"] += sum(
+                len(after[name]) for name in after.keys() - before.keys()
+            )
+            counts["removed"] += sum(
+                len(before[name]) for name in before.keys() - after.keys()
+            )
             changed_names += [f"{variant.label}/{name}" for name in changed]
             for name in changed if args.show_diff else []:
-                print_diff(
-                    f"{plan.stem}/{variant.label}/{name}", before[name], after[name]
-                )
+                before_asms, after_asms = sorted(before[name]), sorted(after[name])
+                if len(before_asms) != len(after_asms):
+                    print(
+                        f"\n{plan.stem}/{variant.label}/{name}: instantiation "
+                        f"count {len(before_asms)} -> {len(after_asms)} "
+                        "(before/after; sorted bodies below are paired by "
+                        "position up to the shorter side only)"
+                    )
+                for index, (one_before, one_after) in enumerate(
+                    zip(before_asms, after_asms)
+                ):
+                    if one_before != one_after:
+                        print_diff(
+                            f"{plan.stem}/{variant.label}/{name}[{index}]",
+                            one_before,
+                            one_after,
+                        )
 
         total_changed += counts["changed"] + counts["added"] + counts["removed"]
         if broken:

--- a/tests/test_compare_kernel_asm_multiset.py
+++ b/tests/test_compare_kernel_asm_multiset.py
@@ -22,7 +22,16 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from scripts.compare_kernel_asm import HASH_RE, collect
+import pytest
+
+from scripts.compare_kernel_asm import (
+    HASH_RE,
+    KernelDelta,
+    collect,
+    diff_names,
+    print_kernel_delta,
+    residual_bodies,
+)
 
 
 def _write_ptx(directory: Path, stem: str, hexhash: str, body: str) -> None:
@@ -119,3 +128,142 @@ def test_naive_single_value_dict_would_falsely_report_a_change(tmp_path: Path) -
     before = collect(before_dir)
     after = collect(after_dir)
     assert sorted(before["mod_gemm_persistent"]) == sorted(after["mod_gemm_persistent"])
+
+
+# ---------------------------------------------------------------------------
+# Aggregation/reporting path: residual_bodies(), diff_names(), and
+# print_kernel_delta(). collect() returning every instantiation under a name
+# (tested above) is necessary but not sufficient -- main() still has to turn
+# "before"/"after" instantiation lists into correct changed/added/removed
+# counts and a correct --show-diff pairing. A positional zip of the two
+# SORTED lists (an earlier, wrong version of this) pairs whichever bodies
+# land at the same sorted index once a multiplicity differs, which is wrong
+# whenever a duplicate-name group genuinely changes rather than merely being
+# unchanged-but-reordered. These tests cover that path directly.
+# ---------------------------------------------------------------------------
+
+
+def test_residual_bodies_one_replacement_inside_a_group() -> None:
+    """before=[A,B,C], after=[B,C,Z]: B and C cancel, only A/Z are residual.
+
+    A positional zip of the sorted lists would pair (A,B) (B,C) (C,Z) and
+    report three changes for what is really one replacement.
+    """
+    residual_before, residual_after = residual_bodies(["A", "B", "C"], ["B", "C", "Z"])
+    assert residual_before == ["A"]
+    assert residual_after == ["Z"]
+
+
+def test_residual_bodies_multiplicity_growth() -> None:
+    """before=[A,B], after=[A,B,C]: nothing changed, C is purely new."""
+    residual_before, residual_after = residual_bodies(["A", "B"], ["A", "B", "C"])
+    assert residual_before == []
+    assert residual_after == ["C"]
+
+
+def test_residual_bodies_multiplicity_shrink() -> None:
+    """before=[A,B,C], after=[A,B]: nothing changed, C is purely gone."""
+    residual_before, residual_after = residual_bodies(["A", "B", "C"], ["A", "B"])
+    assert residual_before == ["C"]
+    assert residual_after == []
+
+
+def test_residual_bodies_duplicate_bodies_cancel_by_count() -> None:
+    """Two copies of A on each side fully cancel; only the extra copy of A
+    on the "after" side, and B's replacement by C, are residual."""
+    residual_before, residual_after = residual_bodies(
+        ["A", "A", "B"], ["A", "A", "A", "C"]
+    )
+    assert residual_before == ["B"]
+    assert residual_after == ["A", "C"]
+
+
+def test_diff_names_reports_added_not_changed_for_a_grown_group() -> None:
+    """Codex's exact regression case: before=[A,B], after=[A,B,C] must report
+    0 changed / +1 new for this name, not 3 changed / +0 new."""
+    before = {"mod_kernel": ["A", "B"]}
+    after = {"mod_kernel": ["A", "B", "C"]}
+    (delta,) = diff_names(before, after)
+    assert delta == KernelDelta(
+        "mod_kernel",
+        changed=0,
+        added=1,
+        removed=0,
+        residual_before=[],
+        residual_after=["C"],
+    )
+
+
+def test_diff_names_reports_one_change_for_one_replacement() -> None:
+    before = {"mod_kernel": ["A", "B", "C"]}
+    after = {"mod_kernel": ["B", "C", "Z"]}
+    (delta,) = diff_names(before, after)
+    assert delta.changed == 1
+    assert delta.added == 0
+    assert delta.removed == 0
+    assert delta.residual_before == ["A"]
+    assert delta.residual_after == ["Z"]
+
+
+def test_diff_names_reports_removed_for_a_shrunk_group() -> None:
+    before = {"mod_kernel": ["A", "B", "C"]}
+    after = {"mod_kernel": ["A", "B"]}
+    (delta,) = diff_names(before, after)
+    assert delta.changed == 0
+    assert delta.added == 0
+    assert delta.removed == 1
+
+
+def test_diff_names_skips_a_name_whose_multiset_is_unchanged() -> None:
+    """Reordered-only (mangling hash moved, bodies identical): no delta at
+    all, matching the fix's original purpose (order-independence)."""
+    before = {"mod_kernel": ["A", "B"]}
+    after = {"mod_kernel": ["B", "A"]}
+    assert diff_names(before, after) == []
+
+
+def test_diff_names_ignores_names_present_on_only_one_side() -> None:
+    """Whole-name add/remove is the caller's fast path (module-level added/
+    removed in main()), not diff_names()'s job."""
+    before = {"only_before": ["A"]}
+    after = {"only_after": ["Z"]}
+    assert diff_names(before, after) == []
+
+
+def test_show_diff_pairs_residuals_not_shifted_sorted_positions(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The --show-diff detail for a replacement must diff the actual
+    replaced pair (A -> Z), not a positional artifact of sorting the whole
+    group (which would show unrelated bodies B and C as "changed")."""
+    before = {"mod_kernel": ["A", "B", "C"]}
+    after = {"mod_kernel": ["B", "C", "Z"]}
+    (delta,) = diff_names(before, after)
+
+    print_kernel_delta("mod/variant/mod_kernel", delta)
+    out = capsys.readouterr().out
+
+    assert "before/mod/variant/mod_kernel[0]" in out
+    assert "after/mod/variant/mod_kernel[0]" in out
+    assert "-A" in out
+    assert "+Z" in out
+    # B and C canceled and must not appear as changed lines in the diff body.
+    assert "-B" not in out
+    assert "-C" not in out
+    assert "+B" not in out
+    assert "+C" not in out
+
+
+def test_show_diff_header_reports_counts_for_a_grown_group(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    before = {"mod_kernel": ["A", "B"]}
+    after = {"mod_kernel": ["A", "B", "C"]}
+    (delta,) = diff_names(before, after)
+
+    print_kernel_delta("mod/variant/mod_kernel", delta)
+    out = capsys.readouterr().out
+
+    assert "0 replaced, 1 added, 0 removed" in out
+    # Nothing to pair, so no unified-diff body -- just the header.
+    assert "@@" not in out

--- a/tests/test_compare_kernel_asm_multiset.py
+++ b/tests/test_compare_kernel_asm_multiset.py
@@ -1,0 +1,121 @@
+"""Regression test for scripts/compare_kernel_asm.py's collect() multiset fix.
+
+Pure Python, no GPU and no `mojo build` -- synthesizes the `.ptx` sidecar
+files a real cross-compile would leave in `--work-dir` and exercises
+`collect()` plus the multiset-compare semantics `main()` builds on top of it
+directly, in isolation.
+
+The bug: a hash-stripped kernel name is not unique within one build -- several
+comptime instantiations of one generically-named function (this repo's bmm
+kernel under its `col_a`/`kmaj_b` layout parameters is a real example) can
+reduce to the same stripped name. The old `collect()` returned a plain
+`dict[str, str]`, so `kernels[stripped_name] = ...` silently kept only the
+LAST sidecar `sorted(out_dir.iterdir())` produced for that name and dropped
+the rest -- and "before"/"after" need not have kept the same one, since which
+survives depends on mangling-hash sort order, not on anything about the code.
+Comparing survivor-vs-survivor then reports unrelated instantiations as
+"changed" even when the true set of kernel bodies under that name is
+identical on both sides.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.compare_kernel_asm import HASH_RE, collect
+
+
+def _write_ptx(directory: Path, stem: str, hexhash: str, body: str) -> None:
+    (directory / f"{stem}_{hexhash}.ptx").write_text(body)
+
+
+def test_collect_keeps_every_instantiation_under_one_stripped_name(
+    tmp_path: Path,
+) -> None:
+    """Three distinct kernel bodies sharing a stripped name must all survive."""
+    _write_ptx(tmp_path, "mod_bmm_nt_batched_persistent", "aaaaaaaa", "BODY_A")
+    _write_ptx(tmp_path, "mod_bmm_nt_batched_persistent", "bbbbbbbb", "BODY_B")
+    _write_ptx(tmp_path, "mod_bmm_nt_batched_persistent", "cccccccc", "BODY_C")
+
+    kernels = collect(tmp_path)
+
+    assert list(kernels.keys()) == ["mod_bmm_nt_batched_persistent"]
+    bodies = kernels["mod_bmm_nt_batched_persistent"]
+    assert sorted(bodies) == ["BODY_A", "BODY_B", "BODY_C"]
+
+
+def test_collect_masks_the_hash_inside_the_body_too(tmp_path: Path) -> None:
+    _write_ptx(tmp_path, "mod_kernel", "12345678", "call @mod_kernel_12345678")
+    body = collect(tmp_path)["mod_kernel"][0]
+    assert "12345678" not in body
+    assert body == "call @mod_kernel_HASH"
+
+
+def test_multiset_compare_is_order_independent(tmp_path: Path) -> None:
+    """Same set of bodies under a name, different on-disk sort order: equal.
+
+    This is the actual property the fix restores. "before" discovers its two
+    instantiations in one hash order, "after" in the reverse order (a
+    completely unrelated, cosmetic mangling-hash change is enough to do this
+    in a real build) -- the SET of kernel bodies for that name is unchanged
+    either way, and a multiset compare (sort before comparing) must say so.
+    """
+    before_dir, after_dir = tmp_path / "before", tmp_path / "after"
+    before_dir.mkdir()
+    after_dir.mkdir()
+    # "before": alphabetically-first hash carries BODY_ONE, second BODY_TWO.
+    _write_ptx(before_dir, "mod_gemm_persistent", "10000000", "BODY_ONE")
+    _write_ptx(before_dir, "mod_gemm_persistent", "20000000", "BODY_TWO")
+    # "after": same two bodies, opposite hash-to-body assignment -- as if
+    # only the mangling hash moved, which this whole script exists to treat
+    # as a non-change.
+    _write_ptx(after_dir, "mod_gemm_persistent", "10000000", "BODY_TWO")
+    _write_ptx(after_dir, "mod_gemm_persistent", "20000000", "BODY_ONE")
+
+    before = collect(before_dir)
+    after = collect(after_dir)
+
+    assert sorted(before["mod_gemm_persistent"]) == sorted(after["mod_gemm_persistent"])
+
+
+def test_naive_single_value_dict_would_falsely_report_a_change(tmp_path: Path) -> None:
+    """RED/GREEN: reproduce the exact bug the multiset return type fixes.
+
+    Same two `before`/`after` directories as the order-independence test
+    above (a genuinely UNCHANGED pair of kernel bodies, only the mangling
+    hash moved). The naive collection this test inlines -- `dict[str, str]`,
+    last write wins, exactly what `collect()` used to do -- picks whichever
+    body `sorted(out_dir.iterdir())` visits last for that name. That pick is
+    independent on each side, so it can (and here, does) differ even though
+    nothing about the kernel changed: this is the false "changed" report
+    `collect()`'s list-per-name return type exists to prevent.
+    """
+    before_dir, after_dir = tmp_path / "before", tmp_path / "after"
+    before_dir.mkdir()
+    after_dir.mkdir()
+    _write_ptx(before_dir, "mod_gemm_persistent", "10000000", "BODY_ONE")
+    _write_ptx(before_dir, "mod_gemm_persistent", "20000000", "BODY_TWO")
+    _write_ptx(after_dir, "mod_gemm_persistent", "10000000", "BODY_TWO")
+    _write_ptx(after_dir, "mod_gemm_persistent", "20000000", "BODY_ONE")
+
+    def naive_collect(out_dir: Path) -> dict[str, str]:
+        # This is collect()'s pre-fix body, inlined so the test does not
+        # depend on the buggy implementation still existing in the tree.
+        kernels: dict[str, str] = {}
+        for path in sorted(out_dir.iterdir()):
+            if path.suffix == ".ptx":
+                kernels[HASH_RE.sub("", path.stem)] = HASH_RE.sub(
+                    "_HASH", path.read_text()
+                )
+        return kernels
+
+    naive_before = naive_collect(before_dir)
+    naive_after = naive_collect(after_dir)
+
+    # The bug: two directories holding an identical SET of kernel bodies
+    # compare unequal under the naive single-value dict.
+    assert naive_before["mod_gemm_persistent"] != naive_after["mod_gemm_persistent"]
+    # The fix: the real collect() correctly calls this unchanged.
+    before = collect(before_dir)
+    after = collect(after_dir)
+    assert sorted(before["mod_gemm_persistent"]) == sorted(after["mod_gemm_persistent"])


### PR DESCRIPTION
## Why

`scripts/compare_kernel_asm.py` is the blast-radius check for every kernel
refactor in this repo -- AGENTS.md's cross-compilation section names it as
*the* way to prove a metaprogramming change didn't move an architecture's
device code. Found and verified by hand while cross-compiling the bmm NT/TT
layout PR (#411): `collect()`'s `dict[str, str]`, keyed by hash-stripped
kernel name, silently drops every instantiation but the last one
`sorted(out_dir.iterdir())` produces for that name whenever a module has more
than one comptime instantiation sharing a base name (different tile sizes,
stage counts, or -- the case that found this -- layout parameters on one
generically-named function, e.g. this repo's `_v4_mma_tile`-style bodies).
Which instantiation survives depends on mangling-hash sort order, which is
not meaningful, and "before"/"after" need not keep the same one -- so a
module whose kernels genuinely did not change can compare survivor-vs-
survivor and report a false diff. A false positive here is exactly the
"clean bill of health that wasn't" failure this tool exists to prevent.

## What was done

`collect()` now returns `dict[str, list[str]]` -- every instantiation under a
stripped name, not just one -- and `main()`'s comparison treats each name as a
multiset (sort both sides' instantiation lists before comparing), so mangling-
hash sort order can no longer decide which two (possibly unrelated)
instantiations get diffed against each other. `run_builds`/`build_both_sides`
type hints and the per-module kernel counts (`counts["kernels"]`,
`total_kernels`, added/removed) are updated to count sidecar files rather
than distinct names, since a name can now carry more than one. `print_diff`'s
caller pairs same-length instantiation lists by sorted position and notes an
explicit count mismatch when the lists differ in length (an instantiation
added or dropped under an existing name).

## Red / green

**Real repo, both before this fix and after:** cross-compiled
`gemm16_matmul_ops` (`sm_90a`, `bfloat16`) between the pre-#411 tree and
#411's bmm NT/TT branch. The pre-fix tool reported **10 false changes** on
the `Bmm16` variant (verified by hand during #411's own work). The fixed
tool run here reports:

```
module             variants  kernels  changed  new/gone  detail
gemm16_matmul_ops         2      202        0    +24/-0
```

`Gemm16.bfloat16` (mm-level, untouched by #411): 67/67 kernels, 0 changed.
`Bmm16.bfloat16` (batched, where #411 added NT/TT): 0 changed among
pre-existing kernels, +24 new (the NT/TT instantiations -- #411's own PR
body reports +48 across both dtypes it checked, bfloat16 alone here gives
24, consistent). This is an independent re-run, not a copy of #411's own
numbers.

**Synthetic, in the new unit tests (no GPU, no mojo build):**
`tests/test_compare_kernel_asm_multiset.py` reproduces the bug mechanism
directly --
`test_naive_single_value_dict_would_falsely_report_a_change` builds two
directories holding an IDENTICAL set of two kernel bodies under one name
(only the mangling hash differs between them, exactly what an unrelated
rename or codegen-hash shuffle looks like), and shows: a naive single-value
dict (the old `collect()` body, inlined so the test doesn't depend on the
bug still being in the tree) picks a different survivor per side and
compares unequal (RED); the real `collect()` compares them equal (GREEN).
Three more tests cover `collect()` grouping every instantiation under one
name, hash-masking still working inside the body text, and order-
independence of the multiset compare on its own.

## Test plan

- [x] `uv run pytest tests/test_compare_kernel_asm_multiset.py -v` -- 4 passed
- [x] `uv run python scripts/compare_kernel_asm.py --before . --after . --dry-run --modules gemm16_matmul_ops` -- smoke test against the real repo, no GPU
- [x] Real before/after cross-compile against #411's branch (see Red/green above) -- 0 false changes, matches #411's own by-hand verification
- [x] `uv run ruff check` / `ruff format --diff` -- clean

## Round 2 (adversarial review)

An adversarial review (Codex) confirmed `collect()`'s fix itself but found
`main()`'s aggregation of the new per-name lists was wrong whenever a
duplicate-name group's membership genuinely changed, not just reordered:

- A changed name was charged as `max(len(before), len(after))` bodies, so
  one real replacement inside a group of N reported as N changed.
- An instantiation added under an already-existing name reported the whole
  group as changed instead of the true added count: for synthetic
  `before=[A,B]`, `after=[A,B,C]`, the tool said "3 changed, +0 new"; the
  true delta is "0 changed, +1 new".
- `--show-diff` zipped the two SORTED lists positionally, so
  `before=[A,B,C]`, `after=[B,C,Z]` printed three shifted, unrelated pairs
  instead of the one real replacement (A -> Z).

Fixed by canceling identical bodies with `collections.Counter` subtraction
first (`residual_bodies()`), then treating only what's left as the real
delta (`diff_names()`): paired up to the shorter residual side counts as
"changed", excess on the after side as "added", excess on the before side
as "removed". `print_kernel_delta()` prints `--show-diff` output from the
same residuals the counts come from, so displayed and counted never
disagree. 11 new tests exercise this path directly (`residual_bodies`,
`diff_names` for one replacement / multiplicity growth / multiplicity
shrink / duplicate-body cancellation / unchanged-reordered / whole-name-
only-on-one-side, and `--show-diff`'s pairing and header text via
`print_kernel_delta` with `capsys`) -- the original 4 tests only exercised
`collect()`, never the aggregation logic where these bugs actually lived.

Re-verified against the real repo: reran the fixed tool against #411's
before/after trees (`sm_90a`, `bfloat16`) after this fix -- still
`gemm16_matmul_ops: 0 changed / +24 new / -0 gone` on 202 kernels, matching
the previous (differently-computed but correct-for-this-case) result. This
fix only changes behavior for a duplicate-name group whose membership
itself moved, which none of #411's groups do -- all of #411's new NT/TT
sidecars are genuinely new names, and the pre-existing NN/TN groups are
identical multisets. Also added `uv run ruff format` to the checked
commands (no new violations).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013Co2wBC1UYzM4y9PEC92Af

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Co2wBC1UYzM4y9PEC92Af

