### PR TITLE
Implement native_group_norm_backward and native_batch_norm_backward

### DIFF
--- a/benchmarks/baselines.html
+++ b/benchmarks/baselines.html
@@ -8168,6 +8168,38 @@ document.addEventListener("DOMContentLoaded", boot);
             }
           }
         },
+        "native_batch_norm_backward": {
+          "dtypes": {
+            "bf16": {
+              "shapes": {
+                "N32xC64xH112xW112": {
+                  "layouts": {
+                    "contig": 2.958
+                  }
+                },
+                "N8xC256xH28xW28": {
+                  "layouts": {
+                    "contig": 11.846
+                  }
+                }
+              }
+            },
+            "f32": {
+              "shapes": {
+                "N32xC64xH112xW112": {
+                  "layouts": {
+                    "contig": 2.649
+                  }
+                },
+                "N8xC256xH28xW28": {
+                  "layouts": {
+                    "contig": 11.676
+                  }
+                }
+              }
+            }
+          }
+        },
         "native_dropout": {
           "dtypes": {
             "f32": {
@@ -8230,6 +8262,38 @@ document.addEventListener("DOMContentLoaded", boot);
                 "N8xC256xH14xW14_G32": {
                   "layouts": {
                     "contig": 0.466
+                  }
+                }
+              }
+            }
+          }
+        },
+        "native_group_norm_backward": {
+          "dtypes": {
+            "bf16": {
+              "shapes": {
+                "N32xC64xH56xW56_G32": {
+                  "layouts": {
+                    "contig": 3.977
+                  }
+                },
+                "N8xC256xH14xW14_G32": {
+                  "layouts": {
+                    "contig": 3.203
+                  }
+                }
+              }
+            },
+            "f32": {
+              "shapes": {
+                "N32xC64xH56xW56_G32": {
+                  "layouts": {
+                    "contig": 2.695
+                  }
+                },
+                "N8xC256xH14xW14_G32": {
+                  "layouts": {
+                    "contig": 2.924
                   }
                 }
               }

--- a/benchmarks/test_norm.py
+++ b/benchmarks/test_norm.py
@@ -33,8 +33,10 @@ COVERS: dict[str, str] = {
     "aten::native_layer_norm": "test_layer_norm",
     "aten::native_layer_norm_backward": "test_layer_norm_backward",
     "aten::native_batch_norm": "test_batch_norm",
+    "aten::native_batch_norm_backward": "test_batch_norm_backward",
     "aten::_native_batch_norm_legit_no_training": "test_batch_norm_inference",
     "aten::native_group_norm": "test_group_norm",
+    "aten::native_group_norm_backward": "test_group_norm_backward",
 }
 
 SKIPPED: dict[str, str] = {}
@@ -122,6 +124,44 @@ def test_batch_norm(
 
 @pytest.mark.parametrize("dtype_id", ("bf16", "f32"))
 @pytest.mark.parametrize("shape_id", BN_SHAPES)
+@pytest.mark.bench_op("native_batch_norm_backward")
+def test_batch_norm_backward(
+    shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
+) -> None:
+    # ATen's backward checks that every per-channel buffer shares ONE dtype
+    # (`check_mixed_data_type`), so the half-precision case is the layout AMP
+    # actually produces: a half input with float32 affine and running stats.
+    # `_bn_operands` gives the affine the input's dtype, which the forward
+    # accepts and the backward rejects, so the operands are built here.
+    n, c, h, w = BN_SHAPES[shape_id]
+    dtype = DTYPES[dtype_id]
+    param_dtype = torch.float32
+    x_ref, x_our = both(torch.randn(n, c, h, w, dtype=dtype), hw, mojo_device)
+    g_ref, g_our = both(torch.randn(n, c, h, w, dtype=dtype), hw, mojo_device)
+    w_ref, w_our = both(torch.randn(c, dtype=param_dtype), hw, mojo_device)
+    b_ref, b_our = both(torch.randn(c, dtype=param_dtype), hw, mojo_device)
+    rm_ref, rm_our = both(torch.zeros(c, dtype=param_dtype), hw, mojo_device)
+    rv_ref, rv_our = both(torch.ones(c, dtype=param_dtype), hw, mojo_device)
+    refs = [x_ref, w_ref, b_ref, rm_ref, rv_ref]
+    ours = [x_our, w_our, b_our, rm_our, rv_our]
+    # Un-timed forward, exactly as the layer-norm backward above: the saved
+    # statistics are an input to the op under measurement, not part of it.
+    _, mean_ref, rstd_ref = torch.ops.aten.native_batch_norm(*refs, True, 0.1, 1e-5)
+    _, mean_our, rstd_our = torch.ops.aten.native_batch_norm(*ours, True, 0.1, 1e-5)
+    mask = [True, True, True]
+    bench.run(
+        lambda: torch.ops.aten.native_batch_norm_backward(
+            g_ref, x_ref, w_ref, rm_ref, rv_ref, mean_ref, rstd_ref, True, 1e-5, mask
+        ),
+        lambda: torch.ops.aten.native_batch_norm_backward(
+            g_our, x_our, w_our, rm_our, rv_our, mean_our, rstd_our, True, 1e-5, mask
+        ),
+        flops=float(x_ref.numel()),
+    )
+
+
+@pytest.mark.parametrize("dtype_id", ("bf16", "f32"))
+@pytest.mark.parametrize("shape_id", BN_SHAPES)
 @pytest.mark.bench_op("_native_batch_norm_legit_no_training")
 def test_batch_norm_inference(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
@@ -151,6 +191,36 @@ def test_group_norm(
         ),
         lambda: torch.ops.aten.native_group_norm(
             x_our, w_our, b_our, n, c, h * w, groups, 1e-5
+        ),
+        flops=float(x_ref.numel()),
+    )
+
+
+@pytest.mark.parametrize("dtype_id", ("bf16", "f32"))
+@pytest.mark.parametrize("shape_id", GN_SHAPES)
+@pytest.mark.bench_op("native_group_norm_backward")
+def test_group_norm_backward(
+    shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
+) -> None:
+    n, c, h, w, groups = GN_SHAPES[shape_id]
+    dtype = DTYPES[dtype_id]
+    x_ref, x_our = both(torch.randn(n, c, h, w, dtype=dtype), hw, mojo_device)
+    w_ref, w_our = both(torch.randn(c, dtype=dtype), hw, mojo_device)
+    b_ref, b_our = both(torch.randn(c, dtype=dtype), hw, mojo_device)
+    g_ref, g_our = both(torch.randn(n, c, h, w, dtype=dtype), hw, mojo_device)
+    _, mean_ref, rstd_ref = torch.ops.aten.native_group_norm(
+        x_ref, w_ref, b_ref, n, c, h * w, groups, 1e-5
+    )
+    _, mean_our, rstd_our = torch.ops.aten.native_group_norm(
+        x_our, w_our, b_our, n, c, h * w, groups, 1e-5
+    )
+    mask = [True, True, True]
+    bench.run(
+        lambda: torch.ops.aten.native_group_norm_backward(
+            g_ref, x_ref, mean_ref, rstd_ref, w_ref, n, c, h * w, groups, mask
+        ),
+        lambda: torch.ops.aten.native_group_norm_backward(
+            g_our, x_our, mean_our, rstd_our, w_our, n, c, h * w, groups, mask
         ),
         flops=float(x_ref.numel()),
     )

--- a/docs/optimization_backlog.md
+++ b/docs/optimization_backlog.md
@@ -63,7 +63,7 @@ different kind of item.
 | [D5](#d5) | `aten::index` only handles a single index tensor on dim 0 | Data movement | Medium | Medium | — |
 | [R2](#r2) | ~~`linalg_vector_norm` is composed: 3 launches + an input-sized temporary~~ **DONE**: `NormSpec` / `NormL2Op`, one pass | Reductions | Low | Low | — |
 | [C3](#c3) | conv is 2-D forward only; no `convolution_backward`, no conv1d/3d/transposed in eager | Conv | High for vision *training* (blocks it) | High | — |
-| [N2](#n2) | BatchNorm training and GroupNorm backward are absent in eager | Normalization | High for vision training (blocks it) | Medium | — |
+| [N2](#n2) | BatchNorm and GroupNorm backward are composed from generic kernels, not fused (2.6-11.8x stock) | Normalization | Medium for vision training | Medium | — |
 | [Q1](#q1) | Graph backend hand-decomposes softmax / log_softmax instead of using MAX's fused ops | Graph | Low–Medium | **Low** | verify MAX does not already re-fuse |
 | [Q3](#q3) | Graph `max_pool2d_with_indices` returns the values as the indices | Graph | Correctness bug | Low | — |
 | [P2](#p2) | Strict-FIFO call queue: one cold variant blocks every warm launch behind it | Compile pipeline | Cold-start only | Medium | — |
@@ -564,39 +564,45 @@ different kind of item.
   cast to bf16.
 
 ### N2
-**BatchNorm and GroupNorm BACKWARD are absent in eager (the BatchNorm training
-forward now exists)**
+**BatchNorm and GroupNorm BACKWARD are composed from generic kernels, not fused**
 
-* **What.** `aten::native_batch_norm_backward` and
-  `aten::native_group_norm_backward` are not registered at all — the file has
-  exactly one `_register_missing`, for `aten::_adaptive_avg_pool2d_backward`.
-* **Current implementation.** The BatchNorm TRAINING FORWARD landed with the
-  shared-moments normalization work: `_fast_batch_norm_training` in
-  `aten_fast.py` over
-  `normalization_forward_ops/batch_norm_kernels.mojo`, which reduces
-  `{0, 2, 3}` in place through `op_utils._moments_scan_contig` and produces
-  `save_mean` / `save_invstd` plus the ATen running-statistic update
-  (measured 0.19-0.85x stock CUDA). Because its backward does not exist,
-  `mojo_device_native_batch_norm` refuses a training call whose inputs require
-  grad IN THE FORWARD — a raise from inside the autograd engine aborts the
-  process on this backend rather than raising. GroupNorm likewise has a fused
-  forward and no backward, and `mojo_device_native_group_norm` now refuses a
-  grad-requiring call in the forward for the same reason — with no `training`
-  flag to key on, that means every such call.
-* **Why it is not optimal.** ResNet / VGG / DenseNet *training* on the mojo
-  device is still blocked — now by the missing backward rather than the
-  missing forward; the `demo_scripts/` vision examples are inference-only for
-  this reason.
-* **What the optimized version looks like.** The two backwards, written like
-  the existing layer-norm pair (`normalization_backward_dx.mojo` +
-  `normalization_backward_params.mojo`), which already solve the identical
-  "per-channel parameter reduction across a large outer extent" problem; the
-  batch-norm one can walk the NCHW geometry exactly as its forward does.
-  Removing the forward preflight is part of that change.
-* **Expected win.** N/A (coverage). Unblocks vision training.
-* **How to measure it.** `tests/test_aten_functions.py` for correctness; a
-  resnet-18 training-step benchmark modelled on `bench_nanogpt_train.py` for
-  speed — none exists today, see [Not audited](#not-audited).
+* **What.** `fast_aten_native_batch_norm_backward` and
+  `fast_aten_native_group_norm_backward` in `aten_fast.py`, registered in
+  `mojo_device_aten_ops.py`; benchmarked by
+  `benchmarks/test_norm.py::test_batch_norm_backward` and
+  `::test_group_norm_backward`.
+* **Current implementation.** Both ops exist and are correct, but only the
+  group-norm grad-input reaches a fused kernel: group norm IS layer norm over
+  the trailing `(C / group) * HxW` elements of the `(N * group, K)` view, so
+  that half calls `fast_aten_native_layer_norm_backward` on that view with the
+  per-channel gamma folded into grad_out first. Everything else -- both affine
+  gradients of both ops, and the whole batch-norm grad-input -- is a chain of
+  ordinary reduce and broadcast-binary launches, because those reductions run
+  over the batch and the spatial extent PER CHANNEL, the complement of the
+  per-sample axes every LayerNorm kernel reduces.
+* **Why it is not optimal.** Measured on H100 (recorded in
+  `benchmarks/baselines.html`): group norm 2.7-4.2x stock, batch norm 2.6x on
+  the large shape and **11.8x** on `N8xC256xH28xW28`. A profile of that worst
+  case says the whole gap is the broadcast-strided binary kernel: five of them
+  per call at ~24 us each on a 6.4 MB tensor (0.5 TB/s) against 3.2 us for the
+  same traffic through the flat vectorized form (~4 TB/s, L2-resident). The
+  reductions and the flat binaries together are under 25 us.
+* **What the optimized version looks like.** One fused per-channel backward in
+  `normalization_backward_ops/`, walking the NCHW geometry the way
+  `batch_norm_kernels.mojo` already does for the forward (a `{0, 2, 3}`
+  reduction in place through `op_utils._moments_scan_contig`) and writing dx in
+  the same pass. That is a new reduction schedule, not a re-parameterization of
+  the LayerNorm pair, which is why it was deliberately left out of the change
+  that added these ops. A cheaper intermediate step -- worth measuring first --
+  is making the broadcast-strided binary kernel vectorize when the broadcast
+  operand is a per-channel vector, which would lift every composed op here at
+  once.
+* **Expected win.** Up to ~10x on the small batch-norm shape, ~3x on the rest.
+  Vision training already runs on the mojo device without it.
+* **How to measure it.** `benchmarks/test_norm.py -k backward`;
+  `tests/test_eager_kernels.py -k "norm_backward"` for correctness. A resnet-18
+  training-step benchmark modelled on `bench_nanogpt_train.py` would show the
+  end-to-end effect -- none exists today, see [Not audited](#not-audited).
 
 ### N3
 **`_TARGET_BLOCKS = 1280` in the LayerNorm-backward parameter reduction is an unlabelled fitted constant**
@@ -940,12 +946,12 @@ temporary** — **DONE** (`NormSpec`)
 * **Current implementation.** conv1d (rank-3 input), conv3d and transposed
   convolutions all return `NOT_HANDLED` → raise. There is no eager conv
   backward, so `mojo_device_convolution` refuses any conv whose operands
-  require grad in the FORWARD (see [N2](#n2) for why it cannot wait for the
-  backward node). A conv weight normally requires grad, so that is every conv
+  require grad in the FORWARD (`mojo_device/aten_ops/autograd_preflight.py`
+  explains why the refusal cannot wait for the backward node). A conv weight normally requires grad, so that is every conv
   in a training model; inference under `torch.no_grad()` is unaffected.
 * **Why it is not optimal.** conv1d is a reshape away — `(N, C, L)` →
   `(N, C, 1, L)` with a `(1, kw)` kernel. The missing backward blocks all vision
-  training together with [N2](#n2) and [C4](#c4).
+  training together with [C4](#c4).
 * **What the optimized version looks like.** conv1d by reshape into the existing
   2-D path; `convolution_backward` as dgrad (col2im of a GEMM) plus wgrad (a
   transposed-A GEMM against the im2col matrix) — the same `TRANSPOSE_A`
@@ -965,7 +971,7 @@ temporary** — **DONE** (`NormSpec`)
   (`mojo_device_aten_ops.py`).
 * **Current implementation.** Forward-only, floor-mode-only, rank-4-only. All
   three pooling forwards refuse a grad-requiring call in the FORWARD (see
-  [N2](#n2)); `_register_missing` on the backward was not enough, because that
+  `mojo_device/aten_ops/autograd_preflight.py`); `_register_missing` on the backward was not enough, because that
   raise still happens inside the autograd node and aborts the process.
 * **Why it is not optimal.** `ceil_mode=True` appears in common torchvision
   configurations; the missing backwards are the third blocker for vision
@@ -1508,11 +1514,12 @@ Stated explicitly so nobody reads this document as complete.
   in passing: `topk`, `sort`, `gather`, `index_select`, `scatter_add`, `div` with
   `rounding_mode` (`aten_fast.py:2498`), `softmax` with `dtype=`
   (`aten_fast.py:7714`), `conv1d`/`conv3d`/transposed conv, `ceil_mode` pooling,
-  and the vision-training backwards.
+  and the conv/pooling training backwards.
 * **No benchmark exists in this repo for convolution or for vision training.**
   The `bench_*.py` family covers GEMM, GPT-2 decode and nanoGPT training only.
-  Items [C1](#c1)–[C4](#c4) and [N2](#n2) therefore have no measurement harness
-  at all; building one is a prerequisite for working on them.
+  Items [C1](#c1)–[C4](#c4) therefore have no end-to-end measurement harness at
+  all; building one is a prerequisite for working on them. [N2](#n2) now has
+  per-op numbers in `benchmarks/test_norm.py`, but no training-step benchmark.
 * **Numerical accuracy was out of scope.** This document is about speed and
   coverage; the one correctness item included ([Q3](#q3)) is here because it is
   masked by xfails rather than tracked.

--- a/tests/test_aten_functions.py
+++ b/tests/test_aten_functions.py
@@ -16,6 +16,8 @@ from torch_mojo_backend.testing import (
     check_outputs,
 )
 
+from .conftest import require_cuda_autograd
+
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 def test_scaled_dot_product_flash_attention_basic(
@@ -2200,6 +2202,293 @@ def test_aten_select_scatter_scalar_src(conf: Conf):
     src = torch.tensor(5.0, dtype=torch.float32)
 
     check_outputs(fn, conf, [self, src])
+
+
+# ---------------------------------------------------------------------------
+# Group / batch norm backward.
+#
+# Tolerance: every gradient here is a float32 reduction over at most a few
+# hundred elements, so the accumulation error is around sqrt(k) * eps ~ 3e-6
+# relative; both sides sum in different orders (ATen's group-norm reference
+# even carries an rstd**3 term), and the inputs are standard normal so rstd is
+# O(1) and does not amplify. 2e-5 is therefore ~5x the noise floor of a
+# correct implementation, while a wrong formula (a mismatched axis, a missing
+# term) moves these outputs by O(1) rather than by ulps.
+# ---------------------------------------------------------------------------
+
+_NORM_BACKWARD_TOLERANCE = 2e-5
+
+# (N, C, HxW, group). Covers group == 1 (layer norm over the whole sample),
+# group == C (instance norm), a group count that is neither, and shapes whose
+# channel and spatial extents are odd / not powers of two.
+_GROUP_NORM_BACKWARD_SHAPES = [
+    (2, 6, 12, 3),
+    (3, 8, 5, 1),
+    (2, 4, 7, 4),
+    (1, 9, 13, 3),
+    (2, 10, 33, 5),
+]
+
+
+@pytest.mark.parametrize(("N", "C", "HxW", "group"), _GROUP_NORM_BACKWARD_SHAPES)
+@pytest.mark.parametrize("affine", [True, False])
+def test_aten_native_group_norm_backward(
+    conf: Conf,
+    call_checker: CallChecker,
+    N: int,
+    C: int,
+    HxW: int,
+    group: int,
+    affine: bool,
+):
+    """`aten.native_group_norm_backward` against the CPU reference."""
+    call_checker.register(aten_functions.aten_native_group_norm_backward)
+
+    def fn(grad_out, x, weight):
+        weight = weight if affine else None
+        _, mean, rstd = aten.native_group_norm(x, weight, None, N, C, HxW, group, 1e-5)
+        # ATen's own CPU kernel cannot produce the affine gradients when there
+        # is no gamma (it reads an undefined tensor's device), and autograd
+        # never asks it to, so only grad_input is requested in that case.
+        mask = [True, True, True] if affine else [True, False, False]
+        outputs = aten.native_group_norm_backward(
+            grad_out, x, mean, rstd, weight, N, C, HxW, group, mask
+        )
+        return tuple(out for out, wanted in zip(outputs, mask) if wanted)
+
+    torch.manual_seed(0)
+    x = torch.randn(N, C, HxW)
+    grad_out = torch.randn(N, C, HxW)
+    weight = torch.randn(C)
+    check_outputs(
+        fn,
+        conf,
+        [grad_out, x, weight],
+        rtol=_NORM_BACKWARD_TOLERANCE,
+        atol=_NORM_BACKWARD_TOLERANCE,
+    )
+
+
+@pytest.mark.parametrize(
+    "mask", [(True, False, False), (False, True, False), (False, False, True)]
+)
+def test_aten_native_group_norm_backward_output_mask(
+    conf: Conf, call_checker: CallChecker, mask: tuple[bool, bool, bool]
+):
+    """Only the requested gradients come back; the rest are None."""
+    call_checker.register(aten_functions.aten_native_group_norm_backward)
+    N, C, HxW, group = 2, 6, 10, 3
+
+    def fn(grad_out, x, weight):
+        _, mean, rstd = aten.native_group_norm(x, weight, None, N, C, HxW, group, 1e-5)
+        outputs = aten.native_group_norm_backward(
+            grad_out, x, mean, rstd, weight, N, C, HxW, group, list(mask)
+        )
+        assert [out is not None for out in outputs] == list(mask)
+        return tuple(out for out, wanted in zip(outputs, mask) if wanted)
+
+    torch.manual_seed(1)
+    check_outputs(
+        fn,
+        conf,
+        [torch.randn(N, C, HxW), torch.randn(N, C, HxW), torch.randn(C)],
+        rtol=_NORM_BACKWARD_TOLERANCE,
+        atol=_NORM_BACKWARD_TOLERANCE,
+    )
+
+
+@pytest.mark.parametrize("affine", [True, False])
+def test_group_norm_autograd(conf: Conf, call_checker: CallChecker, affine: bool):
+    """`F.group_norm` trains: the recorded backward node actually runs.
+
+    This used to be refused from the forward, because reaching an unimplemented
+    backward node aborts the process on this backend rather than raising.
+    """
+    call_checker.register(aten_functions.aten_native_group_norm_backward)
+
+    def fn(x, weight, bias):
+        leaf = x.detach().requires_grad_(True)
+        gamma = weight.detach().requires_grad_(True) if affine else None
+        beta = bias.detach().requires_grad_(True) if affine else None
+        output = torch.nn.functional.group_norm(leaf, 3, gamma, beta)
+        (output * output).sum().backward()
+        if not affine:
+            return (leaf.grad,)
+        return leaf.grad, gamma.grad, beta.grad
+
+    torch.manual_seed(2)
+    check_outputs(
+        fn,
+        conf,
+        [torch.randn(2, 6, 5, 5), torch.randn(6), torch.randn(6)],
+        rtol=_NORM_BACKWARD_TOLERANCE,
+        atol=_NORM_BACKWARD_TOLERANCE,
+    )
+
+
+def _batch_norm_saved_stats(x: torch.Tensor, eps: float):
+    """The per-channel statistics `aten::native_batch_norm` saves, from x alone.
+
+    Written out with mean/sub/mul rather than by calling the forward, so the
+    backward can be tested on a device whose forward covers inference only.
+    Everything happens on the (N, C, spatial) view: a rank-5 broadcast has no
+    kernel on the mojo CPU device, and that gap belongs to `sub`, not here.
+    """
+    channels = x.shape[1]
+    planes = x.reshape(x.shape[0], channels, math.prod(x.shape[2:]))
+    mean = torch.mean(planes, dim=[0, 2])
+    centered = planes - mean.reshape(1, channels, 1)
+    variance = torch.mean(centered * centered, dim=[0, 2])
+    return mean, torch.rsqrt(variance + eps)
+
+
+@pytest.mark.parametrize("shape", [(4, 3, 5, 5), (2, 7, 3), (6, 5), (3, 4, 2, 2, 2)])
+@pytest.mark.parametrize("train", [True, False])
+@pytest.mark.parametrize("affine", [True, False])
+def test_aten_native_batch_norm_backward(
+    conf: Conf,
+    call_checker: CallChecker,
+    shape: tuple[int, ...],
+    train: bool,
+    affine: bool,
+):
+    """`aten.native_batch_norm_backward` in both modes, against the CPU reference.
+
+    Evaluation is not a no-op here: it reads the running buffers rather than
+    the saved statistics, so an `.eval()` BatchNorm still has a real gradient.
+    """
+    call_checker.register(aten_functions.aten_native_batch_norm_backward)
+
+    def fn(grad_out, x, weight, running_mean, running_var):
+        weight = weight if affine else None
+        if train:
+            save_mean, save_invstd = _batch_norm_saved_stats(x, 1e-5)
+        else:
+            # ATen returns empty saved statistics for the inference forward;
+            # the backward reads the running buffers instead.
+            save_mean = running_mean
+            save_invstd = torch.rsqrt(running_var + 1e-5)
+        return aten.native_batch_norm_backward(
+            grad_out,
+            x,
+            weight,
+            running_mean,
+            running_var,
+            save_mean,
+            save_invstd,
+            train,
+            1e-5,
+            [True, True, True],
+        )
+
+    torch.manual_seed(3)
+    channels = shape[1]
+    check_outputs(
+        fn,
+        conf,
+        [
+            torch.randn(shape),
+            torch.randn(shape),
+            torch.randn(channels),
+            torch.zeros(channels),
+            torch.rand(channels) + 0.5,
+        ],
+        rtol=_NORM_BACKWARD_TOLERANCE,
+        atol=_NORM_BACKWARD_TOLERANCE,
+    )
+
+
+@pytest.mark.parametrize("affine", [True, False])
+def test_aten_native_group_norm_backward_compiled(
+    device: str, call_checker: CallChecker, affine: bool
+):
+    """The torch.compile backend serves the group-norm backward too."""
+    call_checker.register(aten_functions.aten_native_group_norm_backward)
+    N, C, HxW, group = 2, 6, 12, 3
+
+    def fn(grad_out, x, weight):
+        weight = weight if affine else None
+        _, mean, rstd = aten.native_group_norm(x, weight, None, N, C, HxW, group, 1e-5)
+        mask = [True, True, True] if affine else [True, False, False]
+        outputs = aten.native_group_norm_backward(
+            grad_out, x, mean, rstd, weight, N, C, HxW, group, mask
+        )
+        return tuple(out for out, wanted in zip(outputs, mask) if wanted)
+
+    torch.manual_seed(5)
+    check_functions_are_equivalent(
+        fn,
+        device,
+        [torch.randn(N, C, HxW), torch.randn(N, C, HxW), torch.randn(C)],
+        rtol=_NORM_BACKWARD_TOLERANCE,
+        atol=_NORM_BACKWARD_TOLERANCE,
+    )
+
+
+@pytest.mark.parametrize("train", [True, False])
+def test_aten_native_batch_norm_backward_compiled(
+    device: str, call_checker: CallChecker, train: bool
+):
+    """The torch.compile backend serves the batch-norm backward too."""
+    call_checker.register(aten_functions.aten_native_batch_norm_backward)
+
+    def fn(grad_out, x, weight, running_mean, running_var):
+        save_mean = running_mean
+        save_invstd = torch.rsqrt(running_var + 1e-5)
+        return aten.native_batch_norm_backward(
+            grad_out,
+            x,
+            weight,
+            running_mean,
+            running_var,
+            save_mean,
+            save_invstd,
+            train,
+            1e-5,
+            [True, True, True],
+        )
+
+    torch.manual_seed(6)
+    check_functions_are_equivalent(
+        fn,
+        device,
+        [
+            torch.randn(2, 4, 3, 3),
+            torch.randn(2, 4, 3, 3),
+            torch.randn(4),
+            torch.zeros(4),
+            torch.rand(4) + 0.5,
+        ],
+        rtol=_NORM_BACKWARD_TOLERANCE,
+        atol=_NORM_BACKWARD_TOLERANCE,
+    )
+
+
+def test_group_norm_autograd_compiled(device: str):
+    """A compiled `F.group_norm` training step.
+
+    The forward's mean/rstd used to be NotImplementedError placeholders, which
+    made every grad-requiring group norm fail to compile: the decomposed
+    backward needs them.
+    """
+    require_cuda_autograd(device)
+
+    def fn(x, weight, bias):
+        leaf = x.detach().requires_grad_(True)
+        gamma = weight.detach().requires_grad_(True)
+        beta = bias.detach().requires_grad_(True)
+        output = torch.nn.functional.group_norm(leaf, 3, gamma, beta)
+        (output * output).sum().backward()
+        return leaf.grad, gamma.grad, beta.grad
+
+    torch.manual_seed(7)
+    check_functions_are_equivalent(
+        fn,
+        device,
+        [torch.randn(2, 6, 4, 4), torch.randn(6), torch.randn(6)],
+        rtol=_NORM_BACKWARD_TOLERANCE,
+        atol=_NORM_BACKWARD_TOLERANCE,
+    )
 
 
 @pytest.mark.parametrize("repeats", [1, 2, 3, 5])

--- a/tests/test_aten_functions.py
+++ b/tests/test_aten_functions.py
@@ -22,6 +22,8 @@ from torch_mojo_backend.testing import (
     check_outputs,
 )
 
+from .conftest import require_cuda_autograd
+
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 def test_scaled_dot_product_flash_attention_basic(
@@ -2204,6 +2206,293 @@ def test_aten_select_scatter_scalar_src(conf: Conf):
     src = torch.tensor(5.0, dtype=torch.float32)
 
     check_outputs(fn, conf, [self, src])
+
+
+# ---------------------------------------------------------------------------
+# Group / batch norm backward.
+#
+# Tolerance: every gradient here is a float32 reduction over at most a few
+# hundred elements, so the accumulation error is around sqrt(k) * eps ~ 3e-6
+# relative; both sides sum in different orders (ATen's group-norm reference
+# even carries an rstd**3 term), and the inputs are standard normal so rstd is
+# O(1) and does not amplify. 2e-5 is therefore ~5x the noise floor of a
+# correct implementation, while a wrong formula (a mismatched axis, a missing
+# term) moves these outputs by O(1) rather than by ulps.
+# ---------------------------------------------------------------------------
+
+_NORM_BACKWARD_TOLERANCE = 2e-5
+
+# (N, C, HxW, group). Covers group == 1 (layer norm over the whole sample),
+# group == C (instance norm), a group count that is neither, and shapes whose
+# channel and spatial extents are odd / not powers of two.
+_GROUP_NORM_BACKWARD_SHAPES = [
+    (2, 6, 12, 3),
+    (3, 8, 5, 1),
+    (2, 4, 7, 4),
+    (1, 9, 13, 3),
+    (2, 10, 33, 5),
+]
+
+
+@pytest.mark.parametrize(("N", "C", "HxW", "group"), _GROUP_NORM_BACKWARD_SHAPES)
+@pytest.mark.parametrize("affine", [True, False])
+def test_aten_native_group_norm_backward(
+    conf: Conf,
+    call_checker: CallChecker,
+    N: int,
+    C: int,
+    HxW: int,
+    group: int,
+    affine: bool,
+):
+    """`aten.native_group_norm_backward` against the CPU reference."""
+    call_checker.register(aten_functions.aten_native_group_norm_backward)
+
+    def fn(grad_out, x, weight):
+        weight = weight if affine else None
+        _, mean, rstd = aten.native_group_norm(x, weight, None, N, C, HxW, group, 1e-5)
+        # ATen's own CPU kernel cannot produce the affine gradients when there
+        # is no gamma (it reads an undefined tensor's device), and autograd
+        # never asks it to, so only grad_input is requested in that case.
+        mask = [True, True, True] if affine else [True, False, False]
+        outputs = aten.native_group_norm_backward(
+            grad_out, x, mean, rstd, weight, N, C, HxW, group, mask
+        )
+        return tuple(out for out, wanted in zip(outputs, mask) if wanted)
+
+    torch.manual_seed(0)
+    x = torch.randn(N, C, HxW)
+    grad_out = torch.randn(N, C, HxW)
+    weight = torch.randn(C)
+    check_outputs(
+        fn,
+        conf,
+        [grad_out, x, weight],
+        rtol=_NORM_BACKWARD_TOLERANCE,
+        atol=_NORM_BACKWARD_TOLERANCE,
+    )
+
+
+@pytest.mark.parametrize(
+    "mask", [(True, False, False), (False, True, False), (False, False, True)]
+)
+def test_aten_native_group_norm_backward_output_mask(
+    conf: Conf, call_checker: CallChecker, mask: tuple[bool, bool, bool]
+):
+    """Only the requested gradients come back; the rest are None."""
+    call_checker.register(aten_functions.aten_native_group_norm_backward)
+    N, C, HxW, group = 2, 6, 10, 3
+
+    def fn(grad_out, x, weight):
+        _, mean, rstd = aten.native_group_norm(x, weight, None, N, C, HxW, group, 1e-5)
+        outputs = aten.native_group_norm_backward(
+            grad_out, x, mean, rstd, weight, N, C, HxW, group, list(mask)
+        )
+        assert [out is not None for out in outputs] == list(mask)
+        return tuple(out for out, wanted in zip(outputs, mask) if wanted)
+
+    torch.manual_seed(1)
+    check_outputs(
+        fn,
+        conf,
+        [torch.randn(N, C, HxW), torch.randn(N, C, HxW), torch.randn(C)],
+        rtol=_NORM_BACKWARD_TOLERANCE,
+        atol=_NORM_BACKWARD_TOLERANCE,
+    )
+
+
+@pytest.mark.parametrize("affine", [True, False])
+def test_group_norm_autograd(conf: Conf, call_checker: CallChecker, affine: bool):
+    """`F.group_norm` trains: the recorded backward node actually runs.
+
+    This used to be refused from the forward, because reaching an unimplemented
+    backward node aborts the process on this backend rather than raising.
+    """
+    call_checker.register(aten_functions.aten_native_group_norm_backward)
+
+    def fn(x, weight, bias):
+        leaf = x.detach().requires_grad_(True)
+        gamma = weight.detach().requires_grad_(True) if affine else None
+        beta = bias.detach().requires_grad_(True) if affine else None
+        output = torch.nn.functional.group_norm(leaf, 3, gamma, beta)
+        (output * output).sum().backward()
+        if not affine:
+            return (leaf.grad,)
+        return leaf.grad, gamma.grad, beta.grad
+
+    torch.manual_seed(2)
+    check_outputs(
+        fn,
+        conf,
+        [torch.randn(2, 6, 5, 5), torch.randn(6), torch.randn(6)],
+        rtol=_NORM_BACKWARD_TOLERANCE,
+        atol=_NORM_BACKWARD_TOLERANCE,
+    )
+
+
+def _batch_norm_saved_stats(x: torch.Tensor, eps: float):
+    """The per-channel statistics `aten::native_batch_norm` saves, from x alone.
+
+    Written out with mean/sub/mul rather than by calling the forward, so the
+    backward can be tested on a device whose forward covers inference only.
+    Everything happens on the (N, C, spatial) view: a rank-5 broadcast has no
+    kernel on the mojo CPU device, and that gap belongs to `sub`, not here.
+    """
+    channels = x.shape[1]
+    planes = x.reshape(x.shape[0], channels, math.prod(x.shape[2:]))
+    mean = torch.mean(planes, dim=[0, 2])
+    centered = planes - mean.reshape(1, channels, 1)
+    variance = torch.mean(centered * centered, dim=[0, 2])
+    return mean, torch.rsqrt(variance + eps)
+
+
+@pytest.mark.parametrize("shape", [(4, 3, 5, 5), (2, 7, 3), (6, 5), (3, 4, 2, 2, 2)])
+@pytest.mark.parametrize("train", [True, False])
+@pytest.mark.parametrize("affine", [True, False])
+def test_aten_native_batch_norm_backward(
+    conf: Conf,
+    call_checker: CallChecker,
+    shape: tuple[int, ...],
+    train: bool,
+    affine: bool,
+):
+    """`aten.native_batch_norm_backward` in both modes, against the CPU reference.
+
+    Evaluation is not a no-op here: it reads the running buffers rather than
+    the saved statistics, so an `.eval()` BatchNorm still has a real gradient.
+    """
+    call_checker.register(aten_functions.aten_native_batch_norm_backward)
+
+    def fn(grad_out, x, weight, running_mean, running_var):
+        weight = weight if affine else None
+        if train:
+            save_mean, save_invstd = _batch_norm_saved_stats(x, 1e-5)
+        else:
+            # ATen returns empty saved statistics for the inference forward;
+            # the backward reads the running buffers instead.
+            save_mean = running_mean
+            save_invstd = torch.rsqrt(running_var + 1e-5)
+        return aten.native_batch_norm_backward(
+            grad_out,
+            x,
+            weight,
+            running_mean,
+            running_var,
+            save_mean,
+            save_invstd,
+            train,
+            1e-5,
+            [True, True, True],
+        )
+
+    torch.manual_seed(3)
+    channels = shape[1]
+    check_outputs(
+        fn,
+        conf,
+        [
+            torch.randn(shape),
+            torch.randn(shape),
+            torch.randn(channels),
+            torch.zeros(channels),
+            torch.rand(channels) + 0.5,
+        ],
+        rtol=_NORM_BACKWARD_TOLERANCE,
+        atol=_NORM_BACKWARD_TOLERANCE,
+    )
+
+
+@pytest.mark.parametrize("affine", [True, False])
+def test_aten_native_group_norm_backward_compiled(
+    device: str, call_checker: CallChecker, affine: bool
+):
+    """The torch.compile backend serves the group-norm backward too."""
+    call_checker.register(aten_functions.aten_native_group_norm_backward)
+    N, C, HxW, group = 2, 6, 12, 3
+
+    def fn(grad_out, x, weight):
+        weight = weight if affine else None
+        _, mean, rstd = aten.native_group_norm(x, weight, None, N, C, HxW, group, 1e-5)
+        mask = [True, True, True] if affine else [True, False, False]
+        outputs = aten.native_group_norm_backward(
+            grad_out, x, mean, rstd, weight, N, C, HxW, group, mask
+        )
+        return tuple(out for out, wanted in zip(outputs, mask) if wanted)
+
+    torch.manual_seed(5)
+    check_functions_are_equivalent(
+        fn,
+        device,
+        [torch.randn(N, C, HxW), torch.randn(N, C, HxW), torch.randn(C)],
+        rtol=_NORM_BACKWARD_TOLERANCE,
+        atol=_NORM_BACKWARD_TOLERANCE,
+    )
+
+
+@pytest.mark.parametrize("train", [True, False])
+def test_aten_native_batch_norm_backward_compiled(
+    device: str, call_checker: CallChecker, train: bool
+):
+    """The torch.compile backend serves the batch-norm backward too."""
+    call_checker.register(aten_functions.aten_native_batch_norm_backward)
+
+    def fn(grad_out, x, weight, running_mean, running_var):
+        save_mean = running_mean
+        save_invstd = torch.rsqrt(running_var + 1e-5)
+        return aten.native_batch_norm_backward(
+            grad_out,
+            x,
+            weight,
+            running_mean,
+            running_var,
+            save_mean,
+            save_invstd,
+            train,
+            1e-5,
+            [True, True, True],
+        )
+
+    torch.manual_seed(6)
+    check_functions_are_equivalent(
+        fn,
+        device,
+        [
+            torch.randn(2, 4, 3, 3),
+            torch.randn(2, 4, 3, 3),
+            torch.randn(4),
+            torch.zeros(4),
+            torch.rand(4) + 0.5,
+        ],
+        rtol=_NORM_BACKWARD_TOLERANCE,
+        atol=_NORM_BACKWARD_TOLERANCE,
+    )
+
+
+def test_group_norm_autograd_compiled(device: str):
+    """A compiled `F.group_norm` training step.
+
+    The forward's mean/rstd used to be NotImplementedError placeholders, which
+    made every grad-requiring group norm fail to compile: the decomposed
+    backward needs them.
+    """
+    require_cuda_autograd(device)
+
+    def fn(x, weight, bias):
+        leaf = x.detach().requires_grad_(True)
+        gamma = weight.detach().requires_grad_(True)
+        beta = bias.detach().requires_grad_(True)
+        output = torch.nn.functional.group_norm(leaf, 3, gamma, beta)
+        (output * output).sum().backward()
+        return leaf.grad, gamma.grad, beta.grad
+
+    torch.manual_seed(7)
+    check_functions_are_equivalent(
+        fn,
+        device,
+        [torch.randn(2, 6, 4, 4), torch.randn(6), torch.randn(6)],
+        rtol=_NORM_BACKWARD_TOLERANCE,
+        atol=_NORM_BACKWARD_TOLERANCE,
+    )
 
 
 @pytest.mark.parametrize("repeats", [1, 2, 3, 5])

--- a/tests/test_aten_functions.py
+++ b/tests/test_aten_functions.py
@@ -12,6 +12,7 @@ from torch._dynamo.exc import BackendCompilerFailed
 # see `torch/ops/__init__.py` or `torch/ops.py`.
 from torch.ops import aten  # ty: ignore[unresolved-import]
 
+from tests.conftest import require_cuda_autograd
 from torch_mojo_backend import aten_functions, mojo_backend, register_mojo_devices
 from torch_mojo_backend.eager_kernels import aten_fast
 from torch_mojo_backend.mojo_device.mojo_device_aten_ops import EAGER_CALL_COUNTERS
@@ -21,8 +22,6 @@ from torch_mojo_backend.testing import (
     check_functions_are_equivalent,
     check_outputs,
 )
-
-from .conftest import require_cuda_autograd
 
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
@@ -2318,6 +2317,8 @@ def test_group_norm_autograd(conf: Conf, call_checker: CallChecker, affine: bool
         (output * output).sum().backward()
         if not affine:
             return (leaf.grad,)
+        assert gamma is not None
+        assert beta is not None
         return leaf.grad, gamma.grad, beta.grad
 
     torch.manual_seed(2)

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -920,23 +920,92 @@ def test_fast_batch_norm_training_outlier_first_element(mojo_gpu, magnitude, cha
     torch.testing.assert_close(our_var.cpu(), ref_var, atol=0, rtol=1e-5)
 
 
-def test_fast_batch_norm_training_refuses_autograd_in_the_forward(mojo_gpu):
-    """A training call that would need a gradient must fail at the FORWARD.
+# Tolerance for the norm backwards: float32 reductions over a few hundred
+# elements accumulate around sqrt(k) * eps ~ 3e-6 relative, the two sides sum
+# in different orders, and the standard-normal inputs keep rstd at O(1) so
+# nothing amplifies that. A wrong axis or a missing term moves these outputs by
+# O(1), not by ulps.
+_NORM_BACKWARD_TOLERANCE = 2e-5
 
-    `aten::native_batch_norm_backward` is not implemented here, and a raise
-    from inside the autograd engine aborts the process on this backend instead
-    of raising, so the refusal cannot wait for the backward node.
+
+# (training, affine). The inference forward needs an affine here -- its fast
+# path takes all four per-channel buffers or none -- so `training=False` with
+# no weight/bias is a pre-existing forward gap, not a backward one.
+@pytest.mark.parametrize(
+    ("training", "affine"), [(True, True), (True, False), (False, True)]
+)
+def test_fast_batch_norm_backward_matches_torch(mojo_gpu, training, affine):
+    """`nn.BatchNorm2d` gradients, training and eval, against CPU autograd.
+
+    Both used to be unreachable. Training was refused from the forward because
+    `aten::native_batch_norm_backward` did not exist, and eval was worse: it
+    was not preflighted at all, on the theory that `training=False` records a
+    backward nobody runs -- but an `.eval()` BatchNorm records
+    NativeBatchNormBackward0 like any other and the engine does come back for
+    it, so the missing kernel aborted the process instead of raising.
     """
-    x = torch.randn(2, 4, 3, 3, device=mojo_gpu, requires_grad=True)
-    running_mean = torch.zeros(4, device=mojo_gpu)
-    running_var = torch.ones(4, device=mojo_gpu)
-    with pytest.raises(NotImplementedError, match="native_batch_norm_backward"):
-        torch.ops.aten.native_batch_norm(
-            x, None, None, running_mean, running_var, True, 0.1, 1e-5
+    torch.manual_seed(0)
+    host_input = torch.randn(3, 4, 5, 5)
+    host_weight = torch.randn(4)
+    host_bias = torch.randn(4)
+    running_mean = torch.randn(4)
+    running_var = torch.rand(4) + 0.5
+
+    def run(device):
+        x = host_input.to(device).detach().requires_grad_(True)
+        gamma = host_weight.to(device).detach().requires_grad_(True) if affine else None
+        beta = host_bias.to(device).detach().requires_grad_(True) if affine else None
+        output = torch.nn.functional.batch_norm(
+            x,
+            running_mean.to(device).clone(),
+            running_var.to(device).clone(),
+            gamma,
+            beta,
+            training,
+            0.1,
+            1e-5,
         )
-    with torch.no_grad():
-        torch.ops.aten.native_batch_norm(
-            x, None, None, running_mean, running_var, True, 0.1, 1e-5
+        (output * output).sum().backward()
+        grads = [x.grad] + ([gamma.grad, beta.grad] if affine else [])
+        return [grad.cpu() for grad in grads]
+
+    for got, want in zip(run(mojo_gpu), run("cpu"), strict=True):
+        torch.testing.assert_close(
+            got, want, rtol=_NORM_BACKWARD_TOLERANCE, atol=_NORM_BACKWARD_TOLERANCE
+        )
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_fast_batch_norm_backward_dtypes(mojo_gpu, dtype):
+    """Half precision accumulates in float32 and narrows back, like ATen."""
+    torch.manual_seed(1)
+    shape = (2, 6, 4, 4)
+    host_grad = torch.randn(shape)
+    host_input = torch.randn(shape)
+    host_weight = torch.randn(6)
+    save_mean = torch.randn(6)
+    save_invstd = torch.rand(6) + 0.5
+
+    def run(device, cast):
+        return torch.ops.aten.native_batch_norm_backward(
+            host_grad.to(device).to(cast),
+            host_input.to(device).to(cast),
+            host_weight.to(device).to(cast),
+            None,
+            None,
+            save_mean.to(device),
+            save_invstd.to(device),
+            True,
+            1e-5,
+            [True, True, True],
+        )
+
+    expected = run("cpu", torch.float32)
+    actual = run(mojo_gpu, dtype)
+    tolerance = _NORM_BACKWARD_TOLERANCE if dtype == torch.float32 else 3e-2
+    for got, want in zip(actual, expected, strict=True):
+        torch.testing.assert_close(
+            got.cpu().float(), want, rtol=tolerance, atol=tolerance
         )
 
 
@@ -1220,45 +1289,99 @@ def test_fast_group_norm_matches_torch(mojo_gpu, dtype, n, c, hxw, groups):
         torch.testing.assert_close(got.cpu(), want, atol=1e-3, rtol=1e-3)
 
 
-def test_fast_group_norm_refuses_autograd_in_the_forward(mojo_gpu):
-    """A grad-requiring group norm must fail at the FORWARD.
+@pytest.mark.parametrize(
+    ("shape", "group"), [((2, 4, 6, 6), 2), ((2, 8, 5, 5), 8), ((1, 6, 7, 3), 1)]
+)
+@pytest.mark.parametrize("affine", [True, False])
+def test_fast_group_norm_backward_matches_torch(mojo_gpu, shape, group, affine):
+    """`F.group_norm` gradients against CPU autograd.
 
-    `aten::native_group_norm_backward` is not implemented here, and a raise
-    from inside the autograd engine aborts the process on this backend instead
-    of propagating, so the refusal cannot wait for NativeGroupNormBackward0.
-    Unlike batch norm there is no `training` flag to key on: every
-    grad-requiring call is refused, and only turning grad off gets the forward.
+    This used to be refused from the forward, because
+    `aten::native_group_norm_backward` had no kernel and reaching an
+    unimplemented backward node aborts the process on this backend rather than
+    raising. The grad-input half now runs on the LayerNorm backward kernel:
+    group norm IS layer norm over the trailing `(C / group) * HxW` elements of
+    the `(N * group, K)` view. `group == C` (instance norm) and `group == 1`
+    (layer norm over the whole sample) are the two degenerate ends of that.
     """
-    host_input, device_input = _preflight_input((2, 4, 6, 6), mojo_gpu)
-    host_weight, device_weight = _preflight_input((4,), mojo_gpu, seed=11)
-    host_bias, device_bias = _preflight_input((4,), mojo_gpu, seed=13)
+    torch.manual_seed(0)
+    host_input = torch.randn(*shape)
+    host_weight = torch.randn(shape[1])
+    host_bias = torch.randn(shape[1])
 
-    expected = torch.nn.functional.group_norm(host_input, 2, host_weight, host_bias)
-    torch.testing.assert_close(
-        torch.nn.functional.group_norm(
-            device_input, 2, device_weight, device_bias
-        ).cpu(),
-        expected,
-        atol=1e-5,
-        rtol=1e-5,
-    )
+    def run(device):
+        x = host_input.to(device).detach().requires_grad_(True)
+        gamma = host_weight.to(device).detach().requires_grad_(True) if affine else None
+        beta = host_bias.to(device).detach().requires_grad_(True) if affine else None
+        output = torch.nn.functional.group_norm(x, group, gamma, beta)
+        (output * output).sum().backward()
+        grads = [x.grad] + ([gamma.grad, beta.grad] if affine else [])
+        return [grad.cpu() for grad in grads]
 
-    # Any one of the three operands wanting a gradient is enough to refuse:
-    # the engine would come back for the same unrunnable node either way.
-    for which in range(3):
-        operands = [device_input.detach(), device_weight.detach(), device_bias.detach()]
-        operands[which] = operands[which].requires_grad_()
-        with pytest.raises(NotImplementedError, match="native_group_norm_backward"):
-            torch.nn.functional.group_norm(operands[0], 2, operands[1], operands[2])
-
-    with torch.no_grad():
+    for got, want in zip(run(mojo_gpu), run("cpu"), strict=True):
         torch.testing.assert_close(
-            torch.nn.functional.group_norm(
-                device_input.detach().requires_grad_(), 2, device_weight, device_bias
-            ).cpu(),
-            expected,
-            atol=1e-5,
-            rtol=1e-5,
+            got, want, rtol=_NORM_BACKWARD_TOLERANCE, atol=_NORM_BACKWARD_TOLERANCE
+        )
+
+
+def test_fast_group_norm_backward_uses_the_layer_norm_kernel(mojo_gpu, monkeypatch):
+    """The grad-input half must reach the fused LayerNorm backward kernel.
+
+    The composition it falls back to is correct but reads the whole tensor
+    several more times, so a silent fallback is a performance regression this
+    test would otherwise not see.
+    """
+    from torch_mojo_backend.eager_kernels import aten_fast
+
+    calls = []
+    original = aten_fast.fast_aten_native_layer_norm_backward
+
+    def spy(*args, **kwargs):
+        result = original(*args, **kwargs)
+        calls.append(result is not aten_fast.NOT_HANDLED)
+        return result
+
+    monkeypatch.setattr(aten_fast, "fast_aten_native_layer_norm_backward", spy)
+
+    torch.manual_seed(0)
+    x = torch.randn(2, 8, 4, 4, device=mojo_gpu, requires_grad=True)
+    weight = torch.randn(8, device=mojo_gpu, requires_grad=True)
+    bias = torch.randn(8, device=mojo_gpu, requires_grad=True)
+    torch.nn.functional.group_norm(x, 4, weight, bias).sum().backward()
+    assert calls == [True]
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_fast_group_norm_backward_dtypes(mojo_gpu, dtype):
+    """Half precision accumulates in float32 and narrows back, like ATen."""
+    torch.manual_seed(1)
+    N, C, HxW, group = 2, 6, 12, 3
+    host_grad = torch.randn(N, C, HxW)
+    host_input = torch.randn(N, C, HxW)
+    host_weight = torch.randn(C)
+    mean = torch.randn(N, group)
+    rstd = torch.rand(N, group) + 0.5
+
+    def run(device, cast):
+        return torch.ops.aten.native_group_norm_backward(
+            host_grad.to(device).to(cast),
+            host_input.to(device).to(cast),
+            mean.to(device),
+            rstd.to(device),
+            host_weight.to(device).to(cast),
+            N,
+            C,
+            HxW,
+            group,
+            [True, True, True],
+        )
+
+    expected = run("cpu", torch.float32)
+    actual = run(mojo_gpu, dtype)
+    tolerance = _NORM_BACKWARD_TOLERANCE if dtype == torch.float32 else 3e-2
+    for got, want in zip(actual, expected, strict=True):
+        torch.testing.assert_close(
+            got.cpu().float(), want, rtol=tolerance, atol=tolerance
         )
 
 

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -1038,7 +1038,14 @@ def test_fast_batch_norm_backward_matches_torch(mojo_gpu, training, affine):
             1e-5,
         )
         (output * output).sum().backward()
-        grads = [x.grad] + ([gamma.grad, beta.grad] if affine else [])
+        assert x.grad is not None
+        grads = [x.grad]
+        if affine:
+            assert gamma is not None
+            assert beta is not None
+            assert gamma.grad is not None
+            assert beta.grad is not None
+            grads += [gamma.grad, beta.grad]
         return [grad.cpu() for grad in grads]
 
     for got, want in zip(run(mojo_gpu), run("cpu"), strict=True):
@@ -1387,7 +1394,14 @@ def test_fast_group_norm_backward_matches_torch(mojo_gpu, shape, group, affine):
         beta = host_bias.to(device).detach().requires_grad_(True) if affine else None
         output = torch.nn.functional.group_norm(x, group, gamma, beta)
         (output * output).sum().backward()
-        grads = [x.grad] + ([gamma.grad, beta.grad] if affine else [])
+        assert x.grad is not None
+        grads = [x.grad]
+        if affine:
+            assert gamma is not None
+            assert beta is not None
+            assert gamma.grad is not None
+            assert beta.grad is not None
+            grads += [gamma.grad, beta.grad]
         return [grad.cpu() for grad in grads]
 
     for got, want in zip(run(mojo_gpu), run("cpu"), strict=True):
@@ -1403,8 +1417,6 @@ def test_fast_group_norm_backward_uses_the_layer_norm_kernel(mojo_gpu, monkeypat
     several more times, so a silent fallback is a performance regression this
     test would otherwise not see.
     """
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     calls = []
     original = aten_fast.fast_aten_native_layer_norm_backward
 

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -992,23 +992,92 @@ def test_fast_batch_norm_training_outlier_first_element(mojo_gpu, magnitude, cha
     torch.testing.assert_close(our_var.cpu(), ref_var, atol=0, rtol=1e-5)
 
 
-def test_fast_batch_norm_training_refuses_autograd_in_the_forward(mojo_gpu):
-    """A training call that would need a gradient must fail at the FORWARD.
+# Tolerance for the norm backwards: float32 reductions over a few hundred
+# elements accumulate around sqrt(k) * eps ~ 3e-6 relative, the two sides sum
+# in different orders, and the standard-normal inputs keep rstd at O(1) so
+# nothing amplifies that. A wrong axis or a missing term moves these outputs by
+# O(1), not by ulps.
+_NORM_BACKWARD_TOLERANCE = 2e-5
 
-    `aten::native_batch_norm_backward` is not implemented here, and a raise
-    from inside the autograd engine aborts the process on this backend instead
-    of raising, so the refusal cannot wait for the backward node.
+
+# (training, affine). The inference forward needs an affine here -- its fast
+# path takes all four per-channel buffers or none -- so `training=False` with
+# no weight/bias is a pre-existing forward gap, not a backward one.
+@pytest.mark.parametrize(
+    ("training", "affine"), [(True, True), (True, False), (False, True)]
+)
+def test_fast_batch_norm_backward_matches_torch(mojo_gpu, training, affine):
+    """`nn.BatchNorm2d` gradients, training and eval, against CPU autograd.
+
+    Both used to be unreachable. Training was refused from the forward because
+    `aten::native_batch_norm_backward` did not exist, and eval was worse: it
+    was not preflighted at all, on the theory that `training=False` records a
+    backward nobody runs -- but an `.eval()` BatchNorm records
+    NativeBatchNormBackward0 like any other and the engine does come back for
+    it, so the missing kernel aborted the process instead of raising.
     """
-    x = torch.randn(2, 4, 3, 3, device=mojo_gpu, requires_grad=True)
-    running_mean = torch.zeros(4, device=mojo_gpu)
-    running_var = torch.ones(4, device=mojo_gpu)
-    with pytest.raises(NotImplementedError, match="native_batch_norm_backward"):
-        torch.ops.aten.native_batch_norm(
-            x, None, None, running_mean, running_var, True, 0.1, 1e-5
+    torch.manual_seed(0)
+    host_input = torch.randn(3, 4, 5, 5)
+    host_weight = torch.randn(4)
+    host_bias = torch.randn(4)
+    running_mean = torch.randn(4)
+    running_var = torch.rand(4) + 0.5
+
+    def run(device):
+        x = host_input.to(device).detach().requires_grad_(True)
+        gamma = host_weight.to(device).detach().requires_grad_(True) if affine else None
+        beta = host_bias.to(device).detach().requires_grad_(True) if affine else None
+        output = torch.nn.functional.batch_norm(
+            x,
+            running_mean.to(device).clone(),
+            running_var.to(device).clone(),
+            gamma,
+            beta,
+            training,
+            0.1,
+            1e-5,
         )
-    with torch.no_grad():
-        torch.ops.aten.native_batch_norm(
-            x, None, None, running_mean, running_var, True, 0.1, 1e-5
+        (output * output).sum().backward()
+        grads = [x.grad] + ([gamma.grad, beta.grad] if affine else [])
+        return [grad.cpu() for grad in grads]
+
+    for got, want in zip(run(mojo_gpu), run("cpu"), strict=True):
+        torch.testing.assert_close(
+            got, want, rtol=_NORM_BACKWARD_TOLERANCE, atol=_NORM_BACKWARD_TOLERANCE
+        )
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_fast_batch_norm_backward_dtypes(mojo_gpu, dtype):
+    """Half precision accumulates in float32 and narrows back, like ATen."""
+    torch.manual_seed(1)
+    shape = (2, 6, 4, 4)
+    host_grad = torch.randn(shape)
+    host_input = torch.randn(shape)
+    host_weight = torch.randn(6)
+    save_mean = torch.randn(6)
+    save_invstd = torch.rand(6) + 0.5
+
+    def run(device, cast):
+        return torch.ops.aten.native_batch_norm_backward(
+            host_grad.to(device).to(cast),
+            host_input.to(device).to(cast),
+            host_weight.to(device).to(cast),
+            None,
+            None,
+            save_mean.to(device),
+            save_invstd.to(device),
+            True,
+            1e-5,
+            [True, True, True],
+        )
+
+    expected = run("cpu", torch.float32)
+    actual = run(mojo_gpu, dtype)
+    tolerance = _NORM_BACKWARD_TOLERANCE if dtype == torch.float32 else 3e-2
+    for got, want in zip(actual, expected, strict=True):
+        torch.testing.assert_close(
+            got.cpu().float(), want, rtol=tolerance, atol=tolerance
         )
 
 
@@ -1292,45 +1361,99 @@ def test_fast_group_norm_matches_torch(mojo_gpu, dtype, n, c, hxw, groups):
         torch.testing.assert_close(got.cpu(), want, atol=1e-3, rtol=1e-3)
 
 
-def test_fast_group_norm_refuses_autograd_in_the_forward(mojo_gpu):
-    """A grad-requiring group norm must fail at the FORWARD.
+@pytest.mark.parametrize(
+    ("shape", "group"), [((2, 4, 6, 6), 2), ((2, 8, 5, 5), 8), ((1, 6, 7, 3), 1)]
+)
+@pytest.mark.parametrize("affine", [True, False])
+def test_fast_group_norm_backward_matches_torch(mojo_gpu, shape, group, affine):
+    """`F.group_norm` gradients against CPU autograd.
 
-    `aten::native_group_norm_backward` is not implemented here, and a raise
-    from inside the autograd engine aborts the process on this backend instead
-    of propagating, so the refusal cannot wait for NativeGroupNormBackward0.
-    Unlike batch norm there is no `training` flag to key on: every
-    grad-requiring call is refused, and only turning grad off gets the forward.
+    This used to be refused from the forward, because
+    `aten::native_group_norm_backward` had no kernel and reaching an
+    unimplemented backward node aborts the process on this backend rather than
+    raising. The grad-input half now runs on the LayerNorm backward kernel:
+    group norm IS layer norm over the trailing `(C / group) * HxW` elements of
+    the `(N * group, K)` view. `group == C` (instance norm) and `group == 1`
+    (layer norm over the whole sample) are the two degenerate ends of that.
     """
-    host_input, device_input = _preflight_input((2, 4, 6, 6), mojo_gpu)
-    host_weight, device_weight = _preflight_input((4,), mojo_gpu, seed=11)
-    host_bias, device_bias = _preflight_input((4,), mojo_gpu, seed=13)
+    torch.manual_seed(0)
+    host_input = torch.randn(*shape)
+    host_weight = torch.randn(shape[1])
+    host_bias = torch.randn(shape[1])
 
-    expected = torch.nn.functional.group_norm(host_input, 2, host_weight, host_bias)
-    torch.testing.assert_close(
-        torch.nn.functional.group_norm(
-            device_input, 2, device_weight, device_bias
-        ).cpu(),
-        expected,
-        atol=1e-5,
-        rtol=1e-5,
-    )
+    def run(device):
+        x = host_input.to(device).detach().requires_grad_(True)
+        gamma = host_weight.to(device).detach().requires_grad_(True) if affine else None
+        beta = host_bias.to(device).detach().requires_grad_(True) if affine else None
+        output = torch.nn.functional.group_norm(x, group, gamma, beta)
+        (output * output).sum().backward()
+        grads = [x.grad] + ([gamma.grad, beta.grad] if affine else [])
+        return [grad.cpu() for grad in grads]
 
-    # Any one of the three operands wanting a gradient is enough to refuse:
-    # the engine would come back for the same unrunnable node either way.
-    for which in range(3):
-        operands = [device_input.detach(), device_weight.detach(), device_bias.detach()]
-        operands[which] = operands[which].requires_grad_()
-        with pytest.raises(NotImplementedError, match="native_group_norm_backward"):
-            torch.nn.functional.group_norm(operands[0], 2, operands[1], operands[2])
-
-    with torch.no_grad():
+    for got, want in zip(run(mojo_gpu), run("cpu"), strict=True):
         torch.testing.assert_close(
-            torch.nn.functional.group_norm(
-                device_input.detach().requires_grad_(), 2, device_weight, device_bias
-            ).cpu(),
-            expected,
-            atol=1e-5,
-            rtol=1e-5,
+            got, want, rtol=_NORM_BACKWARD_TOLERANCE, atol=_NORM_BACKWARD_TOLERANCE
+        )
+
+
+def test_fast_group_norm_backward_uses_the_layer_norm_kernel(mojo_gpu, monkeypatch):
+    """The grad-input half must reach the fused LayerNorm backward kernel.
+
+    The composition it falls back to is correct but reads the whole tensor
+    several more times, so a silent fallback is a performance regression this
+    test would otherwise not see.
+    """
+    from torch_mojo_backend.eager_kernels import aten_fast
+
+    calls = []
+    original = aten_fast.fast_aten_native_layer_norm_backward
+
+    def spy(*args, **kwargs):
+        result = original(*args, **kwargs)
+        calls.append(result is not aten_fast.NOT_HANDLED)
+        return result
+
+    monkeypatch.setattr(aten_fast, "fast_aten_native_layer_norm_backward", spy)
+
+    torch.manual_seed(0)
+    x = torch.randn(2, 8, 4, 4, device=mojo_gpu, requires_grad=True)
+    weight = torch.randn(8, device=mojo_gpu, requires_grad=True)
+    bias = torch.randn(8, device=mojo_gpu, requires_grad=True)
+    torch.nn.functional.group_norm(x, 4, weight, bias).sum().backward()
+    assert calls == [True]
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_fast_group_norm_backward_dtypes(mojo_gpu, dtype):
+    """Half precision accumulates in float32 and narrows back, like ATen."""
+    torch.manual_seed(1)
+    N, C, HxW, group = 2, 6, 12, 3
+    host_grad = torch.randn(N, C, HxW)
+    host_input = torch.randn(N, C, HxW)
+    host_weight = torch.randn(C)
+    mean = torch.randn(N, group)
+    rstd = torch.rand(N, group) + 0.5
+
+    def run(device, cast):
+        return torch.ops.aten.native_group_norm_backward(
+            host_grad.to(device).to(cast),
+            host_input.to(device).to(cast),
+            mean.to(device),
+            rstd.to(device),
+            host_weight.to(device).to(cast),
+            N,
+            C,
+            HxW,
+            group,
+            [True, True, True],
+        )
+
+    expected = run("cpu", torch.float32)
+    actual = run(mojo_gpu, dtype)
+    tolerance = _NORM_BACKWARD_TOLERANCE if dtype == torch.float32 else 3e-2
+    for got, want in zip(actual, expected, strict=True):
+        torch.testing.assert_close(
+            got.cpu().float(), want, rtol=tolerance, atol=tolerance
         )
 
 

--- a/torch_mojo_backend/aten_functions.py
+++ b/torch_mojo_backend/aten_functions.py
@@ -540,7 +540,7 @@ def aten__native_batch_norm_legit_no_training(
     running_var: MaxTensor,
     momentum: float,
     eps: float,
-) -> tuple[MaxTensor, NotImplementedError, NotImplementedError]:
+) -> tuple[MaxTensor, MaxTensor, MaxTensor]:
     """
     Implements batch normalization for inference (no training).
 
@@ -554,8 +554,9 @@ def aten__native_batch_norm_legit_no_training(
         eps: Small value for numerical stability
 
     Returns:
-        Tuple of (normalized_output, save_mean, save_var)
-        where save_mean and save_var are empty tensors in no-training mode
+        Tuple of (normalized_output, save_mean, save_var), where save_mean
+        and save_var are the empty (0,) tensors PyTorch's meta kernel
+        promises for the no-training overload
     """
     # Get input dimensions
     input_shape = input.shape
@@ -582,19 +583,13 @@ def aten__native_batch_norm_legit_no_training(
         bias_reshaped = F.reshape(bias, broadcast_shape)
         normalized = normalized + bias_reshaped
 
-    # It's not sure we'll ever support returning those, notably because of
-    # https://github.com/pytorch/pytorch/issues/85960
-    return (
-        normalized,
-        NotImplementedError(
-            "We don't support returning the saved mean "
-            "in aten._native_batch_norm_legit_no_training yet"
-        ),
-        NotImplementedError(
-            "We don't support returning the saved variance "
-            "in aten._native_batch_norm_legit_no_training yet"
-        ),
-    )
+    # PyTorch's meta kernel gives both saved statistics shape (0,) here (that
+    # is the inconsistency pytorch/pytorch#85960 is about), and the eval
+    # backward reads the RUNNING buffers rather than these, so empty tensors
+    # are the whole contract -- returning NotImplementedError placeholders
+    # instead only made a training graph fail to compile as soon as anything
+    # kept the node's second or third output alive.
+    return (normalized, running_mean[0:0], running_var[0:0])
 
 
 # _pdist_forward(Tensor self, float p=2) -> Tensor
@@ -2907,6 +2902,85 @@ def aten_native_batch_norm(
     return (normalized, save_mean, save_invstd)
 
 
+# native_batch_norm_backward(Tensor grad_out, Tensor input, Tensor? weight, Tensor? running_mean, Tensor? running_var, Tensor? save_mean, Tensor? save_invstd, bool train, float eps, bool[3] output_mask) -> (Tensor, Tensor, Tensor)
+@map_to(aten.native_batch_norm_backward)
+def aten_native_batch_norm_backward(
+    grad_out: MaxTensor,
+    input: MaxTensor,
+    weight: MaxTensor | None,
+    running_mean: MaxTensor | None,
+    running_var: MaxTensor | None,
+    save_mean: MaxTensor | None,
+    save_invstd: MaxTensor | None,
+    train: bool,
+    eps: float,
+    output_mask: list[bool],
+) -> tuple[MaxTensor | None, MaxTensor | None, MaxTensor | None]:
+    """Gradients of `aten.native_batch_norm`, per channel.
+
+    Follows `batch_norm_backward_cpu_template`
+    (aten/src/ATen/native/Normalization.cpp) with `M = numel / C`:
+
+        dbeta[c]  = sum_{n,s} dy          dgamma[c] = sum_{n,s} dy * xhat
+        dx        = (dy - dbeta/M - xhat * dgamma/M) * invstd * gamma   (train)
+        dx        = dy * invstd * gamma                                 (eval)
+
+    Training reads the statistics the forward saved; evaluation recomputes
+    them from the running buffers, which is why an `.eval()` BatchNorm still
+    produces gradients rather than the zeros an "inference needs no backward"
+    reading would give.
+
+    Returns `None` for the outputs `output_mask` turns off, the way
+    `aten_native_layer_norm` returns `None` for statistics nothing reads.
+    """
+    mask = tuple(output_mask)
+    input_shape = input.shape
+    rank = len(input_shape)
+    num_channels = int(input_shape[1])
+    broadcast_shape = [1] * rank
+    broadcast_shape[1] = num_channels
+    reduce_axes = [axis for axis in range(rank) if axis != 1]
+    reduced = math.prod(int(input_shape[axis]) for axis in reduce_axes)
+
+    if train:
+        if save_mean is None or save_invstd is None:
+            raise ValueError(
+                "save_mean and save_invstd are required when train=True in "
+                "aten.native_batch_norm_backward"
+            )
+        mean = F.reshape(save_mean, broadcast_shape)
+        invstd = F.reshape(save_invstd, broadcast_shape)
+    else:
+        if running_mean is None or running_var is None:
+            raise ValueError(
+                "running_mean and running_var are required when train=False "
+                "in aten.native_batch_norm_backward"
+            )
+        mean = F.reshape(running_mean, broadcast_shape)
+        invstd = 1.0 / F.sqrt(F.reshape(running_var, broadcast_shape) + eps)
+
+    normalized = (input - mean) * invstd
+    # dx needs both affine gradients while training, whatever the mask says.
+    sum_grad = aten_sum(grad_out, dim=reduce_axes, keepdim=True)
+    dot_grad = aten_sum(grad_out * normalized, dim=reduce_axes, keepdim=True)
+
+    grad_input = None
+    if mask[0]:
+        scale = invstd
+        if weight is not None:
+            scale = scale * F.reshape(weight, broadcast_shape)
+        if train:
+            projected = (
+                grad_out - sum_grad / reduced - normalized * (dot_grad / reduced)
+            )
+        else:
+            projected = grad_out
+        grad_input = projected * scale
+    grad_weight = F.reshape(dot_grad, [num_channels]) if mask[1] else None
+    grad_bias = F.reshape(sum_grad, [num_channels]) if mask[2] else None
+    return grad_input, grad_weight, grad_bias
+
+
 # native_dropout(Tensor input, float p, bool? train) -> (Tensor, Tensor)
 
 
@@ -2921,10 +2995,11 @@ def aten_native_group_norm(
     HxW: SymIntType,
     group: int,
     eps: float,
-) -> tuple[MaxTensor, NotImplementedError, NotImplementedError]:
+) -> tuple[MaxTensor, MaxTensor, MaxTensor]:
     """
     This is the low-level operation that F.group_norm gets compiled to.
-    Returns (normalized_output, mean, rstd) tuple but we only return the first element for simplicity.
+    Returns (normalized_output, mean, rstd); the two statistics are per
+    (sample, group) and are what `aten.native_group_norm_backward` consumes.
     """
     # Reshape input from [N*C, HxW] back to [N, C, H, W] format
     # First, calculate H and W from HxW
@@ -2942,15 +3017,19 @@ def aten_native_group_norm(
     # Use the regular group_norm implementation
     result = torch_group_norm_equivalent(input_reshaped, group, weight, bias, eps)
 
-    # Return just the normalized output (native_group_norm returns a tuple)
+    # The statistics are per (sample, group) and are what
+    # `aten.native_group_norm_backward` consumes, so a training graph is dead
+    # without them; they used to be NotImplementedError placeholders, which
+    # made every grad-requiring group norm fail to compile.
+    grouped = F.reshape(input, [int(N), group, (int(C) // group) * HW])
+    group_mean = aten_mean(grouped, dim=[2], keepdim=True)
+    group_centered = grouped - group_mean
+    group_var = aten_mean(group_centered * group_centered, dim=[2], keepdim=True)
+    group_rstd = 1 / F.sqrt(group_var + eps)
     return (
         result,
-        NotImplementedError(
-            "The implementation of aten.native_group_norm doesn't support returning mean yet."
-        ),
-        NotImplementedError(
-            "The implementation of aten.native_group_norm doesn't support returning rstd yet."
-        ),
+        F.reshape(group_mean, [int(N), group]),
+        F.reshape(group_rstd, [int(N), group]),
     )
 
 
@@ -3003,6 +3082,77 @@ def torch_group_norm_equivalent(input, num_groups, weight=None, bias=None, eps=1
 
 
 # native_group_norm_backward(Tensor grad_out, Tensor input, Tensor mean, Tensor rstd, Tensor? weight, SymInt N, SymInt C, SymInt HxW, int group, bool[3] output_mask) -> (Tensor, Tensor, Tensor)
+@map_to(aten.native_group_norm_backward)
+def aten_native_group_norm_backward(
+    grad_out: MaxTensor,
+    input: MaxTensor,
+    mean: MaxTensor,
+    rstd: MaxTensor,
+    weight: MaxTensor | None,
+    N: SymIntType,
+    C: SymIntType,
+    HxW: SymIntType,
+    group: int,
+    output_mask: list[bool],
+) -> tuple[MaxTensor | None, MaxTensor | None, MaxTensor | None]:
+    """Gradients of `aten.native_group_norm`.
+
+    Group norm normalizes the trailing `(C / group) * HxW` elements of the
+    `(N, group, K)` view, so its grad-input is the layer-norm formula on that
+    view once the per-channel gamma is folded into grad_out:
+
+        dx = rstd * (q - mean_k(q) - xhat * mean_k(q * xhat)),  q = dy * gamma
+
+    The affine gradients reduce over a different axis set -- the batch and the
+    spatial extent, per channel -- and go through the per-(sample, channel)
+    partial sums ATen's own kernel uses:
+
+        dgamma[c] = sum_n rstd[n, g] * (S2[n, c] - mean[n, g] * S1[n, c])
+        dbeta[c]  = sum_n S1[n, c]
+        S1[n, c]  = sum_hw dy        S2[n, c] = sum_hw dy * x
+    """
+    mask = tuple(output_mask)
+    samples = int(N)
+    channels = int(C)
+    spatial = int(HxW)
+    channels_per_group = channels // group
+    inner = channels_per_group * spatial
+
+    planes = [samples, channels, spatial]
+    grad_planes = F.reshape(grad_out, planes)
+    input_planes = F.reshape(input, planes)
+    mean_groups = F.reshape(mean, [samples, group, 1])
+    rstd_groups = F.reshape(rstd, [samples, group, 1])
+
+    grad_weight = None
+    grad_bias = None
+    if mask[1] or mask[2]:
+        partial_grad = aten_sum(grad_planes, dim=[2])
+        if mask[2]:
+            grad_bias = aten_sum(partial_grad, dim=[0])
+        if mask[1]:
+            partial_dot = aten_sum(grad_planes * input_planes, dim=[2])
+            per_group = [samples, group, channels_per_group]
+            sums = F.reshape(partial_grad, per_group)
+            dots = F.reshape(partial_dot, per_group)
+            centered = (dots - mean_groups * sums) * rstd_groups
+            grad_weight = F.reshape(aten_sum(centered, dim=[0]), [channels])
+
+    grad_input = None
+    if mask[0]:
+        scaled = grad_planes
+        if weight is not None:
+            scaled = scaled * F.reshape(weight, [1, channels, 1])
+        groups = [samples, group, inner]
+        scaled = F.reshape(scaled, groups)
+        normalized = (F.reshape(input_planes, groups) - mean_groups) * rstd_groups
+        mean_scaled = aten_sum(scaled, dim=[2], keepdim=True) / inner
+        mean_dot = aten_sum(scaled * normalized, dim=[2], keepdim=True) / inner
+        grad_input = F.reshape(
+            (scaled - mean_scaled - normalized * mean_dot) * rstd_groups,
+            list(input.shape),
+        )
+    return grad_input, grad_weight, grad_bias
 
 
 # native_layer_norm(Tensor input, SymInt[] normalized_shape, Tensor? weight, Tensor? bias, float eps) -> (Tensor, Tensor, Tensor)

--- a/torch_mojo_backend/aten_functions.py
+++ b/torch_mojo_backend/aten_functions.py
@@ -607,7 +607,7 @@ def aten__native_batch_norm_legit_no_training(
     running_var: MaxTensor,
     momentum: float,
     eps: float,
-) -> tuple[MaxTensor, NotImplementedError, NotImplementedError]:
+) -> tuple[MaxTensor, MaxTensor, MaxTensor]:
     """
     Implements batch normalization for inference (no training).
 
@@ -621,8 +621,9 @@ def aten__native_batch_norm_legit_no_training(
         eps: Small value for numerical stability
 
     Returns:
-        Tuple of (normalized_output, save_mean, save_var)
-        where save_mean and save_var are empty tensors in no-training mode
+        Tuple of (normalized_output, save_mean, save_var), where save_mean
+        and save_var are the empty (0,) tensors PyTorch's meta kernel
+        promises for the no-training overload
     """
     # Get input dimensions
     input_shape = input.shape
@@ -649,19 +650,13 @@ def aten__native_batch_norm_legit_no_training(
         bias_reshaped = F.reshape(bias, broadcast_shape)
         normalized = normalized + bias_reshaped
 
-    # It's not sure we'll ever support returning those, notably because of
-    # https://github.com/pytorch/pytorch/issues/85960
-    return (
-        normalized,
-        NotImplementedError(
-            "We don't support returning the saved mean "
-            "in aten._native_batch_norm_legit_no_training yet"
-        ),
-        NotImplementedError(
-            "We don't support returning the saved variance "
-            "in aten._native_batch_norm_legit_no_training yet"
-        ),
-    )
+    # PyTorch's meta kernel gives both saved statistics shape (0,) here (that
+    # is the inconsistency pytorch/pytorch#85960 is about), and the eval
+    # backward reads the RUNNING buffers rather than these, so empty tensors
+    # are the whole contract -- returning NotImplementedError placeholders
+    # instead only made a training graph fail to compile as soon as anything
+    # kept the node's second or third output alive.
+    return (normalized, running_mean[0:0], running_var[0:0])
 
 
 # _pdist_forward(Tensor self, float p=2) -> Tensor
@@ -3026,6 +3021,85 @@ def aten_native_batch_norm(
     return (normalized, save_mean, save_invstd)
 
 
+# native_batch_norm_backward(Tensor grad_out, Tensor input, Tensor? weight, Tensor? running_mean, Tensor? running_var, Tensor? save_mean, Tensor? save_invstd, bool train, float eps, bool[3] output_mask) -> (Tensor, Tensor, Tensor)
+@map_to(aten.native_batch_norm_backward)
+def aten_native_batch_norm_backward(
+    grad_out: MaxTensor,
+    input: MaxTensor,
+    weight: MaxTensor | None,
+    running_mean: MaxTensor | None,
+    running_var: MaxTensor | None,
+    save_mean: MaxTensor | None,
+    save_invstd: MaxTensor | None,
+    train: bool,
+    eps: float,
+    output_mask: list[bool],
+) -> tuple[MaxTensor | None, MaxTensor | None, MaxTensor | None]:
+    """Gradients of `aten.native_batch_norm`, per channel.
+
+    Follows `batch_norm_backward_cpu_template`
+    (aten/src/ATen/native/Normalization.cpp) with `M = numel / C`:
+
+        dbeta[c]  = sum_{n,s} dy          dgamma[c] = sum_{n,s} dy * xhat
+        dx        = (dy - dbeta/M - xhat * dgamma/M) * invstd * gamma   (train)
+        dx        = dy * invstd * gamma                                 (eval)
+
+    Training reads the statistics the forward saved; evaluation recomputes
+    them from the running buffers, which is why an `.eval()` BatchNorm still
+    produces gradients rather than the zeros an "inference needs no backward"
+    reading would give.
+
+    Returns `None` for the outputs `output_mask` turns off, the way
+    `aten_native_layer_norm` returns `None` for statistics nothing reads.
+    """
+    mask = tuple(output_mask)
+    input_shape = input.shape
+    rank = len(input_shape)
+    num_channels = int(input_shape[1])
+    broadcast_shape = [1] * rank
+    broadcast_shape[1] = num_channels
+    reduce_axes = [axis for axis in range(rank) if axis != 1]
+    reduced = math.prod(int(input_shape[axis]) for axis in reduce_axes)
+
+    if train:
+        if save_mean is None or save_invstd is None:
+            raise ValueError(
+                "save_mean and save_invstd are required when train=True in "
+                "aten.native_batch_norm_backward"
+            )
+        mean = F.reshape(save_mean, broadcast_shape)
+        invstd = F.reshape(save_invstd, broadcast_shape)
+    else:
+        if running_mean is None or running_var is None:
+            raise ValueError(
+                "running_mean and running_var are required when train=False "
+                "in aten.native_batch_norm_backward"
+            )
+        mean = F.reshape(running_mean, broadcast_shape)
+        invstd = 1.0 / F.sqrt(F.reshape(running_var, broadcast_shape) + eps)
+
+    normalized = (input - mean) * invstd
+    # dx needs both affine gradients while training, whatever the mask says.
+    sum_grad = aten_sum(grad_out, dim=reduce_axes, keepdim=True)
+    dot_grad = aten_sum(grad_out * normalized, dim=reduce_axes, keepdim=True)
+
+    grad_input = None
+    if mask[0]:
+        scale = invstd
+        if weight is not None:
+            scale = scale * F.reshape(weight, broadcast_shape)
+        if train:
+            projected = (
+                grad_out - sum_grad / reduced - normalized * (dot_grad / reduced)
+            )
+        else:
+            projected = grad_out
+        grad_input = projected * scale
+    grad_weight = F.reshape(dot_grad, [num_channels]) if mask[1] else None
+    grad_bias = F.reshape(sum_grad, [num_channels]) if mask[2] else None
+    return grad_input, grad_weight, grad_bias
+
+
 # native_dropout(Tensor input, float p, bool? train) -> (Tensor, Tensor)
 
 
@@ -3040,10 +3114,11 @@ def aten_native_group_norm(
     HxW: SymIntType,
     group: int,
     eps: float,
-) -> tuple[MaxTensor, NotImplementedError, NotImplementedError]:
+) -> tuple[MaxTensor, MaxTensor, MaxTensor]:
     """
     This is the low-level operation that F.group_norm gets compiled to.
-    Returns (normalized_output, mean, rstd) tuple but we only return the first element for simplicity.
+    Returns (normalized_output, mean, rstd); the two statistics are per
+    (sample, group) and are what `aten.native_group_norm_backward` consumes.
     """
     # Reshape input from [N*C, HxW] back to [N, C, H, W] format
     # First, calculate H and W from HxW
@@ -3061,15 +3136,19 @@ def aten_native_group_norm(
     # Use the regular group_norm implementation
     result = torch_group_norm_equivalent(input_reshaped, group, weight, bias, eps)
 
-    # Return just the normalized output (native_group_norm returns a tuple)
+    # The statistics are per (sample, group) and are what
+    # `aten.native_group_norm_backward` consumes, so a training graph is dead
+    # without them; they used to be NotImplementedError placeholders, which
+    # made every grad-requiring group norm fail to compile.
+    grouped = F.reshape(input, [int(N), group, (int(C) // group) * HW])
+    group_mean = aten_mean(grouped, dim=[2], keepdim=True)
+    group_centered = grouped - group_mean
+    group_var = aten_mean(group_centered * group_centered, dim=[2], keepdim=True)
+    group_rstd = 1 / F.sqrt(group_var + eps)
     return (
         result,
-        NotImplementedError(
-            "The implementation of aten.native_group_norm doesn't support returning mean yet."
-        ),
-        NotImplementedError(
-            "The implementation of aten.native_group_norm doesn't support returning rstd yet."
-        ),
+        F.reshape(group_mean, [int(N), group]),
+        F.reshape(group_rstd, [int(N), group]),
     )
 
 
@@ -3128,6 +3207,77 @@ def torch_group_norm_equivalent(
 
 
 # native_group_norm_backward(Tensor grad_out, Tensor input, Tensor mean, Tensor rstd, Tensor? weight, SymInt N, SymInt C, SymInt HxW, int group, bool[3] output_mask) -> (Tensor, Tensor, Tensor)
+@map_to(aten.native_group_norm_backward)
+def aten_native_group_norm_backward(
+    grad_out: MaxTensor,
+    input: MaxTensor,
+    mean: MaxTensor,
+    rstd: MaxTensor,
+    weight: MaxTensor | None,
+    N: SymIntType,
+    C: SymIntType,
+    HxW: SymIntType,
+    group: int,
+    output_mask: list[bool],
+) -> tuple[MaxTensor | None, MaxTensor | None, MaxTensor | None]:
+    """Gradients of `aten.native_group_norm`.
+
+    Group norm normalizes the trailing `(C / group) * HxW` elements of the
+    `(N, group, K)` view, so its grad-input is the layer-norm formula on that
+    view once the per-channel gamma is folded into grad_out:
+
+        dx = rstd * (q - mean_k(q) - xhat * mean_k(q * xhat)),  q = dy * gamma
+
+    The affine gradients reduce over a different axis set -- the batch and the
+    spatial extent, per channel -- and go through the per-(sample, channel)
+    partial sums ATen's own kernel uses:
+
+        dgamma[c] = sum_n rstd[n, g] * (S2[n, c] - mean[n, g] * S1[n, c])
+        dbeta[c]  = sum_n S1[n, c]
+        S1[n, c]  = sum_hw dy        S2[n, c] = sum_hw dy * x
+    """
+    mask = tuple(output_mask)
+    samples = int(N)
+    channels = int(C)
+    spatial = int(HxW)
+    channels_per_group = channels // group
+    inner = channels_per_group * spatial
+
+    planes = [samples, channels, spatial]
+    grad_planes = F.reshape(grad_out, planes)
+    input_planes = F.reshape(input, planes)
+    mean_groups = F.reshape(mean, [samples, group, 1])
+    rstd_groups = F.reshape(rstd, [samples, group, 1])
+
+    grad_weight = None
+    grad_bias = None
+    if mask[1] or mask[2]:
+        partial_grad = aten_sum(grad_planes, dim=[2])
+        if mask[2]:
+            grad_bias = aten_sum(partial_grad, dim=[0])
+        if mask[1]:
+            partial_dot = aten_sum(grad_planes * input_planes, dim=[2])
+            per_group = [samples, group, channels_per_group]
+            sums = F.reshape(partial_grad, per_group)
+            dots = F.reshape(partial_dot, per_group)
+            centered = (dots - mean_groups * sums) * rstd_groups
+            grad_weight = F.reshape(aten_sum(centered, dim=[0]), [channels])
+
+    grad_input = None
+    if mask[0]:
+        scaled = grad_planes
+        if weight is not None:
+            scaled = scaled * F.reshape(weight, [1, channels, 1])
+        groups = [samples, group, inner]
+        scaled = F.reshape(scaled, groups)
+        normalized = (F.reshape(input_planes, groups) - mean_groups) * rstd_groups
+        mean_scaled = aten_sum(scaled, dim=[2], keepdim=True) / inner
+        mean_dot = aten_sum(scaled * normalized, dim=[2], keepdim=True) / inner
+        grad_input = F.reshape(
+            (scaled - mean_scaled - normalized * mean_dot) * rstd_groups,
+            list(input.shape),
+        )
+    return grad_input, grad_weight, grad_bias
 
 
 # native_layer_norm(Tensor input, SymInt[] normalized_shape, Tensor? weight, Tensor? bias, float eps) -> (Tensor, Tensor, Tensor)

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -5518,6 +5518,414 @@ def fast_aten_native_layer_norm_backward(
 
 
 # ---------------------------------------------------------------------------
+# Group / batch norm backward
+#
+# Both reduce over axis sets no LayerNorm kernel covers on its own, so they are
+# composed here from the kernels that do exist:
+#
+#   * group norm IS layer norm over the trailing `(C/G) * HxW` elements of the
+#     `(N*G, K)` view, so its grad-input half is exactly
+#     `fast_aten_native_layer_norm_backward` on that view, with the per-channel
+#     affine folded into grad_out first (the LayerNorm kernel's `weight` is
+#     indexed per column, group norm's per channel).
+#   * the affine gradients of both ops reduce over the batch and the spatial
+#     extent for each channel -- the complement of the per-sample axes the
+#     LayerNorm kernels reduce -- so they go through the per-(sample, channel)
+#     partial sums ATen's own kernels use, which are ordinary trailing-axis
+#     reductions of the existing reduce kernels.
+#
+# Half-precision inputs accumulate in float32 (ATen's `at::acc_type`) and the
+# results are narrowed back at the end, so a bf16 model gets ATen's accuracy
+# rather than the input dtype's.
+# ---------------------------------------------------------------------------
+
+
+class _NormBackwardDeclined(Exception):
+    """A composed step declined; the caller returns NOT_HANDLED."""
+
+
+def _norm_bwd(value: object) -> object:
+    """One composed step's result, or decline the whole op.
+
+    The compositions below are a dozen calls deep and every one of them can
+    answer NOT_HANDLED. Letting that sentinel flow into the next call would
+    surface as an unrelated AttributeError inside some other op, so it is
+    turned into a decline here, at the step that produced it.
+    """
+    if value is NOT_HANDLED or value is None:
+        raise _NormBackwardDeclined
+    return value
+
+
+def _norm_bwd_f32(t: TorchMojoTensor) -> TorchMojoTensor:
+    """`t` as a contiguous float32 tensor (ATen's `acc_type` for half input)."""
+    c = _tc(t)
+    if c is None:
+        raise _NormBackwardDeclined
+    if c._dtype == DType.float32:
+        return c
+    if c._dtype not in _CAST_DTYPES:
+        raise _NormBackwardDeclined
+    return _cast_tensor(c, DType.float32)
+
+
+def _norm_bwd_narrow(t: object, dtype: DType) -> object:
+    """`t` cast back down to the dtype ATen gives that output, if needed."""
+    if t is None or t is NOT_HANDLED:
+        return t
+    if t._dtype == dtype:
+        return t
+    if dtype not in _CAST_DTYPES:
+        raise _NormBackwardDeclined
+    return _cast_tensor(t, dtype)
+
+
+def _group_norm_backward_dx(
+    q: TorchMojoTensor,
+    x: TorchMojoTensor,
+    mean: TorchMojoTensor,
+    rstd: TorchMojoTensor,
+    N: int,
+    group: int,
+    K: int,
+) -> TorchMojoTensor:
+    """Group norm grad-input for `q = grad_out * gamma`, x flattened to (N,G,K).
+
+    The fused LayerNorm backward kernel is the whole op on the `(N*G, K)` view:
+    with `weight=None` it forms exactly
+    `rstd/K * (K*q - sum(q) - xhat * sum(q*xhat))` per row, which is group
+    norm's grad-input once gamma is already folded into `q`. It gates itself on
+    float32 GPU operands, so the explicit composition below serves the mojo CPU
+    device (and anything else the kernel declines).
+    """
+    rows = N * group
+    q2 = _norm_bwd(fast_aten_view(q, (rows, K)))
+    x2 = _norm_bwd(fast_aten_view(x, (rows, K)))
+    fused = fast_aten_native_layer_norm_backward(
+        q2, x2, (K,), mean, rstd, None, None, [True, False, False]
+    )
+    if fused is not NOT_HANDLED and fused[0] is not None:
+        return _norm_bwd(fast_aten_view(fused[0], (N, group, K)))
+
+    mean_g = _norm_bwd(fast_aten_view(mean, (N, group, 1)))
+    rstd_g = _norm_bwd(fast_aten_view(rstd, (N, group, 1)))
+    q3 = _norm_bwd(fast_aten_view(q, (N, group, K)))
+    x3 = _norm_bwd(fast_aten_view(x, (N, group, K)))
+    xhat = _norm_bwd(fast_aten_mul(_norm_bwd(fast_aten_sub(x3, mean_g)), rstd_g))
+    mean_q = _norm_bwd(
+        fast_aten_div(_norm_bwd(fast_aten_sum(q3, dim=[2], keepdim=True)), float(K))
+    )
+    mean_qx = _norm_bwd(
+        fast_aten_div(
+            _norm_bwd(
+                fast_aten_sum(_norm_bwd(fast_aten_mul(q3, xhat)), dim=[2], keepdim=True)
+            ),
+            float(K),
+        )
+    )
+    centred = _norm_bwd(fast_aten_sub(q3, mean_q))
+    centred = _norm_bwd(fast_aten_sub(centred, _norm_bwd(fast_aten_mul(xhat, mean_qx))))
+    return _norm_bwd(fast_aten_mul(centred, rstd_g))
+
+
+def fast_aten_native_group_norm_backward(
+    grad_out: object,
+    input: object,
+    mean: object,
+    rstd: object,
+    weight: object,
+    N: object,
+    C: object,
+    HxW: object,
+    group: object,
+    output_mask: object,
+) -> object:
+    """`aten::native_group_norm_backward` (see the section comment above).
+
+        dgamma[c] = sum_n rstd[n, g] * (S2[n, c] - mean[n, g] * S1[n, c])
+        dbeta[c]  = sum_n S1[n, c]
+        S1[n, c]  = sum_hw dy        S2[n, c] = sum_hw dy * x
+
+    with `g = c // (C / group)`; this is the same regrouping ATen's own CUDA
+    kernel does, and it keeps every reduction on a trailing axis.
+    """
+    a = _t(input)
+    grad = _t(grad_out)
+    saved_mean = _t(mean)
+    saved_rstd = _t(rstd)
+    gamma = _t(weight) if weight is not None else None
+    if (
+        a is None
+        or grad is None
+        or saved_mean is None
+        or saved_rstd is None
+        or (weight is not None and gamma is None)
+        or not isinstance(N, int)
+        or not isinstance(C, int)
+        or not isinstance(HxW, int)
+        or not isinstance(group, int)
+        or isinstance(group, bool)
+        or group <= 0
+        or C <= 0
+        or C % group != 0
+        or N < 0
+        or HxW < 0
+        or not isinstance(output_mask, list | tuple)
+    ):
+        return NOT_HANDLED
+    mask = tuple(output_mask)
+    if len(mask) != 3 or any(not isinstance(requested, bool) for requested in mask):
+        return NOT_HANDLED
+    if (
+        a._dtype not in _FLOAT_DTYPES
+        or grad._dtype != a._dtype
+        or a._numel != N * C * HxW
+        or tuple(grad._shape) != tuple(a._shape)
+        or grad._device != a._device
+        or saved_mean._device != a._device
+        or saved_rstd._device != a._device
+        or saved_mean._dtype not in _FLOAT_DTYPES
+        or saved_rstd._dtype not in _FLOAT_DTYPES
+        or saved_mean._numel != N * group
+        or saved_rstd._numel != N * group
+    ):
+        return NOT_HANDLED
+    if gamma is not None and (
+        gamma._device != a._device
+        or gamma._dtype not in _FLOAT_DTYPES
+        or tuple(gamma._shape) != (C,)
+    ):
+        return NOT_HANDLED
+    # ATen allocates the affine gradients with gamma's options, falling back to
+    # the input's (aten/src/ATen/native/group_norm.cpp).
+    param_dtype = gamma._dtype if gamma is not None else a._dtype
+    if not any(mask):
+        return None, None, None
+    if a._numel == 0:
+        # ATen returns zeros for every requested output when N == 0.
+        return (
+            fast_filled(a._shape, 0.0, a._dtype, a._device) if mask[0] else None,
+            fast_filled((C,), 0.0, param_dtype, a._device) if mask[1] else None,
+            fast_filled((C,), 0.0, param_dtype, a._device) if mask[2] else None,
+        )
+
+    channels_per_group = C // group
+    K = channels_per_group * HxW
+    try:
+        x = _norm_bwd_f32(a)
+        dy = _norm_bwd_f32(grad)
+        saved_mean = _norm_bwd_f32(saved_mean)
+        saved_rstd = _norm_bwd_f32(saved_rstd)
+        dy3 = _norm_bwd(fast_aten_view(dy, (N, C, HxW)))
+
+        grad_input = grad_weight = grad_bias = None
+        if mask[1] or mask[2]:
+            partial_dy = _norm_bwd(fast_aten_sum(dy3, dim=[2]))  # (N, C)
+            if mask[2]:
+                grad_bias = _norm_bwd(fast_aten_sum(partial_dy, dim=[0]))
+            if mask[1]:
+                x3 = _norm_bwd(fast_aten_view(x, (N, C, HxW)))
+                partial_dyx = _norm_bwd(
+                    fast_aten_sum(_norm_bwd(fast_aten_mul(dy3, x3)), dim=[2])
+                )
+                shape = (N, group, channels_per_group)
+                s1 = _norm_bwd(fast_aten_view(partial_dy, shape))
+                s2 = _norm_bwd(fast_aten_view(partial_dyx, shape))
+                mean_g = _norm_bwd(fast_aten_view(saved_mean, (N, group, 1)))
+                rstd_g = _norm_bwd(fast_aten_view(saved_rstd, (N, group, 1)))
+                centred = _norm_bwd(
+                    fast_aten_sub(s2, _norm_bwd(fast_aten_mul(mean_g, s1)))
+                )
+                per_sample = _norm_bwd(fast_aten_mul(centred, rstd_g))
+                grad_weight = _norm_bwd(
+                    fast_aten_view(_norm_bwd(fast_aten_sum(per_sample, dim=[0])), (C,))
+                )
+        if mask[0]:
+            if gamma is None:
+                q = dy3
+            else:
+                broadcast_gamma = _norm_bwd(
+                    fast_aten_view(_norm_bwd_f32(gamma), (1, C, 1))
+                )
+                q = _norm_bwd(fast_aten_mul(dy3, broadcast_gamma))
+            dx = _group_norm_backward_dx(q, x, saved_mean, saved_rstd, N, group, K)
+            grad_input = _norm_bwd(fast_aten_view(dx, tuple(a._shape)))
+
+        grad_input = _norm_bwd_narrow(grad_input, a._dtype)
+        grad_weight = _norm_bwd_narrow(grad_weight, param_dtype)
+        grad_bias = _norm_bwd_narrow(grad_bias, param_dtype)
+    except _NormBackwardDeclined:
+        return NOT_HANDLED
+    return grad_input, grad_weight, grad_bias
+
+
+def fast_aten_native_batch_norm_backward(
+    grad_out: object,
+    input: object,
+    weight: object,
+    running_mean: object,
+    running_var: object,
+    save_mean: object,
+    save_invstd: object,
+    train: object,
+    eps: object,
+    output_mask: object,
+) -> object:
+    """`aten::native_batch_norm_backward` for the mojo eager device.
+
+    Follows `batch_norm_backward_cpu_template` exactly
+    (aten/src/ATen/native/Normalization.cpp): with `M = numel / C`,
+
+        dotp[c]   = sum_{n,s} (x - mean) * dy
+        dgamma[c] = dotp * invstd            dbeta[c] = sum_{n,s} dy
+        dx        = (dy - dbeta/M - xhat * dgamma/M) * invstd * gamma   (train)
+        dx        = dy * invstd * gamma                                 (eval)
+
+    `mean` / `invstd` are the saved statistics while training and
+    `running_mean` / `rsqrt(running_var + eps)` in eval, which is why an
+    `.eval()` BatchNorm still produces gradients. The per-channel reduction is
+    split into a trailing-axis pass over the spatial extent and a leading-axis
+    pass over the batch, so both legs are ordinary reduce-kernel shapes.
+    """
+    a = _t(input)
+    grad = _t(grad_out)
+    gamma = _t(weight) if weight is not None else None
+    run_mean = _t(running_mean) if running_mean is not None else None
+    run_var = _t(running_var) if running_var is not None else None
+    saved_mean = _t(save_mean) if save_mean is not None else None
+    saved_invstd = _t(save_invstd) if save_invstd is not None else None
+    if (
+        a is None
+        or grad is None
+        or (weight is not None and gamma is None)
+        or type(train) is not bool
+        or not isinstance(eps, int | float)
+        or isinstance(eps, bool)
+        or not isinstance(output_mask, list | tuple)
+        or len(a._shape) < 2
+    ):
+        return NOT_HANDLED
+    mask = tuple(output_mask)
+    if len(mask) != 3 or any(not isinstance(requested, bool) for requested in mask):
+        return NOT_HANDLED
+    channels = a._shape[1]
+    if (
+        a._dtype not in _FLOAT_DTYPES
+        or grad._dtype != a._dtype
+        or tuple(grad._shape) != tuple(a._shape)
+        or grad._device != a._device
+    ):
+        return NOT_HANDLED
+    # Training reads the statistics the forward saved; inference recomputes
+    # them from the running buffers, exactly as ATen does.
+    stats = (saved_mean, saved_invstd) if train else (run_mean, run_var)
+    if any(
+        stat is None
+        or stat._device != a._device
+        or stat._dtype not in _FLOAT_DTYPES
+        or stat._numel != channels
+        for stat in stats
+    ):
+        return NOT_HANDLED
+    if gamma is not None and (
+        gamma._device != a._device
+        or gamma._dtype not in _FLOAT_DTYPES
+        or tuple(gamma._shape) != (channels,)
+    ):
+        return NOT_HANDLED
+    # ATen widens the affine gradients to float32 exactly when the parameters
+    # are already wider than the input (`mixed_type` in Normalization.cpp).
+    present = [p for p in (gamma, *stats) if p is not None]
+    mixed = any(p._dtype != a._dtype for p in present)
+    param_dtype = DType.float32 if mixed else a._dtype
+    if not any(mask):
+        return None, None, None
+    if a._numel == 0:
+        return (
+            fast_filled(a._shape, 0.0, a._dtype, a._device) if mask[0] else None,
+            fast_filled((channels,), 0.0, param_dtype, a._device) if mask[1] else None,
+            fast_filled((channels,), 0.0, param_dtype, a._device) if mask[2] else None,
+        )
+
+    inner = a._numel // (a._shape[0] * channels)
+    reduced = a._numel // channels
+    try:
+        x = _norm_bwd_f32(a)
+        dy = _norm_bwd_f32(grad)
+        if train:
+            mean = _norm_bwd_f32(stats[0])
+            invstd = _norm_bwd_f32(stats[1])
+        else:
+            mean = _norm_bwd_f32(stats[0])
+            shifted = _norm_bwd(fast_aten_add(_norm_bwd_f32(stats[1]), float(eps)))
+            invstd = _norm_bwd(fast_aten_rsqrt(shifted))
+        planes = (a._shape[0], channels, inner)
+        dy3 = _norm_bwd(fast_aten_view(dy, planes))
+        x3 = _norm_bwd(fast_aten_view(x, planes))
+
+        grad_input = grad_weight = grad_bias = None
+        # dx needs both affine gradients while training, whatever the mask says,
+        # and `xhat` is exactly what the weight gradient needs -- so an
+        # inference dx, or a bias-only call, never materializes it.
+        need_bias = mask[2] or (mask[0] and train)
+        need_weight = mask[1] or (mask[0] and train)
+        xhat = sum_dy = sum_dyxhat = None
+        if need_bias:
+            sum_dy = _norm_bwd(
+                fast_aten_sum(_norm_bwd(fast_aten_sum(dy3, dim=[2])), dim=[0])
+            )
+            grad_bias = sum_dy if mask[2] else None
+        if need_weight:
+            mean_c = _norm_bwd(fast_aten_view(mean, (1, channels, 1)))
+            invstd_c = _norm_bwd(fast_aten_view(invstd, (1, channels, 1)))
+            xhat = _norm_bwd(
+                fast_aten_mul(_norm_bwd(fast_aten_sub(x3, mean_c)), invstd_c)
+            )
+            per_plane = _norm_bwd(
+                fast_aten_sum(_norm_bwd(fast_aten_mul(dy3, xhat)), dim=[2])
+            )
+            sum_dyxhat = _norm_bwd(fast_aten_sum(per_plane, dim=[0]))
+            grad_weight = sum_dyxhat if mask[1] else None
+        if mask[0]:
+            scale = (
+                invstd
+                if gamma is None
+                else _norm_bwd(fast_aten_mul(invstd, _norm_bwd_f32(gamma)))
+            )
+            scale_c = _norm_bwd(fast_aten_view(scale, (1, channels, 1)))
+            if train:
+                mean_dy = _norm_bwd(
+                    fast_aten_view(
+                        _norm_bwd(fast_aten_div(sum_dy, float(reduced))),
+                        (1, channels, 1),
+                    )
+                )
+                mean_dyxhat = _norm_bwd(
+                    fast_aten_view(
+                        _norm_bwd(fast_aten_div(sum_dyxhat, float(reduced))),
+                        (1, channels, 1),
+                    )
+                )
+                projected = _norm_bwd(fast_aten_sub(dy3, mean_dy))
+                projected = _norm_bwd(
+                    fast_aten_sub(
+                        projected, _norm_bwd(fast_aten_mul(xhat, mean_dyxhat))
+                    )
+                )
+            else:
+                projected = dy3
+            dx = _norm_bwd(fast_aten_mul(projected, scale_c))
+            grad_input = _norm_bwd(fast_aten_view(dx, tuple(a._shape)))
+
+        grad_input = _norm_bwd_narrow(grad_input, a._dtype)
+        grad_weight = _norm_bwd_narrow(grad_weight, param_dtype)
+        grad_bias = _norm_bwd_narrow(grad_bias, param_dtype)
+    except _NormBackwardDeclined:
+        return NOT_HANDLED
+    return grad_input, grad_weight, grad_bias
+
+
+# ---------------------------------------------------------------------------
 # Reductions
 # ---------------------------------------------------------------------------
 

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -5928,7 +5928,7 @@ class _NormBackwardDeclined(Exception):
     """A composed step declined; the caller returns NOT_HANDLED."""
 
 
-def _norm_bwd(value: object) -> object:
+def _norm_bwd(value: TorchMojoTensor | _NotHandled | None) -> TorchMojoTensor:
     """One composed step's result, or decline the whole op.
 
     The compositions below are a dozen calls deep and every one of them can
@@ -5936,7 +5936,9 @@ def _norm_bwd(value: object) -> object:
     surface as an unrelated AttributeError inside some other op, so it is
     turned into a decline here, at the step that produced it.
     """
-    if value is NOT_HANDLED or value is None:
+    # isinstance, not `is`: ty doesn't narrow identity checks against a
+    # custom singleton instance the way it does for `is None`.
+    if isinstance(value, _NotHandled) or value is None:
         raise _NormBackwardDeclined
     return value
 
@@ -5953,9 +5955,13 @@ def _norm_bwd_f32(t: TorchMojoTensor) -> TorchMojoTensor:
     return _cast_tensor(c, DType.float32)
 
 
-def _norm_bwd_narrow(t: object, dtype: DType) -> object:
+def _norm_bwd_narrow(
+    t: TorchMojoTensor | _NotHandled | None, dtype: DType
+) -> TorchMojoTensor | _NotHandled | None:
     """`t` cast back down to the dtype ATen gives that output, if needed."""
-    if t is None or t is NOT_HANDLED:
+    # isinstance, not `is`: ty doesn't narrow identity checks against a
+    # custom singleton instance the way it does for `is None`.
+    if isinstance(t, _NotHandled) or t is None:
         return t
     if t._dtype == dtype:
         return t
@@ -5988,7 +5994,9 @@ def _group_norm_backward_dx(
     fused = fast_aten_native_layer_norm_backward(
         q2, x2, (K,), mean, rstd, None, None, [True, False, False]
     )
-    if fused is not NOT_HANDLED and fused[0] is not None:
+    # isinstance, not `is`: ty doesn't narrow identity checks against a
+    # custom singleton instance the way it does for `is None`.
+    if not isinstance(fused, _NotHandled) and fused[0] is not None:
         return _norm_bwd(fast_aten_view(fused[0], (N, group, K)))
 
     mean_g = _norm_bwd(fast_aten_view(mean, (N, group, 1)))
@@ -6202,15 +6210,16 @@ def fast_aten_native_batch_norm_backward(
         return NOT_HANDLED
     # Training reads the statistics the forward saved; inference recomputes
     # them from the running buffers, exactly as ATen does.
-    stats = (saved_mean, saved_invstd) if train else (run_mean, run_var)
+    unwrapped_stats = (saved_mean, saved_invstd) if train else (run_mean, run_var)
     if any(
         stat is None
         or stat._device != a._device
         or stat._dtype not in _FLOAT_DTYPES
         or stat._numel != channels
-        for stat in stats
+        for stat in unwrapped_stats
     ):
         return NOT_HANDLED
+    stats = cast(tuple[TorchMojoTensor, TorchMojoTensor], unwrapped_stats)
     if gamma is not None and (
         gamma._device != a._device
         or gamma._dtype not in _FLOAT_DTYPES
@@ -6278,6 +6287,11 @@ def fast_aten_native_batch_norm_backward(
             )
             scale_c = _norm_bwd(fast_aten_view(scale, (1, channels, 1)))
             if train:
+                # mask[0] and train => need_bias and need_weight, so these
+                # were assigned above.
+                assert sum_dy is not None
+                assert xhat is not None
+                assert sum_dyxhat is not None
                 mean_dy = _norm_bwd(
                     fast_aten_view(
                         _norm_bwd(fast_aten_div(sum_dy, float(reduced))),

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -5902,6 +5902,414 @@ def fast_aten_native_layer_norm_backward(
 
 
 # ---------------------------------------------------------------------------
+# Group / batch norm backward
+#
+# Both reduce over axis sets no LayerNorm kernel covers on its own, so they are
+# composed here from the kernels that do exist:
+#
+#   * group norm IS layer norm over the trailing `(C/G) * HxW` elements of the
+#     `(N*G, K)` view, so its grad-input half is exactly
+#     `fast_aten_native_layer_norm_backward` on that view, with the per-channel
+#     affine folded into grad_out first (the LayerNorm kernel's `weight` is
+#     indexed per column, group norm's per channel).
+#   * the affine gradients of both ops reduce over the batch and the spatial
+#     extent for each channel -- the complement of the per-sample axes the
+#     LayerNorm kernels reduce -- so they go through the per-(sample, channel)
+#     partial sums ATen's own kernels use, which are ordinary trailing-axis
+#     reductions of the existing reduce kernels.
+#
+# Half-precision inputs accumulate in float32 (ATen's `at::acc_type`) and the
+# results are narrowed back at the end, so a bf16 model gets ATen's accuracy
+# rather than the input dtype's.
+# ---------------------------------------------------------------------------
+
+
+class _NormBackwardDeclined(Exception):
+    """A composed step declined; the caller returns NOT_HANDLED."""
+
+
+def _norm_bwd(value: object) -> object:
+    """One composed step's result, or decline the whole op.
+
+    The compositions below are a dozen calls deep and every one of them can
+    answer NOT_HANDLED. Letting that sentinel flow into the next call would
+    surface as an unrelated AttributeError inside some other op, so it is
+    turned into a decline here, at the step that produced it.
+    """
+    if value is NOT_HANDLED or value is None:
+        raise _NormBackwardDeclined
+    return value
+
+
+def _norm_bwd_f32(t: TorchMojoTensor) -> TorchMojoTensor:
+    """`t` as a contiguous float32 tensor (ATen's `acc_type` for half input)."""
+    c = _tc(t)
+    if c is None:
+        raise _NormBackwardDeclined
+    if c._dtype == DType.float32:
+        return c
+    if c._dtype not in _CAST_DTYPES:
+        raise _NormBackwardDeclined
+    return _cast_tensor(c, DType.float32)
+
+
+def _norm_bwd_narrow(t: object, dtype: DType) -> object:
+    """`t` cast back down to the dtype ATen gives that output, if needed."""
+    if t is None or t is NOT_HANDLED:
+        return t
+    if t._dtype == dtype:
+        return t
+    if dtype not in _CAST_DTYPES:
+        raise _NormBackwardDeclined
+    return _cast_tensor(t, dtype)
+
+
+def _group_norm_backward_dx(
+    q: TorchMojoTensor,
+    x: TorchMojoTensor,
+    mean: TorchMojoTensor,
+    rstd: TorchMojoTensor,
+    N: int,
+    group: int,
+    K: int,
+) -> TorchMojoTensor:
+    """Group norm grad-input for `q = grad_out * gamma`, x flattened to (N,G,K).
+
+    The fused LayerNorm backward kernel is the whole op on the `(N*G, K)` view:
+    with `weight=None` it forms exactly
+    `rstd/K * (K*q - sum(q) - xhat * sum(q*xhat))` per row, which is group
+    norm's grad-input once gamma is already folded into `q`. It gates itself on
+    float32 GPU operands, so the explicit composition below serves the mojo CPU
+    device (and anything else the kernel declines).
+    """
+    rows = N * group
+    q2 = _norm_bwd(fast_aten_view(q, (rows, K)))
+    x2 = _norm_bwd(fast_aten_view(x, (rows, K)))
+    fused = fast_aten_native_layer_norm_backward(
+        q2, x2, (K,), mean, rstd, None, None, [True, False, False]
+    )
+    if fused is not NOT_HANDLED and fused[0] is not None:
+        return _norm_bwd(fast_aten_view(fused[0], (N, group, K)))
+
+    mean_g = _norm_bwd(fast_aten_view(mean, (N, group, 1)))
+    rstd_g = _norm_bwd(fast_aten_view(rstd, (N, group, 1)))
+    q3 = _norm_bwd(fast_aten_view(q, (N, group, K)))
+    x3 = _norm_bwd(fast_aten_view(x, (N, group, K)))
+    xhat = _norm_bwd(fast_aten_mul(_norm_bwd(fast_aten_sub(x3, mean_g)), rstd_g))
+    mean_q = _norm_bwd(
+        fast_aten_div(_norm_bwd(fast_aten_sum(q3, dim=[2], keepdim=True)), float(K))
+    )
+    mean_qx = _norm_bwd(
+        fast_aten_div(
+            _norm_bwd(
+                fast_aten_sum(_norm_bwd(fast_aten_mul(q3, xhat)), dim=[2], keepdim=True)
+            ),
+            float(K),
+        )
+    )
+    centred = _norm_bwd(fast_aten_sub(q3, mean_q))
+    centred = _norm_bwd(fast_aten_sub(centred, _norm_bwd(fast_aten_mul(xhat, mean_qx))))
+    return _norm_bwd(fast_aten_mul(centred, rstd_g))
+
+
+def fast_aten_native_group_norm_backward(
+    grad_out: object,
+    input: object,
+    mean: object,
+    rstd: object,
+    weight: object,
+    N: object,
+    C: object,
+    HxW: object,
+    group: object,
+    output_mask: object,
+) -> object:
+    """`aten::native_group_norm_backward` (see the section comment above).
+
+        dgamma[c] = sum_n rstd[n, g] * (S2[n, c] - mean[n, g] * S1[n, c])
+        dbeta[c]  = sum_n S1[n, c]
+        S1[n, c]  = sum_hw dy        S2[n, c] = sum_hw dy * x
+
+    with `g = c // (C / group)`; this is the same regrouping ATen's own CUDA
+    kernel does, and it keeps every reduction on a trailing axis.
+    """
+    a = _t(input)
+    grad = _t(grad_out)
+    saved_mean = _t(mean)
+    saved_rstd = _t(rstd)
+    gamma = _t(weight) if weight is not None else None
+    if (
+        a is None
+        or grad is None
+        or saved_mean is None
+        or saved_rstd is None
+        or (weight is not None and gamma is None)
+        or not isinstance(N, int)
+        or not isinstance(C, int)
+        or not isinstance(HxW, int)
+        or not isinstance(group, int)
+        or isinstance(group, bool)
+        or group <= 0
+        or C <= 0
+        or C % group != 0
+        or N < 0
+        or HxW < 0
+        or not isinstance(output_mask, list | tuple)
+    ):
+        return NOT_HANDLED
+    mask = tuple(output_mask)
+    if len(mask) != 3 or any(not isinstance(requested, bool) for requested in mask):
+        return NOT_HANDLED
+    if (
+        a._dtype not in _FLOAT_DTYPES
+        or grad._dtype != a._dtype
+        or a._numel != N * C * HxW
+        or tuple(grad._shape) != tuple(a._shape)
+        or grad._device != a._device
+        or saved_mean._device != a._device
+        or saved_rstd._device != a._device
+        or saved_mean._dtype not in _FLOAT_DTYPES
+        or saved_rstd._dtype not in _FLOAT_DTYPES
+        or saved_mean._numel != N * group
+        or saved_rstd._numel != N * group
+    ):
+        return NOT_HANDLED
+    if gamma is not None and (
+        gamma._device != a._device
+        or gamma._dtype not in _FLOAT_DTYPES
+        or tuple(gamma._shape) != (C,)
+    ):
+        return NOT_HANDLED
+    # ATen allocates the affine gradients with gamma's options, falling back to
+    # the input's (aten/src/ATen/native/group_norm.cpp).
+    param_dtype = gamma._dtype if gamma is not None else a._dtype
+    if not any(mask):
+        return None, None, None
+    if a._numel == 0:
+        # ATen returns zeros for every requested output when N == 0.
+        return (
+            fast_filled(a._shape, 0.0, a._dtype, a._device) if mask[0] else None,
+            fast_filled((C,), 0.0, param_dtype, a._device) if mask[1] else None,
+            fast_filled((C,), 0.0, param_dtype, a._device) if mask[2] else None,
+        )
+
+    channels_per_group = C // group
+    K = channels_per_group * HxW
+    try:
+        x = _norm_bwd_f32(a)
+        dy = _norm_bwd_f32(grad)
+        saved_mean = _norm_bwd_f32(saved_mean)
+        saved_rstd = _norm_bwd_f32(saved_rstd)
+        dy3 = _norm_bwd(fast_aten_view(dy, (N, C, HxW)))
+
+        grad_input = grad_weight = grad_bias = None
+        if mask[1] or mask[2]:
+            partial_dy = _norm_bwd(fast_aten_sum(dy3, dim=[2]))  # (N, C)
+            if mask[2]:
+                grad_bias = _norm_bwd(fast_aten_sum(partial_dy, dim=[0]))
+            if mask[1]:
+                x3 = _norm_bwd(fast_aten_view(x, (N, C, HxW)))
+                partial_dyx = _norm_bwd(
+                    fast_aten_sum(_norm_bwd(fast_aten_mul(dy3, x3)), dim=[2])
+                )
+                shape = (N, group, channels_per_group)
+                s1 = _norm_bwd(fast_aten_view(partial_dy, shape))
+                s2 = _norm_bwd(fast_aten_view(partial_dyx, shape))
+                mean_g = _norm_bwd(fast_aten_view(saved_mean, (N, group, 1)))
+                rstd_g = _norm_bwd(fast_aten_view(saved_rstd, (N, group, 1)))
+                centred = _norm_bwd(
+                    fast_aten_sub(s2, _norm_bwd(fast_aten_mul(mean_g, s1)))
+                )
+                per_sample = _norm_bwd(fast_aten_mul(centred, rstd_g))
+                grad_weight = _norm_bwd(
+                    fast_aten_view(_norm_bwd(fast_aten_sum(per_sample, dim=[0])), (C,))
+                )
+        if mask[0]:
+            if gamma is None:
+                q = dy3
+            else:
+                broadcast_gamma = _norm_bwd(
+                    fast_aten_view(_norm_bwd_f32(gamma), (1, C, 1))
+                )
+                q = _norm_bwd(fast_aten_mul(dy3, broadcast_gamma))
+            dx = _group_norm_backward_dx(q, x, saved_mean, saved_rstd, N, group, K)
+            grad_input = _norm_bwd(fast_aten_view(dx, tuple(a._shape)))
+
+        grad_input = _norm_bwd_narrow(grad_input, a._dtype)
+        grad_weight = _norm_bwd_narrow(grad_weight, param_dtype)
+        grad_bias = _norm_bwd_narrow(grad_bias, param_dtype)
+    except _NormBackwardDeclined:
+        return NOT_HANDLED
+    return grad_input, grad_weight, grad_bias
+
+
+def fast_aten_native_batch_norm_backward(
+    grad_out: object,
+    input: object,
+    weight: object,
+    running_mean: object,
+    running_var: object,
+    save_mean: object,
+    save_invstd: object,
+    train: object,
+    eps: object,
+    output_mask: object,
+) -> object:
+    """`aten::native_batch_norm_backward` for the mojo eager device.
+
+    Follows `batch_norm_backward_cpu_template` exactly
+    (aten/src/ATen/native/Normalization.cpp): with `M = numel / C`,
+
+        dotp[c]   = sum_{n,s} (x - mean) * dy
+        dgamma[c] = dotp * invstd            dbeta[c] = sum_{n,s} dy
+        dx        = (dy - dbeta/M - xhat * dgamma/M) * invstd * gamma   (train)
+        dx        = dy * invstd * gamma                                 (eval)
+
+    `mean` / `invstd` are the saved statistics while training and
+    `running_mean` / `rsqrt(running_var + eps)` in eval, which is why an
+    `.eval()` BatchNorm still produces gradients. The per-channel reduction is
+    split into a trailing-axis pass over the spatial extent and a leading-axis
+    pass over the batch, so both legs are ordinary reduce-kernel shapes.
+    """
+    a = _t(input)
+    grad = _t(grad_out)
+    gamma = _t(weight) if weight is not None else None
+    run_mean = _t(running_mean) if running_mean is not None else None
+    run_var = _t(running_var) if running_var is not None else None
+    saved_mean = _t(save_mean) if save_mean is not None else None
+    saved_invstd = _t(save_invstd) if save_invstd is not None else None
+    if (
+        a is None
+        or grad is None
+        or (weight is not None and gamma is None)
+        or type(train) is not bool
+        or not isinstance(eps, int | float)
+        or isinstance(eps, bool)
+        or not isinstance(output_mask, list | tuple)
+        or len(a._shape) < 2
+    ):
+        return NOT_HANDLED
+    mask = tuple(output_mask)
+    if len(mask) != 3 or any(not isinstance(requested, bool) for requested in mask):
+        return NOT_HANDLED
+    channels = a._shape[1]
+    if (
+        a._dtype not in _FLOAT_DTYPES
+        or grad._dtype != a._dtype
+        or tuple(grad._shape) != tuple(a._shape)
+        or grad._device != a._device
+    ):
+        return NOT_HANDLED
+    # Training reads the statistics the forward saved; inference recomputes
+    # them from the running buffers, exactly as ATen does.
+    stats = (saved_mean, saved_invstd) if train else (run_mean, run_var)
+    if any(
+        stat is None
+        or stat._device != a._device
+        or stat._dtype not in _FLOAT_DTYPES
+        or stat._numel != channels
+        for stat in stats
+    ):
+        return NOT_HANDLED
+    if gamma is not None and (
+        gamma._device != a._device
+        or gamma._dtype not in _FLOAT_DTYPES
+        or tuple(gamma._shape) != (channels,)
+    ):
+        return NOT_HANDLED
+    # ATen widens the affine gradients to float32 exactly when the parameters
+    # are already wider than the input (`mixed_type` in Normalization.cpp).
+    present = [p for p in (gamma, *stats) if p is not None]
+    mixed = any(p._dtype != a._dtype for p in present)
+    param_dtype = DType.float32 if mixed else a._dtype
+    if not any(mask):
+        return None, None, None
+    if a._numel == 0:
+        return (
+            fast_filled(a._shape, 0.0, a._dtype, a._device) if mask[0] else None,
+            fast_filled((channels,), 0.0, param_dtype, a._device) if mask[1] else None,
+            fast_filled((channels,), 0.0, param_dtype, a._device) if mask[2] else None,
+        )
+
+    inner = a._numel // (a._shape[0] * channels)
+    reduced = a._numel // channels
+    try:
+        x = _norm_bwd_f32(a)
+        dy = _norm_bwd_f32(grad)
+        if train:
+            mean = _norm_bwd_f32(stats[0])
+            invstd = _norm_bwd_f32(stats[1])
+        else:
+            mean = _norm_bwd_f32(stats[0])
+            shifted = _norm_bwd(fast_aten_add(_norm_bwd_f32(stats[1]), float(eps)))
+            invstd = _norm_bwd(fast_aten_rsqrt(shifted))
+        planes = (a._shape[0], channels, inner)
+        dy3 = _norm_bwd(fast_aten_view(dy, planes))
+        x3 = _norm_bwd(fast_aten_view(x, planes))
+
+        grad_input = grad_weight = grad_bias = None
+        # dx needs both affine gradients while training, whatever the mask says,
+        # and `xhat` is exactly what the weight gradient needs -- so an
+        # inference dx, or a bias-only call, never materializes it.
+        need_bias = mask[2] or (mask[0] and train)
+        need_weight = mask[1] or (mask[0] and train)
+        xhat = sum_dy = sum_dyxhat = None
+        if need_bias:
+            sum_dy = _norm_bwd(
+                fast_aten_sum(_norm_bwd(fast_aten_sum(dy3, dim=[2])), dim=[0])
+            )
+            grad_bias = sum_dy if mask[2] else None
+        if need_weight:
+            mean_c = _norm_bwd(fast_aten_view(mean, (1, channels, 1)))
+            invstd_c = _norm_bwd(fast_aten_view(invstd, (1, channels, 1)))
+            xhat = _norm_bwd(
+                fast_aten_mul(_norm_bwd(fast_aten_sub(x3, mean_c)), invstd_c)
+            )
+            per_plane = _norm_bwd(
+                fast_aten_sum(_norm_bwd(fast_aten_mul(dy3, xhat)), dim=[2])
+            )
+            sum_dyxhat = _norm_bwd(fast_aten_sum(per_plane, dim=[0]))
+            grad_weight = sum_dyxhat if mask[1] else None
+        if mask[0]:
+            scale = (
+                invstd
+                if gamma is None
+                else _norm_bwd(fast_aten_mul(invstd, _norm_bwd_f32(gamma)))
+            )
+            scale_c = _norm_bwd(fast_aten_view(scale, (1, channels, 1)))
+            if train:
+                mean_dy = _norm_bwd(
+                    fast_aten_view(
+                        _norm_bwd(fast_aten_div(sum_dy, float(reduced))),
+                        (1, channels, 1),
+                    )
+                )
+                mean_dyxhat = _norm_bwd(
+                    fast_aten_view(
+                        _norm_bwd(fast_aten_div(sum_dyxhat, float(reduced))),
+                        (1, channels, 1),
+                    )
+                )
+                projected = _norm_bwd(fast_aten_sub(dy3, mean_dy))
+                projected = _norm_bwd(
+                    fast_aten_sub(
+                        projected, _norm_bwd(fast_aten_mul(xhat, mean_dyxhat))
+                    )
+                )
+            else:
+                projected = dy3
+            dx = _norm_bwd(fast_aten_mul(projected, scale_c))
+            grad_input = _norm_bwd(fast_aten_view(dx, tuple(a._shape)))
+
+        grad_input = _norm_bwd_narrow(grad_input, a._dtype)
+        grad_weight = _norm_bwd_narrow(grad_weight, param_dtype)
+        grad_bias = _norm_bwd_narrow(grad_bias, param_dtype)
+    except _NormBackwardDeclined:
+        return NOT_HANDLED
+    return grad_input, grad_weight, grad_bias
+
+
+# ---------------------------------------------------------------------------
 # Reductions
 # ---------------------------------------------------------------------------
 

--- a/torch_mojo_backend/mojo_device/aten_ops/autograd_preflight.py
+++ b/torch_mojo_backend/mojo_device/aten_ops/autograd_preflight.py
@@ -17,12 +17,15 @@ from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
 
 from .support import _eager_impl, _fast, _refuse_unsupported_backward, _unsupported
 
-# Most of these ops have no autograd escape other than turning grad off: their
-# parameters legitimately require grad during training, so unlike batch norm
-# (whose `training=False` forward records a node nobody runs) there is no mode
+# These ops have no autograd escape other than turning grad off: their
+# parameters legitimately require grad during training, so there is no mode
 # that keeps training working. `.eval()` specifically does NOT help — it leaves
 # grad mode on and the parameters still require grad — and saying otherwise has
-# sent users chasing a workaround that cannot exist.
+# sent users chasing a workaround that cannot exist. Batch norm used to be the
+# counter-example named here, on the theory that its `training=False` forward
+# records a node nobody runs; that was wrong (an `.eval()` BatchNorm's backward
+# calls `aten::native_batch_norm_backward` like any other) and it is moot now
+# that both norm backwards are implemented.
 _GRAD_OFF_ONLY = (
     "The forward itself is supported: run it under torch.no_grad() or "
     "torch.inference_mode(). Module .eval() alone does not help here, because "
@@ -181,11 +184,11 @@ def mojo_device_convolution(
     engine would come back for is refused here, from the forward, with a
     traceback that names the op.
 
-    Unlike batch norm this has no training-mode escape: a conv weight normally
-    requires grad, so in practice this refuses every conv in a training model,
-    and the honest message is that the backward kernel is missing rather than
-    that some flag is set wrong. Inference is unaffected under
-    `torch.no_grad()` / `torch.inference_mode()`.
+    There is no training-mode escape: a conv weight normally requires grad, so
+    in practice this refuses every conv in a training model, and the honest
+    message is that the backward kernel is missing rather than that some flag
+    is set wrong. Inference is unaffected under `torch.no_grad()` /
+    `torch.inference_mode()`.
     """
     _refuse_unsupported_backward(
         "aten::convolution",
@@ -359,96 +362,6 @@ def mojo_device_linear(
     result = aten_fast.fast_aten_linear(input, weight, bias)
     if result is aten_fast.NOT_HANDLED:
         raise _unsupported("aten::linear", (input, weight, bias))
-    return result
-
-
-def mojo_device_native_batch_norm(
-    input: torch.Tensor,
-    weight: torch.Tensor | None,
-    bias: torch.Tensor | None,
-    running_mean: torch.Tensor | None,
-    running_var: torch.Tensor | None,
-    training: bool,
-    momentum: float,
-    eps: float,
-) -> tuple[TorchMojoTensor, TorchMojoTensor, TorchMojoTensor]:
-    """Batch norm with a forward-time preflight of its native autograd node.
-
-    The training forward exists here; `aten::native_batch_norm_backward` does
-    not (docs/optimization_backlog.md N2). Letting the forward record
-    NativeBatchNormBackward anyway would move the failure into the autograd
-    engine, where an exception aborts the process on this backend rather than
-    raising — the same unwind hazard `mojo_device_linear` above documents — so
-    a training call that would need a gradient is refused here, from the
-    forward, with a traceback that names the op.
-
-    Inference needs no preflight: `training=False` records a backward this
-    backend never has to run.
-    """
-    if (
-        training
-        and torch.is_grad_enabled()
-        and (
-            input.requires_grad
-            or (weight is not None and weight.requires_grad)
-            or (bias is not None and bias.requires_grad)
-        )
-    ):
-        raise NotImplementedError(
-            "aten::native_batch_norm (training=True) would record an autograd "
-            "node (aten::native_batch_norm_backward) that mojo eager mode "
-            f"does not implement (input {tuple(input.shape)} {input.dtype}, "
-            f"device {input.device}). The forward itself is supported: run it "
-            "under torch.no_grad(), or put the module in eval() mode. Raised "
-            "from the forward on purpose: raised from the backward node "
-            "instead, this aborts the process without a traceback."
-        )
-    aten_fast = _fast()
-    result = aten_fast.fast_aten_native_batch_norm(
-        input, weight, bias, running_mean, running_var, training, momentum, eps
-    )
-    if result is aten_fast.NOT_HANDLED:
-        raise _unsupported(
-            "aten::native_batch_norm", (input, weight, bias, running_mean, running_var)
-        )
-    return result
-
-
-def mojo_device_native_group_norm(
-    input: torch.Tensor,
-    weight: torch.Tensor | None,
-    bias: torch.Tensor | None,
-    N: int,
-    C: int,
-    HxW: int,
-    group: int,
-    eps: float,
-) -> tuple[TorchMojoTensor, TorchMojoTensor, TorchMojoTensor]:
-    """Group norm with a forward-time preflight of its native autograd node.
-
-    The forward exists here; `aten::native_group_norm_backward` does not (it
-    needs the per-group reduction statistics). Recording
-    NativeGroupNormBackward0 anyway would move the failure into the autograd
-    engine, where an exception aborts the process instead of raising, so the
-    call is refused from the forward as `mojo_device_native_batch_norm` above
-    refuses its training case.
-
-    Group norm has no `training` flag to key on, so unlike batch norm every
-    grad-requiring call is refused; inference is unaffected under
-    `torch.no_grad()` / `torch.inference_mode()`.
-    """
-    _refuse_unsupported_backward(
-        "aten::native_group_norm",
-        "aten::native_group_norm_backward",
-        (input, weight, bias),
-        _GRAD_OFF_ONLY,
-    )
-    aten_fast = _fast()
-    result = aten_fast.fast_aten_native_group_norm(
-        input, weight, bias, N, C, HxW, group, eps
-    )
-    if result is aten_fast.NOT_HANDLED:
-        raise _unsupported("aten::native_group_norm", (input, weight, bias))
     return result
 
 

--- a/torch_mojo_backend/mojo_device/aten_ops/autograd_preflight.py
+++ b/torch_mojo_backend/mojo_device/aten_ops/autograd_preflight.py
@@ -21,12 +21,15 @@ from torch_mojo_backend.mojo_device.aten_ops.support import (
 )
 from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
 
-# Most of these ops have no autograd escape other than turning grad off: their
-# parameters legitimately require grad during training, so unlike batch norm
-# (whose `training=False` forward records a node nobody runs) there is no mode
+# These ops have no autograd escape other than turning grad off: their
+# parameters legitimately require grad during training, so there is no mode
 # that keeps training working. `.eval()` specifically does NOT help — it leaves
 # grad mode on and the parameters still require grad — and saying otherwise has
-# sent users chasing a workaround that cannot exist.
+# sent users chasing a workaround that cannot exist. Batch norm used to be the
+# counter-example named here, on the theory that its `training=False` forward
+# records a node nobody runs; that was wrong (an `.eval()` BatchNorm's backward
+# calls `aten::native_batch_norm_backward` like any other) and it is moot now
+# that both norm backwards are implemented.
 _GRAD_OFF_ONLY = (
     "The forward itself is supported: run it under torch.no_grad() or "
     "torch.inference_mode(). Module .eval() alone does not help here, because "
@@ -184,11 +187,11 @@ def mojo_device_convolution(
     engine would come back for is refused here, from the forward, with a
     traceback that names the op.
 
-    Unlike batch norm this has no training-mode escape: a conv weight normally
-    requires grad, so in practice this refuses every conv in a training model,
-    and the honest message is that the backward kernel is missing rather than
-    that some flag is set wrong. Inference is unaffected under
-    `torch.no_grad()` / `torch.inference_mode()`.
+    There is no training-mode escape: a conv weight normally requires grad, so
+    in practice this refuses every conv in a training model, and the honest
+    message is that the backward kernel is missing rather than that some flag
+    is set wrong. Inference is unaffected under `torch.no_grad()` /
+    `torch.inference_mode()`.
     """
     _refuse_unsupported_backward(
         "aten::convolution",
@@ -370,96 +373,6 @@ def mojo_device_linear(
     result = aten_fast.fast_aten_linear(input, weight, bias)
     if result is aten_fast.NOT_HANDLED:
         raise _unsupported("aten::linear", (input, weight, bias))
-    return result
-
-
-def mojo_device_native_batch_norm(
-    input: torch.Tensor,
-    weight: torch.Tensor | None,
-    bias: torch.Tensor | None,
-    running_mean: torch.Tensor | None,
-    running_var: torch.Tensor | None,
-    training: bool,
-    momentum: float,
-    eps: float,
-) -> tuple[TorchMojoTensor, TorchMojoTensor, TorchMojoTensor]:
-    """Batch norm with a forward-time preflight of its native autograd node.
-
-    The training forward exists here; `aten::native_batch_norm_backward` does
-    not (docs/optimization_backlog.md N2). Letting the forward record
-    NativeBatchNormBackward anyway would move the failure into the autograd
-    engine, where an exception aborts the process on this backend rather than
-    raising — the same unwind hazard `mojo_device_linear` above documents — so
-    a training call that would need a gradient is refused here, from the
-    forward, with a traceback that names the op.
-
-    Inference needs no preflight: `training=False` records a backward this
-    backend never has to run.
-    """
-    if (
-        training
-        and torch.is_grad_enabled()
-        and (
-            input.requires_grad
-            or (weight is not None and weight.requires_grad)
-            or (bias is not None and bias.requires_grad)
-        )
-    ):
-        raise NotImplementedError(
-            "aten::native_batch_norm (training=True) would record an autograd "
-            "node (aten::native_batch_norm_backward) that mojo eager mode "
-            f"does not implement (input {tuple(input.shape)} {input.dtype}, "
-            f"device {input.device}). The forward itself is supported: run it "
-            "under torch.no_grad(), or put the module in eval() mode. Raised "
-            "from the forward on purpose: raised from the backward node "
-            "instead, this aborts the process without a traceback."
-        )
-    aten_fast = _fast()
-    result = aten_fast.fast_aten_native_batch_norm(
-        input, weight, bias, running_mean, running_var, training, momentum, eps
-    )
-    if result is aten_fast.NOT_HANDLED:
-        raise _unsupported(
-            "aten::native_batch_norm", (input, weight, bias, running_mean, running_var)
-        )
-    return result
-
-
-def mojo_device_native_group_norm(
-    input: torch.Tensor,
-    weight: torch.Tensor | None,
-    bias: torch.Tensor | None,
-    N: int,
-    C: int,
-    HxW: int,
-    group: int,
-    eps: float,
-) -> tuple[TorchMojoTensor, TorchMojoTensor, TorchMojoTensor]:
-    """Group norm with a forward-time preflight of its native autograd node.
-
-    The forward exists here; `aten::native_group_norm_backward` does not (it
-    needs the per-group reduction statistics). Recording
-    NativeGroupNormBackward0 anyway would move the failure into the autograd
-    engine, where an exception aborts the process instead of raising, so the
-    call is refused from the forward as `mojo_device_native_batch_norm` above
-    refuses its training case.
-
-    Group norm has no `training` flag to key on, so unlike batch norm every
-    grad-requiring call is refused; inference is unaffected under
-    `torch.no_grad()` / `torch.inference_mode()`.
-    """
-    _refuse_unsupported_backward(
-        "aten::native_group_norm",
-        "aten::native_group_norm_backward",
-        (input, weight, bias),
-        _GRAD_OFF_ONLY,
-    )
-    aten_fast = _fast()
-    result = aten_fast.fast_aten_native_group_norm(
-        input, weight, bias, N, C, HxW, group, eps
-    )
-    if result is aten_fast.NOT_HANDLED:
-        raise _unsupported("aten::native_group_norm", (input, weight, bias))
     return result
 
 

--- a/torch_mojo_backend/mojo_device/mojo_device_aten_ops.py
+++ b/torch_mojo_backend/mojo_device/mojo_device_aten_ops.py
@@ -31,8 +31,6 @@ from .aten_ops.autograd_preflight import (
     mojo_device_index,
     mojo_device_linear,
     mojo_device_max_pool2d_with_indices,
-    mojo_device_native_batch_norm,
-    mojo_device_native_group_norm,
     mojo_device_relu,
     mojo_device_scatter_src,
     mojo_device_sigmoid,
@@ -326,10 +324,16 @@ _register_fast("aten::mm", "fast_aten_mm")
 register_aten_op("aten::mul_.Tensor")(mojo_device_mul_)
 _register_out("aten::mul.out", "fast_aten_mul")
 _register_fast("aten::mul.Tensor", "fast_aten_mul")
-register_aten_op("aten::native_batch_norm")(mojo_device_native_batch_norm)
+_register_fast("aten::native_batch_norm", "fast_aten_native_batch_norm")
+_register_fast(
+    "aten::native_batch_norm_backward", "fast_aten_native_batch_norm_backward"
+)
 _register_fast("aten::native_dropout", "fast_aten_native_dropout")
 _register_fast("aten::native_dropout_backward", "fast_aten_native_dropout_backward")
-register_aten_op("aten::native_group_norm")(mojo_device_native_group_norm)
+_register_fast("aten::native_group_norm", "fast_aten_native_group_norm")
+_register_fast(
+    "aten::native_group_norm_backward", "fast_aten_native_group_norm_backward"
+)
 _register_fast("aten::native_layer_norm", "fast_aten_native_layer_norm")
 _register_fast(
     "aten::native_layer_norm_backward", "fast_aten_native_layer_norm_backward"

--- a/torch_mojo_backend/mojo_device/mojo_device_aten_ops.py
+++ b/torch_mojo_backend/mojo_device/mojo_device_aten_ops.py
@@ -31,8 +31,6 @@ from torch_mojo_backend.mojo_device.aten_ops.autograd_preflight import (
     mojo_device_index,
     mojo_device_linear,
     mojo_device_max_pool2d_with_indices,
-    mojo_device_native_batch_norm,
-    mojo_device_native_group_norm,
     mojo_device_relu,
     mojo_device_scatter_src,
     mojo_device_sigmoid,
@@ -344,10 +342,16 @@ _register_fast("aten::mm", "fast_aten_mm")
 register_aten_op("aten::mul_.Tensor")(mojo_device_mul_)
 _register_out("aten::mul.out", "fast_aten_mul")
 _register_fast("aten::mul.Tensor", "fast_aten_mul")
-register_aten_op("aten::native_batch_norm")(mojo_device_native_batch_norm)
+_register_fast("aten::native_batch_norm", "fast_aten_native_batch_norm")
+_register_fast(
+    "aten::native_batch_norm_backward", "fast_aten_native_batch_norm_backward"
+)
 _register_fast("aten::native_dropout", "fast_aten_native_dropout")
 _register_fast("aten::native_dropout_backward", "fast_aten_native_dropout_backward")
-register_aten_op("aten::native_group_norm")(mojo_device_native_group_norm)
+_register_fast("aten::native_group_norm", "fast_aten_native_group_norm")
+_register_fast(
+    "aten::native_group_norm_backward", "fast_aten_native_group_norm_backward"
+)
 _register_fast("aten::native_layer_norm", "fast_aten_native_layer_norm")
 _register_fast(
     "aten::native_layer_norm_backward", "fast_aten_native_layer_norm_backward"


### PR DESCRIPTION
## Summary

Implements `aten::native_group_norm_backward` and `aten::native_batch_norm_backward` for both backends, and removes the two forward-time autograd refusals that stood in for them. GroupNorm and BatchNorm now **train** on the mojo eager device, and an `.eval()` BatchNorm now yields gradients instead of aborting the process.

### How the layer-norm backward kernel was reused

Group norm **is** layer norm over the trailing `(C/group) * HxW` elements of the `(N*group, K)` view: same per-sample reduction, same `mean`/`rstd` per row. So the grad-input half calls `fast_aten_native_layer_norm_backward` on exactly that view, with the per-channel gamma folded into `grad_out` first (the LayerNorm kernel indexes `weight` per column, group norm per channel). No new Mojo, no new reduction schedule — a reshape and a runtime shape. `test_fast_group_norm_backward_uses_the_layer_norm_kernel` pins that the fused kernel is really taken, so a silent fall back to the composition is a test failure rather than an invisible slowdown.

The affine gradients of both ops, and batch norm's grad-input, reduce over the **batch and the spatial extent per channel** — the complement of the per-sample axes every LayerNorm kernel reduces, and not reachable by any reshape or stride change. Writing a fused kernel for that is a new reduction schedule, so it was deliberately left out of this PR; both are composed from the existing reduce and broadcast-binary kernels, through the same per-`(sample, channel)` partial sums ATen's own CUDA kernels use:

```
dgamma[c] = sum_n rstd[n,g] * (S2[n,c] - mean[n,g] * S1[n,c])
dbeta[c]  = sum_n S1[n,c]        S1 = sum_hw dy,  S2 = sum_hw dy*x
```

Half-precision inputs accumulate in float32 and narrow back at the end (ATen's `at::acc_type`), so the gates now match the forwards' and the preflights could be removed outright rather than made conditional.

### The eval-BatchNorm bug this fixes

`mojo_device_native_batch_norm` preflighted training only, documented as "inference needs no preflight: `training=False` records a backward this backend never has to run". That is false: an `.eval()` BatchNorm records `NativeBatchNormBackward0` like any other and the engine does call `aten::native_batch_norm_backward`, which read the **running** buffers. With no kernel there, an eval-mode BatchNorm in a grad-enabled graph aborted the process (no traceback) rather than raising. Verified against upstream before and after.

### Compile backend

`native_group_norm_backward` and `native_batch_norm_backward` get real MAX implementations (they were served by `core_aten_decompositions()` before). Two forward gaps had to go with them, because a compiled backward is unreachable without them:

* `aten_native_group_norm` returned `NotImplementedError` placeholders for `mean`/`rstd`, so **every** grad-requiring group norm failed to compile. It now returns the real per-`(sample, group)` statistics.
* `aten__native_batch_norm_legit_no_training` did the same for its saved statistics. PyTorch's meta kernel gives both shape `(0,)` for that overload, so they are now the empty tensors the contract promises.

Still out of scope: `aten::_native_batch_norm_legit_functional` has no compile-backend implementation, so BatchNorm **training** under `torch.compile` still fails in the forward. Unchanged by this PR.

### Performance

New baselines on H100 (`benchmarks/test_norm.py -k backward`), ours/stock device time:

| op | dtype | shape | ratio |
|---|---|---|---|
| native_group_norm_backward | f32 | N32xC64xH56xW56_G32 | 2.70 |
| native_group_norm_backward | bf16 | N32xC64xH56xW56_G32 | 3.98 |
| native_group_norm_backward | f32 | N8xC256xH14xW14_G32 | 2.92 |
| native_group_norm_backward | bf16 | N8xC256xH14xW14_G32 | 3.20 |
| native_batch_norm_backward | f32 | N32xC64xH112xW112 | 2.65 |
| native_batch_norm_backward | bf16 | N32xC64xH112xW112 | 2.96 |
| native_batch_norm_backward | f32 | N8xC256xH28xW28 | 11.68 |
| native_batch_norm_backward | bf16 | N8xC256xH28xW28 | 11.85 |

These are correctness-first compositions, not tuned kernels, and the numbers say where the fused follow-up is worth writing. A profile of the worst cell says the whole gap is one kernel: five broadcast-strided binaries per call at ~24 us each on a 6.4 MB tensor (0.5 TB/s) against 3.2 us for the same traffic through the flat vectorized form (~4 TB/s). `docs/optimization_backlog.md` N2 is rewritten with that measurement and points at both the fused kernel and the cheaper "vectorize the per-channel broadcast" alternative.

## Test plan

* `uv run pytest tests/test_aten_functions.py tests/test_eager_kernels.py -k norm` — 213 passed, 1 skipped, 2 xfailed (both pre-existing: BatchNorm training forward is GPU-only, LayerNorm float64 is unsupported).
* New in `tests/test_aten_functions.py`: both backward ops against the CPU reference over five group-norm geometries (including `group == 1` and `group == C`, and odd/non-power-of-two extents), four batch-norm ranks in both modes, with and without affine, plus every `output_mask` combination; end-to-end `F.group_norm` autograd; and both ops through `torch.compile`.
* New in `tests/test_eager_kernels.py`, replacing the two "refuses autograd in the forward" tests: end-to-end GPU gradients for both ops against CPU autograd, float32 and bfloat16, plus the assertion that group norm's grad-input reaches the LayerNorm kernel.
* Tolerance is `2e-5` rtol/atol, commented where it is defined: these are float32 reductions over a few hundred elements (~sqrt(k)·eps ≈ 3e-6 relative), the two sides sum in different orders, and standard-normal inputs keep `rstd` at O(1) — a wrong axis or a missing term moves these outputs by O(1), not by ulps.
* `uv run pytest benchmarks/test_norm.py -k backward` — 10 passed, baselines recorded; `uv run pytest benchmarks/test_coverage.py` — 2 passed (both new ops declared in `COVERS`).
* `uvx pre-commit run --all-files` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Co2wBC1UYzM4y9PEC92Af
