### PR TITLE
Implement aten::convolution_backward (eager + compile backend): unblock conv training

### DIFF
--- a/benchmarks/baselines.html
+++ b/benchmarks/baselines.html
@@ -6415,7 +6415,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 },
                 "N8xC3x224x224_K64k7s2": {
                   "layouts": {
-                    "contig": 1.311
+                    "contig": 1.074
                   }
                 }
               }

--- a/benchmarks/baselines.html
+++ b/benchmarks/baselines.html
@@ -6546,6 +6546,102 @@ document.addEventListener("DOMContentLoaded", boot);
             }
           }
         },
+        "convolution_backward": {
+          "dtypes": {
+            "bf16": {
+              "shapes": {
+                "N32xC128x28x28_K128k3s2": {
+                  "layouts": {
+                    "bgrad": 0.582,
+                    "dgrad": 10.379,
+                    "wgrad": 13.264
+                  }
+                },
+                "N32xC256x14x14_K256k3s1": {
+                  "layouts": {
+                    "bgrad": 0.885,
+                    "dgrad": 12.392,
+                    "wgrad": 23.246
+                  }
+                },
+                "N32xC512x7x7_K512k3s1": {
+                  "layouts": {
+                    "bgrad": 1.549,
+                    "dgrad": 10.583,
+                    "wgrad": 22.865
+                  }
+                },
+                "N32xC64x56x56_K64k3s1": {
+                  "layouts": {
+                    "bgrad": 0.613,
+                    "dgrad": 10.737,
+                    "wgrad": 11.71
+                  }
+                },
+                "N7xC48x39x53_K80k3s1": {
+                  "layouts": {
+                    "bgrad": 3.21,
+                    "dgrad": 6.114,
+                    "wgrad": 5.401
+                  }
+                },
+                "N8xC3x224x224_K64k7s2": {
+                  "layouts": {
+                    "bgrad": 0.455,
+                    "dgrad": 1.397,
+                    "wgrad": 3.418
+                  }
+                }
+              }
+            },
+            "f32": {
+              "shapes": {
+                "N32xC128x28x28_K128k3s2": {
+                  "layouts": {
+                    "bgrad": 0.389,
+                    "dgrad": 10.945,
+                    "wgrad": 6.845
+                  }
+                },
+                "N32xC256x14x14_K256k3s1": {
+                  "layouts": {
+                    "bgrad": 0.575,
+                    "dgrad": 15.118,
+                    "wgrad": 13.01
+                  }
+                },
+                "N32xC512x7x7_K512k3s1": {
+                  "layouts": {
+                    "bgrad": 1.541,
+                    "dgrad": 11.228,
+                    "wgrad": 18.656
+                  }
+                },
+                "N32xC64x56x56_K64k3s1": {
+                  "layouts": {
+                    "bgrad": 0.92,
+                    "dgrad": 10.376,
+                    "wgrad": 7.896
+                  }
+                },
+                "N7xC48x39x53_K80k3s1": {
+                  "layouts": {
+                    "bgrad": 3.126,
+                    "dgrad": 6.11,
+                    "wgrad": 4.627
+                  }
+                },
+                "N8xC3x224x224_K64k7s2": {
+                  "layouts": {
+                    "bgrad": 0.897,
+                    "dgrad": 3.161,
+                    "wgrad": 3.274
+                  }
+                }
+              }
+            }
+          }
+        },
         "cos": {
           "dtypes": {
             "bf16": {

--- a/benchmarks/baselines.html
+++ b/benchmarks/baselines.html
@@ -6408,14 +6408,49 @@ document.addEventListener("DOMContentLoaded", boot);
           "dtypes": {
             "bf16": {
               "shapes": {
+                "N16xC64x32x32_K64k3s1d2": {
+                  "layouts": {
+                    "contig": 6.791
+                  }
+                },
+                "N16xC96x28x28_K192k3s2": {
+                  "layouts": {
+                    "contig": 5.337
+                  }
+                },
+                "N1xC256x14x14_K256k3s1": {
+                  "layouts": {
+                    "contig": 1.806
+                  }
+                },
+                "N1xC64x56x56_K64k3s1": {
+                  "layouts": {
+                    "contig": 1.375
+                  }
+                },
+                "N32xC128x28x28_K128k3s2": {
+                  "layouts": {
+                    "contig": 12.566
+                  }
+                },
                 "N32xC256x14x14_K256k3s1": {
                   "layouts": {
                     "contig": 1.452
                   }
                 },
+                "N32xC256x14x14_K512k1s2": {
+                  "layouts": {
+                    "contig": 3.482
+                  }
+                },
                 "N32xC256x56x56_K64k1s1": {
                   "layouts": {
                     "contig": 0.783
+                  }
+                },
+                "N32xC512x7x7_K512k3s1": {
+                  "layouts": {
+                    "contig": 2.019
                   }
                 },
                 "N32xC64x56x56_K64k3s1": {
@@ -6428,6 +6463,11 @@ document.addEventListener("DOMContentLoaded", boot);
                     "contig": 1.102
                   }
                 },
+                "N8xC128x112x112_K128k3s1": {
+                  "layouts": {
+                    "contig": 0.981
+                  }
+                },
                 "N8xC3x224x224_K64k7s2": {
                   "layouts": {
                     "contig": 1.074
@@ -6437,14 +6477,49 @@ document.addEventListener("DOMContentLoaded", boot);
             },
             "f32": {
               "shapes": {
+                "N16xC64x32x32_K64k3s1d2": {
+                  "layouts": {
+                    "contig": 7.961
+                  }
+                },
+                "N16xC96x28x28_K192k3s2": {
+                  "layouts": {
+                    "contig": 7.757
+                  }
+                },
+                "N1xC256x14x14_K256k3s1": {
+                  "layouts": {
+                    "contig": 2.278
+                  }
+                },
+                "N1xC64x56x56_K64k3s1": {
+                  "layouts": {
+                    "contig": 4.026
+                  }
+                },
+                "N32xC128x28x28_K128k3s2": {
+                  "layouts": {
+                    "contig": 12.283
+                  }
+                },
                 "N32xC256x14x14_K256k3s1": {
                   "layouts": {
                     "contig": 19.806
                   }
                 },
+                "N32xC256x14x14_K512k1s2": {
+                  "layouts": {
+                    "contig": 4.427
+                  }
+                },
                 "N32xC256x56x56_K64k1s1": {
                   "layouts": {
                     "contig": 1.866
+                  }
+                },
+                "N32xC512x7x7_K512k3s1": {
+                  "layouts": {
+                    "contig": 18.407
                   }
                 },
                 "N32xC64x56x56_K64k3s1": {
@@ -6455,6 +6530,11 @@ document.addEventListener("DOMContentLoaded", boot);
                 "N7xC48x39x53_K80k3s1": {
                   "layouts": {
                     "contig": 2.87
+                  }
+                },
+                "N8xC128x112x112_K128k3s1": {
+                  "layouts": {
+                    "contig": 7.679
                   }
                 },
                 "N8xC3x224x224_K64k7s2": {

--- a/benchmarks/baselines.html
+++ b/benchmarks/baselines.html
@@ -6410,12 +6410,12 @@ document.addEventListener("DOMContentLoaded", boot);
               "shapes": {
                 "N32xC64x56x56_K64k3s1": {
                   "layouts": {
-                    "contig": 24.351
+                    "contig": 9.373
                   }
                 },
                 "N8xC3x224x224_K64k7s2": {
                   "layouts": {
-                    "contig": 4.701
+                    "contig": 1.311
                   }
                 }
               }
@@ -6424,12 +6424,12 @@ document.addEventListener("DOMContentLoaded", boot);
               "shapes": {
                 "N32xC64x56x56_K64k3s1": {
                   "layouts": {
-                    "contig": 12.456
+                    "contig": 7.448
                   }
                 },
                 "N8xC3x224x224_K64k7s2": {
                   "layouts": {
-                    "contig": 4.138
+                    "contig": 1.964
                   }
                 }
               }

--- a/benchmarks/baselines.html
+++ b/benchmarks/baselines.html
@@ -6408,9 +6408,24 @@ document.addEventListener("DOMContentLoaded", boot);
           "dtypes": {
             "bf16": {
               "shapes": {
+                "N32xC256x14x14_K256k3s1": {
+                  "layouts": {
+                    "contig": 1.452
+                  }
+                },
+                "N32xC256x56x56_K64k1s1": {
+                  "layouts": {
+                    "contig": 0.783
+                  }
+                },
                 "N32xC64x56x56_K64k3s1": {
                   "layouts": {
-                    "contig": 9.373
+                    "contig": 0.653
+                  }
+                },
+                "N7xC48x39x53_K80k3s1": {
+                  "layouts": {
+                    "contig": 1.102
                   }
                 },
                 "N8xC3x224x224_K64k7s2": {
@@ -6422,9 +6437,24 @@ document.addEventListener("DOMContentLoaded", boot);
             },
             "f32": {
               "shapes": {
+                "N32xC256x14x14_K256k3s1": {
+                  "layouts": {
+                    "contig": 19.806
+                  }
+                },
+                "N32xC256x56x56_K64k1s1": {
+                  "layouts": {
+                    "contig": 1.866
+                  }
+                },
                 "N32xC64x56x56_K64k3s1": {
                   "layouts": {
                     "contig": 7.448
+                  }
+                },
+                "N7xC48x39x53_K80k3s1": {
+                  "layouts": {
+                    "contig": 2.87
                   }
                 },
                 "N8xC3x224x224_K64k7s2": {

--- a/benchmarks/baselines.html
+++ b/benchmarks/baselines.html
@@ -6390,9 +6390,24 @@ document.addEventListener("DOMContentLoaded", boot);
           "dtypes": {
             "bf16": {
               "shapes": {
+                "N32xC256x14x14_K256k3s1": {
+                  "layouts": {
+                    "contig": 1.452
+                  }
+                },
+                "N32xC256x56x56_K64k1s1": {
+                  "layouts": {
+                    "contig": 0.783
+                  }
+                },
                 "N32xC64x56x56_K64k3s1": {
                   "layouts": {
-                    "contig": 9.373
+                    "contig": 0.653
+                  }
+                },
+                "N7xC48x39x53_K80k3s1": {
+                  "layouts": {
+                    "contig": 1.102
                   }
                 },
                 "N8xC3x224x224_K64k7s2": {
@@ -6404,9 +6419,24 @@ document.addEventListener("DOMContentLoaded", boot);
             },
             "f32": {
               "shapes": {
+                "N32xC256x14x14_K256k3s1": {
+                  "layouts": {
+                    "contig": 19.806
+                  }
+                },
+                "N32xC256x56x56_K64k1s1": {
+                  "layouts": {
+                    "contig": 1.866
+                  }
+                },
                 "N32xC64x56x56_K64k3s1": {
                   "layouts": {
                     "contig": 7.448
+                  }
+                },
+                "N7xC48x39x53_K80k3s1": {
+                  "layouts": {
+                    "contig": 2.87
                   }
                 },
                 "N8xC3x224x224_K64k7s2": {

--- a/benchmarks/baselines.html
+++ b/benchmarks/baselines.html
@@ -6392,12 +6392,12 @@ document.addEventListener("DOMContentLoaded", boot);
               "shapes": {
                 "N32xC64x56x56_K64k3s1": {
                   "layouts": {
-                    "contig": 24.351
+                    "contig": 9.373
                   }
                 },
                 "N8xC3x224x224_K64k7s2": {
                   "layouts": {
-                    "contig": 4.701
+                    "contig": 1.311
                   }
                 }
               }
@@ -6406,12 +6406,12 @@ document.addEventListener("DOMContentLoaded", boot);
               "shapes": {
                 "N32xC64x56x56_K64k3s1": {
                   "layouts": {
-                    "contig": 12.456
+                    "contig": 7.448
                   }
                 },
                 "N8xC3x224x224_K64k7s2": {
                   "layouts": {
-                    "contig": 4.138
+                    "contig": 1.964
                   }
                 }
               }

--- a/benchmarks/baselines.html
+++ b/benchmarks/baselines.html
@@ -6397,7 +6397,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 },
                 "N8xC3x224x224_K64k7s2": {
                   "layouts": {
-                    "contig": 1.311
+                    "contig": 1.074
                   }
                 }
               }

--- a/benchmarks/baselines.html
+++ b/benchmarks/baselines.html
@@ -6528,6 +6528,102 @@ document.addEventListener("DOMContentLoaded", boot);
             }
           }
         },
+        "convolution_backward": {
+          "dtypes": {
+            "bf16": {
+              "shapes": {
+                "N32xC128x28x28_K128k3s2": {
+                  "layouts": {
+                    "bgrad": 0.582,
+                    "dgrad": 10.379,
+                    "wgrad": 13.264
+                  }
+                },
+                "N32xC256x14x14_K256k3s1": {
+                  "layouts": {
+                    "bgrad": 0.885,
+                    "dgrad": 12.392,
+                    "wgrad": 23.246
+                  }
+                },
+                "N32xC512x7x7_K512k3s1": {
+                  "layouts": {
+                    "bgrad": 1.549,
+                    "dgrad": 10.583,
+                    "wgrad": 22.865
+                  }
+                },
+                "N32xC64x56x56_K64k3s1": {
+                  "layouts": {
+                    "bgrad": 0.613,
+                    "dgrad": 10.737,
+                    "wgrad": 11.71
+                  }
+                },
+                "N7xC48x39x53_K80k3s1": {
+                  "layouts": {
+                    "bgrad": 3.21,
+                    "dgrad": 6.114,
+                    "wgrad": 5.401
+                  }
+                },
+                "N8xC3x224x224_K64k7s2": {
+                  "layouts": {
+                    "bgrad": 0.455,
+                    "dgrad": 1.397,
+                    "wgrad": 3.418
+                  }
+                }
+              }
+            },
+            "f32": {
+              "shapes": {
+                "N32xC128x28x28_K128k3s2": {
+                  "layouts": {
+                    "bgrad": 0.389,
+                    "dgrad": 10.945,
+                    "wgrad": 6.845
+                  }
+                },
+                "N32xC256x14x14_K256k3s1": {
+                  "layouts": {
+                    "bgrad": 0.575,
+                    "dgrad": 15.118,
+                    "wgrad": 13.01
+                  }
+                },
+                "N32xC512x7x7_K512k3s1": {
+                  "layouts": {
+                    "bgrad": 1.541,
+                    "dgrad": 11.228,
+                    "wgrad": 18.656
+                  }
+                },
+                "N32xC64x56x56_K64k3s1": {
+                  "layouts": {
+                    "bgrad": 0.92,
+                    "dgrad": 10.376,
+                    "wgrad": 7.896
+                  }
+                },
+                "N7xC48x39x53_K80k3s1": {
+                  "layouts": {
+                    "bgrad": 3.126,
+                    "dgrad": 6.11,
+                    "wgrad": 4.627
+                  }
+                },
+                "N8xC3x224x224_K64k7s2": {
+                  "layouts": {
+                    "bgrad": 0.897,
+                    "dgrad": 3.161,
+                    "wgrad": 3.274
+                  }
+                }
+              }
+            }
+          }
+        },
         "cos": {
           "dtypes": {
             "bf16": {

--- a/benchmarks/baselines.html
+++ b/benchmarks/baselines.html
@@ -6390,14 +6390,49 @@ document.addEventListener("DOMContentLoaded", boot);
           "dtypes": {
             "bf16": {
               "shapes": {
+                "N16xC64x32x32_K64k3s1d2": {
+                  "layouts": {
+                    "contig": 6.791
+                  }
+                },
+                "N16xC96x28x28_K192k3s2": {
+                  "layouts": {
+                    "contig": 5.337
+                  }
+                },
+                "N1xC256x14x14_K256k3s1": {
+                  "layouts": {
+                    "contig": 1.806
+                  }
+                },
+                "N1xC64x56x56_K64k3s1": {
+                  "layouts": {
+                    "contig": 1.375
+                  }
+                },
+                "N32xC128x28x28_K128k3s2": {
+                  "layouts": {
+                    "contig": 12.566
+                  }
+                },
                 "N32xC256x14x14_K256k3s1": {
                   "layouts": {
                     "contig": 1.452
                   }
                 },
+                "N32xC256x14x14_K512k1s2": {
+                  "layouts": {
+                    "contig": 3.482
+                  }
+                },
                 "N32xC256x56x56_K64k1s1": {
                   "layouts": {
                     "contig": 0.783
+                  }
+                },
+                "N32xC512x7x7_K512k3s1": {
+                  "layouts": {
+                    "contig": 2.019
                   }
                 },
                 "N32xC64x56x56_K64k3s1": {
@@ -6410,6 +6445,11 @@ document.addEventListener("DOMContentLoaded", boot);
                     "contig": 1.102
                   }
                 },
+                "N8xC128x112x112_K128k3s1": {
+                  "layouts": {
+                    "contig": 0.981
+                  }
+                },
                 "N8xC3x224x224_K64k7s2": {
                   "layouts": {
                     "contig": 1.074
@@ -6419,14 +6459,49 @@ document.addEventListener("DOMContentLoaded", boot);
             },
             "f32": {
               "shapes": {
+                "N16xC64x32x32_K64k3s1d2": {
+                  "layouts": {
+                    "contig": 7.961
+                  }
+                },
+                "N16xC96x28x28_K192k3s2": {
+                  "layouts": {
+                    "contig": 7.757
+                  }
+                },
+                "N1xC256x14x14_K256k3s1": {
+                  "layouts": {
+                    "contig": 2.278
+                  }
+                },
+                "N1xC64x56x56_K64k3s1": {
+                  "layouts": {
+                    "contig": 4.026
+                  }
+                },
+                "N32xC128x28x28_K128k3s2": {
+                  "layouts": {
+                    "contig": 12.283
+                  }
+                },
                 "N32xC256x14x14_K256k3s1": {
                   "layouts": {
                     "contig": 19.806
                   }
                 },
+                "N32xC256x14x14_K512k1s2": {
+                  "layouts": {
+                    "contig": 4.427
+                  }
+                },
                 "N32xC256x56x56_K64k1s1": {
                   "layouts": {
                     "contig": 1.866
+                  }
+                },
+                "N32xC512x7x7_K512k3s1": {
+                  "layouts": {
+                    "contig": 18.407
                   }
                 },
                 "N32xC64x56x56_K64k3s1": {
@@ -6437,6 +6512,11 @@ document.addEventListener("DOMContentLoaded", boot);
                 "N7xC48x39x53_K80k3s1": {
                   "layouts": {
                     "contig": 2.87
+                  }
+                },
+                "N8xC128x112x112_K128k3s1": {
+                  "layouts": {
+                    "contig": 7.679
                   }
                 },
                 "N8xC3x224x224_K64k7s2": {

--- a/benchmarks/test_vision.py
+++ b/benchmarks/test_vision.py
@@ -62,6 +62,34 @@ CONV_SHAPES: dict[str, tuple[int, int, int, int, int, int, int, int, int]] = {
     # design; this node is what pins the fallback's cost for it.
     "N16xC64x32x32_K64k3s1d2": (16, 64, 32, 32, 64, 3, 1, 2, 2),
 }
+# Backward is measured on a subset of the same CONV_SHAPES geometries, one
+# node per GRADIENT: the three gradients are three different kernels (a
+# col2im-fed GEMM, a transposed-B GEMM plus a batch reduce, and a plain
+# reduction) whose ratios move independently, so folding them into one node
+# would hide which of them regressed.  The subset spans the regimes that
+# matter to the backward specifically: the body/mid shapes the forward is
+# tuned on, the thin-C stem, an awkward one, a stride-2 one (the only
+# regime where col2im's tap loop mostly misses), and the deepest stage,
+# where the weight gradient's per-sample partials buffer is at its largest
+# relative to the column buffer.
+CONV_BACKWARD_SHAPES: tuple[str, ...] = (
+    "N32xC64x56x56_K64k3s1",
+    "N8xC3x224x224_K64k7s2",
+    "N32xC256x14x14_K256k3s1",
+    "N7xC48x39x53_K80k3s1",
+    "N32xC128x28x28_K128k3s2",
+    "N32xC512x7x7_K512k3s1",
+)
+# output_mask, one gradient at a time.  This is the suite's `layout` axis:
+# `bench_key` builds the baseline path op/dtype/shape/layout from the
+# parametrize ids, so naming the gradient selector `layout` is what keeps the
+# three gradients of one shape three separate entries (and lands them next to
+# each other in the tree) instead of three writes to one key.
+CONV_BACKWARD_GRADS: dict[str, list[bool]] = {
+    "dgrad": [True, False, False],
+    "wgrad": [False, True, False],
+    "bgrad": [False, False, True],
+}
 # (N, C, H, W, output)
 ADAPTIVE_SHAPES: dict[str, tuple[int, int, int, int, int]] = {
     "N32xC512x28x28_o7": (32, 512, 28, 28, 7),
@@ -80,6 +108,7 @@ UPSAMPLE_SHAPES: dict[str, tuple[int, int, int, int]] = {
 
 COVERS: dict[str, str] = {
     "aten::convolution": "test_conv2d",
+    "aten::convolution_backward": "test_conv2d_backward",
     "aten::_adaptive_avg_pool2d": "test_adaptive_avg_pool2d",
     "aten::avg_pool2d": "test_avg_pool2d",
     "aten::max_pool2d_with_indices": (
@@ -111,6 +140,54 @@ def test_conv2d(
     bench.run(
         lambda: F.conv2d(x_ref, w_ref, b_ref, stride, pad, dil),
         lambda: F.conv2d(x_our, w_our, b_our, stride, pad, dil),
+        flops=flops,
+    )
+
+
+@pytest.mark.parametrize("dtype_id", ("bf16", "f32"))
+@pytest.mark.parametrize("layout", CONV_BACKWARD_GRADS)
+@pytest.mark.parametrize("shape_id", CONV_BACKWARD_SHAPES)
+@pytest.mark.bench_op("convolution_backward")
+def test_conv2d_backward(
+    shape_id: str,
+    layout: str,
+    dtype_id: str,
+    bench: Bench,
+    hw: Hardware,
+    mojo_device: torch.device,
+) -> None:
+    n, c_in, h, w, c_out, k, stride, pad, dil = CONV_SHAPES[shape_id]
+    dtype = DTYPES[dtype_id]
+    eff_k = dil * (k - 1) + 1
+    h_out = (h + 2 * pad - eff_k) // stride + 1
+    w_out = (w + 2 * pad - eff_k) // stride + 1
+    grad_ref, grad_our = both(
+        torch.randn(n, c_out, h_out, w_out, dtype=dtype), hw, mojo_device
+    )
+    x_ref, x_our = both(torch.randn(n, c_in, h, w, dtype=dtype), hw, mojo_device)
+    w_ref, w_our = both(
+        torch.randn(c_out, c_in, k, k, dtype=dtype) * 0.1, hw, mojo_device
+    )
+    tail = (
+        [c_out],
+        [stride, stride],
+        [pad, pad],
+        [dil, dil],
+        False,
+        [0, 0],
+        1,
+        CONV_BACKWARD_GRADS[layout],
+    )
+    # The bias gradient is a pure reduction over grad_output, so its "flops"
+    # is its element count, the same convention the pooling nodes use.
+    flops = (
+        float(n * c_out * h_out * w_out)
+        if layout == "bgrad"
+        else 2.0 * n * c_out * h_out * w_out * c_in * k * k
+    )
+    bench.run(
+        lambda: torch.ops.aten.convolution_backward(grad_ref, x_ref, w_ref, *tail),
+        lambda: torch.ops.aten.convolution_backward(grad_our, x_our, w_our, *tail),
         flops=flops,
     )
 

--- a/benchmarks/test_vision.py
+++ b/benchmarks/test_vision.py
@@ -20,6 +20,18 @@ from bench_lib.hw import Hardware
 CONV_SHAPES: dict[str, tuple[int, int, int, int, int, int, int, int]] = {
     "N32xC64x56x56_K64k3s1": (32, 64, 56, 56, 64, 3, 1, 1),
     "N8xC3x224x224_K64k7s2": (8, 3, 224, 224, 64, 7, 2, 3),
+    # Deeper-C, small-spatial ResNet stage. Same implicit-GEMM domain as the
+    # body shape above but the output row pitch (hw*2 = 392 B) is not TMA
+    # store aligned, so it exercises the scalar epilogue instead.
+    "N32xC256x14x14_K256k3s1": (32, 256, 14, 14, 256, 3, 1, 1),
+    # Nothing divides anything: C=48 pads to 64 (25% wasted reduction),
+    # out_c=80 is ragged against BM=64, H/W are both odd. Worst-case shape
+    # inside the implicit-GEMM domain.
+    "N7xC48x39x53_K80k3s1": (7, 48, 39, 53, 80, 3, 1, 1),
+    # 1x1 control: the materialized route already skips im2col for this case
+    # (the NCHW input IS the col matrix), so the implicit-GEMM route must
+    # decline it rather than regress it with an added NHWC pass.
+    "N32xC256x56x56_K64k1s1": (32, 256, 56, 56, 64, 1, 1, 0),
 }
 # (N, C, H, W, output)
 ADAPTIVE_SHAPES: dict[str, tuple[int, int, int, int, int]] = {

--- a/benchmarks/test_vision.py
+++ b/benchmarks/test_vision.py
@@ -16,22 +16,51 @@ from bench_lib.cases import DTYPES, both
 from bench_lib.check import Bench
 from bench_lib.hw import Hardware
 
-# (N, C_in, H, W, C_out, kernel, stride, padding)
-CONV_SHAPES: dict[str, tuple[int, int, int, int, int, int, int, int]] = {
-    "N32xC64x56x56_K64k3s1": (32, 64, 56, 56, 64, 3, 1, 1),
-    "N8xC3x224x224_K64k7s2": (8, 3, 224, 224, 64, 7, 2, 3),
+# (N, C_in, H, W, C_out, kernel, stride, padding, dilation)
+#
+# The first five shapes are all stride-1 dense convs, which is exactly the
+# domain of the implicit-GEMM route; the block after them deliberately leaves
+# that domain (stride 2, dilation, 1x1-with-stride, batch 1, ragged channels)
+# so the recorded numbers describe the whole op and not one fast path.
+CONV_SHAPES: dict[str, tuple[int, int, int, int, int, int, int, int, int]] = {
+    "N32xC64x56x56_K64k3s1": (32, 64, 56, 56, 64, 3, 1, 1, 1),
+    "N8xC3x224x224_K64k7s2": (8, 3, 224, 224, 64, 7, 2, 3, 1),
     # Deeper-C, small-spatial ResNet stage. Same implicit-GEMM domain as the
     # body shape above but the output row pitch (hw*2 = 392 B) is not TMA
     # store aligned, so it exercises the scalar epilogue instead.
-    "N32xC256x14x14_K256k3s1": (32, 256, 14, 14, 256, 3, 1, 1),
+    "N32xC256x14x14_K256k3s1": (32, 256, 14, 14, 256, 3, 1, 1, 1),
     # Nothing divides anything: C=48 pads to 64 (25% wasted reduction),
     # out_c=80 is ragged against BM=64, H/W are both odd. Worst-case shape
     # inside the implicit-GEMM domain.
-    "N7xC48x39x53_K80k3s1": (7, 48, 39, 53, 80, 3, 1, 1),
+    "N7xC48x39x53_K80k3s1": (7, 48, 39, 53, 80, 3, 1, 1, 1),
     # 1x1 control: the materialized route already skips im2col for this case
     # (the NCHW input IS the col matrix), so the implicit-GEMM route must
     # decline it rather than regress it with an added NHWC pass.
-    "N32xC256x56x56_K64k1s1": (32, 256, 56, 56, 64, 1, 1, 0),
+    "N32xC256x56x56_K64k1s1": (32, 256, 56, 56, 64, 1, 1, 0, 1),
+    # --- regimes OUTSIDE the implicit-GEMM domain -------------------------
+    # ResNet-50 stage transition. stride != 1 is declined by the implicit
+    # GEMM, so this is the materialized im2col route, whose gather is the
+    # dominant cost at stride 2 (measured: 362 of 409 us here).
+    "N32xC128x28x28_K128k3s2": (32, 128, 28, 28, 128, 3, 2, 1, 1),
+    # ResNet-50 shortcut: a 1x1 that CANNOT reuse the in-place col matrix
+    # (that fast path needs stride 1), so a 1x1 still materializes.
+    "N32xC256x14x14_K512k1s2": (32, 256, 14, 14, 512, 1, 2, 0, 1),
+    # Deepest ResNet-50 stage: 7x7 spatial with C=K=512 puts the per-call
+    # weight repack (a 4.7 MB tensor) on the critical path, not the GEMM.
+    "N32xC512x7x7_K512k3s1": (32, 512, 7, 7, 512, 3, 1, 1, 1),
+    # VGG-style big spatial: the largest activation in the suite, where the
+    # implicit GEMM's saved column buffer matters most.
+    "N8xC128x112x112_K128k3s1": (8, 128, 112, 112, 128, 3, 1, 1, 1),
+    # Batch-1 inference variants of the body and mid shapes: one sample is
+    # 1/32 of the GEMM rows, i.e. the regime where a tile grid either fills
+    # the machine or does not.
+    "N1xC64x56x56_K64k3s1": (1, 64, 56, 56, 64, 3, 1, 1, 1),
+    "N1xC256x14x14_K256k3s1": (1, 256, 14, 14, 256, 3, 1, 1, 1),
+    # C and K both indivisible by the 64-channel tile, at stride 2.
+    "N16xC96x28x28_K192k3s2": (16, 96, 28, 28, 192, 3, 2, 1, 1),
+    # Dilation (segmentation / ASPP). The implicit GEMM declines dilation by
+    # design; this node is what pins the fallback's cost for it.
+    "N16xC64x32x32_K64k3s1d2": (16, 64, 32, 32, 64, 3, 1, 2, 2),
 }
 # (N, C, H, W, output)
 ADAPTIVE_SHAPES: dict[str, tuple[int, int, int, int, int]] = {
@@ -68,19 +97,20 @@ SKIPPED: dict[str, str] = {}
 def test_conv2d(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
 ) -> None:
-    n, c_in, h, w, c_out, k, stride, pad = CONV_SHAPES[shape_id]
+    n, c_in, h, w, c_out, k, stride, pad, dil = CONV_SHAPES[shape_id]
     dtype = DTYPES[dtype_id]
     x_ref, x_our = both(torch.randn(n, c_in, h, w, dtype=dtype), hw, mojo_device)
     w_ref, w_our = both(
         torch.randn(c_out, c_in, k, k, dtype=dtype) * 0.1, hw, mojo_device
     )
     b_ref, b_our = both(torch.randn(c_out, dtype=dtype), hw, mojo_device)
-    h_out = (h + 2 * pad - k) // stride + 1
-    w_out = (w + 2 * pad - k) // stride + 1
+    eff_k = dil * (k - 1) + 1
+    h_out = (h + 2 * pad - eff_k) // stride + 1
+    w_out = (w + 2 * pad - eff_k) // stride + 1
     flops = 2.0 * n * c_out * h_out * w_out * c_in * k * k
     bench.run(
-        lambda: F.conv2d(x_ref, w_ref, b_ref, stride, pad),
-        lambda: F.conv2d(x_our, w_our, b_our, stride, pad),
+        lambda: F.conv2d(x_ref, w_ref, b_ref, stride, pad, dil),
+        lambda: F.conv2d(x_our, w_our, b_our, stride, pad, dil),
         flops=flops,
     )
 

--- a/conformance/known_unsupported.py
+++ b/conformance/known_unsupported.py
@@ -750,7 +750,7 @@ _ACCELERATOR_DELTAS: dict[str, dict[str, dict[str, tuple[str, ...]]]] = {
                 "bool",
             ),
             "nn_functional_batch_norm": ("float32", "bfloat16", "float16"),
-            "nn_functional_conv2d": ("bfloat16", "float16", "int64"),
+            "nn_functional_conv2d": ("bfloat16", "float16", "float32", "int64"),
             "nn_functional_instance_norm": ("float32", "bfloat16", "float16"),
             "pow": ("float32", "int64"),
         },

--- a/docs/optimization_backlog.md
+++ b/docs/optimization_backlog.md
@@ -62,7 +62,7 @@ different kind of item.
 | [A5](#a5) | `attn_mask` is a hard decline in eager SDPA | Attention | High for HF models | Medium | — |
 | [D5](#d5) | `aten::index` only handles a single index tensor on dim 0 | Data movement | Medium | Medium | — |
 | [R2](#r2) | ~~`linalg_vector_norm` is composed: 3 launches + an input-sized temporary~~ **DONE**: `NormSpec` / `NormL2Op`, one pass | Reductions | Low | Low | — |
-| [C3](#c3) | conv is 2-D forward only; no `convolution_backward`, no conv1d/3d/transposed in eager | Conv | High for vision *training* (blocks it) | High | — |
+| [C3](#c3) | eager conv backward rides the materialized im2col route: 1.4-23x cuDNN; forward still 2-D-only (no conv1d/3d/transposed) | Conv | High for vision *training* | High | — |
 | [N2](#n2) | BatchNorm training and GroupNorm backward are absent in eager | Normalization | High for vision training (blocks it) | Medium | — |
 | [Q1](#q1) | Graph backend hand-decomposes softmax / log_softmax instead of using MAX's fused ops | Graph | Low–Medium | **Low** | verify MAX does not already re-fuse |
 | [Q3](#q3) | Graph `max_pool2d_with_indices` returns the values as the indices | Graph | Correctness bug | Low | — |
@@ -932,27 +932,42 @@ temporary** — **DONE** (`NormSpec`)
   (depthwise-heavy) model, and `TORCH_MOJO_BACKEND_TRACE=1` to count launches.
 
 ### C3
-**Convolution is 2-D and forward-only in eager**
+**The eager conv backward rides the materialized im2col route**
 
-* **What.** `fast_aten_convolution`, `aten_fast.py:7438` (`and not transposed`)
-  and `:7442` (`len(a._shape) == 4`). `aten::convolution_backward` is not
-  registered in `mojo_device_aten_ops.py` (`aten::convolution` is).
-* **Current implementation.** conv1d (rank-3 input), conv3d and transposed
-  convolutions all return `NOT_HANDLED` → raise. There is no eager conv
-  backward, so `mojo_device_convolution` refuses any conv whose operands
-  require grad in the FORWARD (see [N2](#n2) for why it cannot wait for the
-  backward node). A conv weight normally requires grad, so that is every conv
-  in a training model; inference under `torch.no_grad()` is unaffected.
-* **Why it is not optimal.** conv1d is a reshape away — `(N, C, L)` →
-  `(N, C, 1, L)` with a `(1, kw)` kernel. The missing backward blocks all vision
-  training together with [N2](#n2) and [C4](#c4).
-* **What the optimized version looks like.** conv1d by reshape into the existing
-  2-D path; `convolution_backward` as dgrad (col2im of a GEMM) plus wgrad (a
-  transposed-A GEMM against the im2col matrix) — the same `TRANSPOSE_A`
-  capability [G2](#g2) asks for.
-* **Expected win.** N/A (coverage).
-* **How to measure it.** `tests/test_aten_functions.py`; then a resnet-18
-  training step.
+* **What.** `fast_aten_convolution_backward` and `fast_aten_convolution`,
+  `aten_fast.py`. Both decline transposed convolutions; the forward also
+  declines rank-3 (conv1d) and rank-5 (conv3d) inputs, while the backward
+  already serves rank-3 through a size-1 H lift.
+* **Current implementation.** `aten::convolution_backward` is registered and
+  computes all three gradients: the bias gradient as one reduction, the weight
+  gradient as a transposed-B GEMM against the im2col matrix plus a reduce over
+  the batch, the data gradient as a shared-A GEMM plus a `Col2im` gather. The
+  implicit-GEMM route of [C1](#c1) is FORWARD-ONLY, so both spatial
+  gradients pay a full column-buffer write and read, which is what the
+  forward's own profiling found was 89% of its device time before that route
+  existed.
+* **Why it is not optimal.** Measured on an H100 PCIe against cuDNN
+  (`benchmarks/baselines.html`, 12 entries each): the data gradient runs
+  1.40-15.12x stock (median 10.58) and the weight gradient 3.27-23.25x
+  (median 11.71), both worst on the deep-C small-spatial stages; the bias
+  gradient is 0.39-3.21x (median 0.90), i.e. usually FASTER, since it is a
+  plain reduction. The weight gradient additionally materializes an
+  `(N, out_c, C*R*S)` partials buffer, because none of the GEMM routes here
+  takes a `beta=1` accumulator — bigger than the column buffer itself whenever
+  `out_c > OH*OW`, i.e. in exactly those deep stages.
+* **What the optimized version looks like.** A patch-major im2col variant (a
+  transposed write, so a different kernel rather than a different index) folds
+  N into the weight GEMM's K, which removes both the partials buffer and the
+  batch reduce and turns `N` small-K GEMMs into one deep-K GEMM. Beyond that,
+  an implicit-GEMM data/weight gradient in the shape of the forward's TMA
+  im2col route would remove the column buffer entirely.
+* **Expected win.** **UNMEASURED**, but the forward's own materialized-route
+  profile bounds it: the column traffic this removes was 89% of that route's
+  device time.
+* **How to measure it.** `benchmarks/test_vision.py::test_conv2d_backward`,
+  whose baseline keys are `convolution_backward/<dtype>/<shape>/{dgrad, wgrad,
+  bgrad}` — one node per gradient, so a change to one of the three kernels is
+  attributable. Then a resnet-18 training step.
 
 ### C4
 **Pooling has no `ceil_mode` and no backward**

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -187,6 +187,20 @@ def call_checker():
     call_checker_instance.check_was_called()
 
 
+def matmul_tolerance(device: str) -> dict[str, float]:
+    """The comparison tolerance a GPU matmul or convolution needs.
+
+    MAX reduces float32 matmuls and convolutions through TF32 tensor cores on
+    an accelerator, whose 10 mantissa bits put the per-term relative error
+    near 2^-11 -- four orders of magnitude looser than the fp32 the same graph
+    computes on CPU. Any test comparing a compiled GPU result against stock
+    torch has to allow for that; on CPU nothing is loosened.
+    """
+    if device == "cpu":
+        return {}
+    return {"rtol": 1e-2, "atol": 2e-2}
+
+
 def require_cuda_autograd(device: str) -> None:
     """Skip when this process can no longer run a CUDA backward.
 

--- a/tests/test_aten_functions.py
+++ b/tests/test_aten_functions.py
@@ -16,6 +16,8 @@ from torch_mojo_backend.testing import (
     check_outputs,
 )
 
+from .conftest import matmul_tolerance, require_cuda_autograd
+
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 def test_scaled_dot_product_flash_attention_basic(
@@ -1640,6 +1642,191 @@ def test_aten_div_rounding_mode_floor_trunc_disagree(
     x = torch.tensor([-7, 7], dtype=torch.int64)
     y = torch.tensor([2, -2], dtype=torch.int64)
     check_outputs(fn, conf, [x, y])
+
+
+def _convolution_backward_tolerance(device: str) -> dict[str, float]:
+    """How far a composed conv backward may sit from stock torch's.
+
+    On CPU the arithmetic is plain fp32 on both sides, but the reductions are
+    reassociated -- this backend folds a matmul and runs a role-swapped
+    convolution where torch runs its own im2col GEMMs -- and reassociation
+    alone moves the last bits: measured at most 2.3e-5 absolute and 9.8e-5
+    relative over these cases. On an accelerator MAX reduces through TF32,
+    four orders looser again, which is what `matmul_tolerance` exists for.
+    """
+    return matmul_tolerance(device) or {"rtol": 1e-4, "atol": 1e-4}
+
+
+# (n, c, h, w, out_c, k, stride, padding, dilation, groups)
+_CONVOLUTION_BACKWARD_CASES = {
+    "k3s1p1": (2, 6, 9, 9, 8, 3, 1, 1, 1, 1),
+    "stride2": (2, 6, 11, 11, 8, 3, 2, 1, 1, 1),
+    "unpadded": (2, 4, 10, 12, 6, 3, 1, 0, 1, 1),
+    "dilation2": (2, 4, 13, 13, 6, 3, 1, 2, 2, 1),
+    "groups2": (2, 8, 9, 9, 12, 3, 1, 1, 1, 2),
+    "depthwise": (2, 6, 9, 9, 6, 3, 1, 1, 1, 6),
+    "pointwise_1x1": (2, 5, 7, 7, 4, 1, 1, 0, 1, 1),
+    # The forward truncates here ((11 + 2 - 3) // 2 + 1 == 5 loses a column),
+    # so the data gradient's last input row/column has no tap at all.
+    "truncating_stride2": (1, 4, 11, 9, 6, 3, 2, 1, 1, 1),
+}
+
+
+def _convolution_backward_inputs(case: str) -> list[torch.Tensor]:
+    n, c, h, w, out_c, k, stride, padding, dilation, groups = (
+        _CONVOLUTION_BACKWARD_CASES[case]
+    )
+    out_h = (h + 2 * padding - (dilation * (k - 1) + 1)) // stride + 1
+    out_w = (w + 2 * padding - (dilation * (k - 1) + 1)) // stride + 1
+    torch.manual_seed(0)
+    return [
+        torch.randn(n, out_c, out_h, out_w),
+        torch.randn(n, c, h, w),
+        torch.randn(out_c, c // groups, k, k) * 0.2,
+    ]
+
+
+def _convolution_backward_call(case: str):
+    _, _, _, _, out_c, _, stride, padding, dilation, groups = (
+        _CONVOLUTION_BACKWARD_CASES[case]
+    )
+
+    def fn(grad_output, x, weight):
+        return aten.convolution_backward(
+            grad_output,
+            x,
+            weight,
+            [out_c],
+            [stride, stride],
+            [padding, padding],
+            [dilation, dilation],
+            False,
+            [0, 0],
+            groups,
+            [True, True, True],
+        )
+
+    return fn
+
+
+@pytest.mark.parametrize("case", _CONVOLUTION_BACKWARD_CASES)
+def test_aten_convolution_backward(case: str, conf: Conf, call_checker: CallChecker):
+    call_checker.register(aten_functions.aten_convolution_backward)
+    check_outputs(
+        _convolution_backward_call(case),
+        conf,
+        _convolution_backward_inputs(case),
+        atol=1e-4,
+        rtol=1e-4,
+    )
+
+
+@pytest.mark.parametrize("case", _CONVOLUTION_BACKWARD_CASES)
+def test_aten_convolution_backward_compiled(case: str, device: str):
+    """The compile backend's own composition of the three gradients.
+
+    `conf` only exercises the mojo eager device, so the MAX-graph path in
+    `aten_functions.py` -- `F.fold` for the data gradient, a role-swapped
+    `F.conv2d` for the weight gradient -- needs its own compiled comparison
+    against stock torch on the same device.
+    """
+    check_functions_are_equivalent(
+        _convolution_backward_call(case),
+        device,
+        _convolution_backward_inputs(case),
+        **_convolution_backward_tolerance(device),
+    )
+
+
+def test_aten_convolution_backward_output_mask_compiled(device: str):
+    """Each gradient in isolation: a masked-off slot must not be computed,
+    and the ones that are must not change because the others were skipped."""
+    grad_output, x, weight = _convolution_backward_inputs("k3s1p1")
+
+    for slot in range(3):
+        mask = [index == slot for index in range(3)]
+
+        def fn(grad_output, x, weight, mask=mask, slot=slot):
+            return aten.convolution_backward(
+                grad_output,
+                x,
+                weight,
+                [8],
+                [1, 1],
+                [1, 1],
+                [1, 1],
+                False,
+                [0, 0],
+                1,
+                mask,
+            )[slot]
+
+        check_functions_are_equivalent(
+            fn,
+            device,
+            [grad_output, x, weight],
+            **_convolution_backward_tolerance(device),
+        )
+
+
+@pytest.mark.parametrize("stride,padding,dilation", [(1, 0, 1), (2, 1, 1), (1, 2, 2)])
+def test_aten_convolution_backward_1d_compiled(
+    device: str, stride: int, padding: int, dilation: int
+):
+    """conv1d's backward, through the same rank-4 path behind a size-1 H
+    axis."""
+    torch.manual_seed(0)
+    length = (17 + 2 * padding - (dilation * 2 + 1)) // stride + 1
+    inputs = [
+        torch.randn(2, 8, length),
+        torch.randn(2, 6, 17),
+        torch.randn(8, 6, 3) * 0.2,
+    ]
+
+    def fn(grad_output, x, weight):
+        return aten.convolution_backward(
+            grad_output,
+            x,
+            weight,
+            [8],
+            [stride],
+            [padding],
+            [dilation],
+            False,
+            [0],
+            1,
+            [True, True, True],
+        )
+
+    check_functions_are_equivalent(
+        fn, device, inputs, **_convolution_backward_tolerance(device)
+    )
+
+
+def test_aten_convolution_trains_end_to_end_compiled(device: str):
+    """The gradient the autograd engine actually asks for: a compiled conv
+    whose input, weight and bias all require grad."""
+    require_cuda_autograd(device)
+    torch.manual_seed(0)
+    x = torch.randn(2, 3, 10, 10)
+    weight = torch.randn(6, 3, 3, 3) * 0.2
+    bias = torch.randn(6) * 0.1
+    upstream = torch.randn(2, 6, 10, 10)
+
+    def fn(x, weight, bias, upstream):
+        x = x.detach().requires_grad_()
+        weight = weight.detach().requires_grad_()
+        bias = bias.detach().requires_grad_()
+        out = torch.nn.functional.conv2d(x, weight, bias, 1, 1)
+        out.backward(upstream)
+        return x.grad, weight.grad, bias.grad
+
+    check_functions_are_equivalent(
+        fn,
+        device,
+        [x, weight, bias, upstream],
+        **_convolution_backward_tolerance(device),
+    )
 
 
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float64, torch.bfloat16])

--- a/tests/test_call_queue.py
+++ b/tests/test_call_queue.py
@@ -19,7 +19,7 @@ import gc
 import threading
 import weakref
 from collections import deque
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from pathlib import Path
 
 import pytest
@@ -653,6 +653,233 @@ def test_keepalive_survives_dropped_intermediates(mojo_gpu, forced_queue):
     finally:
         stall.release()
     torch.testing.assert_close(z.cpu(), torch.full((256,), 12.0))
+
+
+# ---------------------------------------------------------------------------
+# Convolution's im2col/GEMM keep-alive (agent-C review of PR #387): the
+# materialized im2col buffer -- or, for a 1x1 stride-1 conv, the input
+# tensor read in place -- is never seen outside `fast_aten_convolution`.
+# Nothing in these tests holds a reference to it either; its only owner is
+# the stack frame that allocates (or aliases) it, which is gone by the time
+# a queued GEMM launch that reads it actually runs. That is exactly the
+# shape of hazard queue rule 3 exists for: a raw pointer's owning tensor
+# must be in the SAME item's keepalive as the pointer, not just alive
+# somewhere in the caller at enqueue time.
+#
+# `_StalledUnits` forces every specialization the second (post-warm-up) call
+# touches to look cold, so the producer (im2col) and the GEMM both queue
+# instead of launching directly. Releasing only the producer's stall and
+# calling `pump()` (not `drain()`) launches it ALONE and stops with the GEMM
+# item still queued -- the one moment queue rule 3 says a missing keepalive
+# entry drops the buffer's last reference.
+#
+# The assertion is a `weakref` check, not a value comparison: whether the
+# buffer's Python object is still alive right there is a direct read of
+# queue rule 3, and it does not depend on whatever the device allocator
+# happens to do with freed memory (which may not corrupt a value-based
+# check promptly, or at all, on a given allocator/run -- a weakref going
+# dead is unambiguous either way).
+# ---------------------------------------------------------------------------
+
+
+def _spy_keepalive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[tuple[str, tuple[object, ...]]]:
+    """Record every ``(op, keepalive)`` pair `_call_mojo` is invoked with,
+    without changing its behavior."""
+    calls: list[tuple[str, tuple[object, ...]]] = []
+    orig_call_mojo = aten_fast._call_mojo
+
+    def spy(
+        extension: object,
+        op: str,
+        extension_args: tuple[object, ...],
+        *,
+        arg_dtypes: tuple[object, ...],
+        output_dtypes: tuple[object, ...] = (),
+        flags: object = None,
+        keepalive: tuple[object, ...],
+    ) -> object:
+        calls.append((op, keepalive))
+        return orig_call_mojo(
+            extension,
+            op,
+            extension_args,
+            arg_dtypes=arg_dtypes,
+            output_dtypes=output_dtypes,
+            flags=flags,
+            keepalive=keepalive,
+        )
+
+    monkeypatch.setattr(aten_fast, "_call_mojo", spy)
+    return calls
+
+
+def _assert_materialized_col_survives_to_gemm(
+    run: Callable[[], torch.Tensor], monkeypatch: pytest.MonkeyPatch
+) -> torch.Tensor:
+    """Warm up ``run`` (a zero-arg callable issuing one materialized conv2d
+    -- i.e. NOT the 1x1 fast path, which has no separate im2col call), then
+    replay it with every specialization forced cold. Launches the im2col
+    item alone (dropping ITS OWN keepalive, `(col, a)`), then checks -- with
+    the GEMM item still queued, not yet launched -- that the im2col buffer
+    is still alive. It can only be alive there because the GEMM item's own
+    keepalive retains it: nothing else does."""
+    calls = _spy_keepalive(monkeypatch)
+    warm = run()
+    call_queue.drain()
+    del warm
+    calls.clear()
+
+    stall = _StalledUnits(monkeypatch, limit=None)
+    col_survived = None
+    try:
+        y = run()
+        assert call_queue.active()
+        assert len(stall.stalls) >= 2, "expected im2col AND a GEMM unit to stall"
+        assert calls and calls[0][0] == "Im2col", (
+            f"expected the first call to be Im2col, got {calls[0][0] if calls else None!r}"
+        )
+        col = calls[0][1][0]  # keepalive=(col, a): index 0 is `col`
+        weak_col = weakref.ref(col)
+        del col, calls[:]  # this frame must not become col's last owner
+
+        gemm_stall = stall.stalls[-1]
+        for earlier in stall.stalls[:-1]:
+            earlier.release()
+        call_queue.pump()  # launches im2col only; the GEMM item stays queued
+        gc.collect()
+        col_survived = weak_col() is not None
+        gemm_stall.release()
+    finally:
+        stall.release()
+    call_queue.drain()
+    assert col_survived, (
+        "the im2col buffer was garbage-collected after im2col's own queued "
+        "item launched (and dropped its keepalive, rule 3) but BEFORE the "
+        "GEMM item that reads it had launched -- the GEMM item's keepalive "
+        "does not retain its own B operand, so a real cold start can free "
+        "this buffer out from under the GEMM kernel (call_queue.py:18-26)"
+    )
+    return y
+
+
+@pytest.mark.parametrize("case", ["dense_simt_bmm", "grouped_simt_matmul"])
+def test_convolution_gemm_keepalive_survives_a_cold_queued_launch(
+    mojo_gpu, forced_queue, monkeypatch: pytest.MonkeyPatch, case: str
+):
+    """Reproduces the review's use-after-free hazard for the plain SIMT
+    `Bmm` fallback (materialized conv, dense) and the grouped `Matmul` loop
+    (materialized conv, groups > 1, one queue item per (sample, group), all
+    reading the same im2col buffer).
+
+    float32 with matmul precision forced to "highest" (TF32 off) keeps this
+    off the sm_90a-gated Bmm16/TF32 routes regardless of which GPU runs the
+    suite, so it deterministically exercises the SIMT fallbacks these cases
+    target -- patched on `aten_fast.torch` rather than the global, so it
+    cannot leak into another test.
+    """
+    monkeypatch.setattr(
+        aten_fast.torch, "get_float32_matmul_precision", lambda: "highest"
+    )
+    torch.manual_seed(0)
+    if case == "grouped_simt_matmul":
+        n, c, out_c, groups = 2, 8, 8, 2
+    else:
+        n, c, out_c, groups = 2, 6, 5, 1
+    k, pad = 3, 1
+    x = torch.randn(n, c, 9, 9, device=mojo_gpu)
+    weight = torch.randn(out_c, c // groups, k, k, device=mojo_gpu) * 0.1
+    x_cpu, weight_cpu = x.cpu(), weight.cpu()
+
+    def run() -> torch.Tensor:
+        return torch.nn.functional.conv2d(
+            x, weight, None, stride=1, padding=pad, groups=groups
+        )
+
+    y = _assert_materialized_col_survives_to_gemm(run, monkeypatch)
+
+    ref = torch.nn.functional.conv2d(
+        x_cpu, weight_cpu, None, stride=1, padding=pad, groups=groups
+    )
+    torch.testing.assert_close(y.cpu(), ref, atol=1e-4, rtol=1e-4)
+
+
+def test_convolution_gemm16_keepalive_survives_a_cold_queued_launch(
+    mojo_gpu, forced_queue, monkeypatch: pytest.MonkeyPatch
+):
+    """Same hazard as `test_convolution_gemm_keepalive_survives_a_cold_
+    queued_launch`, for the sm_90a Bmm16 route `_try_gemm16_conv_bmm`
+    builds (bf16, the default fast path production actually takes on this
+    hardware) -- skipped off an sm_90a GPU, where it is not reachable."""
+    accelerator = list(get_accelerators())[0]
+    if accelerator.api != "cuda" or accelerator.architecture_name != "sm_90a":
+        pytest.skip("the Bmm16 conv route requires an sm_90a GPU")
+    torch.manual_seed(0)
+    # C = 8 < 32 declines the implicit-GEMM route (`_try_conv_igemm`), so
+    # the materialized im2col + Bmm16 route -- the one this fix touches --
+    # is what actually launches.
+    n, c, out_c, k, pad = 2, 8, 16, 3, 1
+    x = (torch.randn(n, c, 9, 9, device=mojo_gpu)).to(torch.bfloat16)
+    weight = (torch.randn(out_c, c, k, k, device=mojo_gpu) * 0.1).to(torch.bfloat16)
+    x_cpu, weight_cpu = x.float().cpu(), weight.float().cpu()
+
+    def run() -> torch.Tensor:
+        return torch.nn.functional.conv2d(x, weight, None, stride=1, padding=pad)
+
+    y = _assert_materialized_col_survives_to_gemm(run, monkeypatch)
+
+    ref = torch.nn.functional.conv2d(x_cpu, weight_cpu, None, stride=1, padding=pad)
+    torch.testing.assert_close(y.float().cpu(), ref, atol=8e-2, rtol=8e-2)
+
+
+def test_convolution_1x1_alias_keepalive_survives_a_cold_queued_launch(
+    mojo_gpu, forced_queue, monkeypatch: pytest.MonkeyPatch
+):
+    """The 1x1 stride-1 fast path never allocates a separate im2col buffer:
+    `col` in `fast_aten_convolution` IS `a`, the input tensor, read in
+    place. Once this test drops its own reference, the GEMM item's own
+    keepalive is the ONLY thing that can keep the input alive until that
+    item -- forced cold, still queued -- launches. Same TF32-off float32
+    setup as the materialized cases, for the same portability reason."""
+    monkeypatch.setattr(
+        aten_fast.torch, "get_float32_matmul_precision", lambda: "highest"
+    )
+    torch.manual_seed(0)
+    n, c, out_c = 2, 6, 5
+    x = torch.randn(n, c, 9, 9, device=mojo_gpu)
+    weight = torch.randn(out_c, c, 1, 1, device=mojo_gpu) * 0.1
+    x_cpu, weight_cpu = x.cpu(), weight.cpu()
+
+    def run() -> torch.Tensor:
+        return torch.nn.functional.conv2d(x, weight, None, stride=1, padding=0)
+
+    warm = run()
+    call_queue.drain()
+    del warm
+
+    stall = _StalledUnits(monkeypatch, limit=None)
+    x_survived = None
+    try:
+        y = run()
+        assert call_queue.active()
+        assert stall.stalls, "expected the GEMM unit to stall cold"
+        weak_x = weakref.ref(x)
+        x = None  # drop the caller's only reference to the input
+        gc.collect()
+        x_survived = weak_x() is not None
+    finally:
+        stall.release()
+    call_queue.drain()
+    assert x_survived, (
+        "the input tensor was garbage-collected while the queued GEMM item "
+        "that reads it in place (the 1x1 fast path, no separate im2col "
+        "buffer) was still cold -- its keepalive does not retain the input "
+        "(queue rule 3, call_queue.py:18-26)"
+    )
+
+    ref = torch.nn.functional.conv2d(x_cpu, weight_cpu, None, stride=1, padding=0)
+    torch.testing.assert_close(y.cpu(), ref, atol=1e-4, rtol=1e-4)
 
 
 def test_sync_read_drains_the_queue(mojo_gpu, forced_queue):

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -19,7 +19,7 @@ from torch_mojo_backend import (
 )
 from torch_mojo_backend.testing import check_functions_are_equivalent
 
-from .conftest import require_cuda_autograd
+from .conftest import matmul_tolerance, require_cuda_autograd
 
 
 # MAX lowers an fp32 matmul to TF32 tensor cores on NVIDIA GPUs while torch
@@ -36,12 +36,6 @@ from .conftest import require_cuda_autograd
 # the tolerance. atol=2e-2 is ~1.3x the measured worst case and still ~50x
 # below the O(1) error an actually wrong matmul produces on N(0, 1) data.
 # CPU keeps assert_close's exact fp32 defaults.
-def matmul_tolerance(device: str) -> dict[str, float]:
-    if device == "cpu":
-        return {}
-    return {"rtol": 1e-2, "atol": 2e-2}
-
-
 def test_basic_training(device: str):
     require_cuda_autograd(device)
 

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -9499,7 +9499,8 @@ def test_fast_conv2d_tensor_core_benchmark_shapes(
 # Implicit-GEMM conv (sm_90a, bf16): the TMA im2col route that never
 # materializes the patch matrix. Ported from the standalone Mojo harness the
 # kernel was developed in, which checked EVERY output element of each case
-# against an fp64 host reference; here the reference is torch's own fp32 conv.
+# against an fp64 host reference (`_conv_igemm_reference` below is that same
+# criterion, not torch's own fp32 conv).
 # ---------------------------------------------------------------------------
 _CONV_IGEMM_SHAPES = {
     # (n, c, h, w, out_c, kh, kw, pad_h, pad_w)

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -9443,6 +9443,196 @@ def test_fast_conv2d_refuses_autograd_in_the_forward(mojo_gpu):
         )
 
 
+# Shrunk-N copies of benchmarks/test_vision.py's CONV_SHAPES: same C/H/W/kernel
+# (so the same im2col K and GEMM N the benchmark measures), a small batch so
+# the test is cheap.
+_CONV_BENCH_SHAPES = {
+    "body_N32xC64x56x56_K64k3s1": (2, 64, 56, 56, 64, 3, 1, 1),
+    "stem_N8xC3x224x224_K64k7s2": (2, 3, 224, 224, 64, 7, 2, 3),
+}
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("shape_id", _CONV_BENCH_SHAPES)
+def test_fast_conv2d_tensor_core_benchmark_shapes(
+    mojo_h100: torch.device, shape_id: str, dtype: torch.dtype
+) -> None:
+    """The benchmark body/stem conv shapes, N shrunk to 2, through whichever
+    GEMM route sm_90a picks for the dtype: Bmm16 (bf16/f16, always opt-in),
+    the opt-in TF32 BMM (f32, only past the same
+    `float32_matmul_precision() != "highest"` gate `_try_tf32_mm` uses), or
+    the plain SIMT Bmm fallback (f32 at the default "highest" precision)."""
+    n, c_in, h, w, c_out, k, stride, pad = _CONV_BENCH_SHAPES[shape_id]
+    x = torch.randn(n, c_in, h, w, dtype=dtype)
+    weight = torch.randn(c_out, c_in, k, k, dtype=dtype) * 0.1
+    bias = torch.randn(c_out, dtype=dtype)
+
+    old_precision = torch.get_float32_matmul_precision()
+    torch.set_float32_matmul_precision("high")
+    try:
+        dev = torch.nn.functional.conv2d(
+            x.to(mojo_h100), weight.to(mojo_h100), bias.to(mojo_h100), stride, pad
+        ).cpu()
+    finally:
+        torch.set_float32_matmul_precision(old_precision)
+    ref = torch.nn.functional.conv2d(
+        x.float(), weight.float(), bias.float(), stride, pad
+    )
+
+    # float16 has more mantissa bits than bfloat16, so it gets the tighter
+    # bound; both are FP32-accumulated tensor-core GEMMs (see the analogous
+    # gemm16 mm/bmm tests), just rounded to a narrower output type than the
+    # k=333 case those tests calibrate against, hence the wider margin for
+    # this k up to 576. float32 goes through TF32 (or, at default precision,
+    # plain FP32) -- the same calibrated bound the mm/addmm tensor-core tests
+    # use.
+    if dtype == torch.float16:
+        atol, rtol = 3e-2, 3e-3
+    elif dtype == torch.bfloat16:
+        atol, rtol = 8e-2, 8e-2
+    else:
+        atol, rtol = 5e-2, 5e-2
+    torch.testing.assert_close(dev.float(), ref, atol=atol, rtol=rtol)
+
+
+@pytest.mark.parametrize("op", ["bmm16", "1x1_bmm16"])
+def test_fast_conv2d_routes_dense_bf16_through_gemm16_bmm(
+    mojo_h100: torch.device, monkeypatch: pytest.MonkeyPatch, op: str
+) -> None:
+    """Dense (groups == 1) bf16 conv reaches the same Bmm16 kernel fast_aten_bmm
+    already builds -- both the general im2col path and the 1x1 stride-1
+    fast path that reads the NCHW input as the col matrix in place."""
+    calls = _spy_defined_native_calls(
+        monkeypatch, {("gemm16_matmul_ops.mojo", "Bmm16")}
+    )
+    n, c_in, h, w, c_out = 2, 8, 16, 16, 12
+    k, stride, pad = (3, 1, 1) if op == "bmm16" else (1, 1, 0)
+    x = torch.randn(n, c_in, h, w).to(torch.bfloat16)
+    weight = (torch.randn(c_out, c_in, k, k) * 0.1).to(torch.bfloat16)
+    dev = torch.nn.functional.conv2d(
+        x.to(mojo_h100), weight.to(mojo_h100), None, stride, pad
+    ).cpu()
+    ref = torch.nn.functional.conv2d(x.float(), weight.float(), None, stride, pad)
+
+    target = ("gemm16_matmul_ops.mojo", "Bmm16")
+    assert len(calls[target]) == 1, "dense bf16 conv did not reach the Bmm16 bridge"
+    torch.testing.assert_close(dev.float(), ref, atol=8e-2, rtol=8e-2)
+
+
+def test_fast_conv2d_tf32_bmm_is_opt_in_like_mm(
+    mojo_h100: torch.device, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same numerics policy as the mm/bmm TF32 routes: off by default (torch's
+    `float32_matmul_precision() == "highest"`), reachable once the caller
+    opts in with `torch.set_float32_matmul_precision("high")`. The repo has
+    no separate `torch.backends.cudnn.allow_tf32`-style policy for
+    convolution, so this deliberately follows the mm gate instead."""
+    calls = _spy_defined_native_calls(
+        monkeypatch,
+        {("tf32_matmul_ops.mojo", "Tf32BmmF32"), ("matmul_ops.mojo", "Bmm")},
+    )
+    x = torch.randn(2, 8, 16, 16)
+    weight = torch.randn(12, 8, 3, 3) * 0.1
+
+    dev_default = torch.nn.functional.conv2d(
+        x.to(mojo_h100), weight.to(mojo_h100), None, 1, 1
+    ).cpu()
+    assert not calls[("tf32_matmul_ops.mojo", "Tf32BmmF32")]
+    assert len(calls[("matmul_ops.mojo", "Bmm")]) == 1
+
+    old_precision = torch.get_float32_matmul_precision()
+    torch.set_float32_matmul_precision("high")
+    try:
+        dev_tf32 = torch.nn.functional.conv2d(
+            x.to(mojo_h100), weight.to(mojo_h100), None, 1, 1
+        ).cpu()
+    finally:
+        torch.set_float32_matmul_precision(old_precision)
+    assert len(calls[("tf32_matmul_ops.mojo", "Tf32BmmF32")]) == 1
+
+    ref = torch.nn.functional.conv2d(x, weight, None, 1, 1)
+    torch.testing.assert_close(dev_default, ref, atol=1e-3, rtol=1e-3)
+    torch.testing.assert_close(dev_tf32, ref, atol=5e-2, rtol=5e-2)
+
+
+def test_fast_conv2d_grouped_and_noncontiguous_keep_generic_route(
+    mojo_h100: torch.device, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Blast-radius guard: grouped convs and non-contiguous inputs are the
+    cases the tensor-core routes decline (grouped: no single (out_c, ckk) x
+    (ckk, cols) GEMM; non-contiguous: `_tc` materializes it back to dense
+    before either helper ever sees it, per the existing contract) -- both
+    must still land on the untouched SIMT path, not silently regress or
+    raise."""
+    calls = _spy_defined_native_calls(
+        monkeypatch,
+        {
+            ("gemm16_matmul_ops.mojo", "Bmm16"),
+            ("tf32_matmul_ops.mojo", "Tf32BmmF32"),
+            ("matmul_ops.mojo", "Matmul"),
+            ("matmul_ops.mojo", "Bmm"),
+        },
+    )
+    old_precision = torch.get_float32_matmul_precision()
+    torch.set_float32_matmul_precision("high")
+    try:
+        # Grouped conv, bf16: per (sample, group) Matmul, never Bmm16.
+        x = torch.randn(2, 8, 16, 16).to(torch.bfloat16)
+        w = torch.randn(12, 4, 3, 3).to(torch.bfloat16)
+        dev_grouped = torch.nn.functional.conv2d(
+            x.to(mojo_h100), w.to(mojo_h100), None, 1, 1, groups=2
+        ).cpu()
+        ref_grouped = torch.nn.functional.conv2d(
+            x.float(), w.float(), None, 1, 1, groups=2
+        )
+        torch.testing.assert_close(
+            dev_grouped.float(), ref_grouped, atol=8e-2, rtol=8e-2
+        )
+
+        # Non-contiguous (channels-last) f32 input, dense conv: still TF32.
+        x_nc = torch.randn(2, 8, 16, 16).to(memory_format=torch.channels_last)
+        w_nc = torch.randn(12, 8, 3, 3) * 0.1
+        dev_nc = torch.nn.functional.conv2d(
+            x_nc.to(mojo_h100), w_nc.to(mojo_h100), None, 1, 1
+        ).cpu()
+        ref_nc = torch.nn.functional.conv2d(x_nc, w_nc, None, 1, 1)
+        torch.testing.assert_close(dev_nc, ref_nc, atol=5e-2, rtol=5e-2)
+    finally:
+        torch.set_float32_matmul_precision(old_precision)
+
+    assert not calls[("gemm16_matmul_ops.mojo", "Bmm16")]
+    assert len(calls[("matmul_ops.mojo", "Matmul")]) == 2 * 2  # 2 samples x 2 groups
+    assert len(calls[("tf32_matmul_ops.mojo", "Tf32BmmF32")]) == 1
+    assert len(calls[("matmul_ops.mojo", "Bmm")]) == 0
+
+
+def test_fast_conv2d_cpu_device_matches_gpu_row_kernel(mojo_device: str) -> None:
+    """`conv_ops.mojo`'s Im2col/BiasAddChan dispatch on `ctx.api()`: the CPU
+    device (`mojo_device` here, not `mojo_gpu`) takes the scalar
+    `elementwise` path (`_im2col_scalar`/`_bias_add_chan_scalar`), unchanged
+    logic from before this file's GPU row-kernel rewrite, just extracted into
+    a named function -- this is the one test in the module that actually
+    exercises it, on both stride=1 (im2col's contiguous-read branch) and
+    stride=2 (its strided-gather branch)."""
+    torch.manual_seed(0)
+    x = torch.randn(2, 8, 16, 16)
+    w = torch.randn(12, 8, 3, 3) * 0.1
+    b = torch.randn(12)
+    dev = torch.nn.functional.conv2d(
+        x.to(mojo_device), w.to(mojo_device), b.to(mojo_device), stride=1, padding=1
+    ).cpu()
+    ref = torch.nn.functional.conv2d(x, w, b, stride=1, padding=1)
+    torch.testing.assert_close(dev, ref, atol=1e-4, rtol=1e-4)
+
+    x2 = torch.randn(3, 3, 15, 17)
+    w2 = torch.randn(6, 3, 5, 5) * 0.1
+    dev2 = torch.nn.functional.conv2d(
+        x2.to(mojo_device), w2.to(mojo_device), None, stride=2, padding=2
+    ).cpu()
+    ref2 = torch.nn.functional.conv2d(x2, w2, None, stride=2, padding=2)
+    torch.testing.assert_close(dev2, ref2, atol=1e-4, rtol=1e-4)
+
+
 @pytest.mark.parametrize("is_causal", [True, False])
 # kv_len <= 32 exercises the library softmax's warp kernel, kv_len=64 the
 # online/block kernel.

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -9528,6 +9528,56 @@ _CONV_IGEMM_SHAPES = {
     "k7_pad3": (1, 64, 16, 16, 64, 7, 7, 3, 3),
 }
 
+# 2^-24, the fp32 machine epsilon: the GEMM's tile accumulation is fp32, so
+# this is the per-term rounding unit the accumulation-error bound below is
+# built from -- ported from conv_igemm_test.mojo's host-side correctness
+# harness, not re-derived here.
+_CI_EPS_F32 = 2.0**-24
+# 2^-8: one bf16 half-ulp, the max relative error of ONE correctly-rounded
+# fp64/fp32 -> bfloat16 cast.
+_CI_BF16_HALF_ULP = 2.0**-8
+
+
+def _conv_igemm_reference(
+    x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor | None, ph: int, pw: int
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """The fp64 ground truth, a PER-ELEMENT tolerance derived from the fp32
+    accumulation error bound (not a fixed slop), and the bit-exact target --
+    ported from conv_igemm_test.mojo, the kernel's own correctness harness.
+
+    Inputs are bf16 tensors, hence already exactly representable in bf16, so
+    the only error a correct kernel can introduce is (1) the fp32 tile
+    accumulation of the GEMM reduction and (2) the bf16 rounding(s) of the
+    output. The accumulation term is `4 * eps_f32 * sqrt(k_pad) * sum|a*b|`
+    (`k_pad` includes the C-padding to the kernel's 64-channel tile, since
+    the padded zero terms still cost accumulation steps); the 4x is the same
+    safety factor the Mojo harness uses. Bias goes through a SEPARATE kernel
+    (`BiasAddChan`) that reads the already-bf16-rounded GEMM output and
+    rounds again after the add, so a biased case pays a second independent
+    half-ulp term, not a bigger accumulation term, and its bit-exact target
+    is the double-rounded value the real pipeline computes, not
+    `round_bf16(gemm + bias)` directly (double rounding can legitimately
+    differ from single rounding even in exact arithmetic).
+    """
+    c, kh, kw = x.shape[1], weight.shape[2], weight.shape[3]
+    c_pad = ((c + 63) // 64) * 64
+    k_pad = kh * kw * c_pad
+    acc_coeff = 4.0 * _CI_EPS_F32 * math.sqrt(k_pad)
+
+    x64 = x.double()
+    w64 = weight.double()
+    acc_gemm = torch.nn.functional.conv2d(x64, w64, stride=1, padding=(ph, pw))
+    mag = torch.nn.functional.conv2d(x64.abs(), w64.abs(), stride=1, padding=(ph, pw))
+    tol = _CI_BF16_HALF_ULP * acc_gemm.abs() + acc_coeff * mag
+    want_bf16 = acc_gemm.to(torch.bfloat16)
+    if bias is None:
+        return acc_gemm, tol, want_bf16
+    b64 = bias.double().view(1, -1, 1, 1)
+    acc_true = acc_gemm + b64
+    tol = tol + _CI_BF16_HALF_ULP * acc_true.abs()
+    want_bf16 = (want_bf16.double() + b64).to(torch.bfloat16)
+    return acc_true, tol, want_bf16
+
 
 @pytest.mark.parametrize("shape_id", _CONV_IGEMM_SHAPES)
 @pytest.mark.parametrize("with_bias", [False, True])
@@ -9539,6 +9589,7 @@ def test_fast_conv2d_igemm_edge_shapes(
 ) -> None:
     """Every geometry the implicit-GEMM dispatch ACCEPTS, and a check that it
     really is the route that ran."""
+    torch.manual_seed(0)  # exact_frac below is a measured bound, not a tautology
     calls = _spy_defined_native_calls(
         monkeypatch, {("conv_igemm_ops.mojo", "ConvIgemm")}
     )
@@ -9555,20 +9606,33 @@ def test_fast_conv2d_igemm_edge_shapes(
         stride=1,
         padding=(ph, pw),
     ).cpu()
-    ref = torch.nn.functional.conv2d(
-        x.float(),
-        weight.float(),
-        None if bias is None else bias.float(),
-        stride=1,
-        padding=(ph, pw),
-    )
 
     target = ("conv_igemm_ops.mojo", "ConvIgemm")
     assert len(calls[target]) == 1, f"{shape_id} did not take the implicit-GEMM route"
-    # One fp32-accumulated reduction of up to k = 3136, rounded once to
-    # bfloat16 (2^-8 relative): the same calibration the gemm16 mm/bmm tests
-    # use for a bf16 output.
-    torch.testing.assert_close(dev.float(), ref, atol=8e-2, rtol=8e-2)
+    acc, tol, want_bf16 = _conv_igemm_reference(x, weight, bias, ph, pw)
+    got = dev.double()
+    err = (got - acc).abs()
+    bad = err > tol
+    assert not bad.any(), (
+        f"{shape_id} with_bias={with_bias}: {int(bad.sum())}/{bad.numel()} "
+        f"outputs exceed the fp32-accumulation-derived tolerance; worst "
+        f"error={err.max().item():.6g} at tol={tol.flatten()[err.argmax()].item():.6g}"
+    )
+    # fp32 accumulation noise should move at most a handful of outputs off
+    # their correctly-rounded bf16 code; an indexing or accumulation bug
+    # collapses this fraction instead of nudging it. conv_igemm_test.mojo's
+    # deterministic hash-filled inputs measure exactly 1.0 on an H100 and
+    # gate at 0.999; these tests use genuinely random inputs instead (no
+    # per-case tuning), and the deepest reductions here (k7_pad3, k_pad =
+    # 3136; mid_14x14_C256, k_pad = 2304) measure ~99.87% at seed 0 -- still
+    # two orders of magnitude away from anything an indexing or
+    # accumulation bug would produce. 0.99 keeps that margin without
+    # chasing the harness's input-specific figure.
+    exact_frac = (dev == want_bf16).double().mean().item()
+    assert exact_frac >= 0.99, (
+        f"{shape_id} with_bias={with_bias}: only {exact_frac:.4%} of outputs "
+        "are bit-exact against the double-rounded reference"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -9398,49 +9398,344 @@ def test_fast_conv2d_batched_falls_back_correctly(mojo_gpu):
     torch.testing.assert_close(dev, ref, atol=5e-2, rtol=5e-2)
 
 
-def test_fast_conv2d_refuses_autograd_in_the_forward(mojo_gpu):
-    """A grad-requiring conv must fail at the FORWARD.
+# ---------------------------------------------------------------------------
+# Convolution backward: the three gradients through im2col + GEMM + col2im.
+# Every case is checked against an fp64 CPU-autograd ground truth with a
+# PER-ELEMENT tolerance derived from the fp32 accumulation bound (the same
+# criterion `_conv_igemm_reference` uses for the forward), not a fixed slop:
+# a conv backward reduces over n * OH * OW terms for the parameter gradients,
+# so a flat atol would either pass wrong kernels on big shapes or fail right
+# ones on small.
+# ---------------------------------------------------------------------------
 
-    `aten::convolution_backward` is not implemented here, and a raise from
-    inside the autograd engine aborts the process on this backend (exit 134,
-    no traceback) instead of propagating, so the refusal cannot wait for
-    ConvolutionBackward0. A conv weight normally requires grad, so this refuses
-    conv training outright -- the alternative was a dead process -- while
-    inference under `torch.no_grad()` is untouched.
+# (n, c, h, w, out_c, k, stride, padding, dilation, groups)
+_CONV_BWD_SHAPES = {
+    "base_k3s1p1": (2, 6, 12, 12, 8, 3, 1, 1, 1, 1),
+    "stride2": (2, 6, 13, 13, 8, 3, 2, 1, 1, 1),
+    "unpadded_stride3_k4": (2, 5, 14, 14, 7, 4, 3, 0, 1, 1),
+    "dilation2": (2, 6, 15, 15, 8, 3, 1, 2, 2, 1),
+    "groups2": (2, 8, 10, 10, 12, 3, 1, 1, 1, 2),
+    # groups == C: depthwise, one output channel per input channel, the
+    # regime where the per-(sample, group) GEMM loop is longest.
+    "depthwise_g64": (2, 64, 9, 9, 64, 3, 1, 1, 1, 64),
+    # 1x1 stride-1: col2im is the identity and the columns ARE the gradient
+    # image, so this is the branch that skips both spatial kernels.
+    "batch1_1x1": (1, 8, 7, 7, 5, 1, 1, 0, 1, 1),
+    "batch32": (32, 4, 8, 8, 6, 3, 1, 1, 1, 1),
+    # stride 2 with a truncating input extent: (13 + 2*1 - 3) // 2 + 1 == 7
+    # loses the last input column, so col2im must leave those pixels at zero
+    # rather than reading a tap that never existed.
+    "truncating_stride2": (2, 4, 13, 11, 6, 3, 2, 1, 1, 1),
+    # rectangular filter, asymmetric padding
+    "rect_k3x5": (2, 4, 11, 13, 6, (3, 5), 1, (1, 2), 1, 1),
+}
+
+# One bf16 / fp16 / fp32 half-ulp: the largest relative error of ONE
+# correctly-rounded cast into that dtype.
+_CONV_BWD_HALF_ULP = {
+    torch.float32: 2.0**-24,
+    torch.bfloat16: 2.0**-8,
+    torch.float16: 2.0**-11,
+}
+# 2^-24, the fp32 machine epsilon: every reduction here (the GEMMs, the batch
+# reduce, col2im's tap sum) accumulates in fp32, so this is the per-term
+# rounding unit. The 4x safety factor matches `_conv_igemm_reference`.
+_CONV_BWD_EPS_F32 = 2.0**-24
+
+
+def _conv_backward_reference(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    grad_output: torch.Tensor,
+    stride,
+    padding,
+    dilation,
+    groups: int,
+) -> tuple[tuple[torch.Tensor, ...], tuple[torch.Tensor, ...]]:
+    """`(exact_fp64_grads, magnitudes)` for (grad_input, grad_weight,
+    grad_bias).
+
+    The magnitudes are the same three reductions run on the ABSOLUTE values
+    of the operands, i.e. `sum |a*b|` per output element -- the quantity a
+    floating-point accumulation-error bound is proportional to. Deriving them
+    from torch's own backward (rather than by hand) keeps the reference
+    independent of the layout this backend happens to reduce in.
     """
-    host_input, device_input = _preflight_input((2, 3, 8, 8), mojo_gpu)
-    host_weight, device_weight = _preflight_input((4, 3, 3, 3), mojo_gpu, seed=11)
-    host_bias, device_bias = _preflight_input((4,), mojo_gpu, seed=13)
 
-    expected = torch.nn.functional.conv2d(host_input, host_weight, host_bias, padding=1)
-    torch.testing.assert_close(
-        torch.nn.functional.conv2d(
-            device_input, device_weight, device_bias, padding=1
-        ).cpu(),
-        expected,
-        atol=5e-2,
-        rtol=5e-2,
+    def grads(xt: torch.Tensor, wt: torch.Tensor, gt: torch.Tensor):
+        xd = xt.double().detach().requires_grad_()
+        wd = wt.double().detach().requires_grad_()
+        out = torch.nn.functional.conv2d(
+            xd, wd, None, stride, padding, dilation, groups
+        )
+        out.backward(gt.double())
+        return xd.grad, wd.grad
+
+    grad_input, grad_weight = grads(x, weight, grad_output)
+    mag_input, mag_weight = grads(x.abs(), weight.abs(), grad_output.abs())
+    grad_bias = grad_output.double().sum(dim=(0, 2, 3))
+    mag_bias = grad_output.double().abs().sum(dim=(0, 2, 3))
+    return (grad_input, grad_weight, grad_bias), (mag_input, mag_weight, mag_bias)
+
+
+def _assert_conv_grad_close(
+    actual: torch.Tensor,
+    exact: torch.Tensor,
+    magnitude: torch.Tensor,
+    dtype: torch.dtype,
+    reduction_len: int,
+    roundings: int,
+    what: str,
+) -> None:
+    """`actual` is within the fp32 accumulation bound of the fp64 truth.
+
+    `roundings` counts the casts back into `dtype` the value survives: one
+    for a gradient written straight out, two where an intermediate is
+    materialized in `dtype` first (the per-sample weight partials, the column
+    gradient col2im then reads). Each costs a half-ulp of the MAGNITUDE, not
+    of the possibly-cancelled exact value.
+    """
+    tol = (
+        roundings * _CONV_BWD_HALF_ULP[dtype]
+        + 4.0 * _CONV_BWD_EPS_F32 * math.sqrt(max(reduction_len, 1))
+    ) * magnitude
+    err = (actual.double() - exact).abs()
+    worst = int((err - tol).argmax())
+    assert bool((err <= tol).all()), (
+        f"{what}: {int((err > tol).sum())} of {err.numel()} elements outside the "
+        f"fp32 accumulation bound; worst err={err.flatten()[worst]:.3e} "
+        f"tol={tol.flatten()[worst]:.3e} exact={exact.flatten()[worst]:.3e}"
     )
 
-    # The weight-only case is the one every training model actually hits.
-    for which in range(3):
-        operands = [device_input.detach(), device_weight.detach(), device_bias.detach()]
-        operands[which] = operands[which].requires_grad_()
-        with pytest.raises(NotImplementedError, match="convolution_backward"):
-            torch.nn.functional.conv2d(operands[0], operands[1], operands[2], padding=1)
 
-    with torch.no_grad():
-        torch.testing.assert_close(
-            torch.nn.functional.conv2d(
-                device_input.detach().requires_grad_(),
-                device_weight,
-                device_bias,
-                padding=1,
-            ).cpu(),
-            expected,
-            atol=5e-2,
-            rtol=5e-2,
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("shape_id", _CONV_BWD_SHAPES)
+def test_fast_convolution_backward_matches_cpu_autograd(
+    mojo_gpu: torch.device, shape_id: str, dtype: torch.dtype
+) -> None:
+    torch.manual_seed(0)
+    n, c, h, w, out_c, k, stride, padding, dilation, groups = _CONV_BWD_SHAPES[shape_id]
+    kh, kw = k if isinstance(k, tuple) else (k, k)
+    x = torch.randn(n, c, h, w, dtype=dtype)
+    weight = (torch.randn(out_c, c // groups, kh, kw, dtype=dtype) * 0.2).to(dtype)
+    eff_h = dilation * (kh - 1) + 1
+    eff_w = dilation * (kw - 1) + 1
+    ph, pw = padding if isinstance(padding, tuple) else (padding, padding)
+    out_h = (h + 2 * ph - eff_h) // stride + 1
+    out_w = (w + 2 * pw - eff_w) // stride + 1
+    grad_output = torch.randn(n, out_c, out_h, out_w, dtype=dtype)
+
+    exact, magnitude = _conv_backward_reference(
+        x, weight, grad_output, stride, padding, dilation, groups
+    )
+    got = torch.ops.aten.convolution_backward(
+        grad_output.to(mojo_gpu),
+        x.to(mojo_gpu),
+        weight.to(mojo_gpu),
+        [out_c],
+        [stride, stride],
+        list(padding) if isinstance(padding, tuple) else [padding, padding],
+        [dilation, dilation],
+        False,
+        [0, 0],
+        groups,
+        [True, True, True],
+    )
+    cols = out_h * out_w
+    lengths = (out_c // groups * kh * kw, n * cols, n * cols)
+    roundings = (2, 2, 1)
+    for slot, name in enumerate(("grad_input", "grad_weight", "grad_bias")):
+        assert got[slot] is not None
+        assert got[slot].dtype == dtype
+        assert got[slot].shape == exact[slot].shape
+        _assert_conv_grad_close(
+            got[slot].cpu(),
+            exact[slot],
+            magnitude[slot],
+            dtype,
+            lengths[slot],
+            roundings[slot],
+            f"{shape_id}/{dtype}/{name}",
         )
+
+
+@pytest.mark.parametrize(
+    "mask",
+    [
+        (True, False, False),
+        (False, True, False),
+        (False, False, True),
+        (True, True, False),
+        (False, False, False),
+    ],
+)
+def test_fast_convolution_backward_output_mask(
+    mojo_gpu: torch.device, mask: tuple[bool, bool, bool]
+) -> None:
+    """A masked-off slot comes back as `None`, exactly as ATen's undefined
+    tensor does through the Python binding, and the requested slots are
+    bit-identical to what the all-on call returns -- i.e. masking really
+    skips work instead of changing the answer."""
+    torch.manual_seed(0)
+    x = torch.randn(2, 6, 10, 10)
+    weight = torch.randn(8, 6, 3, 3) * 0.2
+    grad_output = torch.randn(2, 8, 10, 10)
+    args = (
+        grad_output.to(mojo_gpu),
+        x.to(mojo_gpu),
+        weight.to(mojo_gpu),
+        [8],
+        [1, 1],
+        [1, 1],
+        [1, 1],
+        False,
+        [0, 0],
+        1,
+    )
+    full = torch.ops.aten.convolution_backward(*args, [True, True, True])
+    got = torch.ops.aten.convolution_backward(*args, list(mask))
+    for slot in range(3):
+        if mask[slot]:
+            assert got[slot] is not None
+            torch.testing.assert_close(
+                got[slot].cpu(), full[slot].cpu(), atol=0, rtol=0
+            )
+        else:
+            assert got[slot] is None
+
+
+def test_fast_convolution_backward_accepts_a_channels_last_grad_output(
+    mojo_gpu: torch.device,
+) -> None:
+    """grad_output routinely arrives non-contiguous (a channels_last op
+    upstream, a permuted view), and ATen contiguifies it inside the backend
+    rather than at the dispatcher, so this op has to do it itself."""
+    torch.manual_seed(0)
+    x = torch.randn(2, 6, 9, 9)
+    weight = torch.randn(8, 6, 3, 3) * 0.2
+    grad_output = torch.randn(2, 8, 9, 9)
+    args = ([8], [1, 1], [1, 1], [1, 1], False, [0, 0], 1, [True, True, True])
+    dense = torch.ops.aten.convolution_backward(
+        grad_output.to(mojo_gpu), x.to(mojo_gpu), weight.to(mojo_gpu), *args
+    )
+    strided = torch.ops.aten.convolution_backward(
+        grad_output.to(mojo_gpu).contiguous(memory_format=torch.channels_last),
+        x.to(mojo_gpu),
+        weight.to(mojo_gpu),
+        *args,
+    )
+    for slot in range(3):
+        torch.testing.assert_close(
+            strided[slot].cpu(), dense[slot].cpu(), atol=0, rtol=0
+        )
+
+
+def test_fast_convolution_backward_declines_transposed(mojo_gpu: torch.device) -> None:
+    """The backward of a conv_transpose FORWARD (input and grad_output swap
+    roles again) is not implemented, and the forward declines `transposed`
+    too, so nothing on this device can produce such a node. It must decline
+    with the actionable NotImplementedError, never silently compute the
+    non-transposed answer."""
+    x = torch.randn(2, 6, 8, 8).to(mojo_gpu)
+    weight = torch.randn(6, 3, 3, 3).to(mojo_gpu)
+    grad_output = torch.randn(2, 3, 10, 10).to(mojo_gpu)
+    with pytest.raises(NotImplementedError, match="convolution_backward"):
+        torch.ops.aten.convolution_backward(
+            grad_output,
+            x,
+            weight,
+            [3],
+            [1, 1],
+            [1, 1],
+            [1, 1],
+            True,
+            [0, 0],
+            1,
+            [True, True, True],
+        )
+
+
+@pytest.mark.parametrize("stride,padding,dilation", [(1, 0, 1), (2, 2, 1), (1, 1, 2)])
+def test_fast_convolution_backward_rank3(
+    mojo_gpu: torch.device, stride: int, padding: int, dilation: int
+) -> None:
+    """conv1d's backward, through the same rank-4 path behind a size-1 H
+    axis. Called at the aten level rather than through autograd because the
+    rank-3 FORWARD is a separate piece of work: the lift has to be correct
+    from the day the backward exists, not from the day something can reach
+    it."""
+    torch.manual_seed(0)
+    x = torch.randn(2, 6, 17)
+    weight = torch.randn(8, 6, 3) * 0.2
+    length = (17 + 2 * padding - (dilation * 2 + 1)) // stride + 1
+    grad_output = torch.randn(2, 8, length)
+
+    xd = x.double().requires_grad_()
+    wd = (weight.double()).requires_grad_()
+    torch.nn.functional.conv1d(xd, wd, None, stride, padding, dilation).backward(
+        grad_output.double()
+    )
+    got = torch.ops.aten.convolution_backward(
+        grad_output.to(mojo_gpu),
+        x.to(mojo_gpu),
+        weight.to(mojo_gpu),
+        [8],
+        [stride],
+        [padding],
+        [dilation],
+        False,
+        [0],
+        1,
+        [True, True, True],
+    )
+    assert got[0].shape == x.shape
+    assert got[1].shape == weight.shape
+    torch.testing.assert_close(got[0].cpu().double(), xd.grad, atol=2e-5, rtol=2e-5)
+    torch.testing.assert_close(got[1].cpu().double(), wd.grad, atol=2e-5, rtol=2e-5)
+    torch.testing.assert_close(
+        got[2].cpu().double(),
+        grad_output.double().sum(dim=(0, 2)),
+        atol=2e-5,
+        rtol=2e-5,
+    )
+
+
+@pytest.mark.parametrize("groups", [1, 2])
+@pytest.mark.parametrize("with_bias", [True, False])
+def test_fast_conv2d_trains_through_autograd(
+    mojo_gpu: torch.device, groups: int, with_bias: bool
+) -> None:
+    """The end-to-end case the preflight used to refuse: a grad-requiring
+    conv now records ConvolutionBackward0 and the engine runs it here.
+
+    Before `aten::convolution_backward` existed, `aten::convolution` had to
+    refuse a grad-requiring call from the FORWARD, because a raise from
+    inside the autograd engine aborts the process on this backend instead of
+    propagating. That refusal is gone with the kernel that replaces it, so
+    this asserts the whole round trip: forward, engine, and all three
+    gradients against a CPU reference.
+    """
+    torch.manual_seed(0)
+    x = torch.randn(3, 8, 11, 11)
+    weight = torch.randn(12, 8 // groups, 3, 3) * 0.2
+    bias = torch.randn(12) * 0.1 if with_bias else None
+    grad_output = torch.randn(3, 12, 11, 11)
+
+    def run(device: torch.device | str):
+        xd = x.to(device).detach().requires_grad_()
+        wd = weight.to(device).detach().requires_grad_()
+        bd = None if bias is None else bias.to(device).detach().requires_grad_()
+        out = torch.nn.functional.conv2d(xd, wd, bd, 1, 1, 1, groups)
+        out.backward(grad_output.to(device))
+        return out, xd.grad, wd.grad, (None if bd is None else bd.grad)
+
+    dev = run(mojo_gpu)
+    ref = run("cpu")
+    for got, want in zip(dev, ref):
+        if want is None:
+            assert got is None
+            continue
+        torch.testing.assert_close(got.cpu(), want, atol=2e-4, rtol=2e-4)
 
 
 # Shrunk-N copies of benchmarks/test_vision.py's CONV_SHAPES: same C/H/W/kernel

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -9495,6 +9495,178 @@ def test_fast_conv2d_tensor_core_benchmark_shapes(
     torch.testing.assert_close(dev.float(), ref, atol=atol, rtol=rtol)
 
 
+# ---------------------------------------------------------------------------
+# Implicit-GEMM conv (sm_90a, bf16): the TMA im2col route that never
+# materializes the patch matrix. Ported from the standalone Mojo harness the
+# kernel was developed in, which checked EVERY output element of each case
+# against an fp64 host reference; here the reference is torch's own fp32 conv.
+# ---------------------------------------------------------------------------
+_CONV_IGEMM_SHAPES = {
+    # (n, c, h, w, out_c, kh, kw, pad_h, pad_w)
+    # hw = 49: fewer pixels than one B tile, so the single im2col transaction
+    # walks past the end of the ONLY sample -- the case that would need a
+    # guard sample if the pixels-per-column tail faulted instead of
+    # zero-filling. Odd row pitch (98 B) -> scalar epilogue.
+    "batch1_pad_7x7": (1, 64, 7, 7, 64, 3, 3, 1, 1),
+    "unpadded_9x9": (2, 64, 9, 9, 64, 3, 3, 0, 0),
+    # body geometry: 16 B aligned row pitch -> TMA-store epilogue
+    "body_56x56": (2, 64, 56, 56, 64, 3, 3, 1, 1),
+    # hw = 196 (392 B) -> scalar epilogue, deep C
+    "mid_14x14_C256": (2, 256, 14, 14, 256, 3, 3, 1, 1),
+    # C = 48 padded to 64, ragged out_c = 80, awkward spatial extent
+    "awkward_C48_K80": (3, 48, 39, 53, 80, 3, 3, 1, 1),
+    # ragged out_c WITH the TMA-store epilogue
+    "ragged_K80_tma_store": (2, 64, 16, 16, 80, 3, 3, 1, 1),
+    "ragged_K96_tma_store": (1, 64, 16, 16, 96, 3, 3, 1, 1),
+    # rectangular filters with ASYMMETRIC padding (pad_h != pad_w), both
+    # epilogues, plus degenerate 1-tap dimensions
+    "rect_R3S5_pad12": (2, 64, 16, 20, 64, 3, 5, 1, 2),
+    "rect_R5S3_pad21_C96": (1, 96, 11, 13, 96, 5, 3, 2, 1),
+    "rect_R1S3_pad01": (2, 64, 13, 13, 64, 1, 3, 0, 1),
+    "rect_R3S1_pad10_C128": (2, 128, 12, 12, 64, 3, 1, 1, 0),
+    # deeper K: 7x7 taps
+    "k7_pad3": (1, 64, 16, 16, 64, 7, 7, 3, 3),
+}
+
+
+@pytest.mark.parametrize("shape_id", _CONV_IGEMM_SHAPES)
+@pytest.mark.parametrize("with_bias", [False, True])
+def test_fast_conv2d_igemm_edge_shapes(
+    mojo_h100: torch.device,
+    monkeypatch: pytest.MonkeyPatch,
+    shape_id: str,
+    with_bias: bool,
+) -> None:
+    """Every geometry the implicit-GEMM dispatch ACCEPTS, and a check that it
+    really is the route that ran."""
+    calls = _spy_defined_native_calls(
+        monkeypatch, {("conv_igemm_ops.mojo", "ConvIgemm")}
+    )
+    n, c, h, w, out_c, kh, kw, ph, pw = _CONV_IGEMM_SHAPES[shape_id]
+    x = torch.randn(n, c, h, w, dtype=torch.bfloat16)
+    weight = (torch.randn(out_c, c, kh, kw, dtype=torch.bfloat16) * 0.1).to(
+        torch.bfloat16
+    )
+    bias = torch.randn(out_c, dtype=torch.bfloat16) if with_bias else None
+    dev = torch.nn.functional.conv2d(
+        x.to(mojo_h100),
+        weight.to(mojo_h100),
+        None if bias is None else bias.to(mojo_h100),
+        stride=1,
+        padding=(ph, pw),
+    ).cpu()
+    ref = torch.nn.functional.conv2d(
+        x.float(),
+        weight.float(),
+        None if bias is None else bias.float(),
+        stride=1,
+        padding=(ph, pw),
+    )
+
+    target = ("conv_igemm_ops.mojo", "ConvIgemm")
+    assert len(calls[target]) == 1, f"{shape_id} did not take the implicit-GEMM route"
+    # One fp32-accumulated reduction of up to k = 3136, rounded once to
+    # bfloat16 (2^-8 relative): the same calibration the gemm16 mm/bmm tests
+    # use for a bf16 output.
+    torch.testing.assert_close(dev.float(), ref, atol=8e-2, rtol=8e-2)
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "stride2",
+        "dilation2",
+        "grouped",
+        "pointwise_1x1",
+        "thin_c",
+        "thin_out_c",
+        "f32",
+        "f16",
+    ],
+)
+def test_fast_conv2d_igemm_declines_outside_its_domain(
+    mojo_h100: torch.device, monkeypatch: pytest.MonkeyPatch, case: str
+) -> None:
+    """Everything the implicit GEMM cannot (or should not) do stays on the
+    materialized-im2col route and still computes the right answer."""
+    calls = _spy_defined_native_calls(
+        monkeypatch, {("conv_igemm_ops.mojo", "ConvIgemm")}
+    )
+    n, c, h, w, out_c, k = 2, 64, 16, 16, 64, 3
+    stride, pad, dilation, groups = 1, 1, 1, 1
+    dtype = torch.bfloat16
+    if case == "stride2":
+        stride = 2
+    elif case == "dilation2":
+        dilation, pad = 2, 2
+    elif case == "grouped":
+        groups = 4
+    elif case == "pointwise_1x1":
+        k, pad = 1, 0
+    elif case == "thin_c":
+        c = 3  # C_pad/C = 21x wasted math on this route
+    elif case == "thin_out_c":
+        out_c = 16  # BM = 64 would waste 3/4 of every output tile
+    elif case == "f32":
+        dtype = torch.float32
+    elif case == "f16":
+        dtype = torch.float16
+
+    x = torch.randn(n, c, h, w, dtype=dtype)
+    weight = (torch.randn(out_c, c // groups, k, k, dtype=dtype) * 0.1).to(dtype)
+    dev = torch.nn.functional.conv2d(
+        x.to(mojo_h100),
+        weight.to(mojo_h100),
+        None,
+        stride=stride,
+        padding=pad,
+        dilation=dilation,
+        groups=groups,
+    ).cpu()
+    ref = torch.nn.functional.conv2d(
+        x.float(),
+        weight.float(),
+        None,
+        stride=stride,
+        padding=pad,
+        dilation=dilation,
+        groups=groups,
+    )
+
+    target = ("conv_igemm_ops.mojo", "ConvIgemm")
+    assert not calls[target], f"{case} must not take the implicit-GEMM route"
+    torch.testing.assert_close(dev.float(), ref, atol=8e-2, rtol=8e-2)
+
+
+def test_conv_igemm_descriptor_domain_gate() -> None:
+    """The im2col TMA descriptor domain, checked on the host before anything
+    is allocated: pixel-box corners are SIGNED CHAR ([-128, 127]) and the
+    filter taps this kernel issues must fit in [0, 255].
+
+    The R = 257 line is the one that matters: that conv satisfies every other
+    eligibility condition (bf16, sm_90a, dense, stride 1, dilation 1, C = 64,
+    and corners -128/-1, 128/-1 that are all legal) yet its last tap is 256,
+    which is undefined behaviour at the instruction rather than a loud
+    failure.
+    """
+    from torch_mojo_backend.eager_kernels.aten_fast import _conv_igemm_descriptor_legal
+
+    assert _conv_igemm_descriptor_legal(1, 1, 3, 3)
+    assert _conv_igemm_descriptor_legal(0, 0, 1, 1)
+    assert _conv_igemm_descriptor_legal(3, 3, 7, 7)
+    # lower corner = -pad
+    assert _conv_igemm_descriptor_legal(128, 1, 3, 3)
+    assert not _conv_igemm_descriptor_legal(129, 1, 3, 3)
+    assert not _conv_igemm_descriptor_legal(1, 129, 3, 3)
+    # upper corner = pad - (filter - 1)
+    assert _conv_igemm_descriptor_legal(0, 0, 129, 3)
+    assert not _conv_igemm_descriptor_legal(0, 0, 130, 3)
+    # legal corners, illegal tap
+    assert _conv_igemm_descriptor_legal(128, 1, 256, 3)
+    assert not _conv_igemm_descriptor_legal(128, 1, 257, 3)
+    assert not _conv_igemm_descriptor_legal(1, 128, 3, 257)
+
+
 @pytest.mark.parametrize("op", ["bmm16", "1x1_bmm16"])
 def test_fast_conv2d_routes_dense_bf16_through_gemm16_bmm(
     mojo_h100: torch.device, monkeypatch: pytest.MonkeyPatch, op: str

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -9471,7 +9471,8 @@ def test_fast_conv2d_tensor_core_benchmark_shapes(
 # Implicit-GEMM conv (sm_90a, bf16): the TMA im2col route that never
 # materializes the patch matrix. Ported from the standalone Mojo harness the
 # kernel was developed in, which checked EVERY output element of each case
-# against an fp64 host reference; here the reference is torch's own fp32 conv.
+# against an fp64 host reference (`_conv_igemm_reference` below is that same
+# criterion, not torch's own fp32 conv).
 # ---------------------------------------------------------------------------
 _CONV_IGEMM_SHAPES = {
     # (n, c, h, w, out_c, kh, kw, pad_h, pad_w)

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -9500,6 +9500,56 @@ _CONV_IGEMM_SHAPES = {
     "k7_pad3": (1, 64, 16, 16, 64, 7, 7, 3, 3),
 }
 
+# 2^-24, the fp32 machine epsilon: the GEMM's tile accumulation is fp32, so
+# this is the per-term rounding unit the accumulation-error bound below is
+# built from -- ported from conv_igemm_test.mojo's host-side correctness
+# harness, not re-derived here.
+_CI_EPS_F32 = 2.0**-24
+# 2^-8: one bf16 half-ulp, the max relative error of ONE correctly-rounded
+# fp64/fp32 -> bfloat16 cast.
+_CI_BF16_HALF_ULP = 2.0**-8
+
+
+def _conv_igemm_reference(
+    x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor | None, ph: int, pw: int
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """The fp64 ground truth, a PER-ELEMENT tolerance derived from the fp32
+    accumulation error bound (not a fixed slop), and the bit-exact target --
+    ported from conv_igemm_test.mojo, the kernel's own correctness harness.
+
+    Inputs are bf16 tensors, hence already exactly representable in bf16, so
+    the only error a correct kernel can introduce is (1) the fp32 tile
+    accumulation of the GEMM reduction and (2) the bf16 rounding(s) of the
+    output. The accumulation term is `4 * eps_f32 * sqrt(k_pad) * sum|a*b|`
+    (`k_pad` includes the C-padding to the kernel's 64-channel tile, since
+    the padded zero terms still cost accumulation steps); the 4x is the same
+    safety factor the Mojo harness uses. Bias goes through a SEPARATE kernel
+    (`BiasAddChan`) that reads the already-bf16-rounded GEMM output and
+    rounds again after the add, so a biased case pays a second independent
+    half-ulp term, not a bigger accumulation term, and its bit-exact target
+    is the double-rounded value the real pipeline computes, not
+    `round_bf16(gemm + bias)` directly (double rounding can legitimately
+    differ from single rounding even in exact arithmetic).
+    """
+    c, kh, kw = x.shape[1], weight.shape[2], weight.shape[3]
+    c_pad = ((c + 63) // 64) * 64
+    k_pad = kh * kw * c_pad
+    acc_coeff = 4.0 * _CI_EPS_F32 * math.sqrt(k_pad)
+
+    x64 = x.double()
+    w64 = weight.double()
+    acc_gemm = torch.nn.functional.conv2d(x64, w64, stride=1, padding=(ph, pw))
+    mag = torch.nn.functional.conv2d(x64.abs(), w64.abs(), stride=1, padding=(ph, pw))
+    tol = _CI_BF16_HALF_ULP * acc_gemm.abs() + acc_coeff * mag
+    want_bf16 = acc_gemm.to(torch.bfloat16)
+    if bias is None:
+        return acc_gemm, tol, want_bf16
+    b64 = bias.double().view(1, -1, 1, 1)
+    acc_true = acc_gemm + b64
+    tol = tol + _CI_BF16_HALF_ULP * acc_true.abs()
+    want_bf16 = (want_bf16.double() + b64).to(torch.bfloat16)
+    return acc_true, tol, want_bf16
+
 
 @pytest.mark.parametrize("shape_id", _CONV_IGEMM_SHAPES)
 @pytest.mark.parametrize("with_bias", [False, True])
@@ -9511,6 +9561,7 @@ def test_fast_conv2d_igemm_edge_shapes(
 ) -> None:
     """Every geometry the implicit-GEMM dispatch ACCEPTS, and a check that it
     really is the route that ran."""
+    torch.manual_seed(0)  # exact_frac below is a measured bound, not a tautology
     calls = _spy_defined_native_calls(
         monkeypatch, {("conv_igemm_ops.mojo", "ConvIgemm")}
     )
@@ -9527,20 +9578,33 @@ def test_fast_conv2d_igemm_edge_shapes(
         stride=1,
         padding=(ph, pw),
     ).cpu()
-    ref = torch.nn.functional.conv2d(
-        x.float(),
-        weight.float(),
-        None if bias is None else bias.float(),
-        stride=1,
-        padding=(ph, pw),
-    )
 
     target = ("conv_igemm_ops.mojo", "ConvIgemm")
     assert len(calls[target]) == 1, f"{shape_id} did not take the implicit-GEMM route"
-    # One fp32-accumulated reduction of up to k = 3136, rounded once to
-    # bfloat16 (2^-8 relative): the same calibration the gemm16 mm/bmm tests
-    # use for a bf16 output.
-    torch.testing.assert_close(dev.float(), ref, atol=8e-2, rtol=8e-2)
+    acc, tol, want_bf16 = _conv_igemm_reference(x, weight, bias, ph, pw)
+    got = dev.double()
+    err = (got - acc).abs()
+    bad = err > tol
+    assert not bad.any(), (
+        f"{shape_id} with_bias={with_bias}: {int(bad.sum())}/{bad.numel()} "
+        f"outputs exceed the fp32-accumulation-derived tolerance; worst "
+        f"error={err.max().item():.6g} at tol={tol.flatten()[err.argmax()].item():.6g}"
+    )
+    # fp32 accumulation noise should move at most a handful of outputs off
+    # their correctly-rounded bf16 code; an indexing or accumulation bug
+    # collapses this fraction instead of nudging it. conv_igemm_test.mojo's
+    # deterministic hash-filled inputs measure exactly 1.0 on an H100 and
+    # gate at 0.999; these tests use genuinely random inputs instead (no
+    # per-case tuning), and the deepest reductions here (k7_pad3, k_pad =
+    # 3136; mid_14x14_C256, k_pad = 2304) measure ~99.87% at seed 0 -- still
+    # two orders of magnitude away from anything an indexing or
+    # accumulation bug would produce. 0.99 keeps that margin without
+    # chasing the harness's input-specific figure.
+    exact_frac = (dev == want_bf16).double().mean().item()
+    assert exact_frac >= 0.99, (
+        f"{shape_id} with_bias={with_bias}: only {exact_frac:.4%} of outputs "
+        "are bit-exact against the double-rounded reference"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -9467,6 +9467,178 @@ def test_fast_conv2d_tensor_core_benchmark_shapes(
     torch.testing.assert_close(dev.float(), ref, atol=atol, rtol=rtol)
 
 
+# ---------------------------------------------------------------------------
+# Implicit-GEMM conv (sm_90a, bf16): the TMA im2col route that never
+# materializes the patch matrix. Ported from the standalone Mojo harness the
+# kernel was developed in, which checked EVERY output element of each case
+# against an fp64 host reference; here the reference is torch's own fp32 conv.
+# ---------------------------------------------------------------------------
+_CONV_IGEMM_SHAPES = {
+    # (n, c, h, w, out_c, kh, kw, pad_h, pad_w)
+    # hw = 49: fewer pixels than one B tile, so the single im2col transaction
+    # walks past the end of the ONLY sample -- the case that would need a
+    # guard sample if the pixels-per-column tail faulted instead of
+    # zero-filling. Odd row pitch (98 B) -> scalar epilogue.
+    "batch1_pad_7x7": (1, 64, 7, 7, 64, 3, 3, 1, 1),
+    "unpadded_9x9": (2, 64, 9, 9, 64, 3, 3, 0, 0),
+    # body geometry: 16 B aligned row pitch -> TMA-store epilogue
+    "body_56x56": (2, 64, 56, 56, 64, 3, 3, 1, 1),
+    # hw = 196 (392 B) -> scalar epilogue, deep C
+    "mid_14x14_C256": (2, 256, 14, 14, 256, 3, 3, 1, 1),
+    # C = 48 padded to 64, ragged out_c = 80, awkward spatial extent
+    "awkward_C48_K80": (3, 48, 39, 53, 80, 3, 3, 1, 1),
+    # ragged out_c WITH the TMA-store epilogue
+    "ragged_K80_tma_store": (2, 64, 16, 16, 80, 3, 3, 1, 1),
+    "ragged_K96_tma_store": (1, 64, 16, 16, 96, 3, 3, 1, 1),
+    # rectangular filters with ASYMMETRIC padding (pad_h != pad_w), both
+    # epilogues, plus degenerate 1-tap dimensions
+    "rect_R3S5_pad12": (2, 64, 16, 20, 64, 3, 5, 1, 2),
+    "rect_R5S3_pad21_C96": (1, 96, 11, 13, 96, 5, 3, 2, 1),
+    "rect_R1S3_pad01": (2, 64, 13, 13, 64, 1, 3, 0, 1),
+    "rect_R3S1_pad10_C128": (2, 128, 12, 12, 64, 3, 1, 1, 0),
+    # deeper K: 7x7 taps
+    "k7_pad3": (1, 64, 16, 16, 64, 7, 7, 3, 3),
+}
+
+
+@pytest.mark.parametrize("shape_id", _CONV_IGEMM_SHAPES)
+@pytest.mark.parametrize("with_bias", [False, True])
+def test_fast_conv2d_igemm_edge_shapes(
+    mojo_h100: torch.device,
+    monkeypatch: pytest.MonkeyPatch,
+    shape_id: str,
+    with_bias: bool,
+) -> None:
+    """Every geometry the implicit-GEMM dispatch ACCEPTS, and a check that it
+    really is the route that ran."""
+    calls = _spy_defined_native_calls(
+        monkeypatch, {("conv_igemm_ops.mojo", "ConvIgemm")}
+    )
+    n, c, h, w, out_c, kh, kw, ph, pw = _CONV_IGEMM_SHAPES[shape_id]
+    x = torch.randn(n, c, h, w, dtype=torch.bfloat16)
+    weight = (torch.randn(out_c, c, kh, kw, dtype=torch.bfloat16) * 0.1).to(
+        torch.bfloat16
+    )
+    bias = torch.randn(out_c, dtype=torch.bfloat16) if with_bias else None
+    dev = torch.nn.functional.conv2d(
+        x.to(mojo_h100),
+        weight.to(mojo_h100),
+        None if bias is None else bias.to(mojo_h100),
+        stride=1,
+        padding=(ph, pw),
+    ).cpu()
+    ref = torch.nn.functional.conv2d(
+        x.float(),
+        weight.float(),
+        None if bias is None else bias.float(),
+        stride=1,
+        padding=(ph, pw),
+    )
+
+    target = ("conv_igemm_ops.mojo", "ConvIgemm")
+    assert len(calls[target]) == 1, f"{shape_id} did not take the implicit-GEMM route"
+    # One fp32-accumulated reduction of up to k = 3136, rounded once to
+    # bfloat16 (2^-8 relative): the same calibration the gemm16 mm/bmm tests
+    # use for a bf16 output.
+    torch.testing.assert_close(dev.float(), ref, atol=8e-2, rtol=8e-2)
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "stride2",
+        "dilation2",
+        "grouped",
+        "pointwise_1x1",
+        "thin_c",
+        "thin_out_c",
+        "f32",
+        "f16",
+    ],
+)
+def test_fast_conv2d_igemm_declines_outside_its_domain(
+    mojo_h100: torch.device, monkeypatch: pytest.MonkeyPatch, case: str
+) -> None:
+    """Everything the implicit GEMM cannot (or should not) do stays on the
+    materialized-im2col route and still computes the right answer."""
+    calls = _spy_defined_native_calls(
+        monkeypatch, {("conv_igemm_ops.mojo", "ConvIgemm")}
+    )
+    n, c, h, w, out_c, k = 2, 64, 16, 16, 64, 3
+    stride, pad, dilation, groups = 1, 1, 1, 1
+    dtype = torch.bfloat16
+    if case == "stride2":
+        stride = 2
+    elif case == "dilation2":
+        dilation, pad = 2, 2
+    elif case == "grouped":
+        groups = 4
+    elif case == "pointwise_1x1":
+        k, pad = 1, 0
+    elif case == "thin_c":
+        c = 3  # C_pad/C = 21x wasted math on this route
+    elif case == "thin_out_c":
+        out_c = 16  # BM = 64 would waste 3/4 of every output tile
+    elif case == "f32":
+        dtype = torch.float32
+    elif case == "f16":
+        dtype = torch.float16
+
+    x = torch.randn(n, c, h, w, dtype=dtype)
+    weight = (torch.randn(out_c, c // groups, k, k, dtype=dtype) * 0.1).to(dtype)
+    dev = torch.nn.functional.conv2d(
+        x.to(mojo_h100),
+        weight.to(mojo_h100),
+        None,
+        stride=stride,
+        padding=pad,
+        dilation=dilation,
+        groups=groups,
+    ).cpu()
+    ref = torch.nn.functional.conv2d(
+        x.float(),
+        weight.float(),
+        None,
+        stride=stride,
+        padding=pad,
+        dilation=dilation,
+        groups=groups,
+    )
+
+    target = ("conv_igemm_ops.mojo", "ConvIgemm")
+    assert not calls[target], f"{case} must not take the implicit-GEMM route"
+    torch.testing.assert_close(dev.float(), ref, atol=8e-2, rtol=8e-2)
+
+
+def test_conv_igemm_descriptor_domain_gate() -> None:
+    """The im2col TMA descriptor domain, checked on the host before anything
+    is allocated: pixel-box corners are SIGNED CHAR ([-128, 127]) and the
+    filter taps this kernel issues must fit in [0, 255].
+
+    The R = 257 line is the one that matters: that conv satisfies every other
+    eligibility condition (bf16, sm_90a, dense, stride 1, dilation 1, C = 64,
+    and corners -128/-1, 128/-1 that are all legal) yet its last tap is 256,
+    which is undefined behaviour at the instruction rather than a loud
+    failure.
+    """
+    from torch_mojo_backend.eager_kernels.aten_fast import _conv_igemm_descriptor_legal
+
+    assert _conv_igemm_descriptor_legal(1, 1, 3, 3)
+    assert _conv_igemm_descriptor_legal(0, 0, 1, 1)
+    assert _conv_igemm_descriptor_legal(3, 3, 7, 7)
+    # lower corner = -pad
+    assert _conv_igemm_descriptor_legal(128, 1, 3, 3)
+    assert not _conv_igemm_descriptor_legal(129, 1, 3, 3)
+    assert not _conv_igemm_descriptor_legal(1, 129, 3, 3)
+    # upper corner = pad - (filter - 1)
+    assert _conv_igemm_descriptor_legal(0, 0, 129, 3)
+    assert not _conv_igemm_descriptor_legal(0, 0, 130, 3)
+    # legal corners, illegal tap
+    assert _conv_igemm_descriptor_legal(128, 1, 256, 3)
+    assert not _conv_igemm_descriptor_legal(128, 1, 257, 3)
+    assert not _conv_igemm_descriptor_legal(1, 128, 3, 257)
+
+
 @pytest.mark.parametrize("op", ["bmm16", "1x1_bmm16"])
 def test_fast_conv2d_routes_dense_bf16_through_gemm16_bmm(
     mojo_h100: torch.device, monkeypatch: pytest.MonkeyPatch, op: str

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -9415,6 +9415,196 @@ def test_fast_conv2d_refuses_autograd_in_the_forward(mojo_gpu):
         )
 
 
+# Shrunk-N copies of benchmarks/test_vision.py's CONV_SHAPES: same C/H/W/kernel
+# (so the same im2col K and GEMM N the benchmark measures), a small batch so
+# the test is cheap.
+_CONV_BENCH_SHAPES = {
+    "body_N32xC64x56x56_K64k3s1": (2, 64, 56, 56, 64, 3, 1, 1),
+    "stem_N8xC3x224x224_K64k7s2": (2, 3, 224, 224, 64, 7, 2, 3),
+}
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("shape_id", _CONV_BENCH_SHAPES)
+def test_fast_conv2d_tensor_core_benchmark_shapes(
+    mojo_h100: torch.device, shape_id: str, dtype: torch.dtype
+) -> None:
+    """The benchmark body/stem conv shapes, N shrunk to 2, through whichever
+    GEMM route sm_90a picks for the dtype: Bmm16 (bf16/f16, always opt-in),
+    the opt-in TF32 BMM (f32, only past the same
+    `float32_matmul_precision() != "highest"` gate `_try_tf32_mm` uses), or
+    the plain SIMT Bmm fallback (f32 at the default "highest" precision)."""
+    n, c_in, h, w, c_out, k, stride, pad = _CONV_BENCH_SHAPES[shape_id]
+    x = torch.randn(n, c_in, h, w, dtype=dtype)
+    weight = torch.randn(c_out, c_in, k, k, dtype=dtype) * 0.1
+    bias = torch.randn(c_out, dtype=dtype)
+
+    old_precision = torch.get_float32_matmul_precision()
+    torch.set_float32_matmul_precision("high")
+    try:
+        dev = torch.nn.functional.conv2d(
+            x.to(mojo_h100), weight.to(mojo_h100), bias.to(mojo_h100), stride, pad
+        ).cpu()
+    finally:
+        torch.set_float32_matmul_precision(old_precision)
+    ref = torch.nn.functional.conv2d(
+        x.float(), weight.float(), bias.float(), stride, pad
+    )
+
+    # float16 has more mantissa bits than bfloat16, so it gets the tighter
+    # bound; both are FP32-accumulated tensor-core GEMMs (see the analogous
+    # gemm16 mm/bmm tests), just rounded to a narrower output type than the
+    # k=333 case those tests calibrate against, hence the wider margin for
+    # this k up to 576. float32 goes through TF32 (or, at default precision,
+    # plain FP32) -- the same calibrated bound the mm/addmm tensor-core tests
+    # use.
+    if dtype == torch.float16:
+        atol, rtol = 3e-2, 3e-3
+    elif dtype == torch.bfloat16:
+        atol, rtol = 8e-2, 8e-2
+    else:
+        atol, rtol = 5e-2, 5e-2
+    torch.testing.assert_close(dev.float(), ref, atol=atol, rtol=rtol)
+
+
+@pytest.mark.parametrize("op", ["bmm16", "1x1_bmm16"])
+def test_fast_conv2d_routes_dense_bf16_through_gemm16_bmm(
+    mojo_h100: torch.device, monkeypatch: pytest.MonkeyPatch, op: str
+) -> None:
+    """Dense (groups == 1) bf16 conv reaches the same Bmm16 kernel fast_aten_bmm
+    already builds -- both the general im2col path and the 1x1 stride-1
+    fast path that reads the NCHW input as the col matrix in place."""
+    calls = _spy_defined_native_calls(
+        monkeypatch, {("gemm16_matmul_ops.mojo", "Bmm16")}
+    )
+    n, c_in, h, w, c_out = 2, 8, 16, 16, 12
+    k, stride, pad = (3, 1, 1) if op == "bmm16" else (1, 1, 0)
+    x = torch.randn(n, c_in, h, w).to(torch.bfloat16)
+    weight = (torch.randn(c_out, c_in, k, k) * 0.1).to(torch.bfloat16)
+    dev = torch.nn.functional.conv2d(
+        x.to(mojo_h100), weight.to(mojo_h100), None, stride, pad
+    ).cpu()
+    ref = torch.nn.functional.conv2d(x.float(), weight.float(), None, stride, pad)
+
+    target = ("gemm16_matmul_ops.mojo", "Bmm16")
+    assert len(calls[target]) == 1, "dense bf16 conv did not reach the Bmm16 bridge"
+    torch.testing.assert_close(dev.float(), ref, atol=8e-2, rtol=8e-2)
+
+
+def test_fast_conv2d_tf32_bmm_is_opt_in_like_mm(
+    mojo_h100: torch.device, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same numerics policy as the mm/bmm TF32 routes: off by default (torch's
+    `float32_matmul_precision() == "highest"`), reachable once the caller
+    opts in with `torch.set_float32_matmul_precision("high")`. The repo has
+    no separate `torch.backends.cudnn.allow_tf32`-style policy for
+    convolution, so this deliberately follows the mm gate instead."""
+    calls = _spy_defined_native_calls(
+        monkeypatch,
+        {("tf32_matmul_ops.mojo", "Tf32BmmF32"), ("matmul_ops.mojo", "Bmm")},
+    )
+    x = torch.randn(2, 8, 16, 16)
+    weight = torch.randn(12, 8, 3, 3) * 0.1
+
+    dev_default = torch.nn.functional.conv2d(
+        x.to(mojo_h100), weight.to(mojo_h100), None, 1, 1
+    ).cpu()
+    assert not calls[("tf32_matmul_ops.mojo", "Tf32BmmF32")]
+    assert len(calls[("matmul_ops.mojo", "Bmm")]) == 1
+
+    old_precision = torch.get_float32_matmul_precision()
+    torch.set_float32_matmul_precision("high")
+    try:
+        dev_tf32 = torch.nn.functional.conv2d(
+            x.to(mojo_h100), weight.to(mojo_h100), None, 1, 1
+        ).cpu()
+    finally:
+        torch.set_float32_matmul_precision(old_precision)
+    assert len(calls[("tf32_matmul_ops.mojo", "Tf32BmmF32")]) == 1
+
+    ref = torch.nn.functional.conv2d(x, weight, None, 1, 1)
+    torch.testing.assert_close(dev_default, ref, atol=1e-3, rtol=1e-3)
+    torch.testing.assert_close(dev_tf32, ref, atol=5e-2, rtol=5e-2)
+
+
+def test_fast_conv2d_grouped_and_noncontiguous_keep_generic_route(
+    mojo_h100: torch.device, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Blast-radius guard: grouped convs and non-contiguous inputs are the
+    cases the tensor-core routes decline (grouped: no single (out_c, ckk) x
+    (ckk, cols) GEMM; non-contiguous: `_tc` materializes it back to dense
+    before either helper ever sees it, per the existing contract) -- both
+    must still land on the untouched SIMT path, not silently regress or
+    raise."""
+    calls = _spy_defined_native_calls(
+        monkeypatch,
+        {
+            ("gemm16_matmul_ops.mojo", "Bmm16"),
+            ("tf32_matmul_ops.mojo", "Tf32BmmF32"),
+            ("matmul_ops.mojo", "Matmul"),
+            ("matmul_ops.mojo", "Bmm"),
+        },
+    )
+    old_precision = torch.get_float32_matmul_precision()
+    torch.set_float32_matmul_precision("high")
+    try:
+        # Grouped conv, bf16: per (sample, group) Matmul, never Bmm16.
+        x = torch.randn(2, 8, 16, 16).to(torch.bfloat16)
+        w = torch.randn(12, 4, 3, 3).to(torch.bfloat16)
+        dev_grouped = torch.nn.functional.conv2d(
+            x.to(mojo_h100), w.to(mojo_h100), None, 1, 1, groups=2
+        ).cpu()
+        ref_grouped = torch.nn.functional.conv2d(
+            x.float(), w.float(), None, 1, 1, groups=2
+        )
+        torch.testing.assert_close(
+            dev_grouped.float(), ref_grouped, atol=8e-2, rtol=8e-2
+        )
+
+        # Non-contiguous (channels-last) f32 input, dense conv: still TF32.
+        x_nc = torch.randn(2, 8, 16, 16).to(memory_format=torch.channels_last)
+        w_nc = torch.randn(12, 8, 3, 3) * 0.1
+        dev_nc = torch.nn.functional.conv2d(
+            x_nc.to(mojo_h100), w_nc.to(mojo_h100), None, 1, 1
+        ).cpu()
+        ref_nc = torch.nn.functional.conv2d(x_nc, w_nc, None, 1, 1)
+        torch.testing.assert_close(dev_nc, ref_nc, atol=5e-2, rtol=5e-2)
+    finally:
+        torch.set_float32_matmul_precision(old_precision)
+
+    assert not calls[("gemm16_matmul_ops.mojo", "Bmm16")]
+    assert len(calls[("matmul_ops.mojo", "Matmul")]) == 2 * 2  # 2 samples x 2 groups
+    assert len(calls[("tf32_matmul_ops.mojo", "Tf32BmmF32")]) == 1
+    assert len(calls[("matmul_ops.mojo", "Bmm")]) == 0
+
+
+def test_fast_conv2d_cpu_device_matches_gpu_row_kernel(mojo_device: str) -> None:
+    """`conv_ops.mojo`'s Im2col/BiasAddChan dispatch on `ctx.api()`: the CPU
+    device (`mojo_device` here, not `mojo_gpu`) takes the scalar
+    `elementwise` path (`_im2col_scalar`/`_bias_add_chan_scalar`), unchanged
+    logic from before this file's GPU row-kernel rewrite, just extracted into
+    a named function -- this is the one test in the module that actually
+    exercises it, on both stride=1 (im2col's contiguous-read branch) and
+    stride=2 (its strided-gather branch)."""
+    torch.manual_seed(0)
+    x = torch.randn(2, 8, 16, 16)
+    w = torch.randn(12, 8, 3, 3) * 0.1
+    b = torch.randn(12)
+    dev = torch.nn.functional.conv2d(
+        x.to(mojo_device), w.to(mojo_device), b.to(mojo_device), stride=1, padding=1
+    ).cpu()
+    ref = torch.nn.functional.conv2d(x, w, b, stride=1, padding=1)
+    torch.testing.assert_close(dev, ref, atol=1e-4, rtol=1e-4)
+
+    x2 = torch.randn(3, 3, 15, 17)
+    w2 = torch.randn(6, 3, 5, 5) * 0.1
+    dev2 = torch.nn.functional.conv2d(
+        x2.to(mojo_device), w2.to(mojo_device), None, stride=2, padding=2
+    ).cpu()
+    ref2 = torch.nn.functional.conv2d(x2, w2, None, stride=2, padding=2)
+    torch.testing.assert_close(dev2, ref2, atol=1e-4, rtol=1e-4)
+
+
 @pytest.mark.parametrize("is_causal", [True, False])
 # kv_len <= 32 exercises the library softmax's warp kernel, kv_len=64 the
 # online/block kernel.

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -9370,49 +9370,344 @@ def test_fast_conv2d_batched_falls_back_correctly(mojo_gpu):
     torch.testing.assert_close(dev, ref, atol=5e-2, rtol=5e-2)
 
 
-def test_fast_conv2d_refuses_autograd_in_the_forward(mojo_gpu):
-    """A grad-requiring conv must fail at the FORWARD.
+# ---------------------------------------------------------------------------
+# Convolution backward: the three gradients through im2col + GEMM + col2im.
+# Every case is checked against an fp64 CPU-autograd ground truth with a
+# PER-ELEMENT tolerance derived from the fp32 accumulation bound (the same
+# criterion `_conv_igemm_reference` uses for the forward), not a fixed slop:
+# a conv backward reduces over n * OH * OW terms for the parameter gradients,
+# so a flat atol would either pass wrong kernels on big shapes or fail right
+# ones on small.
+# ---------------------------------------------------------------------------
 
-    `aten::convolution_backward` is not implemented here, and a raise from
-    inside the autograd engine aborts the process on this backend (exit 134,
-    no traceback) instead of propagating, so the refusal cannot wait for
-    ConvolutionBackward0. A conv weight normally requires grad, so this refuses
-    conv training outright -- the alternative was a dead process -- while
-    inference under `torch.no_grad()` is untouched.
+# (n, c, h, w, out_c, k, stride, padding, dilation, groups)
+_CONV_BWD_SHAPES = {
+    "base_k3s1p1": (2, 6, 12, 12, 8, 3, 1, 1, 1, 1),
+    "stride2": (2, 6, 13, 13, 8, 3, 2, 1, 1, 1),
+    "unpadded_stride3_k4": (2, 5, 14, 14, 7, 4, 3, 0, 1, 1),
+    "dilation2": (2, 6, 15, 15, 8, 3, 1, 2, 2, 1),
+    "groups2": (2, 8, 10, 10, 12, 3, 1, 1, 1, 2),
+    # groups == C: depthwise, one output channel per input channel, the
+    # regime where the per-(sample, group) GEMM loop is longest.
+    "depthwise_g64": (2, 64, 9, 9, 64, 3, 1, 1, 1, 64),
+    # 1x1 stride-1: col2im is the identity and the columns ARE the gradient
+    # image, so this is the branch that skips both spatial kernels.
+    "batch1_1x1": (1, 8, 7, 7, 5, 1, 1, 0, 1, 1),
+    "batch32": (32, 4, 8, 8, 6, 3, 1, 1, 1, 1),
+    # stride 2 with a truncating input extent: (13 + 2*1 - 3) // 2 + 1 == 7
+    # loses the last input column, so col2im must leave those pixels at zero
+    # rather than reading a tap that never existed.
+    "truncating_stride2": (2, 4, 13, 11, 6, 3, 2, 1, 1, 1),
+    # rectangular filter, asymmetric padding
+    "rect_k3x5": (2, 4, 11, 13, 6, (3, 5), 1, (1, 2), 1, 1),
+}
+
+# One bf16 / fp16 / fp32 half-ulp: the largest relative error of ONE
+# correctly-rounded cast into that dtype.
+_CONV_BWD_HALF_ULP = {
+    torch.float32: 2.0**-24,
+    torch.bfloat16: 2.0**-8,
+    torch.float16: 2.0**-11,
+}
+# 2^-24, the fp32 machine epsilon: every reduction here (the GEMMs, the batch
+# reduce, col2im's tap sum) accumulates in fp32, so this is the per-term
+# rounding unit. The 4x safety factor matches `_conv_igemm_reference`.
+_CONV_BWD_EPS_F32 = 2.0**-24
+
+
+def _conv_backward_reference(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    grad_output: torch.Tensor,
+    stride,
+    padding,
+    dilation,
+    groups: int,
+) -> tuple[tuple[torch.Tensor, ...], tuple[torch.Tensor, ...]]:
+    """`(exact_fp64_grads, magnitudes)` for (grad_input, grad_weight,
+    grad_bias).
+
+    The magnitudes are the same three reductions run on the ABSOLUTE values
+    of the operands, i.e. `sum |a*b|` per output element -- the quantity a
+    floating-point accumulation-error bound is proportional to. Deriving them
+    from torch's own backward (rather than by hand) keeps the reference
+    independent of the layout this backend happens to reduce in.
     """
-    host_input, device_input = _preflight_input((2, 3, 8, 8), mojo_gpu)
-    host_weight, device_weight = _preflight_input((4, 3, 3, 3), mojo_gpu, seed=11)
-    host_bias, device_bias = _preflight_input((4,), mojo_gpu, seed=13)
 
-    expected = torch.nn.functional.conv2d(host_input, host_weight, host_bias, padding=1)
-    torch.testing.assert_close(
-        torch.nn.functional.conv2d(
-            device_input, device_weight, device_bias, padding=1
-        ).cpu(),
-        expected,
-        atol=5e-2,
-        rtol=5e-2,
+    def grads(xt: torch.Tensor, wt: torch.Tensor, gt: torch.Tensor):
+        xd = xt.double().detach().requires_grad_()
+        wd = wt.double().detach().requires_grad_()
+        out = torch.nn.functional.conv2d(
+            xd, wd, None, stride, padding, dilation, groups
+        )
+        out.backward(gt.double())
+        return xd.grad, wd.grad
+
+    grad_input, grad_weight = grads(x, weight, grad_output)
+    mag_input, mag_weight = grads(x.abs(), weight.abs(), grad_output.abs())
+    grad_bias = grad_output.double().sum(dim=(0, 2, 3))
+    mag_bias = grad_output.double().abs().sum(dim=(0, 2, 3))
+    return (grad_input, grad_weight, grad_bias), (mag_input, mag_weight, mag_bias)
+
+
+def _assert_conv_grad_close(
+    actual: torch.Tensor,
+    exact: torch.Tensor,
+    magnitude: torch.Tensor,
+    dtype: torch.dtype,
+    reduction_len: int,
+    roundings: int,
+    what: str,
+) -> None:
+    """`actual` is within the fp32 accumulation bound of the fp64 truth.
+
+    `roundings` counts the casts back into `dtype` the value survives: one
+    for a gradient written straight out, two where an intermediate is
+    materialized in `dtype` first (the per-sample weight partials, the column
+    gradient col2im then reads). Each costs a half-ulp of the MAGNITUDE, not
+    of the possibly-cancelled exact value.
+    """
+    tol = (
+        roundings * _CONV_BWD_HALF_ULP[dtype]
+        + 4.0 * _CONV_BWD_EPS_F32 * math.sqrt(max(reduction_len, 1))
+    ) * magnitude
+    err = (actual.double() - exact).abs()
+    worst = int((err - tol).argmax())
+    assert bool((err <= tol).all()), (
+        f"{what}: {int((err > tol).sum())} of {err.numel()} elements outside the "
+        f"fp32 accumulation bound; worst err={err.flatten()[worst]:.3e} "
+        f"tol={tol.flatten()[worst]:.3e} exact={exact.flatten()[worst]:.3e}"
     )
 
-    # The weight-only case is the one every training model actually hits.
-    for which in range(3):
-        operands = [device_input.detach(), device_weight.detach(), device_bias.detach()]
-        operands[which] = operands[which].requires_grad_()
-        with pytest.raises(NotImplementedError, match="convolution_backward"):
-            torch.nn.functional.conv2d(operands[0], operands[1], operands[2], padding=1)
 
-    with torch.no_grad():
-        torch.testing.assert_close(
-            torch.nn.functional.conv2d(
-                device_input.detach().requires_grad_(),
-                device_weight,
-                device_bias,
-                padding=1,
-            ).cpu(),
-            expected,
-            atol=5e-2,
-            rtol=5e-2,
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("shape_id", _CONV_BWD_SHAPES)
+def test_fast_convolution_backward_matches_cpu_autograd(
+    mojo_gpu: torch.device, shape_id: str, dtype: torch.dtype
+) -> None:
+    torch.manual_seed(0)
+    n, c, h, w, out_c, k, stride, padding, dilation, groups = _CONV_BWD_SHAPES[shape_id]
+    kh, kw = k if isinstance(k, tuple) else (k, k)
+    x = torch.randn(n, c, h, w, dtype=dtype)
+    weight = (torch.randn(out_c, c // groups, kh, kw, dtype=dtype) * 0.2).to(dtype)
+    eff_h = dilation * (kh - 1) + 1
+    eff_w = dilation * (kw - 1) + 1
+    ph, pw = padding if isinstance(padding, tuple) else (padding, padding)
+    out_h = (h + 2 * ph - eff_h) // stride + 1
+    out_w = (w + 2 * pw - eff_w) // stride + 1
+    grad_output = torch.randn(n, out_c, out_h, out_w, dtype=dtype)
+
+    exact, magnitude = _conv_backward_reference(
+        x, weight, grad_output, stride, padding, dilation, groups
+    )
+    got = torch.ops.aten.convolution_backward(
+        grad_output.to(mojo_gpu),
+        x.to(mojo_gpu),
+        weight.to(mojo_gpu),
+        [out_c],
+        [stride, stride],
+        list(padding) if isinstance(padding, tuple) else [padding, padding],
+        [dilation, dilation],
+        False,
+        [0, 0],
+        groups,
+        [True, True, True],
+    )
+    cols = out_h * out_w
+    lengths = (out_c // groups * kh * kw, n * cols, n * cols)
+    roundings = (2, 2, 1)
+    for slot, name in enumerate(("grad_input", "grad_weight", "grad_bias")):
+        assert got[slot] is not None
+        assert got[slot].dtype == dtype
+        assert got[slot].shape == exact[slot].shape
+        _assert_conv_grad_close(
+            got[slot].cpu(),
+            exact[slot],
+            magnitude[slot],
+            dtype,
+            lengths[slot],
+            roundings[slot],
+            f"{shape_id}/{dtype}/{name}",
         )
+
+
+@pytest.mark.parametrize(
+    "mask",
+    [
+        (True, False, False),
+        (False, True, False),
+        (False, False, True),
+        (True, True, False),
+        (False, False, False),
+    ],
+)
+def test_fast_convolution_backward_output_mask(
+    mojo_gpu: torch.device, mask: tuple[bool, bool, bool]
+) -> None:
+    """A masked-off slot comes back as `None`, exactly as ATen's undefined
+    tensor does through the Python binding, and the requested slots are
+    bit-identical to what the all-on call returns -- i.e. masking really
+    skips work instead of changing the answer."""
+    torch.manual_seed(0)
+    x = torch.randn(2, 6, 10, 10)
+    weight = torch.randn(8, 6, 3, 3) * 0.2
+    grad_output = torch.randn(2, 8, 10, 10)
+    args = (
+        grad_output.to(mojo_gpu),
+        x.to(mojo_gpu),
+        weight.to(mojo_gpu),
+        [8],
+        [1, 1],
+        [1, 1],
+        [1, 1],
+        False,
+        [0, 0],
+        1,
+    )
+    full = torch.ops.aten.convolution_backward(*args, [True, True, True])
+    got = torch.ops.aten.convolution_backward(*args, list(mask))
+    for slot in range(3):
+        if mask[slot]:
+            assert got[slot] is not None
+            torch.testing.assert_close(
+                got[slot].cpu(), full[slot].cpu(), atol=0, rtol=0
+            )
+        else:
+            assert got[slot] is None
+
+
+def test_fast_convolution_backward_accepts_a_channels_last_grad_output(
+    mojo_gpu: torch.device,
+) -> None:
+    """grad_output routinely arrives non-contiguous (a channels_last op
+    upstream, a permuted view), and ATen contiguifies it inside the backend
+    rather than at the dispatcher, so this op has to do it itself."""
+    torch.manual_seed(0)
+    x = torch.randn(2, 6, 9, 9)
+    weight = torch.randn(8, 6, 3, 3) * 0.2
+    grad_output = torch.randn(2, 8, 9, 9)
+    args = ([8], [1, 1], [1, 1], [1, 1], False, [0, 0], 1, [True, True, True])
+    dense = torch.ops.aten.convolution_backward(
+        grad_output.to(mojo_gpu), x.to(mojo_gpu), weight.to(mojo_gpu), *args
+    )
+    strided = torch.ops.aten.convolution_backward(
+        grad_output.to(mojo_gpu).contiguous(memory_format=torch.channels_last),
+        x.to(mojo_gpu),
+        weight.to(mojo_gpu),
+        *args,
+    )
+    for slot in range(3):
+        torch.testing.assert_close(
+            strided[slot].cpu(), dense[slot].cpu(), atol=0, rtol=0
+        )
+
+
+def test_fast_convolution_backward_declines_transposed(mojo_gpu: torch.device) -> None:
+    """The backward of a conv_transpose FORWARD (input and grad_output swap
+    roles again) is not implemented, and the forward declines `transposed`
+    too, so nothing on this device can produce such a node. It must decline
+    with the actionable NotImplementedError, never silently compute the
+    non-transposed answer."""
+    x = torch.randn(2, 6, 8, 8).to(mojo_gpu)
+    weight = torch.randn(6, 3, 3, 3).to(mojo_gpu)
+    grad_output = torch.randn(2, 3, 10, 10).to(mojo_gpu)
+    with pytest.raises(NotImplementedError, match="convolution_backward"):
+        torch.ops.aten.convolution_backward(
+            grad_output,
+            x,
+            weight,
+            [3],
+            [1, 1],
+            [1, 1],
+            [1, 1],
+            True,
+            [0, 0],
+            1,
+            [True, True, True],
+        )
+
+
+@pytest.mark.parametrize("stride,padding,dilation", [(1, 0, 1), (2, 2, 1), (1, 1, 2)])
+def test_fast_convolution_backward_rank3(
+    mojo_gpu: torch.device, stride: int, padding: int, dilation: int
+) -> None:
+    """conv1d's backward, through the same rank-4 path behind a size-1 H
+    axis. Called at the aten level rather than through autograd because the
+    rank-3 FORWARD is a separate piece of work: the lift has to be correct
+    from the day the backward exists, not from the day something can reach
+    it."""
+    torch.manual_seed(0)
+    x = torch.randn(2, 6, 17)
+    weight = torch.randn(8, 6, 3) * 0.2
+    length = (17 + 2 * padding - (dilation * 2 + 1)) // stride + 1
+    grad_output = torch.randn(2, 8, length)
+
+    xd = x.double().requires_grad_()
+    wd = (weight.double()).requires_grad_()
+    torch.nn.functional.conv1d(xd, wd, None, stride, padding, dilation).backward(
+        grad_output.double()
+    )
+    got = torch.ops.aten.convolution_backward(
+        grad_output.to(mojo_gpu),
+        x.to(mojo_gpu),
+        weight.to(mojo_gpu),
+        [8],
+        [stride],
+        [padding],
+        [dilation],
+        False,
+        [0],
+        1,
+        [True, True, True],
+    )
+    assert got[0].shape == x.shape
+    assert got[1].shape == weight.shape
+    torch.testing.assert_close(got[0].cpu().double(), xd.grad, atol=2e-5, rtol=2e-5)
+    torch.testing.assert_close(got[1].cpu().double(), wd.grad, atol=2e-5, rtol=2e-5)
+    torch.testing.assert_close(
+        got[2].cpu().double(),
+        grad_output.double().sum(dim=(0, 2)),
+        atol=2e-5,
+        rtol=2e-5,
+    )
+
+
+@pytest.mark.parametrize("groups", [1, 2])
+@pytest.mark.parametrize("with_bias", [True, False])
+def test_fast_conv2d_trains_through_autograd(
+    mojo_gpu: torch.device, groups: int, with_bias: bool
+) -> None:
+    """The end-to-end case the preflight used to refuse: a grad-requiring
+    conv now records ConvolutionBackward0 and the engine runs it here.
+
+    Before `aten::convolution_backward` existed, `aten::convolution` had to
+    refuse a grad-requiring call from the FORWARD, because a raise from
+    inside the autograd engine aborts the process on this backend instead of
+    propagating. That refusal is gone with the kernel that replaces it, so
+    this asserts the whole round trip: forward, engine, and all three
+    gradients against a CPU reference.
+    """
+    torch.manual_seed(0)
+    x = torch.randn(3, 8, 11, 11)
+    weight = torch.randn(12, 8 // groups, 3, 3) * 0.2
+    bias = torch.randn(12) * 0.1 if with_bias else None
+    grad_output = torch.randn(3, 12, 11, 11)
+
+    def run(device: torch.device | str):
+        xd = x.to(device).detach().requires_grad_()
+        wd = weight.to(device).detach().requires_grad_()
+        bd = None if bias is None else bias.to(device).detach().requires_grad_()
+        out = torch.nn.functional.conv2d(xd, wd, bd, 1, 1, 1, groups)
+        out.backward(grad_output.to(device))
+        return out, xd.grad, wd.grad, (None if bd is None else bd.grad)
+
+    dev = run(mojo_gpu)
+    ref = run("cpu")
+    for got, want in zip(dev, ref):
+        if want is None:
+            assert got is None
+            continue
+        torch.testing.assert_close(got.cpu(), want, atol=2e-4, rtol=2e-4)
 
 
 # Shrunk-N copies of benchmarks/test_vision.py's CONV_SHAPES: same C/H/W/kernel

--- a/torch_mojo_backend/aten_functions.py
+++ b/torch_mojo_backend/aten_functions.py
@@ -1879,6 +1879,237 @@ def aten_convolution(
 
 
 # convolution_backward(Tensor grad_output, Tensor input, Tensor weight, SymInt[]? bias_sizes, SymInt[] stride, SymInt[] padding, SymInt[] dilation, bool transposed, SymInt[] output_padding, SymInt groups, bool[3] output_mask) -> (Tensor, Tensor, Tensor)
+#
+# MAX has no convolution-gradient op of any kind, and its one adjacent
+# primitive, `conv2d_transpose`, is cuDNN-only on GPU (the kernel aborts the
+# process with "symbol not found: cudnnCreate" on an accelerator that has no
+# cuDNN), so neither gradient may be expressed with it. Both are therefore
+# composed here from ops that run everywhere:
+#
+#   grad_input  = fold(weight^T @ grad_output_columns) -- `F.fold` IS col2im,
+#                 the exact adjoint of the im2col a convolution lowers to.
+#   grad_weight = a convolution with the operand ROLES swapped: the input's
+#                 channels become the batch, the batch becomes the reduction,
+#                 and grad_output becomes the filter, with stride and
+#                 dilation exchanged.
+#   grad_bias   = grad_output summed over batch and space.
+#
+# `transposed=True` is not implemented (input and grad_output swap roles
+# again); it raises rather than silently returning the non-transposed answer.
+
+
+def _conv2d_backward_input(
+    grad_output: MaxTensor,
+    input: MaxTensor,
+    weight: MaxTensor,
+    stride: tuple[int, int],
+    padding: tuple[int, int],
+    dilation: tuple[int, int],
+    groups: int,
+) -> MaxTensor:
+    """col2im of (weight^T x grad_output), i.e. the data gradient.
+
+    `F.fold`'s own `padding` argument does NOT match torch's fold (measured:
+    it agrees for padding 0 and diverges for every nonzero padding), so the
+    padded case is expressed the way it is defined instead -- fold into the
+    PADDED image extent with zero padding, then crop the border back off.
+    That is the identity `fold(x, H, pad=p) == fold(x, H + 2p, pad=0)[p:-p]`,
+    and it keeps this path on the one fold configuration that is verified
+    against torch.
+    """
+    kh, kw = int(weight.shape[2]), int(weight.shape[3])
+    ph, pw = padding
+    batch = grad_output.shape[0]
+    columns = grad_output.shape[2] * grad_output.shape[3]
+    grad_cols = F.reshape(grad_output, (batch, grad_output.shape[1], columns))
+    padded_size = (input.shape[2] + 2 * ph, input.shape[3] + 2 * pw)
+
+    if groups == 1:
+        weight_groups, grad_groups = [weight], [grad_cols]
+    else:
+        out_channels = int(weight.shape[0])
+        if out_channels % groups != 0:
+            raise ValueError(
+                f"Weight dim 0 ({out_channels}) must be divisible by groups ({groups})."
+            )
+        weight_groups = F.split(weight, [out_channels // groups] * groups, axis=0)
+        grad_groups = F.split(grad_cols, [out_channels // groups] * groups, axis=1)
+
+    parts = []
+    for weight_group, grad_group in zip(weight_groups, grad_groups):
+        # (out_c/groups, C/groups * KH * KW) -> transposed, so the matmul
+        # reduces over the output channels exactly as the forward reduces
+        # over the patch rows.
+        weight_matrix = F.reshape(
+            weight_group, (weight_group.shape[0], weight_group.shape[1] * kh * kw)
+        )
+        columns_grad = F.matmul(F.transpose(weight_matrix, 0, 1), grad_group)
+        parts.append(
+            F.fold(
+                columns_grad,
+                output_size=padded_size,
+                kernel_size=(kh, kw),
+                stride=stride,
+                dilation=dilation,
+                padding=0,
+            )
+        )
+    padded = parts[0] if len(parts) == 1 else F.concat(parts, axis=1)
+    slices = [
+        slice(None),
+        slice(None),
+        slice(ph, -ph) if ph else slice(None),
+        slice(pw, -pw) if pw else slice(None),
+    ]
+    return padded[*slices]
+
+
+def _conv2d_backward_weight(
+    grad_output: MaxTensor,
+    input: MaxTensor,
+    weight: MaxTensor,
+    stride: tuple[int, int],
+    padding: tuple[int, int],
+    dilation: tuple[int, int],
+    groups: int,
+) -> MaxTensor:
+    """The weight gradient as a convolution with the roles permuted.
+
+    `grad_weight[k, c, r, s] = sum_{n, oh, ow} grad_output[n, k, oh, ow] *
+    input[n, c, r*dh - ph + oh*sh, s*dw - pw + ow*sw]` is itself a
+    convolution: over an "input" whose batch is the channel axis `c` and
+    whose channels are the batch `n`, with grad_output as the filter (its
+    `oh, ow` are the filter taps), the forward's DILATION as the stride and
+    its STRIDE as the dilation. The result is bigger than the filter
+    whenever the forward truncated, so it is cropped to the kernel extent.
+    """
+    kh, kw = int(weight.shape[2]), int(weight.shape[3])
+    ph, pw = padding
+    # (N, C, H, W) -> NHWC with C as the batch and N as the channels.
+    input_nhwc = F.permute(input, [1, 2, 3, 0])
+    # (N, K, OH, OW) -> RSCF = (tap_h, tap_w, in_channels=N, out_channels=K).
+    grad_rscf = F.permute(grad_output, [2, 3, 0, 1])
+
+    if groups == 1:
+        pairs = [(input_nhwc, grad_rscf)]
+    else:
+        in_channels = int(input.shape[1])
+        out_channels = int(grad_output.shape[1])
+        if in_channels % groups != 0 or out_channels % groups != 0:
+            raise ValueError(
+                f"Input channels ({in_channels}) and output channels "
+                f"({out_channels}) must both be divisible by groups ({groups})."
+            )
+        pairs = list(
+            zip(
+                F.split(input_nhwc, [in_channels // groups] * groups, axis=0),
+                F.split(grad_rscf, [out_channels // groups] * groups, axis=3),
+            )
+        )
+
+    parts = []
+    for input_group, grad_group in pairs:
+        correlated = F.conv2d(
+            input_group,
+            grad_group,
+            bias=None,
+            stride=dilation,
+            dilation=stride,
+            padding=(ph, ph, pw, pw),
+            groups=1,
+            input_layout=max_type.ConvInputLayout.NHWC,
+            filter_layout=max_type.FilterLayout.RSCF,
+        )
+        # (C/groups, R', S', out_c/groups) -> (out_c/groups, C/groups, KH, KW)
+        parts.append(F.permute(correlated[:, :kh, :kw, :], [3, 0, 1, 2]))
+    return parts[0] if len(parts) == 1 else F.concat(parts, axis=0)
+
+
+@map_to(aten.convolution_backward)
+def aten_convolution_backward(
+    grad_output: MaxTensor,
+    input: MaxTensor,
+    weight: MaxTensor,
+    bias_sizes: list[SymIntType] | None,
+    stride: list[SymIntType],
+    padding: list[SymIntType],
+    dilation: list[SymIntType],
+    transposed: bool,
+    output_padding: list[SymIntType],
+    groups: SymIntType,
+    output_mask: list[bool],
+) -> tuple[MaxTensor | None, MaxTensor | None, MaxTensor | None]:
+    mask = tuple(output_mask)
+    if len(mask) != 3 or any(not isinstance(requested, bool) for requested in mask):
+        raise ValueError("convolution_backward output_mask must contain three booleans")
+    if transposed:
+        raise NotImplementedError(
+            "convolution_backward is not implemented for transposed convolutions "
+            "(the backward of a conv_transpose forward, where input and "
+            "grad_output swap roles)."
+        )
+    groups = int(groups)
+    input_rank = len(input.shape)
+
+    if input_rank == 3:
+        # conv1d: a synthetic size-1 H axis makes every operand look like
+        # conv2d's, the single stride/padding/dilation maps onto the W axis,
+        # and the two spatial gradients get the dummy axis squeezed back out.
+        grad_input, grad_weight, grad_bias = aten_convolution_backward(
+            F.unsqueeze(grad_output, axis=2),
+            F.unsqueeze(input, axis=2),
+            F.unsqueeze(weight, axis=2),
+            bias_sizes,
+            [1, stride[0]],
+            [0, padding[0]],
+            [1, dilation[0]],
+            transposed,
+            [0, output_padding[0] if output_padding else 0],
+            groups,
+            output_mask,
+        )
+        if grad_input is not None:
+            grad_input = F.squeeze(grad_input, axis=2)
+        if grad_weight is not None:
+            grad_weight = F.squeeze(grad_weight, axis=2)
+        return grad_input, grad_weight, grad_bias
+
+    if input_rank != 4:
+        raise ValueError(
+            f"Unsupported input rank for convolution_backward: {input_rank}. "
+            "Expected 3 (1D) or 4 (2D)."
+        )
+
+    stride, padding, dilation, _ = _normalize_2d_params(
+        stride, padding, dilation, output_padding
+    )
+    if padding[0] != padding[1] or padding[2] != padding[3]:
+        raise NotImplementedError(
+            "convolution_backward does not support asymmetric padding."
+        )
+    padding = (int(padding[0]), int(padding[2]))
+    stride = (int(stride[0]), int(stride[1]))
+    dilation = (int(dilation[0]), int(dilation[1]))
+
+    grad_input = None
+    if mask[0]:
+        grad_input = _conv2d_backward_input(
+            grad_output, input, weight, stride, padding, dilation, groups
+        )
+    grad_weight = None
+    if mask[1]:
+        grad_weight = _conv2d_backward_weight(
+            grad_output, input, weight, stride, padding, dilation, groups
+        )
+    grad_bias = None
+    if mask[2]:
+        # ATen computes this straight from grad_output whenever the backend
+        # did not, so `bias_sizes` -- which only records that the forward HAD
+        # a bias, something mask[2] already says -- is not consulted.
+        grad_bias = aten_sum(grad_output, dim=[0, 2, 3])
+    return grad_input, grad_weight, grad_bias
+
+
 # copy(Tensor self, Tensor src, bool non_blocking=False) -> Tensor
 @map_to(aten.copy)
 def aten_copy(

--- a/torch_mojo_backend/aten_functions.py
+++ b/torch_mojo_backend/aten_functions.py
@@ -1699,6 +1699,237 @@ def aten_convolution(
 
 
 # convolution_backward(Tensor grad_output, Tensor input, Tensor weight, SymInt[]? bias_sizes, SymInt[] stride, SymInt[] padding, SymInt[] dilation, bool transposed, SymInt[] output_padding, SymInt groups, bool[3] output_mask) -> (Tensor, Tensor, Tensor)
+#
+# MAX has no convolution-gradient op of any kind, and its one adjacent
+# primitive, `conv2d_transpose`, is cuDNN-only on GPU (the kernel aborts the
+# process with "symbol not found: cudnnCreate" on an accelerator that has no
+# cuDNN), so neither gradient may be expressed with it. Both are therefore
+# composed here from ops that run everywhere:
+#
+#   grad_input  = fold(weight^T @ grad_output_columns) -- `F.fold` IS col2im,
+#                 the exact adjoint of the im2col a convolution lowers to.
+#   grad_weight = a convolution with the operand ROLES swapped: the input's
+#                 channels become the batch, the batch becomes the reduction,
+#                 and grad_output becomes the filter, with stride and
+#                 dilation exchanged.
+#   grad_bias   = grad_output summed over batch and space.
+#
+# `transposed=True` is not implemented (input and grad_output swap roles
+# again); it raises rather than silently returning the non-transposed answer.
+
+
+def _conv2d_backward_input(
+    grad_output: MaxTensor,
+    input: MaxTensor,
+    weight: MaxTensor,
+    stride: tuple[int, int],
+    padding: tuple[int, int],
+    dilation: tuple[int, int],
+    groups: int,
+) -> MaxTensor:
+    """col2im of (weight^T x grad_output), i.e. the data gradient.
+
+    `F.fold`'s own `padding` argument does NOT match torch's fold (measured:
+    it agrees for padding 0 and diverges for every nonzero padding), so the
+    padded case is expressed the way it is defined instead -- fold into the
+    PADDED image extent with zero padding, then crop the border back off.
+    That is the identity `fold(x, H, pad=p) == fold(x, H + 2p, pad=0)[p:-p]`,
+    and it keeps this path on the one fold configuration that is verified
+    against torch.
+    """
+    kh, kw = int(weight.shape[2]), int(weight.shape[3])
+    ph, pw = padding
+    batch = grad_output.shape[0]
+    columns = grad_output.shape[2] * grad_output.shape[3]
+    grad_cols = F.reshape(grad_output, (batch, grad_output.shape[1], columns))
+    padded_size = (input.shape[2] + 2 * ph, input.shape[3] + 2 * pw)
+
+    if groups == 1:
+        weight_groups, grad_groups = [weight], [grad_cols]
+    else:
+        out_channels = int(weight.shape[0])
+        if out_channels % groups != 0:
+            raise ValueError(
+                f"Weight dim 0 ({out_channels}) must be divisible by groups ({groups})."
+            )
+        weight_groups = F.split(weight, [out_channels // groups] * groups, axis=0)
+        grad_groups = F.split(grad_cols, [out_channels // groups] * groups, axis=1)
+
+    parts = []
+    for weight_group, grad_group in zip(weight_groups, grad_groups):
+        # (out_c/groups, C/groups * KH * KW) -> transposed, so the matmul
+        # reduces over the output channels exactly as the forward reduces
+        # over the patch rows.
+        weight_matrix = F.reshape(
+            weight_group, (weight_group.shape[0], weight_group.shape[1] * kh * kw)
+        )
+        columns_grad = F.matmul(F.transpose(weight_matrix, 0, 1), grad_group)
+        parts.append(
+            F.fold(
+                columns_grad,
+                output_size=padded_size,
+                kernel_size=(kh, kw),
+                stride=stride,
+                dilation=dilation,
+                padding=0,
+            )
+        )
+    padded = parts[0] if len(parts) == 1 else F.concat(parts, axis=1)
+    slices = [
+        slice(None),
+        slice(None),
+        slice(ph, -ph) if ph else slice(None),
+        slice(pw, -pw) if pw else slice(None),
+    ]
+    return padded[*slices]
+
+
+def _conv2d_backward_weight(
+    grad_output: MaxTensor,
+    input: MaxTensor,
+    weight: MaxTensor,
+    stride: tuple[int, int],
+    padding: tuple[int, int],
+    dilation: tuple[int, int],
+    groups: int,
+) -> MaxTensor:
+    """The weight gradient as a convolution with the roles permuted.
+
+    `grad_weight[k, c, r, s] = sum_{n, oh, ow} grad_output[n, k, oh, ow] *
+    input[n, c, r*dh - ph + oh*sh, s*dw - pw + ow*sw]` is itself a
+    convolution: over an "input" whose batch is the channel axis `c` and
+    whose channels are the batch `n`, with grad_output as the filter (its
+    `oh, ow` are the filter taps), the forward's DILATION as the stride and
+    its STRIDE as the dilation. The result is bigger than the filter
+    whenever the forward truncated, so it is cropped to the kernel extent.
+    """
+    kh, kw = int(weight.shape[2]), int(weight.shape[3])
+    ph, pw = padding
+    # (N, C, H, W) -> NHWC with C as the batch and N as the channels.
+    input_nhwc = F.permute(input, [1, 2, 3, 0])
+    # (N, K, OH, OW) -> RSCF = (tap_h, tap_w, in_channels=N, out_channels=K).
+    grad_rscf = F.permute(grad_output, [2, 3, 0, 1])
+
+    if groups == 1:
+        pairs = [(input_nhwc, grad_rscf)]
+    else:
+        in_channels = int(input.shape[1])
+        out_channels = int(grad_output.shape[1])
+        if in_channels % groups != 0 or out_channels % groups != 0:
+            raise ValueError(
+                f"Input channels ({in_channels}) and output channels "
+                f"({out_channels}) must both be divisible by groups ({groups})."
+            )
+        pairs = list(
+            zip(
+                F.split(input_nhwc, [in_channels // groups] * groups, axis=0),
+                F.split(grad_rscf, [out_channels // groups] * groups, axis=3),
+            )
+        )
+
+    parts = []
+    for input_group, grad_group in pairs:
+        correlated = F.conv2d(
+            input_group,
+            grad_group,
+            bias=None,
+            stride=dilation,
+            dilation=stride,
+            padding=(ph, ph, pw, pw),
+            groups=1,
+            input_layout=max_type.ConvInputLayout.NHWC,
+            filter_layout=max_type.FilterLayout.RSCF,
+        )
+        # (C/groups, R', S', out_c/groups) -> (out_c/groups, C/groups, KH, KW)
+        parts.append(F.permute(correlated[:, :kh, :kw, :], [3, 0, 1, 2]))
+    return parts[0] if len(parts) == 1 else F.concat(parts, axis=0)
+
+
+@map_to(aten.convolution_backward)
+def aten_convolution_backward(
+    grad_output: MaxTensor,
+    input: MaxTensor,
+    weight: MaxTensor,
+    bias_sizes: list[SymIntType] | None,
+    stride: list[SymIntType],
+    padding: list[SymIntType],
+    dilation: list[SymIntType],
+    transposed: bool,
+    output_padding: list[SymIntType],
+    groups: SymIntType,
+    output_mask: list[bool],
+) -> tuple[MaxTensor | None, MaxTensor | None, MaxTensor | None]:
+    mask = tuple(output_mask)
+    if len(mask) != 3 or any(not isinstance(requested, bool) for requested in mask):
+        raise ValueError("convolution_backward output_mask must contain three booleans")
+    if transposed:
+        raise NotImplementedError(
+            "convolution_backward is not implemented for transposed convolutions "
+            "(the backward of a conv_transpose forward, where input and "
+            "grad_output swap roles)."
+        )
+    groups = int(groups)
+    input_rank = len(input.shape)
+
+    if input_rank == 3:
+        # conv1d: a synthetic size-1 H axis makes every operand look like
+        # conv2d's, the single stride/padding/dilation maps onto the W axis,
+        # and the two spatial gradients get the dummy axis squeezed back out.
+        grad_input, grad_weight, grad_bias = aten_convolution_backward(
+            F.unsqueeze(grad_output, axis=2),
+            F.unsqueeze(input, axis=2),
+            F.unsqueeze(weight, axis=2),
+            bias_sizes,
+            [1, stride[0]],
+            [0, padding[0]],
+            [1, dilation[0]],
+            transposed,
+            [0, output_padding[0] if output_padding else 0],
+            groups,
+            output_mask,
+        )
+        if grad_input is not None:
+            grad_input = F.squeeze(grad_input, axis=2)
+        if grad_weight is not None:
+            grad_weight = F.squeeze(grad_weight, axis=2)
+        return grad_input, grad_weight, grad_bias
+
+    if input_rank != 4:
+        raise ValueError(
+            f"Unsupported input rank for convolution_backward: {input_rank}. "
+            "Expected 3 (1D) or 4 (2D)."
+        )
+
+    stride, padding, dilation, _ = _normalize_2d_params(
+        stride, padding, dilation, output_padding
+    )
+    if padding[0] != padding[1] or padding[2] != padding[3]:
+        raise NotImplementedError(
+            "convolution_backward does not support asymmetric padding."
+        )
+    padding = (int(padding[0]), int(padding[2]))
+    stride = (int(stride[0]), int(stride[1]))
+    dilation = (int(dilation[0]), int(dilation[1]))
+
+    grad_input = None
+    if mask[0]:
+        grad_input = _conv2d_backward_input(
+            grad_output, input, weight, stride, padding, dilation, groups
+        )
+    grad_weight = None
+    if mask[1]:
+        grad_weight = _conv2d_backward_weight(
+            grad_output, input, weight, stride, padding, dilation, groups
+        )
+    grad_bias = None
+    if mask[2]:
+        # ATen computes this straight from grad_output whenever the backend
+        # did not, so `bias_sizes` -- which only records that the forward HAD
+        # a bias, something mask[2] already says -- is not consulted.
+        grad_bias = aten_sum(grad_output, dim=[0, 2, 3])
+    return grad_input, grad_weight, grad_bias
+
+
 # copy(Tensor self, Tensor src, bool non_blocking=False) -> Tensor
 @map_to(aten.copy)
 def aten_copy(

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -9004,21 +9004,20 @@ def _fast_aten_bmm_transpose_b(input, mat2):
 
 
 def _try_gemm16_conv_bmm(
-    w: TorchMojoTensor,
-    a: TorchMojoTensor,
-    col_ptr: int,
-    n: int,
-    out_c: int,
-    cols: int,
-    ckk: int,
+    w: TorchMojoTensor, col: TorchMojoTensor, n: int, out_c: int, cols: int, ckk: int
 ) -> TorchMojoTensor | None:
     """Dense conv GEMM (shared weight x per-sample im2col) via Bmm16, or
-    ``None``. ``w`` is the contiguous (out_c, ckk) weight; ``col_ptr`` is the
+    ``None``. ``w`` is the contiguous (out_c, ckk) weight; ``col`` OWNS the
     per-sample dense row-major (ckk, cols) im2col slice (or, for 1x1
-    stride-1 convs, the NCHW input reread in place)."""
+    stride-1 convs, ``col`` IS the input tensor, reread in place). ``col``
+    must be the actual owning tensor, not a bare pointer: under the default
+    kernel-call queue the launch this enqueues can be deferred behind a
+    still-compiling specialization, and the caller's last reference to the
+    buffer it points at can drop before that launch runs unless this frame's
+    keepalive tuple holds it too (queue rule 3, call_queue.py:18-26)."""
     if (
         w._dtype not in _GEMM16_DTYPES
-        or w._device != a._device
+        or w._device != col._device
         or w._device.label != "gpu"
         or w._device.api != "cuda"
         or w._device.architecture_name != "sm_90a"
@@ -9033,7 +9032,7 @@ def _try_gemm16_conv_bmm(
         (
             out._ptr,
             w._ptr,
-            col_ptr,
+            col._ptr,
             n,
             out_c,
             cols,
@@ -9048,31 +9047,27 @@ def _try_gemm16_conv_bmm(
         arg_dtypes=(w._dtype, w._dtype),
         output_dtypes=(out._dtype,),
         flags={"TRANSPOSE_B": False},
-        keepalive=(out, w),
+        keepalive=(out, w, col),
     )
     return out
 
 
 def _try_tf32_conv_bmm(
-    w: TorchMojoTensor,
-    a: TorchMojoTensor,
-    col_ptr: int,
-    n: int,
-    out_c: int,
-    cols: int,
-    ckk: int,
+    w: TorchMojoTensor, col: TorchMojoTensor, n: int, out_c: int, cols: int, ckk: int
 ) -> TorchMojoTensor | None:
     """Dense conv GEMM (shared weight x per-sample im2col) via the opt-in
     TF32 BMM, or ``None``. Same numerics policy as ``_try_tf32_bmm``: TF32 is
     off when the user asked for full FP32 (`torch.set_float32_matmul_precision
     ("highest")`) -- the repo has no separate `torch.backends.cudnn.
     allow_tf32`-style policy for convolution, so this follows the exact gate
-    the mm/bmm TF32 paths already use."""
+    the mm/bmm TF32 paths already use. ``col`` must be the tensor that OWNS
+    the im2col buffer (or the input tensor itself for a 1x1 conv), not a
+    bare pointer -- see ``_try_gemm16_conv_bmm``'s docstring for why."""
     if torch.get_float32_matmul_precision() == "highest":
         return None
     if (
         w._dtype != DType.float32
-        or w._device != a._device
+        or w._device != col._device
         or w._device.label != "gpu"
         or w._device.api != "cuda"
         or w._device.architecture_name != "sm_90a"
@@ -9087,7 +9082,7 @@ def _try_tf32_conv_bmm(
         (
             out._ptr,
             w._ptr,
-            col_ptr,
+            col._ptr,
             n,
             out_c,
             cols,
@@ -9102,7 +9097,7 @@ def _try_tf32_conv_bmm(
         arg_dtypes=(w._dtype, w._dtype),
         output_dtypes=(out._dtype,),
         flags={"TRANSPOSE_B": False},
-        keepalive=(out, w),
+        keepalive=(out, w, col),
     )
     return out
 
@@ -9262,6 +9257,7 @@ def fast_aten_convolution(
         and not transposed
         and (bias is None or bias_t is not None)
         and a._dtype == w._dtype
+        and a._device == w._device
         and a._dtype in _FLOAT_DTYPES
         and len(a._shape) == 4
         and len(w._shape) == 4
@@ -9279,7 +9275,9 @@ def fast_aten_convolution(
         out_w = (in_w + 2 * pw - (dw * (kw - 1) + 1)) // sw + 1
         if c_per_group * groups == c and out_h > 0 and out_w > 0:
             if bias_t is not None and (
-                bias_t._dtype != a._dtype or tuple(bias_t._shape) != (out_c,)
+                bias_t._dtype != a._dtype
+                or bias_t._device != a._device
+                or tuple(bias_t._shape) != (out_c,)
             ):
                 return NOT_HANDLED
             ctx = _ctx_ptr(a._device)
@@ -9304,7 +9302,11 @@ def fast_aten_convolution(
             if out is None:
                 if (kh, kw, sh, sw, ph, pw, dh, dw) == (1, 1, 1, 1, 0, 0, 1, 1):
                     # 1x1 stride-1 conv: NCHW input already is the col matrix.
-                    col_ptr = a._ptr
+                    # `col` ALIASES `a` (no allocation) -- it is still the
+                    # tensor that must stay alive until every GEMM reading it
+                    # has launched, so it flows through exactly like the
+                    # materialized branch's freshly allocated `col` below.
+                    col = a
                 else:
                     col = _alloc((n, ckk, cols), a._dtype, a._device)
                     _call_mojo(
@@ -9336,7 +9338,6 @@ def fast_aten_convolution(
                         output_dtypes=(col._dtype,),
                         keepalive=(col, a),
                     )
-                    col_ptr = col._ptr
                 if groups == 1:
                     # H100 tensor cores first: bf16/f16 through the same Bmm16
                     # kernel fast_aten_bmm already builds, f32 through the same
@@ -9345,9 +9346,9 @@ def fast_aten_convolution(
                     # bridge sources missing, and the plain SIMT Bmm below is the
                     # fallback for every regime they decline, including grouped
                     # convs (untouched, handled in the `else` branch).
-                    out = _try_gemm16_conv_bmm(w, a, col_ptr, n, out_c, cols, ckk)
+                    out = _try_gemm16_conv_bmm(w, col, n, out_c, cols, ckk)
                     if out is None:
-                        out = _try_tf32_conv_bmm(w, a, col_ptr, n, out_c, cols, ckk)
+                        out = _try_tf32_conv_bmm(w, col, n, out_c, cols, ckk)
                     if out is None:
                         out = _alloc((n, out_c, cols), a._dtype, a._device)
                         _call_mojo(
@@ -9356,7 +9357,7 @@ def fast_aten_convolution(
                             (
                                 out._ptr,
                                 w._ptr,
-                                col_ptr,
+                                col._ptr,
                                 (n, out_c, cols, ckk, 0, 1),
                                 a._dtype.value,
                                 ctx,
@@ -9369,7 +9370,12 @@ def fast_aten_convolution(
                             # it here would only fork this call site onto a
                             # second .so of identical code.
                             flags={"TRANSPOSE_B": False},
-                            keepalive=(out, w),
+                            # `col` (the im2col buffer, or `a` itself for the
+                            # 1x1 fast path) owns the pointer this call names
+                            # and must outlive the deferred launch (kernel
+                            # queue rule 3, call_queue.py:18-26) -- it is not
+                            # implied by `w`/`out` alone.
+                            keepalive=(out, w, col),
                         )
                 else:
                     out = _alloc((n, out_c, cols), a._dtype, a._device)
@@ -9385,7 +9391,7 @@ def fast_aten_convolution(
                                 (
                                     out._ptr,
                                     w._ptr,
-                                    col_ptr,
+                                    col._ptr,
                                     (
                                         oc_g,
                                         cols,
@@ -9401,7 +9407,10 @@ def fast_aten_convolution(
                                 arg_dtypes=(w._dtype, a._dtype),
                                 output_dtypes=(out._dtype,),
                                 flags={"TRANSPOSE_B": False},
-                                keepalive=(out, w),
+                                # Same rationale as the dense-path Bmm call
+                                # above: `col` owns the pointer this call
+                                # names.
+                                keepalive=(out, w, col),
                             )
             if bias_t is not None:
                 _call_mojo(

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -9003,103 +9003,178 @@ def _fast_aten_bmm_transpose_b(input, mat2):
 # ---------------------------------------------------------------------------
 
 
-def _try_gemm16_conv_bmm(
-    w: TorchMojoTensor, col: TorchMojoTensor, n: int, out_c: int, cols: int, ckk: int
+def _try_gemm16_shared_a_bmm(
+    a: TorchMojoTensor, b: TorchMojoTensor, batch: int, m: int, n: int, k: int
 ) -> TorchMojoTensor | None:
-    """Dense conv GEMM (shared weight x per-sample im2col) via Bmm16, or
-    ``None``. ``w`` is the contiguous (out_c, ckk) weight; ``col`` OWNS the
-    per-sample dense row-major (ckk, cols) im2col slice (or, for 1x1
-    stride-1 convs, ``col`` IS the input tensor, reread in place). ``col``
-    must be the actual owning tensor, not a bare pointer: under the default
-    kernel-call queue the launch this enqueues can be deferred behind a
-    still-compiling specialization, and the caller's last reference to the
-    buffer it points at can drop before that launch runs unless this frame's
-    keepalive tuple holds it too (queue rule 3, call_queue.py:18-26)."""
+    """``batch`` GEMMs of one shared (m, k) ``a`` against a densely packed
+    per-sample (k, n) ``b``, through Bmm16, or ``None`` when a gate declines.
+
+    Both convolution directions have this shape: the forward multiplies the
+    (out_c, C*R*S) weight by each sample's im2col, and the data gradient
+    multiplies the (C*R*S, out_c) transposed weight by each sample's
+    grad_output. ``b`` must be the tensor that OWNS the buffer it points at
+    (the im2col slice, or the input tensor itself for a 1x1 conv), not a bare
+    pointer: under the default kernel-call queue the launch this enqueues can
+    be deferred behind a still-compiling specialization, and the caller's last
+    reference to the buffer can drop before that launch runs unless this
+    frame's keepalive tuple holds it too (queue rule 3, call_queue.py:18-26).
+    """
     if (
-        w._dtype not in _GEMM16_DTYPES
-        or w._device != col._device
-        or w._device.label != "gpu"
-        or w._device.api != "cuda"
-        or w._device.architecture_name != "sm_90a"
-        or min(n, out_c, cols, ckk) <= 0
+        a._dtype not in _GEMM16_DTYPES
+        or a._device != b._device
+        or a._device.label != "gpu"
+        or a._device.api != "cuda"
+        or a._device.architecture_name != "sm_90a"
+        or min(batch, m, n, k) <= 0
         or not _gemm16_bridge_available()
     ):
         return None
-    out = _alloc((n, out_c, cols), w._dtype, w._device)
+    out = _alloc((batch, m, n), a._dtype, a._device)
     _call_mojo(
         _Gemm16MatmulExtension,
         "Bmm16",
         (
             out._ptr,
-            w._ptr,
-            col._ptr,
+            a._ptr,
+            b._ptr,
+            batch,
+            m,
             n,
-            out_c,
-            cols,
-            ckk,
-            out_c * cols,
+            k,
+            m * n,
             0,
-            ckk * cols,
+            k * n,
             0,
             0,
-            _ctx_ptr(w._device),
+            _ctx_ptr(a._device),
         ),
-        arg_dtypes=(w._dtype, w._dtype),
+        arg_dtypes=(a._dtype, a._dtype),
         output_dtypes=(out._dtype,),
         flags={"TRANSPOSE_B": False},
-        keepalive=(out, w, col),
+        keepalive=(out, a, b),
     )
     return out
 
 
-def _try_tf32_conv_bmm(
-    w: TorchMojoTensor, col: TorchMojoTensor, n: int, out_c: int, cols: int, ckk: int
+def _try_tf32_shared_a_bmm(
+    a: TorchMojoTensor, b: TorchMojoTensor, batch: int, m: int, n: int, k: int
 ) -> TorchMojoTensor | None:
-    """Dense conv GEMM (shared weight x per-sample im2col) via the opt-in
-    TF32 BMM, or ``None``. Same numerics policy as ``_try_tf32_bmm``: TF32 is
-    off when the user asked for full FP32 (`torch.set_float32_matmul_precision
-    ("highest")`) -- the repo has no separate `torch.backends.cudnn.
-    allow_tf32`-style policy for convolution, so this follows the exact gate
-    the mm/bmm TF32 paths already use. ``col`` must be the tensor that OWNS
-    the im2col buffer (or the input tensor itself for a 1x1 conv), not a
-    bare pointer -- see ``_try_gemm16_conv_bmm``'s docstring for why."""
+    """The same shared-A batched GEMM through the opt-in TF32 BMM, or
+    ``None``. Same numerics policy as ``_try_tf32_bmm``: TF32 is off when the
+    user asked for full FP32 (`torch.set_float32_matmul_precision("highest")`)
+    -- the repo has no separate `torch.backends.cudnn.allow_tf32`-style policy
+    for convolution, so this follows the exact gate the mm/bmm TF32 paths
+    already use. ``b`` must own its buffer, for the reason
+    ``_try_gemm16_shared_a_bmm``'s docstring gives."""
     if torch.get_float32_matmul_precision() == "highest":
         return None
     if (
-        w._dtype != DType.float32
-        or w._device != col._device
-        or w._device.label != "gpu"
-        or w._device.api != "cuda"
-        or w._device.architecture_name != "sm_90a"
-        or min(n, out_c, cols, ckk) <= 0
+        a._dtype != DType.float32
+        or a._device != b._device
+        or a._device.label != "gpu"
+        or a._device.api != "cuda"
+        or a._device.architecture_name != "sm_90a"
+        or min(batch, m, n, k) <= 0
         or not _tf32_bridge_available()
     ):
         return None
-    out = _alloc((n, out_c, cols), w._dtype, w._device)
+    out = _alloc((batch, m, n), a._dtype, a._device)
     _call_mojo(
         _Tf32MatmulExtension,
         "Tf32BmmF32",
         (
             out._ptr,
-            w._ptr,
-            col._ptr,
+            a._ptr,
+            b._ptr,
+            batch,
+            m,
             n,
-            out_c,
-            cols,
-            ckk,
-            out_c * cols,
+            k,
+            m * n,
             0,
-            ckk * cols,
+            k * n,
             0,
             0,
-            _ctx_ptr(w._device),
+            _ctx_ptr(a._device),
         ),
-        arg_dtypes=(w._dtype, w._dtype),
+        arg_dtypes=(a._dtype, a._dtype),
         output_dtypes=(out._dtype,),
         flags={"TRANSPOSE_B": False},
-        keepalive=(out, w, col),
+        keepalive=(out, a, b),
     )
     return out
+
+
+def _conv_shared_a_bmm(
+    a: TorchMojoTensor, b: TorchMojoTensor, batch: int, m: int, n: int, k: int, ctx: int
+) -> TorchMojoTensor:
+    """``batch`` GEMMs of the shared (m, k) ``a`` against per-sample (k, n)
+    ``b``, on whichever route this device and dtype support.
+
+    H100 tensor cores first: bf16/f16 through the same Bmm16 kernel
+    `fast_aten_bmm` already builds, f32 through the same opt-in TF32 route
+    `_try_tf32_mm` already gates. Both decline (return None) off sm_90a, off
+    their dtype, or with the bridge sources missing, and the plain SIMT Bmm
+    below is the fallback for every regime they decline.
+    """
+    out = _try_gemm16_shared_a_bmm(a, b, batch, m, n, k)
+    if out is None:
+        out = _try_tf32_shared_a_bmm(a, b, batch, m, n, k)
+    if out is None:
+        out = _alloc((batch, m, n), a._dtype, a._device)
+        _call_mojo(
+            _MatmulExtension,
+            "Bmm",
+            (out._ptr, a._ptr, b._ptr, (batch, m, n, k, 0, 1), a._dtype.value, ctx),
+            arg_dtypes=(a._dtype, b._dtype),
+            output_dtypes=(out._dtype,),
+            # Same define shape as every other Bmm site: the shared-A
+            # broadcast is RUNTIME data (the trailing 1 in the params tuple,
+            # matmul_ops._bmm_go), so naming it here would only fork this call
+            # site onto a second .so of identical code.
+            flags={"TRANSPOSE_B": False},
+            # `b` owns the pointer this call names and must outlive the
+            # deferred launch (kernel queue rule 3, call_queue.py:18-26) -- it
+            # is not implied by `a`/`out` alone.
+            keepalive=(out, a, b),
+        )
+    return out
+
+
+def _conv_col_matrix(
+    a: TorchMojoTensor, geom: tuple[int, ...], ctx: int
+) -> TorchMojoTensor | object:
+    """The tensor OWNING the (batch, C*KH*KW, OH*OW) im2col patch buffer of
+    the NCHW ``a``.
+
+    ``geom`` is the shared convolution descriptor
+    ``(n, c, in_h, in_w, out_h, out_w, kh, kw, sh, sw, ph, pw, dh, dw)``.
+    A 1x1 stride-1 unpadded convolution has no im2col at all: every patch is
+    one pixel, so the NCHW input already IS that matrix and is reread in
+    place. ``a`` ITSELF comes back then -- still rank 4, not a reshaped view
+    -- because it is the tensor that must appear in the keepalive of every
+    queued GEMM reading the buffer (queue rule 3), and a caller that needs
+    the (batch, C*KH*KW, OH*OW) matrix shape should take that view itself.
+    """
+    n, c, in_h, in_w, out_h, out_w, kh, kw, sh, sw, ph, pw, dh, dw = geom
+    if (kh, kw, sh, sw, ph, pw, dh, dw) == (1, 1, 1, 1, 0, 0, 1, 1):
+        return a
+    col = _alloc((n, c * kh * kw, out_h * out_w), a._dtype, a._device)
+    _call_mojo(
+        _ConvExtension,
+        "Im2col",
+        (
+            col._ptr,
+            a._ptr,
+            (in_h, in_w, out_h, out_w, kh, kw, sh, sw, ph, pw, dh, dw, c, n),
+            a._dtype.value,
+            ctx,
+        ),
+        arg_dtypes=(a._dtype,),
+        output_dtypes=(col._dtype,),
+        keepalive=(col, a),
+    )
+    return col
 
 
 # ---------------------------------------------------------------------------
@@ -9282,6 +9357,14 @@ def fast_aten_convolution(
         and groups >= 1
         and None not in (strides, pads, dils)
         and 0 not in a._shape
+        # ATen's own "expected weight to be at least 1 at dimension 0" check
+        # does NOT run on the PrivateUse1 path -- a 0-out-channel conv that
+        # CPU and CUDA both reject returns a 0-channel tensor here instead --
+        # so this is the only thing between a degenerate weight and a made-up
+        # answer. It also keeps `fast_aten_convolution_backward`'s matching
+        # gate implied by this one, which that function's header explains is
+        # the difference between a NotImplementedError and a dead process.
+        and 0 not in w._shape
     ):
         n, c, in_h, in_w = a._shape
         out_c, c_per_group, kh, kw = w._shape
@@ -9324,83 +9407,16 @@ def fast_aten_convolution(
                     ctx,
                 )
             if out is None:
-                if (kh, kw, sh, sw, ph, pw, dh, dw) == (1, 1, 1, 1, 0, 0, 1, 1):
-                    # 1x1 stride-1 conv: NCHW input already is the col matrix.
-                    # `col` ALIASES `a` (no allocation) -- it is still the
-                    # tensor that must stay alive until every GEMM reading it
-                    # has launched, so it flows through exactly like the
-                    # materialized branch's freshly allocated `col` below.
-                    col = a
-                else:
-                    col = _alloc((n, ckk, cols), a._dtype, a._device)
-                    _call_mojo(
-                        _ConvExtension,
-                        "Im2col",
-                        (
-                            col._ptr,
-                            a._ptr,
-                            (
-                                in_h,
-                                in_w,
-                                out_h,
-                                out_w,
-                                kh,
-                                kw,
-                                sh,
-                                sw,
-                                ph,
-                                pw,
-                                dh,
-                                dw,
-                                c,
-                                n,
-                            ),
-                            a._dtype.value,
-                            ctx,
-                        ),
-                        arg_dtypes=(a._dtype,),
-                        output_dtypes=(col._dtype,),
-                        keepalive=(col, a),
-                    )
+                # `col` is the tensor that OWNS the column buffer -- or, for a
+                # 1x1 stride-1 conv, a zero-copy view of `a` itself -- and must
+                # stay alive until every GEMM reading it has launched.
+                col = _conv_col_matrix(
+                    a,
+                    (n, c, in_h, in_w, out_h, out_w, kh, kw, sh, sw, ph, pw, dh, dw),
+                    ctx,
+                )
                 if groups == 1:
-                    # H100 tensor cores first: bf16/f16 through the same Bmm16
-                    # kernel fast_aten_bmm already builds, f32 through the same
-                    # opt-in TF32 route _try_tf32_mm already gates. Both decline
-                    # (return None) off sm_90a, off their dtype, or with the
-                    # bridge sources missing, and the plain SIMT Bmm below is the
-                    # fallback for every regime they decline, including grouped
-                    # convs (untouched, handled in the `else` branch).
-                    out = _try_gemm16_conv_bmm(w, col, n, out_c, cols, ckk)
-                    if out is None:
-                        out = _try_tf32_conv_bmm(w, col, n, out_c, cols, ckk)
-                    if out is None:
-                        out = _alloc((n, out_c, cols), a._dtype, a._device)
-                        _call_mojo(
-                            _MatmulExtension,
-                            "Bmm",
-                            (
-                                out._ptr,
-                                w._ptr,
-                                col._ptr,
-                                (n, out_c, cols, ckk, 0, 1),
-                                a._dtype.value,
-                                ctx,
-                            ),
-                            arg_dtypes=(w._dtype, a._dtype),
-                            output_dtypes=(out._dtype,),
-                            # Same define shape as every other Bmm site: the
-                            # shared-A broadcast is RUNTIME data (the trailing 1
-                            # in the params tuple, matmul_ops._bmm_go), so naming
-                            # it here would only fork this call site onto a
-                            # second .so of identical code.
-                            flags={"TRANSPOSE_B": False},
-                            # `col` (the im2col buffer, or `a` itself for the
-                            # 1x1 fast path) owns the pointer this call names
-                            # and must outlive the deferred launch (kernel
-                            # queue rule 3, call_queue.py:18-26) -- it is not
-                            # implied by `w`/`out` alone.
-                            keepalive=(out, w, col),
-                        )
+                    out = _conv_shared_a_bmm(w, col, n, out_c, cols, ckk, ctx)
                 else:
                     out = _alloc((n, out_c, cols), a._dtype, a._device)
                     # Channel-major im2col rows make each group a contiguous
@@ -9458,6 +9474,356 @@ def fast_aten_convolution(
                 out._offset,
             )
     return NOT_HANDLED
+
+
+# ---------------------------------------------------------------------------
+# Convolution backward, pure Mojo: the same im2col + GEMM machinery the
+# forward uses, with the operand roles permuted.
+#
+#   grad_bias   = grad_output summed over (N, H, W)             -- one reduce
+#   grad_weight = grad_output x im2col(input)^T, summed over N  -- the forward
+#                 GEMM with the two operands' roles swapped, so the reduction
+#                 runs over the OUTPUT pixels instead of over the patch rows
+#   grad_input  = col2im(weight^T x grad_output)                -- the forward
+#                 GEMM transposed, then im2col's adjoint
+#
+# `transposed=True` (the backward of a conv_transpose forward, where the
+# input/grad_output roles swap again) is declined: the forward declines it
+# too, so nothing on this device can produce such a node.
+#
+# THAT SENTENCE IS AN INVARIANT, not an aside. This function runs INSIDE the
+# autograd engine, where a raise does not propagate -- it aborts the process
+# (the unwind hazard `mojo_device/aten_ops/autograd_preflight.py` documents at
+# length), and returning NOT_HANDLED from here raises. So every gate below
+# must already be implied by something that ran EARLIER, on a path that can
+# still raise: either a gate `fast_aten_convolution` enforces (transposed,
+# rank, dtype, device, 0-sized extents) or a check ATen itself makes before
+# dispatch (`aten::convolution` rejects `out_c % groups != 0` outright, which
+# is why the same condition here is unreachable defensive code, and why the
+# forward carries a matching `0 not in w._shape` -- ATen's degenerate-weight
+# check does NOT run on this dispatch path, so that one had to be added there
+# rather than assumed). Adding a gate to this function that the forward does
+# not imply turns a would-be NotImplementedError into a dead process, so a new
+# restriction belongs in the FORWARD first.
+#
+# Memory: the weight gradient's per-sample partials are an (N, out_c, C*R*S)
+# buffer that a batch reduce then collapses, because none of the GEMM routes
+# here takes a beta=1 accumulator. That is smaller than the column buffer it
+# is computed from whenever out_c <= OH*OW, i.e. everywhere except the last
+# stages of a deep net; folding N into the GEMM's K instead would need a
+# patch-major im2col variant (a transposed write, so a different kernel, not
+# a different index), which is left for a perf pass.
+# ---------------------------------------------------------------------------
+
+
+def _conv_backward_1d(
+    grad_output: TorchMojoTensor,
+    input: TorchMojoTensor,
+    weight: TorchMojoTensor,
+    bias_sizes: Sequence[int] | None,
+    stride: Sequence[int],
+    padding: Sequence[int],
+    dilation: Sequence[int],
+    transposed: bool,
+    output_padding: Sequence[int],
+    groups: int,
+    output_mask: Sequence[bool],
+) -> object:
+    """conv1d backward through the rank-4 path, or ``NOT_HANDLED``.
+
+    Same lift the rank-3 forward uses: a synthetic size-1 H axis (unsqueeze
+    is a zero-copy view) makes the rank-3 operands look like conv2d's, the
+    single stride/padding/dilation maps onto the W axis while the dummy H
+    axis is pinned at kernel=1/stride=1/pad=0/dilation=1, and the two
+    spatial gradients get the dummy axis squeezed back out (zero-copy
+    again). grad_bias is already (out_c,) and needs no fixup.
+    """
+    lifted = [fast_aten_unsqueeze(t, 2) for t in (grad_output, input, weight)]
+    if any(t is NOT_HANDLED for t in lifted):
+        return NOT_HANDLED
+    result = fast_aten_convolution_backward(
+        lifted[0],
+        lifted[1],
+        lifted[2],
+        bias_sizes,
+        [1, int(stride[0])],
+        [0, int(padding[0])],
+        [1, int(dilation[0])],
+        transposed,
+        [0, int(output_padding[0]) if output_padding else 0],
+        groups,
+        output_mask,
+    )
+    if result is NOT_HANDLED:
+        return NOT_HANDLED
+    grad_input, grad_weight, grad_bias = result
+    if grad_input is not None:
+        grad_input = fast_aten_squeeze_dim(grad_input, 2)
+        if grad_input is NOT_HANDLED:
+            return NOT_HANDLED
+    if grad_weight is not None:
+        grad_weight = fast_aten_squeeze_dim(grad_weight, 2)
+        if grad_weight is NOT_HANDLED:
+            return NOT_HANDLED
+    return grad_input, grad_weight, grad_bias
+
+
+def fast_aten_convolution_backward(
+    grad_output: TorchMojoTensor,
+    input: TorchMojoTensor,
+    weight: TorchMojoTensor,
+    bias_sizes: Sequence[int] | None,
+    stride: Sequence[int],
+    padding: Sequence[int],
+    dilation: Sequence[int],
+    transposed: bool,
+    output_padding: Sequence[int],
+    groups: int,
+    output_mask: Sequence[bool],
+) -> object:
+    """``(grad_input, grad_weight, grad_bias)``, or ``NOT_HANDLED``.
+
+    Each gradient is ``None`` when its ``output_mask`` slot is off, matching
+    the undefined tensor ATen returns there. The return type can only be
+    ``object``: ``NOT_HANDLED`` is a bare ``object()`` sentinel with no type
+    of its own, so any union naming it collapses to ``object`` anyway.
+    """
+    # `_t()` first, like the forward: every gate below reads metadata only, so
+    # a call this cannot serve must return NOT_HANDLED before `_tc()` pays for
+    # the allocation + copy of a non-contiguous operand.
+    g = _t(grad_output)
+    a = _t(input)
+    w = _t(weight)
+    if g is None or a is None or w is None or transposed:
+        return NOT_HANDLED
+    mask = tuple(output_mask) if isinstance(output_mask, list | tuple) else ()
+    if len(mask) != 3 or any(not isinstance(requested, bool) for requested in mask):
+        return NOT_HANDLED
+    if not isinstance(groups, int) or isinstance(groups, bool) or groups < 1:
+        return NOT_HANDLED
+    if not all(
+        isinstance(seq, list | tuple) and all(isinstance(i, int) for i in seq)
+        for seq in (stride, padding, dilation)
+    ):
+        return NOT_HANDLED
+    if not isinstance(output_padding, list | tuple):
+        return NOT_HANDLED
+
+    if len(a._shape) == 3 and len(w._shape) == 3 and len(g._shape) == 3:
+        if len(stride) != 1 or len(padding) != 1 or len(dilation) != 1:
+            return NOT_HANDLED
+        return _conv_backward_1d(
+            g,
+            a,
+            w,
+            bias_sizes,
+            stride,
+            padding,
+            dilation,
+            transposed,
+            output_padding,
+            groups,
+            output_mask,
+        )
+
+    strides = _pair(list(stride))
+    pads = _pair(list(padding))
+    dils = _pair(list(dilation))
+    if (
+        len(a._shape) != 4
+        or len(w._shape) != 4
+        or len(g._shape) != 4
+        or a._dtype != w._dtype
+        or a._dtype != g._dtype
+        or a._dtype not in _FLOAT_DTYPES
+        or a._device != w._device
+        or a._device != g._device
+        or None in (strides, pads, dils)
+        or 0 in a._shape
+        or 0 in w._shape
+    ):
+        return NOT_HANDLED
+
+    n, c, in_h, in_w = a._shape
+    out_c, c_per_group, kh, kw = w._shape
+    sh, sw = strides
+    ph, pw = pads
+    dh, dw = dils
+    if min(sh, sw, dh, dw) < 1 or min(ph, pw) < 0:
+        return NOT_HANDLED
+    if c_per_group * groups != c or out_c % groups != 0:
+        return NOT_HANDLED
+    out_h = (in_h + 2 * ph - (dh * (kh - 1) + 1)) // sh + 1
+    out_w = (in_w + 2 * pw - (dw * (kw - 1) + 1)) // sw + 1
+    if out_h < 1 or out_w < 1 or tuple(g._shape) != (n, out_c, out_h, out_w):
+        return NOT_HANDLED
+
+    if not any(mask):
+        return None, None, None
+
+    # Only now is a non-contiguous operand worth what `_tc()` costs. The
+    # gradients come back plain contiguous NCHW whatever memory format the
+    # forward's operands had: the autograd engine validates a returned
+    # gradient's shape, dtype, layout and device but never its strides
+    # (torch/csrc/autograd/engine.cpp, validate_outputs_impl), so a
+    # channels_last input is a performance question here, not a correctness
+    # one.
+    g = _tc(g)
+    ctx = _ctx_ptr(a._device)
+    cols = out_h * out_w
+    ckk = c * kh * kw
+    crs_g = c_per_group * kh * kw
+    oc_g = out_c // groups
+    geom = (n, c, in_h, in_w, out_h, out_w, kh, kw, sh, sw, ph, pw, dh, dw)
+    g3 = fast_aten_view(g, (n, out_c, cols))
+    if g3 is NOT_HANDLED:
+        return NOT_HANDLED
+
+    grad_bias = None
+    if mask[2]:
+        # ATen computes this straight from grad_output whenever the backend
+        # did not (Convolution.cpp's `grad_output.sum({0, 2, 3})` fixup), so
+        # `bias_sizes` is not consulted: it only records that the forward HAD
+        # a bias, which mask[2] already says. The reduce accumulates in fp32
+        # for every float dtype, like torch's own.
+        grad_bias = fast_aten_sum(g, dim=[0, 2, 3], keepdim=False)
+        if grad_bias is NOT_HANDLED:
+            return NOT_HANDLED
+
+    grad_weight = None
+    if mask[1]:
+        col = _conv_col_matrix(_tc(a), geom, ctx)
+        # The 1x1 fast path hands back the rank-4 input itself (it owns the
+        # buffer); the GEMMs below want the (n, ckk, cols) matrix shape.
+        col_matrix = (
+            col if len(col._shape) == 3 else fast_aten_view(col, (n, ckk, cols))
+        )
+        if col_matrix is NOT_HANDLED:
+            return NOT_HANDLED
+        if groups == 1:
+            # (n, out_c, cols) x (n, ckk, cols)^T: both operands have the
+            # reduction (the output pixels) as their contiguous last axis,
+            # which is exactly the transposed-B GEMM the accepted Bmm16 /
+            # TF32 / SIMT routes already build for `fast_aten_bmm`.
+            partial = _fast_aten_bmm_transpose_b(g3, col_matrix)
+            if partial is NOT_HANDLED:
+                return NOT_HANDLED
+        else:
+            # Channel-major im2col rows make each group's rows a contiguous
+            # (crs_g, cols) slice, and each group's grad_output rows a
+            # contiguous (oc_g, cols) slice, so one offset GEMM per
+            # (sample, group) covers it -- the same decomposition the
+            # forward's grouped path uses, with transpose_b flipped on.
+            partial = _alloc((n, out_c, crs_g), a._dtype, a._device)
+            for s in range(n):
+                for group in range(groups):
+                    _call_mojo(
+                        _MatmulExtension,
+                        "Matmul",
+                        (
+                            partial._ptr,
+                            g3._ptr,
+                            col_matrix._ptr,
+                            (
+                                oc_g,
+                                crs_g,
+                                cols,
+                                1,
+                                (s * out_c + group * oc_g) * crs_g,
+                                (s * out_c + group * oc_g) * cols,
+                                (s * ckk + group * crs_g) * cols,
+                            ),
+                            a._dtype.value,
+                            ctx,
+                        ),
+                        arg_dtypes=(g3._dtype, col_matrix._dtype),
+                        output_dtypes=(partial._dtype,),
+                        flags={"TRANSPOSE_B": True},
+                        keepalive=(partial, g3, col_matrix),
+                    )
+        # The batch reduce is what turns the per-sample products into the
+        # gradient; it accumulates in fp32 like every float reduce here.
+        summed = fast_aten_sum(partial, dim=[0], keepdim=False)
+        if summed is NOT_HANDLED:
+            return NOT_HANDLED
+        grad_weight = fast_aten_view(summed, w._shape)
+        if grad_weight is NOT_HANDLED:
+            return NOT_HANDLED
+        # Drop the column buffer and the partials before the data gradient
+        # allocates its own column-sized buffer below: both are the size of
+        # an im2col, and nothing reads them past this point.
+        col = None
+        col_matrix = None
+        partial = None
+
+    grad_input = None
+    if mask[0]:
+        # (groups, crs_g, oc_g): each group's weight block transposed, which
+        # is what the data gradient's GEMM reads as its shared A operand. The
+        # weight is the smallest tensor in the op, so materializing its
+        # transpose costs nothing next to the column buffer below.
+        wt = fast_aten_view(_tc(w), (groups, oc_g, crs_g))
+        if wt is NOT_HANDLED:
+            return NOT_HANDLED
+        wt = fast_aten_transpose(wt, 1, 2)
+        if wt is NOT_HANDLED:
+            return NOT_HANDLED
+        wt = _tc(wt)
+        if groups == 1:
+            colgrad = _conv_shared_a_bmm(wt, g3, n, ckk, cols, out_c, ctx)
+        else:
+            colgrad = _alloc((n, ckk, cols), a._dtype, a._device)
+            for s in range(n):
+                for group in range(groups):
+                    _call_mojo(
+                        _MatmulExtension,
+                        "Matmul",
+                        (
+                            colgrad._ptr,
+                            wt._ptr,
+                            g3._ptr,
+                            (
+                                crs_g,
+                                cols,
+                                oc_g,
+                                0,
+                                (s * ckk + group * crs_g) * cols,
+                                group * crs_g * oc_g,
+                                (s * out_c + group * oc_g) * cols,
+                            ),
+                            a._dtype.value,
+                            ctx,
+                        ),
+                        arg_dtypes=(wt._dtype, g3._dtype),
+                        output_dtypes=(colgrad._dtype,),
+                        flags={"TRANSPOSE_B": False},
+                        keepalive=(colgrad, wt, g3),
+                    )
+        if (kh, kw, sh, sw, ph, pw, dh, dw) == (1, 1, 1, 1, 0, 0, 1, 1):
+            # The adjoint of the forward's in-place 1x1 column matrix: every
+            # patch is one pixel, so col2im is the identity and the columns
+            # ARE the gradient image.
+            grad_input = fast_aten_view(colgrad, (n, c, in_h, in_w))
+        else:
+            grad_input = _alloc((n, c, in_h, in_w), a._dtype, a._device)
+            _call_mojo(
+                _ConvExtension,
+                "Col2im",
+                (
+                    grad_input._ptr,
+                    colgrad._ptr,
+                    (in_h, in_w, out_h, out_w, kh, kw, sh, sw, ph, pw, dh, dw, c, n),
+                    a._dtype.value,
+                    ctx,
+                ),
+                arg_dtypes=(colgrad._dtype,),
+                output_dtypes=(grad_input._dtype,),
+                keepalive=(grad_input, colgrad),
+            )
+        if grad_input is NOT_HANDLED:
+            return NOT_HANDLED
+
+    return grad_input, grad_weight, grad_bias
 
 
 # ---------------------------------------------------------------------------

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -9245,9 +9245,14 @@ def _try_conv_igemm(
 def fast_aten_convolution(
     input, weight, bias, stride, padding, dilation, transposed, output_padding, groups
 ):
-    a = _tc(input)
-    w = _tc(weight)
-    bias_t = _tc(bias) if bias is not None else None
+    # `_t()` here, not `_tc()`: every gate below (dtype, device, shape) reads
+    # metadata only, so it must run before paying for `_tc()`'s allocation +
+    # copy of a non-contiguous operand -- including the device-equality gate,
+    # so a cross-device pair returns NOT_HANDLED before any materialization,
+    # not just before the eventual conv kernel launch.
+    a = _t(input)
+    w = _t(weight)
+    bias_t = _t(bias) if bias is not None else None
     strides = _pair(list(stride))
     pads = _pair(list(padding))
     dils = _pair(list(dilation))
@@ -9280,6 +9285,13 @@ def fast_aten_convolution(
                 or tuple(bias_t._shape) != (out_c,)
             ):
                 return NOT_HANDLED
+            # Every reason to decline (dtype/device/shape mismatch, a
+            # cross-device pair included) has already returned NOT_HANDLED
+            # above; only now is a non-contiguous operand worth the
+            # allocation + copy `_tc()` pays for.
+            a = _tc(a)
+            w = _tc(w)
+            bias_t = _tc(bias_t) if bias_t is not None else None
             ctx = _ctx_ptr(a._device)
             cols = out_h * out_w
             ckk = c * kh * kw

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -9109,7 +9109,19 @@ def _try_tf32_conv_bmm(
 # the GEMM, where the materialized route costs a full im2col write + read
 # (89% of the body conv's device time) plus the same GEMM. Measured on an
 # H100 PCIe at a 1395 MHz pin, bf16 N32xC64x56x56 K64 k3s1: 59.0 us vs
-# 861 us on the materialized route and 71.95 us for cuDNN (0.82x cuDNN).
+# 861 us on the materialized route and 71.95 us for cuDNN.
+#
+# That 71.95 us is cuDNN reached the way torch.nn.Conv2d reaches it from an
+# NCHW tensor, which is NOT cuDNN's own speed: 31.2 us of convolution plus
+# 41.0 us of nchwToNhwc / nhwcToNchw transposes around it. Handed a
+# channels_last tensor cuDNN does the same convolution in 33.9 us with no
+# transposes, against 54.6 us for the three kernels of this route (NHWC
+# pass + weight repack + implicit GEMM). So this route wins the NCHW
+# comparison because it needs no layout conversion, and loses the
+# same-layout comparison by ~1.6x. Both statements are about the forward
+# convolution only; the separate BiasAddChan kernel is another 12.2 us here
+# against 25.3 us for the elementwise bias add torch appends to cuDNN, which
+# is where a further chunk of the end-to-end ratio comes from.
 #
 # Everything the route cannot do stays on the materialized route: grouped
 # convolution (not implemented here at all), stride != 1, dilation != 1,

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -8985,7 +8985,123 @@ def _fast_aten_bmm_transpose_b(input, mat2):
 # (K,C,R,S) weight used as-is and NCHW output — no layout permutes.
 # Grouped convolutions slice the channel-major im2col rows and weights per
 # group with element offsets.
+#
+# The dense (groups == 1) GEMM shares one (out_c, ckk) weight matrix across
+# every sample in the batch, so it is a batched matmul with the A operand
+# broadcast (runtime batch stride 0) against a densely packed, per-sample
+# row-major im2col B. That broadcast is not a new capability: the plain SIMT
+# `Bmm` bridge below already threads it through as `a_shared`, and the
+# accepted Bmm16/Tf32BmmF32 kernels already prove their pointer arithmetic
+# for a zero A-batch-stride (`_opt_bmm_address_proof`'s `a_bstride > 0`
+# guards treat zero as the trivial case). The two helpers below reuse those
+# kernels as-is: same OP name, same dtype, same TRANSPOSE_B=False flag that
+# fast_aten_bmm already builds, so no new compiled variant exists anywhere
+# because of them -- only a new host-side call site.
 # ---------------------------------------------------------------------------
+
+
+def _try_gemm16_conv_bmm(
+    w: TorchMojoTensor,
+    a: TorchMojoTensor,
+    col_ptr: int,
+    n: int,
+    out_c: int,
+    cols: int,
+    ckk: int,
+) -> TorchMojoTensor | None:
+    """Dense conv GEMM (shared weight x per-sample im2col) via Bmm16, or
+    ``None``. ``w`` is the contiguous (out_c, ckk) weight; ``col_ptr`` is the
+    per-sample dense row-major (ckk, cols) im2col slice (or, for 1x1
+    stride-1 convs, the NCHW input reread in place)."""
+    if (
+        w._dtype not in _GEMM16_DTYPES
+        or w._device != a._device
+        or w._device.label != "gpu"
+        or w._device.api != "cuda"
+        or w._device.architecture_name != "sm_90a"
+        or min(n, out_c, cols, ckk) <= 0
+        or not _gemm16_bridge_available()
+    ):
+        return None
+    out = _alloc((n, out_c, cols), w._dtype, w._device)
+    _call_mojo(
+        _Gemm16MatmulExtension,
+        "Bmm16",
+        (
+            out._ptr,
+            w._ptr,
+            col_ptr,
+            n,
+            out_c,
+            cols,
+            ckk,
+            out_c * cols,
+            0,
+            ckk * cols,
+            0,
+            0,
+            _ctx_ptr(w._device),
+        ),
+        arg_dtypes=(w._dtype, w._dtype),
+        output_dtypes=(out._dtype,),
+        flags={"TRANSPOSE_B": False},
+        keepalive=(out, w),
+    )
+    return out
+
+
+def _try_tf32_conv_bmm(
+    w: TorchMojoTensor,
+    a: TorchMojoTensor,
+    col_ptr: int,
+    n: int,
+    out_c: int,
+    cols: int,
+    ckk: int,
+) -> TorchMojoTensor | None:
+    """Dense conv GEMM (shared weight x per-sample im2col) via the opt-in
+    TF32 BMM, or ``None``. Same numerics policy as ``_try_tf32_bmm``: TF32 is
+    off when the user asked for full FP32 (`torch.set_float32_matmul_precision
+    ("highest")`) -- the repo has no separate `torch.backends.cudnn.
+    allow_tf32`-style policy for convolution, so this follows the exact gate
+    the mm/bmm TF32 paths already use."""
+    if torch.get_float32_matmul_precision() == "highest":
+        return None
+    if (
+        w._dtype != DType.float32
+        or w._device != a._device
+        or w._device.label != "gpu"
+        or w._device.api != "cuda"
+        or w._device.architecture_name != "sm_90a"
+        or min(n, out_c, cols, ckk) <= 0
+        or not _tf32_bridge_available()
+    ):
+        return None
+    out = _alloc((n, out_c, cols), w._dtype, w._device)
+    _call_mojo(
+        _Tf32MatmulExtension,
+        "Tf32BmmF32",
+        (
+            out._ptr,
+            w._ptr,
+            col_ptr,
+            n,
+            out_c,
+            cols,
+            ckk,
+            out_c * cols,
+            0,
+            ckk * cols,
+            0,
+            0,
+            _ctx_ptr(w._device),
+        ),
+        arg_dtypes=(w._dtype, w._dtype),
+        output_dtypes=(out._dtype,),
+        flags={"TRANSPOSE_B": False},
+        keepalive=(out, w),
+    )
+    return out
 
 
 def fast_aten_convolution(
@@ -9061,29 +9177,42 @@ def fast_aten_convolution(
                     keepalive=(col, a),
                 )
                 col_ptr = col._ptr
-            out = _alloc((n, out_c, cols), a._dtype, a._device)
             if groups == 1:
-                _call_mojo(
-                    _MatmulExtension,
-                    "Bmm",
-                    (
-                        out._ptr,
-                        w._ptr,
-                        col_ptr,
-                        (n, out_c, cols, ckk, 0, 1),
-                        a._dtype.value,
-                        ctx,
-                    ),
-                    arg_dtypes=(w._dtype, a._dtype),
-                    output_dtypes=(out._dtype,),
-                    # Same define shape as every other Bmm site: the shared-A
-                    # broadcast is RUNTIME data (the trailing 1 in the params
-                    # tuple, matmul_ops._bmm_go), so naming it here would only
-                    # fork this call site onto a second .so of identical code.
-                    flags={"TRANSPOSE_B": False},
-                    keepalive=(out, w),
-                )
+                # H100 tensor cores first: bf16/f16 through the same Bmm16
+                # kernel fast_aten_bmm already builds, f32 through the same
+                # opt-in TF32 route _try_tf32_mm already gates. Both decline
+                # (return None) off sm_90a, off their dtype, or with the
+                # bridge sources missing, and the plain SIMT Bmm below is the
+                # fallback for every regime they decline, including grouped
+                # convs (untouched, handled in the `else` branch).
+                out = _try_gemm16_conv_bmm(w, a, col_ptr, n, out_c, cols, ckk)
+                if out is None:
+                    out = _try_tf32_conv_bmm(w, a, col_ptr, n, out_c, cols, ckk)
+                if out is None:
+                    out = _alloc((n, out_c, cols), a._dtype, a._device)
+                    _call_mojo(
+                        _MatmulExtension,
+                        "Bmm",
+                        (
+                            out._ptr,
+                            w._ptr,
+                            col_ptr,
+                            (n, out_c, cols, ckk, 0, 1),
+                            a._dtype.value,
+                            ctx,
+                        ),
+                        arg_dtypes=(w._dtype, a._dtype),
+                        output_dtypes=(out._dtype,),
+                        # Same define shape as every other Bmm site: the
+                        # shared-A broadcast is RUNTIME data (the trailing 1
+                        # in the params tuple, matmul_ops._bmm_go), so naming
+                        # it here would only fork this call site onto a
+                        # second .so of identical code.
+                        flags={"TRANSPOSE_B": False},
+                        keepalive=(out, w),
+                    )
             else:
+                out = _alloc((n, out_c, cols), a._dtype, a._device)
                 # Channel-major im2col rows make each group a contiguous
                 # (crs_g, cols) slice; run one offset GEMM per (sample, group).
                 crs_g = c_per_group * kh * kw

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -40,6 +40,9 @@ from torch_mojo_backend.eager_kernels.activation_backward_ops import (
 from torch_mojo_backend.eager_kernels.activation_forward_ops import (
     ActivationForwardExtension as _ActivationForwardExtension,
 )
+from torch_mojo_backend.eager_kernels.conv_igemm_ops import (
+    ConvIgemmExtension as _ConvIgemmExtension,
+)
 from torch_mojo_backend.eager_kernels.conv_ops import ConvExtension as _ConvExtension
 from torch_mojo_backend.eager_kernels.data_movement_ops import (
     DataMovementExtension as _DataMovementExtension,
@@ -9104,6 +9107,146 @@ def _try_tf32_conv_bmm(
     return out
 
 
+# ---------------------------------------------------------------------------
+# Implicit-GEMM conv2d (sm_90a): the (N*OH*OW) x (R*S*C) patch matrix is never
+# written to memory. The hardware im2col TMA reads each B tile straight out of
+# an NHWC copy of the activation, so the route costs one NCHW->NHWC pass plus
+# the GEMM, where the materialized route costs a full im2col write + read
+# (89% of the body conv's device time) plus the same GEMM. Measured on an
+# H100 PCIe at a 1395 MHz pin, bf16 N32xC64x56x56 K64 k3s1: 59.0 us vs
+# 861 us on the materialized route and 71.95 us for cuDNN (0.82x cuDNN).
+#
+# Everything the route cannot do stays on the materialized route: grouped
+# convolution (not implemented here at all), stride != 1, dilation != 1,
+# 1x1 filters (which skip im2col entirely there and are already at 0.94x
+# cuDNN), thin-C shapes like a 3-channel stem, and float32/TF32 (feasible --
+# the descriptor path is dtype-generic -- but the 128 B swizzle makes the
+# k-tile, the C padding and the wgmma shape all change with the element
+# width, so it is a separate piece of work and is not built).
+# ---------------------------------------------------------------------------
+
+_CONV_IGEMM_SOURCE_PATHS = (
+    eager_kernels._PACKAGE_DIR / _ConvIgemmExtension.MOJO_FILE,
+    eager_kernels._PACKAGE_DIR / "wgmma_c_epilogue.mojo",
+)
+
+# 16-bit only: the kernel is a wgmma path whose k-tile is one 128 B swizzle
+# row. float16 is the same instruction with a different operand token and the
+# Mojo source instantiates for it, but only bfloat16 has been measured, so
+# only bfloat16 is admitted here.
+_CONV_IGEMM_DTYPES = (DType.bfloat16,)
+
+# C is padded up to the 64-channel k-tile and the padded reduction is real
+# work: at C = 32 the GEMM already does 2x the necessary math, and a
+# 3-channel stem would do 21x. Below this the materialized route wins.
+_CONV_IGEMM_MIN_C = 32
+# With BM = 64 a ragged out_c wastes up to half of every output tile.
+_CONV_IGEMM_MIN_OUT_C = 32
+_CONV_IGEMM_CHANNEL_TILE = 64
+
+
+def _conv_igemm_bridge_available() -> bool:
+    """Whether the implicit-GEMM conv bridge and its sources are present."""
+    return _bridge_available("conv_igemm", _CONV_IGEMM_SOURCE_PATHS)
+
+
+def _conv_igemm_descriptor_legal(ph: int, pw: int, kh: int, kw: int) -> bool:
+    """Whether the im2col TMA descriptor this conv needs is legal at all.
+
+    `cuTensorMapEncodeIm2col` takes the pixel-box corners as SIGNED CHAR --
+    both corners of both spatial dimensions must land in [-128, 127] -- and
+    the per-transaction im2col offsets (the filter taps this kernel issues,
+    0..R-1 and 0..S-1) are limited to [0, 255]. The two failure modes differ
+    and both have to be caught HERE, before anything is allocated: an illegal
+    corner makes descriptor creation fail outright, while an illegal tap is
+    undefined behaviour at the instruction and does not fail loudly. E.g.
+    N=1, C=64, H=W=7, K=64, R=257, S=3, pad=(128, 1) satisfies every other
+    condition on this route and produces tap r = 256.
+    """
+    corners = (-ph, -pw, ph - (kh - 1), pw - (kw - 1))
+    return (
+        all(-128 <= corner <= 127 for corner in corners)
+        and kh - 1 <= 255
+        and kw - 1 <= 255
+    )
+
+
+def _try_conv_igemm(
+    a: TorchMojoTensor,
+    w: TorchMojoTensor,
+    in_shape: tuple[int, int, int, int],
+    filt: tuple[int, int, int],
+    strides: tuple[int, int],
+    pads: tuple[int, int],
+    dils: tuple[int, int],
+    out_hw: tuple[int, int],
+    ctx: int,
+) -> TorchMojoTensor | None:
+    """Dense conv2d forward through the sm_90a implicit GEMM, or ``None`` when
+    any gate declines (the caller then takes the materialized im2col route).
+
+    Only ``groups == 1`` reaches here; grouped convolution is not implemented
+    by this kernel.
+    """
+    n, c, in_h, in_w = in_shape
+    out_c, kh, kw = filt
+    ph, pw = pads
+    out_h, out_w = out_hw
+    if (
+        a._dtype not in _CONV_IGEMM_DTYPES
+        or w._dtype != a._dtype
+        or w._device != a._device
+        or a._device.label != "gpu"
+        or a._device.api != "cuda"
+        or a._device.architecture_name != "sm_90a"
+        or not _conv_igemm_bridge_available()
+    ):
+        return None
+    if strides != (1, 1) or dils != (1, 1):
+        # The box convention (lower = -pad, upper = pad - (filter - 1)) makes
+        # the pixel box the output grid, which is only true at stride 1;
+        # dilation needs a different box.
+        return None
+    if kh * kw <= 1:
+        # A 1x1 conv has no im2col on the materialized route either (the NCHW
+        # input is reread in place) and is already faster than cuDNN there;
+        # routing it here would only add the NHWC pass.
+        return None
+    if c < _CONV_IGEMM_MIN_C or out_c < _CONV_IGEMM_MIN_OUT_C:
+        return None
+    if min(n, in_h, in_w, out_h, out_w) <= 0:
+        return None
+    if not _conv_igemm_descriptor_legal(ph, pw, kh, kw):
+        return None
+    c_pad = (
+        (c + _CONV_IGEMM_CHANNEL_TILE - 1) // _CONV_IGEMM_CHANNEL_TILE
+    ) * _CONV_IGEMM_CHANNEL_TILE
+    # Scratch: the NHWC activation and the k-major weight. Both are smaller
+    # than the (n, C*R*S, OH*OW) column buffer this route replaces -- the
+    # activation by R*S, the weight by the batch.
+    act = _alloc((n, in_h, in_w, c_pad), a._dtype, a._device)
+    wpack = _alloc((out_c, kh * kw * c_pad), a._dtype, a._device)
+    out = _alloc((n, out_c, out_h * out_w), a._dtype, a._device)
+    _call_mojo(
+        _ConvIgemmExtension,
+        "ConvIgemm",
+        (
+            out._ptr,
+            act._ptr,
+            wpack._ptr,
+            a._ptr,
+            w._ptr,
+            (n, c, c_pad, in_h, in_w, out_c, kh, kw, ph, pw, out_h, out_w),
+            a._dtype.value,
+            ctx,
+        ),
+        arg_dtypes=(a._dtype,),
+        output_dtypes=(out._dtype,),
+        keepalive=(out, act, wpack, a, w),
+    )
+    return out
+
+
 def fast_aten_convolution(
     input, weight, bias, stride, padding, dilation, transposed, output_padding, groups
 ):
@@ -9142,107 +9285,124 @@ def fast_aten_convolution(
             ctx = _ctx_ptr(a._device)
             cols = out_h * out_w
             ckk = c * kh * kw
-            if (kh, kw, sh, sw, ph, pw, dh, dw) == (1, 1, 1, 1, 0, 0, 1, 1):
-                # 1x1 stride-1 conv: NCHW input already is the col matrix.
-                col_ptr = a._ptr
-            else:
-                col = _alloc((n, ckk, cols), a._dtype, a._device)
-                _call_mojo(
-                    _ConvExtension,
-                    "Im2col",
-                    (
-                        col._ptr,
-                        a._ptr,
-                        (
-                            in_h,
-                            in_w,
-                            out_h,
-                            out_w,
-                            kh,
-                            kw,
-                            sh,
-                            sw,
-                            ph,
-                            pw,
-                            dh,
-                            dw,
-                            c,
-                            n,
-                        ),
-                        a._dtype.value,
-                        ctx,
-                    ),
-                    arg_dtypes=(a._dtype,),
-                    output_dtypes=(col._dtype,),
-                    keepalive=(col, a),
-                )
-                col_ptr = col._ptr
+            out = None
             if groups == 1:
-                # H100 tensor cores first: bf16/f16 through the same Bmm16
-                # kernel fast_aten_bmm already builds, f32 through the same
-                # opt-in TF32 route _try_tf32_mm already gates. Both decline
-                # (return None) off sm_90a, off their dtype, or with the
-                # bridge sources missing, and the plain SIMT Bmm below is the
-                # fallback for every regime they decline, including grouped
-                # convs (untouched, handled in the `else` branch).
-                out = _try_gemm16_conv_bmm(w, a, col_ptr, n, out_c, cols, ckk)
-                if out is None:
-                    out = _try_tf32_conv_bmm(w, a, col_ptr, n, out_c, cols, ckk)
-                if out is None:
-                    out = _alloc((n, out_c, cols), a._dtype, a._device)
+                # Implicit GEMM (the patch matrix is never materialized) when
+                # the shape is inside its domain; everything else, grouped
+                # convs included, falls through to the im2col route below.
+                out = _try_conv_igemm(
+                    a,
+                    w,
+                    (n, c, in_h, in_w),
+                    (out_c, kh, kw),
+                    (sh, sw),
+                    (ph, pw),
+                    (dh, dw),
+                    (out_h, out_w),
+                    ctx,
+                )
+            if out is None:
+                if (kh, kw, sh, sw, ph, pw, dh, dw) == (1, 1, 1, 1, 0, 0, 1, 1):
+                    # 1x1 stride-1 conv: NCHW input already is the col matrix.
+                    col_ptr = a._ptr
+                else:
+                    col = _alloc((n, ckk, cols), a._dtype, a._device)
                     _call_mojo(
-                        _MatmulExtension,
-                        "Bmm",
+                        _ConvExtension,
+                        "Im2col",
                         (
-                            out._ptr,
-                            w._ptr,
-                            col_ptr,
-                            (n, out_c, cols, ckk, 0, 1),
+                            col._ptr,
+                            a._ptr,
+                            (
+                                in_h,
+                                in_w,
+                                out_h,
+                                out_w,
+                                kh,
+                                kw,
+                                sh,
+                                sw,
+                                ph,
+                                pw,
+                                dh,
+                                dw,
+                                c,
+                                n,
+                            ),
                             a._dtype.value,
                             ctx,
                         ),
-                        arg_dtypes=(w._dtype, a._dtype),
-                        output_dtypes=(out._dtype,),
-                        # Same define shape as every other Bmm site: the
-                        # shared-A broadcast is RUNTIME data (the trailing 1
-                        # in the params tuple, matmul_ops._bmm_go), so naming
-                        # it here would only fork this call site onto a
-                        # second .so of identical code.
-                        flags={"TRANSPOSE_B": False},
-                        keepalive=(out, w),
+                        arg_dtypes=(a._dtype,),
+                        output_dtypes=(col._dtype,),
+                        keepalive=(col, a),
                     )
-            else:
-                out = _alloc((n, out_c, cols), a._dtype, a._device)
-                # Channel-major im2col rows make each group a contiguous
-                # (crs_g, cols) slice; run one offset GEMM per (sample, group).
-                crs_g = c_per_group * kh * kw
-                oc_g = out_c // groups
-                for s in range(n):
-                    for g in range(groups):
+                    col_ptr = col._ptr
+                if groups == 1:
+                    # H100 tensor cores first: bf16/f16 through the same Bmm16
+                    # kernel fast_aten_bmm already builds, f32 through the same
+                    # opt-in TF32 route _try_tf32_mm already gates. Both decline
+                    # (return None) off sm_90a, off their dtype, or with the
+                    # bridge sources missing, and the plain SIMT Bmm below is the
+                    # fallback for every regime they decline, including grouped
+                    # convs (untouched, handled in the `else` branch).
+                    out = _try_gemm16_conv_bmm(w, a, col_ptr, n, out_c, cols, ckk)
+                    if out is None:
+                        out = _try_tf32_conv_bmm(w, a, col_ptr, n, out_c, cols, ckk)
+                    if out is None:
+                        out = _alloc((n, out_c, cols), a._dtype, a._device)
                         _call_mojo(
                             _MatmulExtension,
-                            "Matmul",
+                            "Bmm",
                             (
                                 out._ptr,
                                 w._ptr,
                                 col_ptr,
-                                (
-                                    oc_g,
-                                    cols,
-                                    crs_g,
-                                    0,
-                                    (s * out_c + g * oc_g) * cols,
-                                    g * oc_g * crs_g,
-                                    (s * c + g * c_per_group) * kh * kw * cols,
-                                ),
+                                (n, out_c, cols, ckk, 0, 1),
                                 a._dtype.value,
                                 ctx,
                             ),
                             arg_dtypes=(w._dtype, a._dtype),
                             output_dtypes=(out._dtype,),
+                            # Same define shape as every other Bmm site: the
+                            # shared-A broadcast is RUNTIME data (the trailing 1
+                            # in the params tuple, matmul_ops._bmm_go), so naming
+                            # it here would only fork this call site onto a
+                            # second .so of identical code.
                             flags={"TRANSPOSE_B": False},
                             keepalive=(out, w),
                         )
+                else:
+                    out = _alloc((n, out_c, cols), a._dtype, a._device)
+                    # Channel-major im2col rows make each group a contiguous
+                    # (crs_g, cols) slice; run one offset GEMM per (sample, group).
+                    crs_g = c_per_group * kh * kw
+                    oc_g = out_c // groups
+                    for s in range(n):
+                        for g in range(groups):
+                            _call_mojo(
+                                _MatmulExtension,
+                                "Matmul",
+                                (
+                                    out._ptr,
+                                    w._ptr,
+                                    col_ptr,
+                                    (
+                                        oc_g,
+                                        cols,
+                                        crs_g,
+                                        0,
+                                        (s * out_c + g * oc_g) * cols,
+                                        g * oc_g * crs_g,
+                                        (s * c + g * c_per_group) * kh * kw * cols,
+                                    ),
+                                    a._dtype.value,
+                                    ctx,
+                                ),
+                                arg_dtypes=(w._dtype, a._dtype),
+                                output_dtypes=(out._dtype,),
+                                flags={"TRANSPOSE_B": False},
+                                keepalive=(out, w),
+                            )
             if bias_t is not None:
                 _call_mojo(
                     _ConvExtension,

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -8682,103 +8682,178 @@ def _fast_aten_bmm_transpose_b(input, mat2):
 # ---------------------------------------------------------------------------
 
 
-def _try_gemm16_conv_bmm(
-    w: TorchMojoTensor, col: TorchMojoTensor, n: int, out_c: int, cols: int, ckk: int
+def _try_gemm16_shared_a_bmm(
+    a: TorchMojoTensor, b: TorchMojoTensor, batch: int, m: int, n: int, k: int
 ) -> TorchMojoTensor | None:
-    """Dense conv GEMM (shared weight x per-sample im2col) via Bmm16, or
-    ``None``. ``w`` is the contiguous (out_c, ckk) weight; ``col`` OWNS the
-    per-sample dense row-major (ckk, cols) im2col slice (or, for 1x1
-    stride-1 convs, ``col`` IS the input tensor, reread in place). ``col``
-    must be the actual owning tensor, not a bare pointer: under the default
-    kernel-call queue the launch this enqueues can be deferred behind a
-    still-compiling specialization, and the caller's last reference to the
-    buffer it points at can drop before that launch runs unless this frame's
-    keepalive tuple holds it too (queue rule 3, call_queue.py:18-26)."""
+    """``batch`` GEMMs of one shared (m, k) ``a`` against a densely packed
+    per-sample (k, n) ``b``, through Bmm16, or ``None`` when a gate declines.
+
+    Both convolution directions have this shape: the forward multiplies the
+    (out_c, C*R*S) weight by each sample's im2col, and the data gradient
+    multiplies the (C*R*S, out_c) transposed weight by each sample's
+    grad_output. ``b`` must be the tensor that OWNS the buffer it points at
+    (the im2col slice, or the input tensor itself for a 1x1 conv), not a bare
+    pointer: under the default kernel-call queue the launch this enqueues can
+    be deferred behind a still-compiling specialization, and the caller's last
+    reference to the buffer can drop before that launch runs unless this
+    frame's keepalive tuple holds it too (queue rule 3, call_queue.py:18-26).
+    """
     if (
-        w._dtype not in _GEMM16_DTYPES
-        or w._device != col._device
-        or w._device.label != "gpu"
-        or w._device.api != "cuda"
-        or w._device.architecture_name != "sm_90a"
-        or min(n, out_c, cols, ckk) <= 0
+        a._dtype not in _GEMM16_DTYPES
+        or a._device != b._device
+        or a._device.label != "gpu"
+        or a._device.api != "cuda"
+        or a._device.architecture_name != "sm_90a"
+        or min(batch, m, n, k) <= 0
         or not _gemm16_bridge_available()
     ):
         return None
-    out = _alloc((n, out_c, cols), w._dtype, w._device)
+    out = _alloc((batch, m, n), a._dtype, a._device)
     _call_mojo(
         _Gemm16MatmulExtension,
         "Bmm16",
         (
             out._ptr,
-            w._ptr,
-            col._ptr,
+            a._ptr,
+            b._ptr,
+            batch,
+            m,
             n,
-            out_c,
-            cols,
-            ckk,
-            out_c * cols,
+            k,
+            m * n,
             0,
-            ckk * cols,
+            k * n,
             0,
             0,
-            _ctx_ptr(w._device),
+            _ctx_ptr(a._device),
         ),
-        arg_dtypes=(w._dtype, w._dtype),
+        arg_dtypes=(a._dtype, a._dtype),
         output_dtypes=(out._dtype,),
         flags={"TRANSPOSE_B": False},
-        keepalive=(out, w, col),
+        keepalive=(out, a, b),
     )
     return out
 
 
-def _try_tf32_conv_bmm(
-    w: TorchMojoTensor, col: TorchMojoTensor, n: int, out_c: int, cols: int, ckk: int
+def _try_tf32_shared_a_bmm(
+    a: TorchMojoTensor, b: TorchMojoTensor, batch: int, m: int, n: int, k: int
 ) -> TorchMojoTensor | None:
-    """Dense conv GEMM (shared weight x per-sample im2col) via the opt-in
-    TF32 BMM, or ``None``. Same numerics policy as ``_try_tf32_bmm``: TF32 is
-    off when the user asked for full FP32 (`torch.set_float32_matmul_precision
-    ("highest")`) -- the repo has no separate `torch.backends.cudnn.
-    allow_tf32`-style policy for convolution, so this follows the exact gate
-    the mm/bmm TF32 paths already use. ``col`` must be the tensor that OWNS
-    the im2col buffer (or the input tensor itself for a 1x1 conv), not a
-    bare pointer -- see ``_try_gemm16_conv_bmm``'s docstring for why."""
+    """The same shared-A batched GEMM through the opt-in TF32 BMM, or
+    ``None``. Same numerics policy as ``_try_tf32_bmm``: TF32 is off when the
+    user asked for full FP32 (`torch.set_float32_matmul_precision("highest")`)
+    -- the repo has no separate `torch.backends.cudnn.allow_tf32`-style policy
+    for convolution, so this follows the exact gate the mm/bmm TF32 paths
+    already use. ``b`` must own its buffer, for the reason
+    ``_try_gemm16_shared_a_bmm``'s docstring gives."""
     if torch.get_float32_matmul_precision() == "highest":
         return None
     if (
-        w._dtype != DType.float32
-        or w._device != col._device
-        or w._device.label != "gpu"
-        or w._device.api != "cuda"
-        or w._device.architecture_name != "sm_90a"
-        or min(n, out_c, cols, ckk) <= 0
+        a._dtype != DType.float32
+        or a._device != b._device
+        or a._device.label != "gpu"
+        or a._device.api != "cuda"
+        or a._device.architecture_name != "sm_90a"
+        or min(batch, m, n, k) <= 0
         or not _tf32_bridge_available()
     ):
         return None
-    out = _alloc((n, out_c, cols), w._dtype, w._device)
+    out = _alloc((batch, m, n), a._dtype, a._device)
     _call_mojo(
         _Tf32MatmulExtension,
         "Tf32BmmF32",
         (
             out._ptr,
-            w._ptr,
-            col._ptr,
+            a._ptr,
+            b._ptr,
+            batch,
+            m,
             n,
-            out_c,
-            cols,
-            ckk,
-            out_c * cols,
+            k,
+            m * n,
             0,
-            ckk * cols,
+            k * n,
             0,
             0,
-            _ctx_ptr(w._device),
+            _ctx_ptr(a._device),
         ),
-        arg_dtypes=(w._dtype, w._dtype),
+        arg_dtypes=(a._dtype, a._dtype),
         output_dtypes=(out._dtype,),
         flags={"TRANSPOSE_B": False},
-        keepalive=(out, w, col),
+        keepalive=(out, a, b),
     )
     return out
+
+
+def _conv_shared_a_bmm(
+    a: TorchMojoTensor, b: TorchMojoTensor, batch: int, m: int, n: int, k: int, ctx: int
+) -> TorchMojoTensor:
+    """``batch`` GEMMs of the shared (m, k) ``a`` against per-sample (k, n)
+    ``b``, on whichever route this device and dtype support.
+
+    H100 tensor cores first: bf16/f16 through the same Bmm16 kernel
+    `fast_aten_bmm` already builds, f32 through the same opt-in TF32 route
+    `_try_tf32_mm` already gates. Both decline (return None) off sm_90a, off
+    their dtype, or with the bridge sources missing, and the plain SIMT Bmm
+    below is the fallback for every regime they decline.
+    """
+    out = _try_gemm16_shared_a_bmm(a, b, batch, m, n, k)
+    if out is None:
+        out = _try_tf32_shared_a_bmm(a, b, batch, m, n, k)
+    if out is None:
+        out = _alloc((batch, m, n), a._dtype, a._device)
+        _call_mojo(
+            _MatmulExtension,
+            "Bmm",
+            (out._ptr, a._ptr, b._ptr, (batch, m, n, k, 0, 1), a._dtype.value, ctx),
+            arg_dtypes=(a._dtype, b._dtype),
+            output_dtypes=(out._dtype,),
+            # Same define shape as every other Bmm site: the shared-A
+            # broadcast is RUNTIME data (the trailing 1 in the params tuple,
+            # matmul_ops._bmm_go), so naming it here would only fork this call
+            # site onto a second .so of identical code.
+            flags={"TRANSPOSE_B": False},
+            # `b` owns the pointer this call names and must outlive the
+            # deferred launch (kernel queue rule 3, call_queue.py:18-26) -- it
+            # is not implied by `a`/`out` alone.
+            keepalive=(out, a, b),
+        )
+    return out
+
+
+def _conv_col_matrix(
+    a: TorchMojoTensor, geom: tuple[int, ...], ctx: int
+) -> TorchMojoTensor | object:
+    """The tensor OWNING the (batch, C*KH*KW, OH*OW) im2col patch buffer of
+    the NCHW ``a``.
+
+    ``geom`` is the shared convolution descriptor
+    ``(n, c, in_h, in_w, out_h, out_w, kh, kw, sh, sw, ph, pw, dh, dw)``.
+    A 1x1 stride-1 unpadded convolution has no im2col at all: every patch is
+    one pixel, so the NCHW input already IS that matrix and is reread in
+    place. ``a`` ITSELF comes back then -- still rank 4, not a reshaped view
+    -- because it is the tensor that must appear in the keepalive of every
+    queued GEMM reading the buffer (queue rule 3), and a caller that needs
+    the (batch, C*KH*KW, OH*OW) matrix shape should take that view itself.
+    """
+    n, c, in_h, in_w, out_h, out_w, kh, kw, sh, sw, ph, pw, dh, dw = geom
+    if (kh, kw, sh, sw, ph, pw, dh, dw) == (1, 1, 1, 1, 0, 0, 1, 1):
+        return a
+    col = _alloc((n, c * kh * kw, out_h * out_w), a._dtype, a._device)
+    _call_mojo(
+        _ConvExtension,
+        "Im2col",
+        (
+            col._ptr,
+            a._ptr,
+            (in_h, in_w, out_h, out_w, kh, kw, sh, sw, ph, pw, dh, dw, c, n),
+            a._dtype.value,
+            ctx,
+        ),
+        arg_dtypes=(a._dtype,),
+        output_dtypes=(col._dtype,),
+        keepalive=(col, a),
+    )
+    return col
 
 
 # ---------------------------------------------------------------------------
@@ -8961,6 +9036,14 @@ def fast_aten_convolution(
         and groups >= 1
         and None not in (strides, pads, dils)
         and 0 not in a._shape
+        # ATen's own "expected weight to be at least 1 at dimension 0" check
+        # does NOT run on the PrivateUse1 path -- a 0-out-channel conv that
+        # CPU and CUDA both reject returns a 0-channel tensor here instead --
+        # so this is the only thing between a degenerate weight and a made-up
+        # answer. It also keeps `fast_aten_convolution_backward`'s matching
+        # gate implied by this one, which that function's header explains is
+        # the difference between a NotImplementedError and a dead process.
+        and 0 not in w._shape
     ):
         n, c, in_h, in_w = a._shape
         out_c, c_per_group, kh, kw = w._shape
@@ -9003,83 +9086,16 @@ def fast_aten_convolution(
                     ctx,
                 )
             if out is None:
-                if (kh, kw, sh, sw, ph, pw, dh, dw) == (1, 1, 1, 1, 0, 0, 1, 1):
-                    # 1x1 stride-1 conv: NCHW input already is the col matrix.
-                    # `col` ALIASES `a` (no allocation) -- it is still the
-                    # tensor that must stay alive until every GEMM reading it
-                    # has launched, so it flows through exactly like the
-                    # materialized branch's freshly allocated `col` below.
-                    col = a
-                else:
-                    col = _alloc((n, ckk, cols), a._dtype, a._device)
-                    _call_mojo(
-                        _ConvExtension,
-                        "Im2col",
-                        (
-                            col._ptr,
-                            a._ptr,
-                            (
-                                in_h,
-                                in_w,
-                                out_h,
-                                out_w,
-                                kh,
-                                kw,
-                                sh,
-                                sw,
-                                ph,
-                                pw,
-                                dh,
-                                dw,
-                                c,
-                                n,
-                            ),
-                            a._dtype.value,
-                            ctx,
-                        ),
-                        arg_dtypes=(a._dtype,),
-                        output_dtypes=(col._dtype,),
-                        keepalive=(col, a),
-                    )
+                # `col` is the tensor that OWNS the column buffer -- or, for a
+                # 1x1 stride-1 conv, a zero-copy view of `a` itself -- and must
+                # stay alive until every GEMM reading it has launched.
+                col = _conv_col_matrix(
+                    a,
+                    (n, c, in_h, in_w, out_h, out_w, kh, kw, sh, sw, ph, pw, dh, dw),
+                    ctx,
+                )
                 if groups == 1:
-                    # H100 tensor cores first: bf16/f16 through the same Bmm16
-                    # kernel fast_aten_bmm already builds, f32 through the same
-                    # opt-in TF32 route _try_tf32_mm already gates. Both decline
-                    # (return None) off sm_90a, off their dtype, or with the
-                    # bridge sources missing, and the plain SIMT Bmm below is the
-                    # fallback for every regime they decline, including grouped
-                    # convs (untouched, handled in the `else` branch).
-                    out = _try_gemm16_conv_bmm(w, col, n, out_c, cols, ckk)
-                    if out is None:
-                        out = _try_tf32_conv_bmm(w, col, n, out_c, cols, ckk)
-                    if out is None:
-                        out = _alloc((n, out_c, cols), a._dtype, a._device)
-                        _call_mojo(
-                            _MatmulExtension,
-                            "Bmm",
-                            (
-                                out._ptr,
-                                w._ptr,
-                                col._ptr,
-                                (n, out_c, cols, ckk, 0, 1),
-                                a._dtype.value,
-                                ctx,
-                            ),
-                            arg_dtypes=(w._dtype, a._dtype),
-                            output_dtypes=(out._dtype,),
-                            # Same define shape as every other Bmm site: the
-                            # shared-A broadcast is RUNTIME data (the trailing 1
-                            # in the params tuple, matmul_ops._bmm_go), so naming
-                            # it here would only fork this call site onto a
-                            # second .so of identical code.
-                            flags={"TRANSPOSE_B": False},
-                            # `col` (the im2col buffer, or `a` itself for the
-                            # 1x1 fast path) owns the pointer this call names
-                            # and must outlive the deferred launch (kernel
-                            # queue rule 3, call_queue.py:18-26) -- it is not
-                            # implied by `w`/`out` alone.
-                            keepalive=(out, w, col),
-                        )
+                    out = _conv_shared_a_bmm(w, col, n, out_c, cols, ckk, ctx)
                 else:
                     out = _alloc((n, out_c, cols), a._dtype, a._device)
                     # Channel-major im2col rows make each group a contiguous
@@ -9137,6 +9153,356 @@ def fast_aten_convolution(
                 out._offset,
             )
     return NOT_HANDLED
+
+
+# ---------------------------------------------------------------------------
+# Convolution backward, pure Mojo: the same im2col + GEMM machinery the
+# forward uses, with the operand roles permuted.
+#
+#   grad_bias   = grad_output summed over (N, H, W)             -- one reduce
+#   grad_weight = grad_output x im2col(input)^T, summed over N  -- the forward
+#                 GEMM with the two operands' roles swapped, so the reduction
+#                 runs over the OUTPUT pixels instead of over the patch rows
+#   grad_input  = col2im(weight^T x grad_output)                -- the forward
+#                 GEMM transposed, then im2col's adjoint
+#
+# `transposed=True` (the backward of a conv_transpose forward, where the
+# input/grad_output roles swap again) is declined: the forward declines it
+# too, so nothing on this device can produce such a node.
+#
+# THAT SENTENCE IS AN INVARIANT, not an aside. This function runs INSIDE the
+# autograd engine, where a raise does not propagate -- it aborts the process
+# (the unwind hazard `mojo_device/aten_ops/autograd_preflight.py` documents at
+# length), and returning NOT_HANDLED from here raises. So every gate below
+# must already be implied by something that ran EARLIER, on a path that can
+# still raise: either a gate `fast_aten_convolution` enforces (transposed,
+# rank, dtype, device, 0-sized extents) or a check ATen itself makes before
+# dispatch (`aten::convolution` rejects `out_c % groups != 0` outright, which
+# is why the same condition here is unreachable defensive code, and why the
+# forward carries a matching `0 not in w._shape` -- ATen's degenerate-weight
+# check does NOT run on this dispatch path, so that one had to be added there
+# rather than assumed). Adding a gate to this function that the forward does
+# not imply turns a would-be NotImplementedError into a dead process, so a new
+# restriction belongs in the FORWARD first.
+#
+# Memory: the weight gradient's per-sample partials are an (N, out_c, C*R*S)
+# buffer that a batch reduce then collapses, because none of the GEMM routes
+# here takes a beta=1 accumulator. That is smaller than the column buffer it
+# is computed from whenever out_c <= OH*OW, i.e. everywhere except the last
+# stages of a deep net; folding N into the GEMM's K instead would need a
+# patch-major im2col variant (a transposed write, so a different kernel, not
+# a different index), which is left for a perf pass.
+# ---------------------------------------------------------------------------
+
+
+def _conv_backward_1d(
+    grad_output: TorchMojoTensor,
+    input: TorchMojoTensor,
+    weight: TorchMojoTensor,
+    bias_sizes: Sequence[int] | None,
+    stride: Sequence[int],
+    padding: Sequence[int],
+    dilation: Sequence[int],
+    transposed: bool,
+    output_padding: Sequence[int],
+    groups: int,
+    output_mask: Sequence[bool],
+) -> object:
+    """conv1d backward through the rank-4 path, or ``NOT_HANDLED``.
+
+    Same lift the rank-3 forward uses: a synthetic size-1 H axis (unsqueeze
+    is a zero-copy view) makes the rank-3 operands look like conv2d's, the
+    single stride/padding/dilation maps onto the W axis while the dummy H
+    axis is pinned at kernel=1/stride=1/pad=0/dilation=1, and the two
+    spatial gradients get the dummy axis squeezed back out (zero-copy
+    again). grad_bias is already (out_c,) and needs no fixup.
+    """
+    lifted = [fast_aten_unsqueeze(t, 2) for t in (grad_output, input, weight)]
+    if any(t is NOT_HANDLED for t in lifted):
+        return NOT_HANDLED
+    result = fast_aten_convolution_backward(
+        lifted[0],
+        lifted[1],
+        lifted[2],
+        bias_sizes,
+        [1, int(stride[0])],
+        [0, int(padding[0])],
+        [1, int(dilation[0])],
+        transposed,
+        [0, int(output_padding[0]) if output_padding else 0],
+        groups,
+        output_mask,
+    )
+    if result is NOT_HANDLED:
+        return NOT_HANDLED
+    grad_input, grad_weight, grad_bias = result
+    if grad_input is not None:
+        grad_input = fast_aten_squeeze_dim(grad_input, 2)
+        if grad_input is NOT_HANDLED:
+            return NOT_HANDLED
+    if grad_weight is not None:
+        grad_weight = fast_aten_squeeze_dim(grad_weight, 2)
+        if grad_weight is NOT_HANDLED:
+            return NOT_HANDLED
+    return grad_input, grad_weight, grad_bias
+
+
+def fast_aten_convolution_backward(
+    grad_output: TorchMojoTensor,
+    input: TorchMojoTensor,
+    weight: TorchMojoTensor,
+    bias_sizes: Sequence[int] | None,
+    stride: Sequence[int],
+    padding: Sequence[int],
+    dilation: Sequence[int],
+    transposed: bool,
+    output_padding: Sequence[int],
+    groups: int,
+    output_mask: Sequence[bool],
+) -> object:
+    """``(grad_input, grad_weight, grad_bias)``, or ``NOT_HANDLED``.
+
+    Each gradient is ``None`` when its ``output_mask`` slot is off, matching
+    the undefined tensor ATen returns there. The return type can only be
+    ``object``: ``NOT_HANDLED`` is a bare ``object()`` sentinel with no type
+    of its own, so any union naming it collapses to ``object`` anyway.
+    """
+    # `_t()` first, like the forward: every gate below reads metadata only, so
+    # a call this cannot serve must return NOT_HANDLED before `_tc()` pays for
+    # the allocation + copy of a non-contiguous operand.
+    g = _t(grad_output)
+    a = _t(input)
+    w = _t(weight)
+    if g is None or a is None or w is None or transposed:
+        return NOT_HANDLED
+    mask = tuple(output_mask) if isinstance(output_mask, list | tuple) else ()
+    if len(mask) != 3 or any(not isinstance(requested, bool) for requested in mask):
+        return NOT_HANDLED
+    if not isinstance(groups, int) or isinstance(groups, bool) or groups < 1:
+        return NOT_HANDLED
+    if not all(
+        isinstance(seq, list | tuple) and all(isinstance(i, int) for i in seq)
+        for seq in (stride, padding, dilation)
+    ):
+        return NOT_HANDLED
+    if not isinstance(output_padding, list | tuple):
+        return NOT_HANDLED
+
+    if len(a._shape) == 3 and len(w._shape) == 3 and len(g._shape) == 3:
+        if len(stride) != 1 or len(padding) != 1 or len(dilation) != 1:
+            return NOT_HANDLED
+        return _conv_backward_1d(
+            g,
+            a,
+            w,
+            bias_sizes,
+            stride,
+            padding,
+            dilation,
+            transposed,
+            output_padding,
+            groups,
+            output_mask,
+        )
+
+    strides = _pair(list(stride))
+    pads = _pair(list(padding))
+    dils = _pair(list(dilation))
+    if (
+        len(a._shape) != 4
+        or len(w._shape) != 4
+        or len(g._shape) != 4
+        or a._dtype != w._dtype
+        or a._dtype != g._dtype
+        or a._dtype not in _FLOAT_DTYPES
+        or a._device != w._device
+        or a._device != g._device
+        or None in (strides, pads, dils)
+        or 0 in a._shape
+        or 0 in w._shape
+    ):
+        return NOT_HANDLED
+
+    n, c, in_h, in_w = a._shape
+    out_c, c_per_group, kh, kw = w._shape
+    sh, sw = strides
+    ph, pw = pads
+    dh, dw = dils
+    if min(sh, sw, dh, dw) < 1 or min(ph, pw) < 0:
+        return NOT_HANDLED
+    if c_per_group * groups != c or out_c % groups != 0:
+        return NOT_HANDLED
+    out_h = (in_h + 2 * ph - (dh * (kh - 1) + 1)) // sh + 1
+    out_w = (in_w + 2 * pw - (dw * (kw - 1) + 1)) // sw + 1
+    if out_h < 1 or out_w < 1 or tuple(g._shape) != (n, out_c, out_h, out_w):
+        return NOT_HANDLED
+
+    if not any(mask):
+        return None, None, None
+
+    # Only now is a non-contiguous operand worth what `_tc()` costs. The
+    # gradients come back plain contiguous NCHW whatever memory format the
+    # forward's operands had: the autograd engine validates a returned
+    # gradient's shape, dtype, layout and device but never its strides
+    # (torch/csrc/autograd/engine.cpp, validate_outputs_impl), so a
+    # channels_last input is a performance question here, not a correctness
+    # one.
+    g = _tc(g)
+    ctx = _ctx_ptr(a._device)
+    cols = out_h * out_w
+    ckk = c * kh * kw
+    crs_g = c_per_group * kh * kw
+    oc_g = out_c // groups
+    geom = (n, c, in_h, in_w, out_h, out_w, kh, kw, sh, sw, ph, pw, dh, dw)
+    g3 = fast_aten_view(g, (n, out_c, cols))
+    if g3 is NOT_HANDLED:
+        return NOT_HANDLED
+
+    grad_bias = None
+    if mask[2]:
+        # ATen computes this straight from grad_output whenever the backend
+        # did not (Convolution.cpp's `grad_output.sum({0, 2, 3})` fixup), so
+        # `bias_sizes` is not consulted: it only records that the forward HAD
+        # a bias, which mask[2] already says. The reduce accumulates in fp32
+        # for every float dtype, like torch's own.
+        grad_bias = fast_aten_sum(g, dim=[0, 2, 3], keepdim=False)
+        if grad_bias is NOT_HANDLED:
+            return NOT_HANDLED
+
+    grad_weight = None
+    if mask[1]:
+        col = _conv_col_matrix(_tc(a), geom, ctx)
+        # The 1x1 fast path hands back the rank-4 input itself (it owns the
+        # buffer); the GEMMs below want the (n, ckk, cols) matrix shape.
+        col_matrix = (
+            col if len(col._shape) == 3 else fast_aten_view(col, (n, ckk, cols))
+        )
+        if col_matrix is NOT_HANDLED:
+            return NOT_HANDLED
+        if groups == 1:
+            # (n, out_c, cols) x (n, ckk, cols)^T: both operands have the
+            # reduction (the output pixels) as their contiguous last axis,
+            # which is exactly the transposed-B GEMM the accepted Bmm16 /
+            # TF32 / SIMT routes already build for `fast_aten_bmm`.
+            partial = _fast_aten_bmm_transpose_b(g3, col_matrix)
+            if partial is NOT_HANDLED:
+                return NOT_HANDLED
+        else:
+            # Channel-major im2col rows make each group's rows a contiguous
+            # (crs_g, cols) slice, and each group's grad_output rows a
+            # contiguous (oc_g, cols) slice, so one offset GEMM per
+            # (sample, group) covers it -- the same decomposition the
+            # forward's grouped path uses, with transpose_b flipped on.
+            partial = _alloc((n, out_c, crs_g), a._dtype, a._device)
+            for s in range(n):
+                for group in range(groups):
+                    _call_mojo(
+                        _MatmulExtension,
+                        "Matmul",
+                        (
+                            partial._ptr,
+                            g3._ptr,
+                            col_matrix._ptr,
+                            (
+                                oc_g,
+                                crs_g,
+                                cols,
+                                1,
+                                (s * out_c + group * oc_g) * crs_g,
+                                (s * out_c + group * oc_g) * cols,
+                                (s * ckk + group * crs_g) * cols,
+                            ),
+                            a._dtype.value,
+                            ctx,
+                        ),
+                        arg_dtypes=(g3._dtype, col_matrix._dtype),
+                        output_dtypes=(partial._dtype,),
+                        flags={"TRANSPOSE_B": True},
+                        keepalive=(partial, g3, col_matrix),
+                    )
+        # The batch reduce is what turns the per-sample products into the
+        # gradient; it accumulates in fp32 like every float reduce here.
+        summed = fast_aten_sum(partial, dim=[0], keepdim=False)
+        if summed is NOT_HANDLED:
+            return NOT_HANDLED
+        grad_weight = fast_aten_view(summed, w._shape)
+        if grad_weight is NOT_HANDLED:
+            return NOT_HANDLED
+        # Drop the column buffer and the partials before the data gradient
+        # allocates its own column-sized buffer below: both are the size of
+        # an im2col, and nothing reads them past this point.
+        col = None
+        col_matrix = None
+        partial = None
+
+    grad_input = None
+    if mask[0]:
+        # (groups, crs_g, oc_g): each group's weight block transposed, which
+        # is what the data gradient's GEMM reads as its shared A operand. The
+        # weight is the smallest tensor in the op, so materializing its
+        # transpose costs nothing next to the column buffer below.
+        wt = fast_aten_view(_tc(w), (groups, oc_g, crs_g))
+        if wt is NOT_HANDLED:
+            return NOT_HANDLED
+        wt = fast_aten_transpose(wt, 1, 2)
+        if wt is NOT_HANDLED:
+            return NOT_HANDLED
+        wt = _tc(wt)
+        if groups == 1:
+            colgrad = _conv_shared_a_bmm(wt, g3, n, ckk, cols, out_c, ctx)
+        else:
+            colgrad = _alloc((n, ckk, cols), a._dtype, a._device)
+            for s in range(n):
+                for group in range(groups):
+                    _call_mojo(
+                        _MatmulExtension,
+                        "Matmul",
+                        (
+                            colgrad._ptr,
+                            wt._ptr,
+                            g3._ptr,
+                            (
+                                crs_g,
+                                cols,
+                                oc_g,
+                                0,
+                                (s * ckk + group * crs_g) * cols,
+                                group * crs_g * oc_g,
+                                (s * out_c + group * oc_g) * cols,
+                            ),
+                            a._dtype.value,
+                            ctx,
+                        ),
+                        arg_dtypes=(wt._dtype, g3._dtype),
+                        output_dtypes=(colgrad._dtype,),
+                        flags={"TRANSPOSE_B": False},
+                        keepalive=(colgrad, wt, g3),
+                    )
+        if (kh, kw, sh, sw, ph, pw, dh, dw) == (1, 1, 1, 1, 0, 0, 1, 1):
+            # The adjoint of the forward's in-place 1x1 column matrix: every
+            # patch is one pixel, so col2im is the identity and the columns
+            # ARE the gradient image.
+            grad_input = fast_aten_view(colgrad, (n, c, in_h, in_w))
+        else:
+            grad_input = _alloc((n, c, in_h, in_w), a._dtype, a._device)
+            _call_mojo(
+                _ConvExtension,
+                "Col2im",
+                (
+                    grad_input._ptr,
+                    colgrad._ptr,
+                    (in_h, in_w, out_h, out_w, kh, kw, sh, sw, ph, pw, dh, dw, c, n),
+                    a._dtype.value,
+                    ctx,
+                ),
+                arg_dtypes=(colgrad._dtype,),
+                output_dtypes=(grad_input._dtype,),
+                keepalive=(grad_input, colgrad),
+            )
+        if grad_input is NOT_HANDLED:
+            return NOT_HANDLED
+
+    return grad_input, grad_weight, grad_bias
 
 
 # ---------------------------------------------------------------------------

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -8664,7 +8664,123 @@ def _fast_aten_bmm_transpose_b(input, mat2):
 # (K,C,R,S) weight used as-is and NCHW output — no layout permutes.
 # Grouped convolutions slice the channel-major im2col rows and weights per
 # group with element offsets.
+#
+# The dense (groups == 1) GEMM shares one (out_c, ckk) weight matrix across
+# every sample in the batch, so it is a batched matmul with the A operand
+# broadcast (runtime batch stride 0) against a densely packed, per-sample
+# row-major im2col B. That broadcast is not a new capability: the plain SIMT
+# `Bmm` bridge below already threads it through as `a_shared`, and the
+# accepted Bmm16/Tf32BmmF32 kernels already prove their pointer arithmetic
+# for a zero A-batch-stride (`_opt_bmm_address_proof`'s `a_bstride > 0`
+# guards treat zero as the trivial case). The two helpers below reuse those
+# kernels as-is: same OP name, same dtype, same TRANSPOSE_B=False flag that
+# fast_aten_bmm already builds, so no new compiled variant exists anywhere
+# because of them -- only a new host-side call site.
 # ---------------------------------------------------------------------------
+
+
+def _try_gemm16_conv_bmm(
+    w: TorchMojoTensor,
+    a: TorchMojoTensor,
+    col_ptr: int,
+    n: int,
+    out_c: int,
+    cols: int,
+    ckk: int,
+) -> TorchMojoTensor | None:
+    """Dense conv GEMM (shared weight x per-sample im2col) via Bmm16, or
+    ``None``. ``w`` is the contiguous (out_c, ckk) weight; ``col_ptr`` is the
+    per-sample dense row-major (ckk, cols) im2col slice (or, for 1x1
+    stride-1 convs, the NCHW input reread in place)."""
+    if (
+        w._dtype not in _GEMM16_DTYPES
+        or w._device != a._device
+        or w._device.label != "gpu"
+        or w._device.api != "cuda"
+        or w._device.architecture_name != "sm_90a"
+        or min(n, out_c, cols, ckk) <= 0
+        or not _gemm16_bridge_available()
+    ):
+        return None
+    out = _alloc((n, out_c, cols), w._dtype, w._device)
+    _call_mojo(
+        _Gemm16MatmulExtension,
+        "Bmm16",
+        (
+            out._ptr,
+            w._ptr,
+            col_ptr,
+            n,
+            out_c,
+            cols,
+            ckk,
+            out_c * cols,
+            0,
+            ckk * cols,
+            0,
+            0,
+            _ctx_ptr(w._device),
+        ),
+        arg_dtypes=(w._dtype, w._dtype),
+        output_dtypes=(out._dtype,),
+        flags={"TRANSPOSE_B": False},
+        keepalive=(out, w),
+    )
+    return out
+
+
+def _try_tf32_conv_bmm(
+    w: TorchMojoTensor,
+    a: TorchMojoTensor,
+    col_ptr: int,
+    n: int,
+    out_c: int,
+    cols: int,
+    ckk: int,
+) -> TorchMojoTensor | None:
+    """Dense conv GEMM (shared weight x per-sample im2col) via the opt-in
+    TF32 BMM, or ``None``. Same numerics policy as ``_try_tf32_bmm``: TF32 is
+    off when the user asked for full FP32 (`torch.set_float32_matmul_precision
+    ("highest")`) -- the repo has no separate `torch.backends.cudnn.
+    allow_tf32`-style policy for convolution, so this follows the exact gate
+    the mm/bmm TF32 paths already use."""
+    if torch.get_float32_matmul_precision() == "highest":
+        return None
+    if (
+        w._dtype != DType.float32
+        or w._device != a._device
+        or w._device.label != "gpu"
+        or w._device.api != "cuda"
+        or w._device.architecture_name != "sm_90a"
+        or min(n, out_c, cols, ckk) <= 0
+        or not _tf32_bridge_available()
+    ):
+        return None
+    out = _alloc((n, out_c, cols), w._dtype, w._device)
+    _call_mojo(
+        _Tf32MatmulExtension,
+        "Tf32BmmF32",
+        (
+            out._ptr,
+            w._ptr,
+            col_ptr,
+            n,
+            out_c,
+            cols,
+            ckk,
+            out_c * cols,
+            0,
+            ckk * cols,
+            0,
+            0,
+            _ctx_ptr(w._device),
+        ),
+        arg_dtypes=(w._dtype, w._dtype),
+        output_dtypes=(out._dtype,),
+        flags={"TRANSPOSE_B": False},
+        keepalive=(out, w),
+    )
+    return out
 
 
 def fast_aten_convolution(
@@ -8740,29 +8856,42 @@ def fast_aten_convolution(
                     keepalive=(col, a),
                 )
                 col_ptr = col._ptr
-            out = _alloc((n, out_c, cols), a._dtype, a._device)
             if groups == 1:
-                _call_mojo(
-                    _MatmulExtension,
-                    "Bmm",
-                    (
-                        out._ptr,
-                        w._ptr,
-                        col_ptr,
-                        (n, out_c, cols, ckk, 0, 1),
-                        a._dtype.value,
-                        ctx,
-                    ),
-                    arg_dtypes=(w._dtype, a._dtype),
-                    output_dtypes=(out._dtype,),
-                    # Same define shape as every other Bmm site: the shared-A
-                    # broadcast is RUNTIME data (the trailing 1 in the params
-                    # tuple, matmul_ops._bmm_go), so naming it here would only
-                    # fork this call site onto a second .so of identical code.
-                    flags={"TRANSPOSE_B": False},
-                    keepalive=(out, w),
-                )
+                # H100 tensor cores first: bf16/f16 through the same Bmm16
+                # kernel fast_aten_bmm already builds, f32 through the same
+                # opt-in TF32 route _try_tf32_mm already gates. Both decline
+                # (return None) off sm_90a, off their dtype, or with the
+                # bridge sources missing, and the plain SIMT Bmm below is the
+                # fallback for every regime they decline, including grouped
+                # convs (untouched, handled in the `else` branch).
+                out = _try_gemm16_conv_bmm(w, a, col_ptr, n, out_c, cols, ckk)
+                if out is None:
+                    out = _try_tf32_conv_bmm(w, a, col_ptr, n, out_c, cols, ckk)
+                if out is None:
+                    out = _alloc((n, out_c, cols), a._dtype, a._device)
+                    _call_mojo(
+                        _MatmulExtension,
+                        "Bmm",
+                        (
+                            out._ptr,
+                            w._ptr,
+                            col_ptr,
+                            (n, out_c, cols, ckk, 0, 1),
+                            a._dtype.value,
+                            ctx,
+                        ),
+                        arg_dtypes=(w._dtype, a._dtype),
+                        output_dtypes=(out._dtype,),
+                        # Same define shape as every other Bmm site: the
+                        # shared-A broadcast is RUNTIME data (the trailing 1
+                        # in the params tuple, matmul_ops._bmm_go), so naming
+                        # it here would only fork this call site onto a
+                        # second .so of identical code.
+                        flags={"TRANSPOSE_B": False},
+                        keepalive=(out, w),
+                    )
             else:
+                out = _alloc((n, out_c, cols), a._dtype, a._device)
                 # Channel-major im2col rows make each group a contiguous
                 # (crs_g, cols) slice; run one offset GEMM per (sample, group).
                 crs_g = c_per_group * kh * kw

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -8683,21 +8683,20 @@ def _fast_aten_bmm_transpose_b(input, mat2):
 
 
 def _try_gemm16_conv_bmm(
-    w: TorchMojoTensor,
-    a: TorchMojoTensor,
-    col_ptr: int,
-    n: int,
-    out_c: int,
-    cols: int,
-    ckk: int,
+    w: TorchMojoTensor, col: TorchMojoTensor, n: int, out_c: int, cols: int, ckk: int
 ) -> TorchMojoTensor | None:
     """Dense conv GEMM (shared weight x per-sample im2col) via Bmm16, or
-    ``None``. ``w`` is the contiguous (out_c, ckk) weight; ``col_ptr`` is the
+    ``None``. ``w`` is the contiguous (out_c, ckk) weight; ``col`` OWNS the
     per-sample dense row-major (ckk, cols) im2col slice (or, for 1x1
-    stride-1 convs, the NCHW input reread in place)."""
+    stride-1 convs, ``col`` IS the input tensor, reread in place). ``col``
+    must be the actual owning tensor, not a bare pointer: under the default
+    kernel-call queue the launch this enqueues can be deferred behind a
+    still-compiling specialization, and the caller's last reference to the
+    buffer it points at can drop before that launch runs unless this frame's
+    keepalive tuple holds it too (queue rule 3, call_queue.py:18-26)."""
     if (
         w._dtype not in _GEMM16_DTYPES
-        or w._device != a._device
+        or w._device != col._device
         or w._device.label != "gpu"
         or w._device.api != "cuda"
         or w._device.architecture_name != "sm_90a"
@@ -8712,7 +8711,7 @@ def _try_gemm16_conv_bmm(
         (
             out._ptr,
             w._ptr,
-            col_ptr,
+            col._ptr,
             n,
             out_c,
             cols,
@@ -8727,31 +8726,27 @@ def _try_gemm16_conv_bmm(
         arg_dtypes=(w._dtype, w._dtype),
         output_dtypes=(out._dtype,),
         flags={"TRANSPOSE_B": False},
-        keepalive=(out, w),
+        keepalive=(out, w, col),
     )
     return out
 
 
 def _try_tf32_conv_bmm(
-    w: TorchMojoTensor,
-    a: TorchMojoTensor,
-    col_ptr: int,
-    n: int,
-    out_c: int,
-    cols: int,
-    ckk: int,
+    w: TorchMojoTensor, col: TorchMojoTensor, n: int, out_c: int, cols: int, ckk: int
 ) -> TorchMojoTensor | None:
     """Dense conv GEMM (shared weight x per-sample im2col) via the opt-in
     TF32 BMM, or ``None``. Same numerics policy as ``_try_tf32_bmm``: TF32 is
     off when the user asked for full FP32 (`torch.set_float32_matmul_precision
     ("highest")`) -- the repo has no separate `torch.backends.cudnn.
     allow_tf32`-style policy for convolution, so this follows the exact gate
-    the mm/bmm TF32 paths already use."""
+    the mm/bmm TF32 paths already use. ``col`` must be the tensor that OWNS
+    the im2col buffer (or the input tensor itself for a 1x1 conv), not a
+    bare pointer -- see ``_try_gemm16_conv_bmm``'s docstring for why."""
     if torch.get_float32_matmul_precision() == "highest":
         return None
     if (
         w._dtype != DType.float32
-        or w._device != a._device
+        or w._device != col._device
         or w._device.label != "gpu"
         or w._device.api != "cuda"
         or w._device.architecture_name != "sm_90a"
@@ -8766,7 +8761,7 @@ def _try_tf32_conv_bmm(
         (
             out._ptr,
             w._ptr,
-            col_ptr,
+            col._ptr,
             n,
             out_c,
             cols,
@@ -8781,7 +8776,7 @@ def _try_tf32_conv_bmm(
         arg_dtypes=(w._dtype, w._dtype),
         output_dtypes=(out._dtype,),
         flags={"TRANSPOSE_B": False},
-        keepalive=(out, w),
+        keepalive=(out, w, col),
     )
     return out
 
@@ -8941,6 +8936,7 @@ def fast_aten_convolution(
         and not transposed
         and (bias is None or bias_t is not None)
         and a._dtype == w._dtype
+        and a._device == w._device
         and a._dtype in _FLOAT_DTYPES
         and len(a._shape) == 4
         and len(w._shape) == 4
@@ -8958,7 +8954,9 @@ def fast_aten_convolution(
         out_w = (in_w + 2 * pw - (dw * (kw - 1) + 1)) // sw + 1
         if c_per_group * groups == c and out_h > 0 and out_w > 0:
             if bias_t is not None and (
-                bias_t._dtype != a._dtype or tuple(bias_t._shape) != (out_c,)
+                bias_t._dtype != a._dtype
+                or bias_t._device != a._device
+                or tuple(bias_t._shape) != (out_c,)
             ):
                 return NOT_HANDLED
             ctx = _ctx_ptr(a._device)
@@ -8983,7 +8981,11 @@ def fast_aten_convolution(
             if out is None:
                 if (kh, kw, sh, sw, ph, pw, dh, dw) == (1, 1, 1, 1, 0, 0, 1, 1):
                     # 1x1 stride-1 conv: NCHW input already is the col matrix.
-                    col_ptr = a._ptr
+                    # `col` ALIASES `a` (no allocation) -- it is still the
+                    # tensor that must stay alive until every GEMM reading it
+                    # has launched, so it flows through exactly like the
+                    # materialized branch's freshly allocated `col` below.
+                    col = a
                 else:
                     col = _alloc((n, ckk, cols), a._dtype, a._device)
                     _call_mojo(
@@ -9015,7 +9017,6 @@ def fast_aten_convolution(
                         output_dtypes=(col._dtype,),
                         keepalive=(col, a),
                     )
-                    col_ptr = col._ptr
                 if groups == 1:
                     # H100 tensor cores first: bf16/f16 through the same Bmm16
                     # kernel fast_aten_bmm already builds, f32 through the same
@@ -9024,9 +9025,9 @@ def fast_aten_convolution(
                     # bridge sources missing, and the plain SIMT Bmm below is the
                     # fallback for every regime they decline, including grouped
                     # convs (untouched, handled in the `else` branch).
-                    out = _try_gemm16_conv_bmm(w, a, col_ptr, n, out_c, cols, ckk)
+                    out = _try_gemm16_conv_bmm(w, col, n, out_c, cols, ckk)
                     if out is None:
-                        out = _try_tf32_conv_bmm(w, a, col_ptr, n, out_c, cols, ckk)
+                        out = _try_tf32_conv_bmm(w, col, n, out_c, cols, ckk)
                     if out is None:
                         out = _alloc((n, out_c, cols), a._dtype, a._device)
                         _call_mojo(
@@ -9035,7 +9036,7 @@ def fast_aten_convolution(
                             (
                                 out._ptr,
                                 w._ptr,
-                                col_ptr,
+                                col._ptr,
                                 (n, out_c, cols, ckk, 0, 1),
                                 a._dtype.value,
                                 ctx,
@@ -9048,7 +9049,12 @@ def fast_aten_convolution(
                             # it here would only fork this call site onto a
                             # second .so of identical code.
                             flags={"TRANSPOSE_B": False},
-                            keepalive=(out, w),
+                            # `col` (the im2col buffer, or `a` itself for the
+                            # 1x1 fast path) owns the pointer this call names
+                            # and must outlive the deferred launch (kernel
+                            # queue rule 3, call_queue.py:18-26) -- it is not
+                            # implied by `w`/`out` alone.
+                            keepalive=(out, w, col),
                         )
                 else:
                     out = _alloc((n, out_c, cols), a._dtype, a._device)
@@ -9064,7 +9070,7 @@ def fast_aten_convolution(
                                 (
                                     out._ptr,
                                     w._ptr,
-                                    col_ptr,
+                                    col._ptr,
                                     (
                                         oc_g,
                                         cols,
@@ -9080,7 +9086,10 @@ def fast_aten_convolution(
                                 arg_dtypes=(w._dtype, a._dtype),
                                 output_dtypes=(out._dtype,),
                                 flags={"TRANSPOSE_B": False},
-                                keepalive=(out, w),
+                                # Same rationale as the dense-path Bmm call
+                                # above: `col` owns the pointer this call
+                                # names.
+                                keepalive=(out, w, col),
                             )
             if bias_t is not None:
                 _call_mojo(

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -8788,7 +8788,19 @@ def _try_tf32_conv_bmm(
 # the GEMM, where the materialized route costs a full im2col write + read
 # (89% of the body conv's device time) plus the same GEMM. Measured on an
 # H100 PCIe at a 1395 MHz pin, bf16 N32xC64x56x56 K64 k3s1: 59.0 us vs
-# 861 us on the materialized route and 71.95 us for cuDNN (0.82x cuDNN).
+# 861 us on the materialized route and 71.95 us for cuDNN.
+#
+# That 71.95 us is cuDNN reached the way torch.nn.Conv2d reaches it from an
+# NCHW tensor, which is NOT cuDNN's own speed: 31.2 us of convolution plus
+# 41.0 us of nchwToNhwc / nhwcToNchw transposes around it. Handed a
+# channels_last tensor cuDNN does the same convolution in 33.9 us with no
+# transposes, against 54.6 us for the three kernels of this route (NHWC
+# pass + weight repack + implicit GEMM). So this route wins the NCHW
+# comparison because it needs no layout conversion, and loses the
+# same-layout comparison by ~1.6x. Both statements are about the forward
+# convolution only; the separate BiasAddChan kernel is another 12.2 us here
+# against 25.3 us for the elementwise bias add torch appends to cuDNN, which
+# is where a further chunk of the end-to-end ratio comes from.
 #
 # Everything the route cannot do stays on the materialized route: grouped
 # convolution (not implemented here at all), stride != 1, dilation != 1,

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -8924,9 +8924,14 @@ def _try_conv_igemm(
 def fast_aten_convolution(
     input, weight, bias, stride, padding, dilation, transposed, output_padding, groups
 ):
-    a = _tc(input)
-    w = _tc(weight)
-    bias_t = _tc(bias) if bias is not None else None
+    # `_t()` here, not `_tc()`: every gate below (dtype, device, shape) reads
+    # metadata only, so it must run before paying for `_tc()`'s allocation +
+    # copy of a non-contiguous operand -- including the device-equality gate,
+    # so a cross-device pair returns NOT_HANDLED before any materialization,
+    # not just before the eventual conv kernel launch.
+    a = _t(input)
+    w = _t(weight)
+    bias_t = _t(bias) if bias is not None else None
     strides = _pair(list(stride))
     pads = _pair(list(padding))
     dils = _pair(list(dilation))
@@ -8959,6 +8964,13 @@ def fast_aten_convolution(
                 or tuple(bias_t._shape) != (out_c,)
             ):
                 return NOT_HANDLED
+            # Every reason to decline (dtype/device/shape mismatch, a
+            # cross-device pair included) has already returned NOT_HANDLED
+            # above; only now is a non-contiguous operand worth the
+            # allocation + copy `_tc()` pays for.
+            a = _tc(a)
+            w = _tc(w)
+            bias_t = _tc(bias_t) if bias_t is not None else None
             ctx = _ctx_ptr(a._device)
             cols = out_h * out_w
             ckk = c * kh * kw

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -39,6 +39,9 @@ from torch_mojo_backend.eager_kernels.activation_backward_ops import (
 from torch_mojo_backend.eager_kernels.activation_forward_ops import (
     ActivationForwardExtension as _ActivationForwardExtension,
 )
+from torch_mojo_backend.eager_kernels.conv_igemm_ops import (
+    ConvIgemmExtension as _ConvIgemmExtension,
+)
 from torch_mojo_backend.eager_kernels.conv_ops import ConvExtension as _ConvExtension
 from torch_mojo_backend.eager_kernels.data_movement_ops import (
     DataMovementExtension as _DataMovementExtension,
@@ -8783,6 +8786,146 @@ def _try_tf32_conv_bmm(
     return out
 
 
+# ---------------------------------------------------------------------------
+# Implicit-GEMM conv2d (sm_90a): the (N*OH*OW) x (R*S*C) patch matrix is never
+# written to memory. The hardware im2col TMA reads each B tile straight out of
+# an NHWC copy of the activation, so the route costs one NCHW->NHWC pass plus
+# the GEMM, where the materialized route costs a full im2col write + read
+# (89% of the body conv's device time) plus the same GEMM. Measured on an
+# H100 PCIe at a 1395 MHz pin, bf16 N32xC64x56x56 K64 k3s1: 59.0 us vs
+# 861 us on the materialized route and 71.95 us for cuDNN (0.82x cuDNN).
+#
+# Everything the route cannot do stays on the materialized route: grouped
+# convolution (not implemented here at all), stride != 1, dilation != 1,
+# 1x1 filters (which skip im2col entirely there and are already at 0.94x
+# cuDNN), thin-C shapes like a 3-channel stem, and float32/TF32 (feasible --
+# the descriptor path is dtype-generic -- but the 128 B swizzle makes the
+# k-tile, the C padding and the wgmma shape all change with the element
+# width, so it is a separate piece of work and is not built).
+# ---------------------------------------------------------------------------
+
+_CONV_IGEMM_SOURCE_PATHS = (
+    eager_kernels._PACKAGE_DIR / _ConvIgemmExtension.MOJO_FILE,
+    eager_kernels._PACKAGE_DIR / "wgmma_c_epilogue.mojo",
+)
+
+# 16-bit only: the kernel is a wgmma path whose k-tile is one 128 B swizzle
+# row. float16 is the same instruction with a different operand token and the
+# Mojo source instantiates for it, but only bfloat16 has been measured, so
+# only bfloat16 is admitted here.
+_CONV_IGEMM_DTYPES = (DType.bfloat16,)
+
+# C is padded up to the 64-channel k-tile and the padded reduction is real
+# work: at C = 32 the GEMM already does 2x the necessary math, and a
+# 3-channel stem would do 21x. Below this the materialized route wins.
+_CONV_IGEMM_MIN_C = 32
+# With BM = 64 a ragged out_c wastes up to half of every output tile.
+_CONV_IGEMM_MIN_OUT_C = 32
+_CONV_IGEMM_CHANNEL_TILE = 64
+
+
+def _conv_igemm_bridge_available() -> bool:
+    """Whether the implicit-GEMM conv bridge and its sources are present."""
+    return _bridge_available("conv_igemm", _CONV_IGEMM_SOURCE_PATHS)
+
+
+def _conv_igemm_descriptor_legal(ph: int, pw: int, kh: int, kw: int) -> bool:
+    """Whether the im2col TMA descriptor this conv needs is legal at all.
+
+    `cuTensorMapEncodeIm2col` takes the pixel-box corners as SIGNED CHAR --
+    both corners of both spatial dimensions must land in [-128, 127] -- and
+    the per-transaction im2col offsets (the filter taps this kernel issues,
+    0..R-1 and 0..S-1) are limited to [0, 255]. The two failure modes differ
+    and both have to be caught HERE, before anything is allocated: an illegal
+    corner makes descriptor creation fail outright, while an illegal tap is
+    undefined behaviour at the instruction and does not fail loudly. E.g.
+    N=1, C=64, H=W=7, K=64, R=257, S=3, pad=(128, 1) satisfies every other
+    condition on this route and produces tap r = 256.
+    """
+    corners = (-ph, -pw, ph - (kh - 1), pw - (kw - 1))
+    return (
+        all(-128 <= corner <= 127 for corner in corners)
+        and kh - 1 <= 255
+        and kw - 1 <= 255
+    )
+
+
+def _try_conv_igemm(
+    a: TorchMojoTensor,
+    w: TorchMojoTensor,
+    in_shape: tuple[int, int, int, int],
+    filt: tuple[int, int, int],
+    strides: tuple[int, int],
+    pads: tuple[int, int],
+    dils: tuple[int, int],
+    out_hw: tuple[int, int],
+    ctx: int,
+) -> TorchMojoTensor | None:
+    """Dense conv2d forward through the sm_90a implicit GEMM, or ``None`` when
+    any gate declines (the caller then takes the materialized im2col route).
+
+    Only ``groups == 1`` reaches here; grouped convolution is not implemented
+    by this kernel.
+    """
+    n, c, in_h, in_w = in_shape
+    out_c, kh, kw = filt
+    ph, pw = pads
+    out_h, out_w = out_hw
+    if (
+        a._dtype not in _CONV_IGEMM_DTYPES
+        or w._dtype != a._dtype
+        or w._device != a._device
+        or a._device.label != "gpu"
+        or a._device.api != "cuda"
+        or a._device.architecture_name != "sm_90a"
+        or not _conv_igemm_bridge_available()
+    ):
+        return None
+    if strides != (1, 1) or dils != (1, 1):
+        # The box convention (lower = -pad, upper = pad - (filter - 1)) makes
+        # the pixel box the output grid, which is only true at stride 1;
+        # dilation needs a different box.
+        return None
+    if kh * kw <= 1:
+        # A 1x1 conv has no im2col on the materialized route either (the NCHW
+        # input is reread in place) and is already faster than cuDNN there;
+        # routing it here would only add the NHWC pass.
+        return None
+    if c < _CONV_IGEMM_MIN_C or out_c < _CONV_IGEMM_MIN_OUT_C:
+        return None
+    if min(n, in_h, in_w, out_h, out_w) <= 0:
+        return None
+    if not _conv_igemm_descriptor_legal(ph, pw, kh, kw):
+        return None
+    c_pad = (
+        (c + _CONV_IGEMM_CHANNEL_TILE - 1) // _CONV_IGEMM_CHANNEL_TILE
+    ) * _CONV_IGEMM_CHANNEL_TILE
+    # Scratch: the NHWC activation and the k-major weight. Both are smaller
+    # than the (n, C*R*S, OH*OW) column buffer this route replaces -- the
+    # activation by R*S, the weight by the batch.
+    act = _alloc((n, in_h, in_w, c_pad), a._dtype, a._device)
+    wpack = _alloc((out_c, kh * kw * c_pad), a._dtype, a._device)
+    out = _alloc((n, out_c, out_h * out_w), a._dtype, a._device)
+    _call_mojo(
+        _ConvIgemmExtension,
+        "ConvIgemm",
+        (
+            out._ptr,
+            act._ptr,
+            wpack._ptr,
+            a._ptr,
+            w._ptr,
+            (n, c, c_pad, in_h, in_w, out_c, kh, kw, ph, pw, out_h, out_w),
+            a._dtype.value,
+            ctx,
+        ),
+        arg_dtypes=(a._dtype,),
+        output_dtypes=(out._dtype,),
+        keepalive=(out, act, wpack, a, w),
+    )
+    return out
+
+
 def fast_aten_convolution(
     input, weight, bias, stride, padding, dilation, transposed, output_padding, groups
 ):
@@ -8821,107 +8964,124 @@ def fast_aten_convolution(
             ctx = _ctx_ptr(a._device)
             cols = out_h * out_w
             ckk = c * kh * kw
-            if (kh, kw, sh, sw, ph, pw, dh, dw) == (1, 1, 1, 1, 0, 0, 1, 1):
-                # 1x1 stride-1 conv: NCHW input already is the col matrix.
-                col_ptr = a._ptr
-            else:
-                col = _alloc((n, ckk, cols), a._dtype, a._device)
-                _call_mojo(
-                    _ConvExtension,
-                    "Im2col",
-                    (
-                        col._ptr,
-                        a._ptr,
-                        (
-                            in_h,
-                            in_w,
-                            out_h,
-                            out_w,
-                            kh,
-                            kw,
-                            sh,
-                            sw,
-                            ph,
-                            pw,
-                            dh,
-                            dw,
-                            c,
-                            n,
-                        ),
-                        a._dtype.value,
-                        ctx,
-                    ),
-                    arg_dtypes=(a._dtype,),
-                    output_dtypes=(col._dtype,),
-                    keepalive=(col, a),
-                )
-                col_ptr = col._ptr
+            out = None
             if groups == 1:
-                # H100 tensor cores first: bf16/f16 through the same Bmm16
-                # kernel fast_aten_bmm already builds, f32 through the same
-                # opt-in TF32 route _try_tf32_mm already gates. Both decline
-                # (return None) off sm_90a, off their dtype, or with the
-                # bridge sources missing, and the plain SIMT Bmm below is the
-                # fallback for every regime they decline, including grouped
-                # convs (untouched, handled in the `else` branch).
-                out = _try_gemm16_conv_bmm(w, a, col_ptr, n, out_c, cols, ckk)
-                if out is None:
-                    out = _try_tf32_conv_bmm(w, a, col_ptr, n, out_c, cols, ckk)
-                if out is None:
-                    out = _alloc((n, out_c, cols), a._dtype, a._device)
+                # Implicit GEMM (the patch matrix is never materialized) when
+                # the shape is inside its domain; everything else, grouped
+                # convs included, falls through to the im2col route below.
+                out = _try_conv_igemm(
+                    a,
+                    w,
+                    (n, c, in_h, in_w),
+                    (out_c, kh, kw),
+                    (sh, sw),
+                    (ph, pw),
+                    (dh, dw),
+                    (out_h, out_w),
+                    ctx,
+                )
+            if out is None:
+                if (kh, kw, sh, sw, ph, pw, dh, dw) == (1, 1, 1, 1, 0, 0, 1, 1):
+                    # 1x1 stride-1 conv: NCHW input already is the col matrix.
+                    col_ptr = a._ptr
+                else:
+                    col = _alloc((n, ckk, cols), a._dtype, a._device)
                     _call_mojo(
-                        _MatmulExtension,
-                        "Bmm",
+                        _ConvExtension,
+                        "Im2col",
                         (
-                            out._ptr,
-                            w._ptr,
-                            col_ptr,
-                            (n, out_c, cols, ckk, 0, 1),
+                            col._ptr,
+                            a._ptr,
+                            (
+                                in_h,
+                                in_w,
+                                out_h,
+                                out_w,
+                                kh,
+                                kw,
+                                sh,
+                                sw,
+                                ph,
+                                pw,
+                                dh,
+                                dw,
+                                c,
+                                n,
+                            ),
                             a._dtype.value,
                             ctx,
                         ),
-                        arg_dtypes=(w._dtype, a._dtype),
-                        output_dtypes=(out._dtype,),
-                        # Same define shape as every other Bmm site: the
-                        # shared-A broadcast is RUNTIME data (the trailing 1
-                        # in the params tuple, matmul_ops._bmm_go), so naming
-                        # it here would only fork this call site onto a
-                        # second .so of identical code.
-                        flags={"TRANSPOSE_B": False},
-                        keepalive=(out, w),
+                        arg_dtypes=(a._dtype,),
+                        output_dtypes=(col._dtype,),
+                        keepalive=(col, a),
                     )
-            else:
-                out = _alloc((n, out_c, cols), a._dtype, a._device)
-                # Channel-major im2col rows make each group a contiguous
-                # (crs_g, cols) slice; run one offset GEMM per (sample, group).
-                crs_g = c_per_group * kh * kw
-                oc_g = out_c // groups
-                for s in range(n):
-                    for g in range(groups):
+                    col_ptr = col._ptr
+                if groups == 1:
+                    # H100 tensor cores first: bf16/f16 through the same Bmm16
+                    # kernel fast_aten_bmm already builds, f32 through the same
+                    # opt-in TF32 route _try_tf32_mm already gates. Both decline
+                    # (return None) off sm_90a, off their dtype, or with the
+                    # bridge sources missing, and the plain SIMT Bmm below is the
+                    # fallback for every regime they decline, including grouped
+                    # convs (untouched, handled in the `else` branch).
+                    out = _try_gemm16_conv_bmm(w, a, col_ptr, n, out_c, cols, ckk)
+                    if out is None:
+                        out = _try_tf32_conv_bmm(w, a, col_ptr, n, out_c, cols, ckk)
+                    if out is None:
+                        out = _alloc((n, out_c, cols), a._dtype, a._device)
                         _call_mojo(
                             _MatmulExtension,
-                            "Matmul",
+                            "Bmm",
                             (
                                 out._ptr,
                                 w._ptr,
                                 col_ptr,
-                                (
-                                    oc_g,
-                                    cols,
-                                    crs_g,
-                                    0,
-                                    (s * out_c + g * oc_g) * cols,
-                                    g * oc_g * crs_g,
-                                    (s * c + g * c_per_group) * kh * kw * cols,
-                                ),
+                                (n, out_c, cols, ckk, 0, 1),
                                 a._dtype.value,
                                 ctx,
                             ),
                             arg_dtypes=(w._dtype, a._dtype),
                             output_dtypes=(out._dtype,),
+                            # Same define shape as every other Bmm site: the
+                            # shared-A broadcast is RUNTIME data (the trailing 1
+                            # in the params tuple, matmul_ops._bmm_go), so naming
+                            # it here would only fork this call site onto a
+                            # second .so of identical code.
                             flags={"TRANSPOSE_B": False},
                             keepalive=(out, w),
                         )
+                else:
+                    out = _alloc((n, out_c, cols), a._dtype, a._device)
+                    # Channel-major im2col rows make each group a contiguous
+                    # (crs_g, cols) slice; run one offset GEMM per (sample, group).
+                    crs_g = c_per_group * kh * kw
+                    oc_g = out_c // groups
+                    for s in range(n):
+                        for g in range(groups):
+                            _call_mojo(
+                                _MatmulExtension,
+                                "Matmul",
+                                (
+                                    out._ptr,
+                                    w._ptr,
+                                    col_ptr,
+                                    (
+                                        oc_g,
+                                        cols,
+                                        crs_g,
+                                        0,
+                                        (s * out_c + g * oc_g) * cols,
+                                        g * oc_g * crs_g,
+                                        (s * c + g * c_per_group) * kh * kw * cols,
+                                    ),
+                                    a._dtype.value,
+                                    ctx,
+                                ),
+                                arg_dtypes=(w._dtype, a._dtype),
+                                output_dtypes=(out._dtype,),
+                                flags={"TRANSPOSE_B": False},
+                                keepalive=(out, w),
+                            )
             if bias_t is not None:
                 _call_mojo(
                     _ConvExtension,

--- a/torch_mojo_backend/eager_kernels/conv_igemm_ops/__init__.py
+++ b/torch_mojo_backend/eager_kernels/conv_igemm_ops/__init__.py
@@ -1,0 +1,3 @@
+from .conv_igemm_ops import ConvIgemmExtension
+
+__all__ = ["ConvIgemmExtension"]

--- a/torch_mojo_backend/eager_kernels/conv_igemm_ops/conv_igemm_ops.mojo
+++ b/torch_mojo_backend/eager_kernels/conv_igemm_ops/conv_igemm_ops.mojo
@@ -1,0 +1,982 @@
+"""Implicit-GEMM conv2d forward on sm_90a — no materialized im2col.
+
+The patch matrix is never written to memory: the activation is read tile by
+tile straight out of an NHWC buffer by the hardware im2col TMA
+(`cp.async.bulk.tensor.4d...im2col`, `cta_group=1`).  On the body shape of a
+ResNet (N32 C64 56x56 K64 3x3 s1, bf16) the materialized route spends 89% of
+its device time writing and re-reading that matrix; this route spends none.
+
+Operand assignment (the load-bearing design choice):
+
+    D[oc, p] = sum_k  Wt[oc, k] * Act[p, k]          k = (r, s, c)
+    A = repacked weight   (out_c x K_pad), k-major
+    B = im2col activation (pixels x K_pad), k-major   <- TMA im2col box
+    D = (out_c x pixels)                              <- ALREADY NCHW
+
+The im2col box delivers (pixels_per_column x channels_per_pixel) with the
+channels contiguous, i.e. exactly a k-major B operand, so wgmma consumes it
+with `transpose_b=True` and no shuffle.  Putting `out_c` on the GEMM's M axis
+makes the accumulator tile (out_c x pixels) = NCHW, so unlike cuDNN — whose
+fprop kernels are NHWC-only and pay an `nhwcToNchwKernel` on the way out —
+there is no output transpose at all.  One NCHW->NHWC pass on the input is
+still needed: TMA requires the descriptor's innermost dimension to be
+contiguous, and for im2col that dimension is C.
+
+Body/mainloop/epilogue are the 16-bit GEMM family's "tiny" batched BMM body
+(`gemm16_bmm_v5_kernels._b5_bmm_nn_tiny`): one 128-thread warp group per work
+item, an mbarrier TMA pipeline, wgmma m64 x bn x k16, and — shared verbatim,
+not copied — the C epilogue in `wgmma_c_epilogue.mojo`.  Only the B producer
+is new.
+
+Two pieces of hard-won knowledge about this instruction on sm_90a, both
+established by experiment on an H100 PCIe (the modular repo only exercises
+im2col TMA under B200 gating, so none of it was documented):
+
+  * `layout.tma_async.TMATensorTileIm2col.async_copy` computes WRONG
+    coordinates here — tap (0,0) is exact and every other tap returns pixels
+    displaced in the pixel stream.  The descriptor itself is fine, so this
+    file keeps `TMATensorTileIm2col` only as the descriptor carrier and
+    issues `cp_async_bulk_tensor_shared_cluster_global_im2col` directly with
+    locally computed coordinates.
+  * `_im2col_desc_shape`'s 256-element box cap (`max_tma_box_elements`) is
+    not a hardware limit.  One transaction per B tile (`pixels_per_column ==
+    bn`, 16 KB) is 7.3x faster end to end than the 4-pixel box that cap
+    implies, and is what this kernel issues.
+
+Dtype: the source is width-generic and instantiates for bfloat16 or float16
+(same operand width, same wgmma shapes); only bfloat16 is enabled at the
+dispatch, because only bfloat16 has been measured.
+"""
+
+from std.gpu import (
+    MAX_THREADS_PER_BLOCK_METADATA,
+    block_dim,
+    block_idx,
+    thread_idx,
+)
+from max.gpu.host import DeviceBuffer, DeviceContext
+from max.gpu.host._tensormap import SwizzleMode, create_tensormap_im2col
+from max.gpu.host.nvidia.tma import (
+    TMADescriptor,
+    TensorMapSwizzle,
+    create_tma_descriptor,
+)
+from max.gpu.memory import cp_async_bulk_tensor_shared_cluster_global_im2col
+from max.gpu.sync import barrier
+from std.memory import AddressSpace, stack_allocation
+from std.os import abort
+from std.python import PythonObject
+from std.python._cpython import PyObjectPtr, Py_ssize_t
+from std.python.bindings import PythonModuleBuilder
+from std.sys import size_of
+from std.sys.info import _is_sm_9x
+from std.utils.index import Index, IndexList
+from std.utils.static_tuple import StaticTuple
+
+from layout import Layout, LayoutTensor
+from layout.tensor_core_async import (
+    TensorCoreAsync,
+    tile_layout_k_major,
+    warpgroup_fence,
+)
+from layout.tma_async import (
+    SharedMemBarrier,
+    TMATensorTile,
+    TMATensorTileIm2col,
+)
+
+from op_utils import (
+    _enqueue_cached,
+    _make_ptr,
+    _raw_ctx,
+    _raw_dtype_int,
+    _raw_int,
+    _raw_ret_none,
+    _raw_tuple_int,
+    _spec_unsupported,
+)
+from variant_gates import _dtype_arg_on, _op_on, _register_call
+from wgmma_c_epilogue import _wgmma_store_c_tile
+
+comptime _CI_F32 = DType.float32
+comptime _CI_SWZ = TensorMapSwizzle.SWIZZLE_128B
+# 128 B swizzle / 2 B element: the im2col box's channels_per_pixel, and
+# therefore the GEMM's k-tile.  K_pad is a multiple of it by construction, so
+# one k-tile never straddles two (r, s) taps.
+comptime _CI_BK = 64
+comptime _CI_BM = 64
+# The 16-bit dtypes this kernel is instantiated for.  float16 is byte-for-byte
+# the same tensor-core path as bfloat16 (same operand width, same wgmma tile,
+# same fp32 accumulator); it is listed here so the source stays honest about
+# what it supports, while the Python dispatch admits bfloat16 only.
+comptime _CI_DTYPES = [DType.bfloat16, DType.float16]
+
+
+@always_inline
+def _ci_tag[dtype: DType]() -> StaticString:
+    """The dtype token the kernel names carry: what CUPTI and Nsight print."""
+    comptime if dtype == DType.float16:
+        return "f16"
+    return "bf16"
+
+
+@always_inline
+def _ci_store_tag[tma_store: Bool]() -> StaticString:
+    comptime if tma_store:
+        return ""
+    return "_scalar_c"
+
+
+# ---------------------------------------------------------------------------
+# NCHW -> NHWC with C padded up to a multiple of BK.  The pad channels are
+# zeroed and the repacked weight's matching rows are zero too, so the padded
+# reduction is exact.
+#
+# A thread owns a SUB x SUB (channel x pixel) sub-tile, loads it along the
+# contiguous HW axis, transposes it IN REGISTERS (comptime index math, free)
+# and moves it through shared memory in SUB-element vector accesses; the
+# read-back puts one wavefront on one pixel's channels, so the global store is
+# 128 B contiguous.
+#
+# SUB is 4, not 8, and that is counter-intuitive: the 8-wide (16 B) version
+# measured 0.80 waves per SM on the body shape -- 64 elements per thread
+# leaves too few warps resident to cover DRAM latency, and it ran at 13% of
+# DRAM peak with nothing saturated.  Halving the tile edge quadrupled the warp
+# count for the same bytes and took the body's transpose from ~38 us to
+# ~18 us (1.4 TB/s, i.e. faster than the `nchwToNhwcKernel` cuDNN pays on the
+# same shape).  Fitted on an H100 PCIe.
+# ---------------------------------------------------------------------------
+comptime _CI_T_SUB = 4
+comptime _CI_T_PIX = 16 * _CI_T_SUB  # pixels per tile
+comptime _CI_T_CH = 64  # channels per tile
+comptime _CI_T_THREADS = (_CI_T_PIX // _CI_T_SUB) * (_CI_T_CH // _CI_T_SUB)
+# Row stride of the transposed smem tile, in elements.  The write phase
+# touches rows SUB apart (a thread owns SUB consecutive pixels) and any
+# 16 B-aligned row stride is a multiple of 32 banks, so those rows collide;
+# the channel offset therefore carries an XOR swizzle keyed on the row GROUP
+# (p // SUB).  The read phase has every lane of a wavefront on ONE row, so the
+# swizzle is constant there and costs it nothing.
+comptime _CI_T_SPAD = _CI_T_CH + _CI_T_SUB
+
+
+@always_inline
+def _ci_swz(p: Int) -> Int:
+    """XOR applied to the SUB-element-aligned channel offset of smem row p."""
+    return ((p // _CI_T_SUB) % (_CI_T_CH // _CI_T_SUB)) * _CI_T_SUB
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(_CI_T_THREADS))
+)
+@__name(t"conv_nchw_to_nhwc_padc_{_ci_tag[dtype]()}")
+def _ci_nchw_to_nhwc_kernel[
+    dtype: DType
+](
+    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    hw_arg: Int32,
+    c_arg: Int32,
+    c_pad_arg: Int32,
+):
+    var hw = Int(hw_arg)
+    var c = Int(c_arg)
+    var c_pad = Int(c_pad_arg)
+    var p0 = Int(block_idx.x) * _CI_T_PIX
+    var c0 = Int(block_idx.y) * _CI_T_CH
+    var n = Int(block_idx.z)
+    var tid = Int(thread_idx.x)
+
+    var smem = LayoutTensor[
+        dtype,
+        Layout.row_major(_CI_T_PIX, _CI_T_SPAD),
+        MutAnyOrigin,
+        address_space=AddressSpace.SHARED,
+        alignment=16,
+    ].stack_allocation()
+
+    comptime PG = _CI_T_PIX // _CI_T_SUB
+    var cg = tid // PG
+    var pg = tid % PG
+    var lc = c0 + cg * _CI_T_SUB
+    var lp = p0 + pg * _CI_T_SUB
+
+    var frag = StaticTuple[SIMD[dtype, _CI_T_SUB], _CI_T_SUB]()
+    comptime for j in range(_CI_T_SUB):
+        var v = SIMD[dtype, _CI_T_SUB](0)
+        # The global side stays at natural (2 B) alignment on purpose: the
+        # NCHW plane pitch `hw` is arbitrary, so (n*c + lc + j)*hw + lp is not
+        # a multiple of SUB in general and an alignment claim here would be a
+        # lie -- a vector path over the input has to be gated on the RUNTIME
+        # address, not on a dimension test.
+        if lc + j < c and lp + _CI_T_SUB - 1 < hw:
+            v = in_ptr.load[width=_CI_T_SUB]((n * c + lc + j) * hw + lp)
+        elif lc + j < c:
+            for i in range(_CI_T_SUB):
+                if lp + i < hw:
+                    v[i] = in_ptr[(n * c + lc + j) * hw + lp + i]
+        frag[j] = v
+
+    # register transpose: out row i (pixel) gathers channel j from frag[j][i]
+    comptime for i in range(_CI_T_SUB):
+        var row = SIMD[dtype, _CI_T_SUB](0)
+        comptime for j in range(_CI_T_SUB):
+            row[j] = frag[j][i]
+        var pp = pg * _CI_T_SUB + i
+        # 8 B shared stores.  The element offset is a multiple of SUB
+        # (_CI_T_SPAD * 2 B = 136 B is a multiple of 8, and both the channel
+        # offset and the XOR swizzle are multiples of SUB), so the alignment
+        # is honest -- and without it Mojo defaults to align-4 and the store
+        # reaches PTX as four scalar `st.shared.b16`.
+        smem.ptr.store[alignment=_CI_T_SUB * 2](
+            pp * _CI_T_SPAD + ((cg * _CI_T_SUB) ^ _ci_swz(pp)), row
+        )
+    barrier()
+
+    # read-back: one wavefront covers one pixel's channels = one 128 B store
+    comptime CHUNKS = _CI_T_CH // _CI_T_SUB
+    comptime for m in range(_CI_T_PIX * CHUNKS // _CI_T_THREADS):
+        var slot = m * _CI_T_THREADS + tid
+        var sp = slot // CHUNKS
+        var sc = (slot % CHUNKS) * _CI_T_SUB
+        if p0 + sp < hw and c0 + sc < c_pad:
+            # Both sides are 8 B here: c_pad is a multiple of BK = 64 elements
+            # by construction (the caller pads C up to it), c0 is a multiple
+            # of _CI_T_CH and sc of SUB, and the destination is a fresh
+            # allocation.
+            out_ptr.store[alignment=_CI_T_SUB * 2](
+                (n * hw + p0 + sp) * c_pad + c0 + sc,
+                smem.ptr.load[width=_CI_T_SUB, alignment=_CI_T_SUB * 2](
+                    sp * _CI_T_SPAD + (sc ^ _ci_swz(sp))
+                ),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Weight (out_c, C, R, S) -> A matrix (out_c, K_pad) with
+# k = (r * S + s) * C_pad + c, matching the im2col K decomposition, and zeros
+# wherever c >= C.  A is k-major, which is what wgmma wants for its A operand,
+# so nothing further happens to it in the kernel.
+# ---------------------------------------------------------------------------
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(256))
+)
+@__name(t"conv_weight_repack_rsc_{_ci_tag[dtype]()}")
+def _ci_weight_repack_kernel[
+    dtype: DType
+](
+    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    w_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    out_c_arg: Int32,
+    c_arg: Int32,
+    c_pad_arg: Int32,
+    r_arg: Int32,
+    s_arg: Int32,
+):
+    var out_c = Int(out_c_arg)
+    var c = Int(c_arg)
+    var c_pad = Int(c_pad_arg)
+    var r_f = Int(r_arg)
+    var s_f = Int(s_arg)
+    var k_pad = r_f * s_f * c_pad
+    var idx = Int(block_idx.x) * Int(block_dim.x) + Int(thread_idx.x)
+    if idx >= out_c * k_pad:
+        return
+    var oc = idx // k_pad
+    var k = idx % k_pad
+    var ch = k % c_pad
+    var fi = k // c_pad
+    var val = Scalar[dtype](0)
+    if ch < c:
+        var r = fi // s_f
+        var s = fi % s_f
+        val = w_ptr[((oc * c + ch) * r_f + r) * s_f + s]
+    out_ptr[idx] = val
+
+
+# ---------------------------------------------------------------------------
+# The im2col B producer.
+#
+# One transaction delivers the whole `bn`-pixel B tile x BK channels
+# (pixels_per_column == bn).  The hardware advances the base pixel inside the
+# descriptor's pixel BOX, and with the CUTLASS fprop corner convention
+# (lower = -pad, upper = pad - (filter - 1)) that box IS the (n, oh, ow)
+# output grid, so a transaction that crosses a row -- or a sample -- boundary
+# lands on the right pixels with no software help.
+#
+# Two DIFFERENT out-of-range behaviours matter here and must not be conflated:
+#
+#   * the BASE coordinate handed to the instruction must lie inside the pixel
+#     box; an out-of-box base raises CUDA_ERROR_ILLEGAL_INSTRUCTION.  With one
+#     transaction per B tile the base is (sample, n0) with n0 < OH*OW, so it
+#     is in-box by construction: no clamp, and no guard sample.
+#   * the pixels the transaction walks onto INTERNALLY (the pixels-per-column
+#     tail) are generated by the hardware and follow ordinary im2col
+#     out-of-bounds semantics -- past the end of the tensor they are
+#     zero-filled, not faulted.  Every tail tile of the last sample exercises
+#     this, down to a batch of 1 whose single transaction runs 79 pixels past
+#     the only sample there is.
+# ---------------------------------------------------------------------------
+@always_inline
+def _ci_im2col_load[
+    dtype: DType, bn: Int
+](
+    tma: TMATensorTileIm2col[dtype, 2, Index(bn, _CI_BK), Index(bn, _CI_BK)],
+    dst: UnsafePointer[
+        Scalar[dtype], MutAnyOrigin, address_space=AddressSpace.SHARED
+    ],
+    ref[AddressSpace.SHARED] bar: SharedMemBarrier,
+    ch: Int,  # channel base within C_pad
+    tap_s: Int,
+    tap_r: Int,
+    pix_n: Int,
+    pix_h: Int,
+    pix_w: Int,
+):
+    cp_async_bulk_tensor_shared_cluster_global_im2col[cta_group=1](
+        dst,
+        UnsafePointer(to=tma.descriptor).bitcast[NoneType](),
+        bar.unsafe_ptr(),
+        Index(ch, pix_w, pix_h, pix_n),
+        Index(tap_s, tap_r),
+    )
+
+
+@__llvm_arg_metadata(a_tma, `nvvm.grid_constant`)
+@__llvm_arg_metadata(b_tma, `nvvm.grid_constant`)
+@__llvm_arg_metadata(c_tma, `nvvm.grid_constant`)
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(128))
+)
+@__name(
+    t"conv_fprop_igemm_tma_im2col_{_ci_tag[dtype]()}_m64n{bn}{_ci_store_tag[tma_store]()}"
+)
+def _ci_conv_igemm_kernel[
+    dtype: DType,
+    stages: Int,
+    bn: Int,
+    tma_store: Bool,
+](
+    a_tma: TMATensorTile[
+        dtype, 2, Index(_CI_BM, _CI_BK), Index(_CI_BM, _CI_BK)
+    ],
+    b_tma: TMATensorTileIm2col[dtype, 2, Index(bn, _CI_BK), Index(bn, _CI_BK)],
+    c_tma: TMATensorTile[dtype, 3, Index(1, _CI_BM, 64), Index(1, _CI_BM, 64)],
+    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    out_c_arg: Int32,
+    hw_arg: Int32,
+    k_pad_arg: Int32,
+    c_pad_arg: Int32,
+    ow_arg: Int32,
+    pad_h_arg: Int32,
+    pad_w_arg: Int32,
+    s_f_arg: Int32,
+):
+    # Legality of the tile parameters, at BUILD time.  An illegal combination
+    # would be a runtime HANG rather than a wrong answer: the mbarrier is
+    # armed for the whole (BM + bn) x BK tile, so a `bn` the single-
+    # transaction B producer cannot fill leaves the consumer waiting forever.
+    comptime assert stages >= 2, "conv igemm needs at least 2 pipeline stages"
+    comptime assert (
+        bn >= 64 and bn % 64 == 0
+    ), "conv igemm needs bn a positive multiple of 64 (wgmma N granularity)"
+    comptime assert bn * _CI_BK * 2 <= 32768, (
+        "the im2col box is ONE transaction of bn x BK elements; keep it under"
+        " the 32 KB TMA transaction limit"
+    )
+    comptime assert _CI_BK * 2 == 128, (
+        "conv igemm assumes a 128 B swizzle, i.e. channels_per_pixel *"
+        " sizeof(dtype) == 128"
+    )
+    comptime assert (
+        size_of[dtype]() == 2
+    ), "conv igemm is a 16-bit tensor-core kernel"
+    comptime if _is_sm_9x():
+        var out_c = Int(out_c_arg)
+        var hw = Int(hw_arg)
+        var k_pad = Int(k_pad_arg)
+        var c_pad = Int(c_pad_arg)
+        var ow = Int(ow_arg)
+        var s_f = Int(s_f_arg)
+
+        comptime A_LAYOUT = tile_layout_k_major[
+            dtype, _CI_BM, _CI_BK, _CI_SWZ
+        ]()
+        comptime B_LAYOUT = tile_layout_k_major[dtype, bn, _CI_BK, _CI_SWZ]()
+
+        var a_pipe = LayoutTensor[
+            dtype,
+            Layout.row_major(stages, _CI_BM * _CI_BK),
+            MutAnyOrigin,
+            address_space=AddressSpace.SHARED,
+            alignment=128,
+        ].stack_allocation()
+        var b_pipe = LayoutTensor[
+            dtype,
+            Layout.row_major(stages, bn * _CI_BK),
+            MutAnyOrigin,
+            address_space=AddressSpace.SHARED,
+            alignment=128,
+        ].stack_allocation()
+        comptime C_SMEM_ELEMS = _CI_BM * bn if tma_store else 32
+        var c_smem = LayoutTensor[
+            dtype,
+            Layout.row_major(1, C_SMEM_ELEMS),
+            MutAnyOrigin,
+            address_space=AddressSpace.SHARED,
+            alignment=1024,
+        ].stack_allocation()
+        var full_barriers = stack_allocation[
+            stages,
+            SharedMemBarrier,
+            address_space=AddressSpace.SHARED,
+            alignment=8,
+        ]()
+        if thread_idx.x == 0:
+            comptime for stage in range(stages):
+                full_barriers[stage].init()
+            a_tma.prefetch_descriptor()
+            b_tma.prefetch_descriptor()
+            comptime if tma_store:
+                c_tma.prefetch_descriptor()
+        barrier()
+
+        comptime CFRAG = 64 * bn // 128
+        comptime TMA_BYTES = (_CI_BM + bn) * _CI_BK * 2
+
+        var blocks_n = (hw + bn - 1) // bn
+        var macro_rows = (out_c + _CI_BM - 1) // _CI_BM
+        var works_per_item = macro_rows * blocks_n
+        var num_tiles = (k_pad + _CI_BK - 1) // _CI_BK
+        var w = Int(block_idx.x)
+        var sample = w // works_per_item
+        var rem = w % works_per_item
+        var m0 = (rem // blocks_n) * _CI_BM
+        var n0 = (rem % blocks_n) * bn
+
+        # Base pixel of this tile's single im2col transaction: constant across
+        # the whole k loop, so it is decoded once here instead of per k-tile.
+        # n0 < hw by construction, so (sample, n0) is always inside the pixel
+        # box -- this is what makes a guard sample unnecessary.
+        var pix_n = sample
+        var pix_h = n0 // ow - Int(pad_h_arg)
+        var pix_w = n0 % ow - Int(pad_w_arg)
+
+        @parameter
+        @always_inline
+        def issue_tile(t: Int):
+            var stage = t % stages
+            var k0 = t * _CI_BK
+            if thread_idx.x == 0:
+                full_barriers[stage].expect_bytes(Int32(TMA_BYTES))
+                var a_tile = LayoutTensor[
+                    dtype,
+                    A_LAYOUT,
+                    MutAnyOrigin,
+                    address_space=AddressSpace.SHARED,
+                    alignment=128,
+                ](a_pipe.ptr + stage * _CI_BM * _CI_BK)
+                a_tma.async_copy(a_tile, full_barriers[stage], (k0, m0))
+                # One transaction per B tile, issued from the same lane as the
+                # A copy.  BK divides C_pad, so one k-tile never straddles two
+                # (r, s) taps and the tap indices are loop-invariant here.
+                var ch = k0 % c_pad
+                var fi = k0 // c_pad
+                _ci_im2col_load[dtype, bn](
+                    b_tma,
+                    (b_pipe.ptr + stage * bn * _CI_BK).bitcast[Scalar[dtype]](),
+                    full_barriers[stage],
+                    ch,
+                    fi % s_f,
+                    fi // s_f,
+                    pix_n,
+                    pix_h,
+                    pix_w,
+                )
+
+        var pre = min(stages, num_tiles)
+        for t in range(pre):
+            issue_tile(t)
+
+        var accum = LayoutTensor[
+            _CI_F32,
+            Layout.row_major(1, CFRAG),
+            MutAnyOrigin,
+            address_space=AddressSpace.LOCAL,
+        ].stack_allocation()
+        _ = accum.fill(0.0)
+        comptime wgmma = TensorCoreAsync[
+            _CI_F32,
+            dtype,
+            dtype,
+            Index(64, bn, 16),
+            a_swizzle=_CI_SWZ,
+            b_swizzle=_CI_SWZ,
+            transpose_b=True,
+        ]()
+
+        var t = 0
+        while t < num_tiles:
+            var stage = t % stages
+            var phase = UInt32((t // stages) % 2)
+            full_barriers[stage].wait(phase)
+            var a_tile = LayoutTensor[
+                dtype,
+                A_LAYOUT,
+                MutAnyOrigin,
+                address_space=AddressSpace.SHARED,
+                alignment=128,
+            ](a_pipe.ptr + stage * _CI_BM * _CI_BK)
+            var b_tile = LayoutTensor[
+                dtype,
+                B_LAYOUT,
+                MutAnyOrigin,
+                address_space=AddressSpace.SHARED,
+                alignment=128,
+            ](b_pipe.ptr + stage * bn * _CI_BK)
+            warpgroup_fence(accum)
+            wgmma.arrive()
+            wgmma.wgmma[1](a_tile, b_tile, accum, 0)
+            wgmma.commit_group()
+            warpgroup_fence(accum)
+            wgmma.wait_group()
+            if t + stages < num_tiles:
+                issue_tile(t + stages)
+            t += 1
+
+        # (out_c x pixels) per sample IS the (batch, m, n) tile the GEMM
+        # family's epilogue writes, so it is shared, not copied.
+        _wgmma_store_c_tile[dtype, _CI_BM, bn, tma_store](
+            c_tma,
+            c_smem.ptr,
+            accum.ptr,
+            output,
+            out_c,
+            hw,
+            out_c * hw,
+            m0,
+            n0,
+            sample,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Host side
+# ---------------------------------------------------------------------------
+
+
+def conv_igemm_descriptor_legal(
+    pad_h: Int, pad_w: Int, r_f: Int, s_f: Int
+) -> Bool:
+    """Whether the im2col descriptor and the taps this kernel issues are
+    inside the hardware's documented domain.
+
+    `cuTensorMapEncodeIm2col` takes the pixel-box corners as SIGNED CHAR, so
+    both corners of both spatial dimensions must be in [-128, 127], and the
+    per-transaction im2col offsets (the filter taps) are limited to [0, 255].
+    A conv that violates either must decline BEFORE the descriptor is
+    created: an illegal corner fails descriptor creation outright, and an
+    illegal tap is undefined behaviour at the instruction -- it does not fail
+    loudly.  E.g. R = 257 passes every other eligibility test and produces
+    tap r = 256.
+
+    The Python dispatch tests the same predicate before it allocates
+    anything (`_conv_igemm_descriptor_legal` in aten_fast.py); this is the
+    backstop that keeps an illegal descriptor from reaching the driver if a
+    future caller forgets.
+    """
+
+    @always_inline
+    def corner_ok(v: Int) -> Bool:
+        return v >= -128 and v <= 127
+
+    return (
+        corner_ok(-pad_h)
+        and corner_ok(-pad_w)
+        and corner_ok(pad_h - (r_f - 1))
+        and corner_ok(pad_w - (s_f - 1))
+        and r_f >= 1
+        and s_f >= 1
+        and r_f - 1 <= 255
+        and s_f - 1 <= 255
+    )
+
+
+def _ci_make_im2col_tma[
+    dtype: DType, bn: Int
+](
+    ctx: DeviceContext,
+    act: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    n: Int,
+    h: Int,
+    w: Int,
+    c_pad: Int,
+    pad_h: Int,
+    pad_w: Int,
+    r_f: Int,
+    s_f: Int,
+    out_h: Int,
+    out_w: Int,
+) raises -> TMATensorTileIm2col[dtype, 2, Index(bn, _CI_BK), Index(bn, _CI_BK)]:
+    """CUTLASS fprop corners: lower = -pad, upper = pad - (filter - 1), which
+    makes the pixel box exactly the output grid (box_w == out_w,
+    box_h == out_h) for stride = dilation = 1.  The dimensions are handed in
+    NHWC order and reversed to CWHDN inside `create_tensormap_im2col`; the
+    strides are element counts, not bytes."""
+    if not conv_igemm_descriptor_legal(pad_h, pad_w, r_f, s_f):
+        raise Error("conv igemm: im2col descriptor domain violated")
+    var tensormap = create_tensormap_im2col[dtype, 4, 2](
+        DeviceBuffer(
+            ctx, act.address_space_cast[AddressSpace.GENERIC](), 1, owning=False
+        ),
+        IndexList[4](n, h, w, c_pad),
+        IndexList[4](h * w * c_pad, w * c_pad, c_pad, 1),
+        IndexList[2](-pad_h, -pad_w),
+        IndexList[2](pad_h - (r_f - 1), pad_w - (s_f - 1)),
+        _CI_BK,
+        bn,
+        SwizzleMode(Int32(Int(_CI_SWZ))),
+    )
+    var desc = TMADescriptor()
+    desc.data = tensormap.data
+    return TMATensorTileIm2col[dtype, 2, Index(bn, _CI_BK), Index(bn, _CI_BK)](
+        desc,
+        UInt32(out_h),
+        UInt32(out_w),
+        UInt32(r_f),
+        UInt32(s_f),
+        UInt32(c_pad),
+        Int32(-pad_h),
+        Int32(-pad_w),
+    )
+
+
+def _ci_enqueue_gemm[
+    dtype: DType, stages: Int, bn: Int, tma_store: Bool
+](
+    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],  # (N, out_c, OH*OW)
+    act_nhwc: UnsafePointer[Scalar[dtype], MutAnyOrigin],  # (N, H, W, C_pad)
+    wpack: UnsafePointer[Scalar[dtype], MutAnyOrigin],  # (out_c, K_pad)
+    n: Int,
+    c_pad: Int,
+    h: Int,
+    w: Int,
+    out_c: Int,
+    r_f: Int,
+    s_f: Int,
+    pad_h: Int,
+    pad_w: Int,
+    out_h: Int,
+    out_w: Int,
+    ctx: DeviceContext,
+) raises:
+    var k_pad = r_f * s_f * c_pad
+    var hw = out_h * out_w
+    var a_desc = create_tma_descriptor[dtype, 2, _CI_SWZ](
+        DeviceBuffer(
+            ctx,
+            wpack.address_space_cast[AddressSpace.GENERIC](),
+            1,
+            owning=False,
+        ),
+        IndexList[2](out_c, k_pad),
+        IndexList[2](k_pad, 1),
+        IndexList[2](_CI_BM, _CI_BK),
+    )
+    # A TMA store needs a 16 B aligned output row pitch; a dummy descriptor
+    # over the first tile keeps the kernel signature uniform when the shape
+    # cannot have one (the scalar epilogue then owns the store).
+    var c_dim0 = n if tma_store else 1
+    var c_dim1 = out_c if tma_store else _CI_BM
+    var c_dim2 = hw if tma_store else 64
+    var c_str0 = out_c * hw if tma_store else _CI_BM * 64
+    var c_str1 = hw if tma_store else 64
+    var c_desc = create_tma_descriptor[dtype, 3, _CI_SWZ](
+        DeviceBuffer(
+            ctx,
+            out_ptr.address_space_cast[AddressSpace.GENERIC](),
+            1,
+            owning=False,
+        ),
+        IndexList[3](c_dim0, c_dim1, c_dim2),
+        IndexList[3](c_str0, c_str1, 1),
+        IndexList[3](1, _CI_BM, 64),
+    )
+    var a_tma = TMATensorTile[
+        dtype, 2, Index(_CI_BM, _CI_BK), Index(_CI_BM, _CI_BK)
+    ](a_desc)
+    var c_tma = TMATensorTile[
+        dtype, 3, Index(1, _CI_BM, 64), Index(1, _CI_BM, 64)
+    ](c_desc)
+    var b_tma = _ci_make_im2col_tma[dtype, bn](
+        ctx, act_nhwc, n, h, w, c_pad, pad_h, pad_w, r_f, s_f, out_h, out_w
+    )
+    var works = n * ((out_c + _CI_BM - 1) // _CI_BM) * ((hw + bn - 1) // bn)
+    # Not `_enqueue_cached`: the TMA descriptors are per-call `grid_constant`
+    # kernel arguments, which is also why every other TMA family in this
+    # package (gemm16, flash attention) enqueues directly.  The three
+    # `create_tma_descriptor` calls above dominate the host cost here anyway.
+    ctx.enqueue_function[_ci_conv_igemm_kernel[dtype, stages, bn, tma_store]](
+        a_tma,
+        b_tma,
+        c_tma,
+        out_ptr,
+        Int32(out_c),
+        Int32(hw),
+        Int32(k_pad),
+        Int32(c_pad),
+        Int32(out_w),
+        Int32(pad_h),
+        Int32(pad_w),
+        Int32(s_f),
+        grid_dim=(works,),
+        block_dim=(128,),
+    )
+
+
+@always_inline
+def _ci_conv_igemm[
+    dtype: DType
+](
+    out_addr: Int,
+    act_addr: Int,
+    wpack_addr: Int,
+    in_addr: Int,
+    weight_addr: Int,
+    n: Int,
+    c: Int,
+    c_pad: Int,
+    h: Int,
+    w: Int,
+    out_c: Int,
+    r_f: Int,
+    s_f: Int,
+    pad_h: Int,
+    pad_w: Int,
+    out_h: Int,
+    out_w: Int,
+    ctx: DeviceContext,
+) raises:
+    """The whole route: NHWC transpose, weight repack, implicit GEMM."""
+    var out_ptr = _make_ptr[dtype](out_addr).as_unsafe_any_origin()
+    var act_ptr = _make_ptr[dtype](act_addr).as_unsafe_any_origin()
+    var wpack_ptr = _make_ptr[dtype](wpack_addr).as_unsafe_any_origin()
+    var in_ptr = _make_ptr[dtype](in_addr).as_unsafe_any_origin()
+    var weight_ptr = _make_ptr[dtype](weight_addr).as_unsafe_any_origin()
+    var hw_in = h * w
+    var hw = out_h * out_w
+
+    _enqueue_cached[_ci_nchw_to_nhwc_kernel[dtype]](
+        ctx,
+        String(t"conv_nchw_to_nhwc_padc_{dtype}"),
+        (hw_in + _CI_T_PIX - 1) // _CI_T_PIX,
+        (c_pad + _CI_T_CH - 1) // _CI_T_CH,
+        n,
+        _CI_T_THREADS,
+        act_ptr,
+        in_ptr,
+        Int32(hw_in),
+        Int32(c),
+        Int32(c_pad),
+    )
+    _enqueue_cached[_ci_weight_repack_kernel[dtype]](
+        ctx,
+        String(t"conv_weight_repack_rsc_{dtype}"),
+        (out_c * r_f * s_f * c_pad + 255) // 256,
+        1,
+        1,
+        256,
+        wpack_ptr,
+        weight_ptr,
+        Int32(out_c),
+        Int32(c),
+        Int32(c_pad),
+        Int32(r_f),
+        Int32(s_f),
+    )
+
+    # A TMA-store descriptor needs a 16 B aligned output row pitch; the
+    # scalar epilogue covers every other pitch.
+    var tma_store = (hw * size_of[dtype]()) % 16 == 0
+    # bn: 128 everywhere except small pixel counts, where the finer tile
+    # wastes less of the last block and fills the grid better (measured on an
+    # H100 PCIe: mid 32x256x14x14 hw=196 is 66.6 us at bn=64 vs 68.3 at
+    # bn=128; the body's hw=3136 is 59.0 at bn=128 vs 59.5 at bn=64).
+    var small_hw = hw < 512
+    if tma_store:
+        if small_hw:
+            _ci_enqueue_gemm[dtype, 2, 64, True](
+                out_ptr,
+                act_ptr,
+                wpack_ptr,
+                n,
+                c_pad,
+                h,
+                w,
+                out_c,
+                r_f,
+                s_f,
+                pad_h,
+                pad_w,
+                out_h,
+                out_w,
+                ctx,
+            )
+        else:
+            _ci_enqueue_gemm[dtype, 2, 128, True](
+                out_ptr,
+                act_ptr,
+                wpack_ptr,
+                n,
+                c_pad,
+                h,
+                w,
+                out_c,
+                r_f,
+                s_f,
+                pad_h,
+                pad_w,
+                out_h,
+                out_w,
+                ctx,
+            )
+    else:
+        if small_hw:
+            _ci_enqueue_gemm[dtype, 2, 64, False](
+                out_ptr,
+                act_ptr,
+                wpack_ptr,
+                n,
+                c_pad,
+                h,
+                w,
+                out_c,
+                r_f,
+                s_f,
+                pad_h,
+                pad_w,
+                out_h,
+                out_w,
+                ctx,
+            )
+        else:
+            _ci_enqueue_gemm[dtype, 2, 128, False](
+                out_ptr,
+                act_ptr,
+                wpack_ptr,
+                n,
+                c_pad,
+                h,
+                w,
+                out_c,
+                r_f,
+                s_f,
+                pad_h,
+                pad_w,
+                out_h,
+                out_w,
+                ctx,
+            )
+
+
+def _conv_igemm_go(
+    out_ptr: PyObjectPtr,
+    act_ptr: PyObjectPtr,
+    wpack_ptr: PyObjectPtr,
+    in_ptr: PyObjectPtr,
+    weight_ptr: PyObjectPtr,
+    params: PyObjectPtr,
+    dtype_obj: PyObjectPtr,
+    device_context_ptr: PyObjectPtr,
+) raises:
+    var dtype = _raw_dtype_int(dtype_obj)
+    var out_addr = _raw_int(out_ptr)
+    var act_addr = _raw_int(act_ptr)
+    var wpack_addr = _raw_int(wpack_ptr)
+    var in_addr = _raw_int(in_ptr)
+    var weight_addr = _raw_int(weight_ptr)
+    var n = _raw_tuple_int(params, 0)
+    var c = _raw_tuple_int(params, 1)
+    var c_pad = _raw_tuple_int(params, 2)
+    var h = _raw_tuple_int(params, 3)
+    var w = _raw_tuple_int(params, 4)
+    var out_c = _raw_tuple_int(params, 5)
+    var r_f = _raw_tuple_int(params, 6)
+    var s_f = _raw_tuple_int(params, 7)
+    var pad_h = _raw_tuple_int(params, 8)
+    var pad_w = _raw_tuple_int(params, 9)
+    var out_h = _raw_tuple_int(params, 10)
+    var out_w = _raw_tuple_int(params, 11)
+    var ctx = _raw_ctx(device_context_ptr)
+
+    var handled = False
+    comptime for dt in _CI_DTYPES:
+        comptime if _dtype_arg_on[0, dt]():
+            if dtype == dt:
+                _ci_conv_igemm[dt](
+                    out_addr,
+                    act_addr,
+                    wpack_addr,
+                    in_addr,
+                    weight_addr,
+                    n,
+                    c,
+                    c_pad,
+                    h,
+                    w,
+                    out_c,
+                    r_f,
+                    s_f,
+                    pad_h,
+                    pad_w,
+                    out_h,
+                    out_w,
+                    ctx,
+                )
+                handled = True
+    if not handled:
+        raise Error(
+            "unsupported dtype for the implicit-GEMM conv: " + String(dtype)
+        )
+
+
+def _conv_igemm_dispatcher(
+    py_self: PyObjectPtr,
+    args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
+    nargs: Py_ssize_t,
+) abi("C") -> PyObjectPtr:
+    var args = UnsafePointer(args_safe)
+    try:
+        _conv_igemm_go(
+            args[0],
+            args[1],
+            args[2],
+            args[3],
+            args[4],
+            args[5],
+            args[6],
+            args[7],
+        )
+    except e:
+        return _spec_unsupported(e)
+    return _raw_ret_none()
+
+
+@export
+def PyInit_conv_igemm_ops() abi("C") -> PythonObject:
+    try:
+        var b = PythonModuleBuilder("conv_igemm_ops")
+        comptime if _op_on["ConvIgemm"]():
+            _register_call(
+                b,
+                _conv_igemm_dispatcher,
+                docstring=(
+                    "(out_ptr, act_nhwc_ptr, weight_pack_ptr, in_ptr,"
+                    " weight_ptr, (n, c, c_pad, h, w, out_c, r, s, pad_h,"
+                    " pad_w, out_h, out_w), dtype, context_ptr); sm_90a"
+                    " implicit-GEMM conv2d forward with no materialized"
+                    " im2col"
+                ),
+            )
+        return b.finalize()
+    except e:
+        abort(t"failed to create conv_igemm_ops python module: {e}")

--- a/torch_mojo_backend/eager_kernels/conv_igemm_ops/conv_igemm_ops.py
+++ b/torch_mojo_backend/eager_kernels/conv_igemm_ops/conv_igemm_ops.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+from typing import ClassVar
+
+from torch_mojo_backend.eager_kernels import MojoFileExtension
+
+
+class ConvIgemmExtension(MojoFileExtension):
+    """sm_90a implicit-GEMM conv2d forward (TMA im2col, no col buffer).
+
+    A separate extension from ``ConvExtension`` on purpose: this one pulls in
+    the 16-bit tensor-core GEMM family's sources, which a source checkout or
+    wheel may not ship, and the materialized-im2col route must keep working
+    (including on CPU) when they are absent.
+    """
+
+    MOJO_FILE: ClassVar[Path] = Path("conv_igemm_ops/conv_igemm_ops.mojo")

--- a/torch_mojo_backend/eager_kernels/conv_ops/conv_ops.mojo
+++ b/torch_mojo_backend/eager_kernels/conv_ops/conv_ops.mojo
@@ -15,6 +15,7 @@ from max.gpu.host import DeviceContext
 from std.python import PythonObject
 from std.python._cpython import PyObjectPtr, Py_ssize_t
 from std.python.bindings import PythonModuleBuilder
+from std.sys.info import has_accelerator
 from std.utils.coord import Coord as StdCoord
 
 from op_utils import (
@@ -349,7 +350,18 @@ def _im2col[
             batch,
             ctx,
         )
-    else:
+        return
+    # `_im2col_gpu` pulls in `_enqueue_cached`, which needs a target GPU
+    # architecture at compile time (`gpu/host/info.mojo`). A runtime
+    # `if`/`else` does not stop Mojo from instantiating the `else` branch
+    # too (same hazard matmul_ops.mojo's MFMA gate documents), so on a host
+    # with no accelerator at all this has to be a comptime gate, or the
+    # whole module fails to build -- and with it every conv test, including
+    # the CPU-device ones (AGENTS.md eager rule 1: a torch-cpu-only install
+    # must still build this file). `ctx.api() == "cpu"` already returned
+    # above, so this is unreachable when `has_accelerator()` is False; the
+    # gate below exists only to keep it out of that host's build.
+    comptime if has_accelerator():
         _im2col_gpu[dtype](
             out_addr,
             in_addr,
@@ -560,7 +572,12 @@ def _bias_add_chan[
         _bias_add_chan_scalar[dtype](
             out_addr, bias_addr, total, plane, channels, ctx
         )
-    else:
+        return
+    # Same comptime-gate requirement as `_im2col` above: `_bias_add_chan_gpu`
+    # pulls in `_enqueue_cached`, which fails to build with no target GPU
+    # architecture at all. `ctx.api() == "cpu"` already returned above, so
+    # this is unreachable when `has_accelerator()` is False.
+    comptime if has_accelerator():
         _bias_add_chan_gpu[dtype](
             out_addr, bias_addr, total, plane, channels, ctx
         )

--- a/torch_mojo_backend/eager_kernels/conv_ops/conv_ops.mojo
+++ b/torch_mojo_backend/eager_kernels/conv_ops/conv_ops.mojo
@@ -453,6 +453,383 @@ def _im2col_dispatcher(
 
 
 # ---------------------------------------------------------------------------
+# col2im: the exact adjoint of the im2col above, used by the conv backward's
+# data gradient. `_im2col` GATHERS one input element per (patch row, output
+# column); its adjoint SCATTERS the same value back, so every input pixel
+# accumulates the columns of every filter tap that read it.
+#
+# Written as a gather over the OUTPUT (one thread owns one input pixel and
+# loops over the taps that could have read it) rather than as a scatter over
+# the input (one thread per column element, atomically adding into the image).
+# Two reasons, both structural: the gather needs no atomics at all, and it is
+# bit-for-bit deterministic -- an atomic scatter would sum the taps of a pixel
+# in launch order, so two runs of the same backward could return different
+# gradients. The tap loop is `kh * kw` iterations of integer arithmetic per
+# pixel, against `kh * kw` atomic round trips per pixel for the scatter.
+#
+# The tap condition inverts the forward index map
+#   ih = oh * stride_h - pad_h + r * dil_h
+# for a fixed `ih`: `oh` exists iff `th = ih + pad_h - r * dil_h` is
+# non-negative, divisible by `stride_h` and lands inside `[0, out_h)`.
+# `th >= 0` is tested BEFORE the modulo on purpose -- a negative dividend
+# makes `%` implementation-defined between languages, and every negative `th`
+# is out of range anyway.
+#
+# Accumulation is float32 for every supported dtype (FLOAT_DTYPES tops out at
+# f32), matching both torch's own accumulator and the fp32 accumulation of the
+# GEMM that produced the columns; a bf16 accumulator would lose the small taps
+# of a 7x7 filter outright.
+# ---------------------------------------------------------------------------
+
+
+@always_inline
+def _col2im_scalar[
+    dtype: DType
+](
+    out_addr: Int,
+    in_addr: Int,
+    in_h: Int,
+    in_w: Int,
+    out_h: Int,
+    out_w: Int,
+    kh: Int,
+    kw: Int,
+    stride_h: Int,
+    stride_w: Int,
+    pad_h: Int,
+    pad_w: Int,
+    dil_h: Int,
+    dil_w: Int,
+    channels: Int,
+    batch: Int,
+    ctx: DeviceContext,
+) raises:
+    """One input pixel per thread, on the generic `elementwise` framework.
+
+    The CPU device's only path (`_parallel_for` runs `elementwise` on host
+    there); `_col2im_gpu` below replaces it on GPU with the same
+    warp-per-row shape `_im2col_gpu` uses.
+    """
+    var out_ptr = _make_ptr[dtype](out_addr)
+    var in_ptr = _make_ptr[dtype](in_addr)
+
+    @always_inline
+    @parameter
+    @__copy_capture(out_ptr, in_ptr)
+    def func[width: Int, alignment: Int = 1](idx: StdCoord):
+        var i = Int(idx[0].value())
+        var cols = out_h * out_w
+        var iw = i % in_w
+        var ih = (i // in_w) % in_h
+        var c = (i // (in_w * in_h)) % channels
+        var s = i // (in_w * in_h * channels)
+        var col_base = (s * channels + c) * kh * kw * cols
+        var acc = Scalar[DType.float32](0)
+        for r in range(kh):
+            var th = ih + pad_h - r * dil_h
+            if th < 0 or th % stride_h != 0:
+                continue
+            var oh = th // stride_h
+            if oh >= out_h:
+                continue
+            var row_base = col_base + r * kw * cols + oh * out_w
+            for fw in range(kw):
+                var tw = iw + pad_w - fw * dil_w
+                if tw < 0 or tw % stride_w != 0:
+                    continue
+                var ow = tw // stride_w
+                if ow >= out_w:
+                    continue
+                acc += in_ptr[row_base + fw * cols + ow].cast[DType.float32]()
+        out_ptr[i] = acc.cast[dtype]()
+
+    _parallel_for[func](batch * channels * in_h * in_w, ctx)
+
+
+# One warp (32 lanes) per (sample, channel, input row), one lane per input
+# column (striding by 32 when in_w > 32) -- the same shape `_im2col_gpu`
+# settled on, for the same reasons: the `(s, c, ih)` decomposition is
+# computed once per row instead of once per pixel, and consecutive lanes own
+# consecutive `iw`, so the store is always warp-coalesced and the loads are
+# too whenever `stride_w == 1` (then `ow = iw + pad_w - fw * dil_w` is
+# consecutive across lanes as well). The per-row `r`-loop bookkeeping
+# (`th`, `oh`) is warp-uniform, so unlike im2col's much heavier
+# multi-division decomposition there is nothing worth broadcasting through
+# `warp.shuffle_idx`: every lane recomputes a couple of cheap integer ops
+# rather than paying a shuffle plus the register pressure of holding them.
+#
+# The grid is `batch * channels * in_h` rows, which is COARSER than im2col's
+# `batch * channels * kh * kw * out_h`: the tap loop is folded into each lane
+# instead of being spread across the grid, because a pixel's taps have to be
+# summed by ONE thread for the gather to stay atomic-free. That trades
+# parallelism for determinism deliberately; if a shape ever starves the
+# machine of blocks, the fix is a split over taps with a second reduce pass,
+# not an atomic scatter.
+@__name(t"col2im_row_{dtype}")
+def _col2im_row_kernel[
+    dtype: DType
+](
+    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    in_h_arg: Int64,
+    in_w_arg: Int64,
+    out_h_arg: Int64,
+    out_w_arg: Int64,
+    kh_arg: Int64,
+    kw_arg: Int64,
+    stride_h_arg: Int64,
+    stride_w_arg: Int64,
+    pad_h_arg: Int64,
+    pad_w_arg: Int64,
+    dil_h_arg: Int64,
+    dil_w_arg: Int64,
+    channels_arg: Int64,
+    total_rows_arg: Int64,
+):
+    var in_h = Int(in_h_arg)
+    var in_w = Int(in_w_arg)
+    var out_h = Int(out_h_arg)
+    var out_w = Int(out_w_arg)
+    var kh = Int(kh_arg)
+    var kw = Int(kw_arg)
+    var stride_h = Int(stride_h_arg)
+    var stride_w = Int(stride_w_arg)
+    var pad_h = Int(pad_h_arg)
+    var pad_w = Int(pad_w_arg)
+    var dil_h = Int(dil_h_arg)
+    var dil_w = Int(dil_w_arg)
+    var channels = Int(channels_arg)
+    var total_rows = Int(total_rows_arg)
+
+    var cols = out_h * out_w
+    var row_stride = Int(grid_dim.x)
+    var lane = Int(thread_idx.x)
+
+    var row = Int(block_idx.x)
+    while row < total_rows:
+        var ih = row % in_h
+        var sc = row // in_h
+        # `sc` is the flat (sample, channel) index and the column block of
+        # that pair starts at `sc * kh * kw * cols`, so the sample and the
+        # channel never need to be separated.
+        var col_base = sc * kh * kw * cols
+        var out_base = row * in_w
+
+        var iw = lane
+        while iw < in_w:
+            var acc = Scalar[DType.float32](0)
+            for r in range(kh):
+                var th = ih + pad_h - r * dil_h
+                if th < 0 or th % stride_h != 0:
+                    continue
+                var oh = th // stride_h
+                if oh >= out_h:
+                    continue
+                var row_base = col_base + r * kw * cols + oh * out_w
+                for fw in range(kw):
+                    var tw = iw + pad_w - fw * dil_w
+                    if tw < 0 or tw % stride_w != 0:
+                        continue
+                    var ow = tw // stride_w
+                    if ow >= out_w:
+                        continue
+                    acc += in_ptr[row_base + fw * cols + ow].cast[
+                        DType.float32
+                    ]()
+            out_ptr[out_base + iw] = acc.cast[dtype]()
+            iw += _IM2COL_WARP
+
+        row += row_stride
+
+
+@always_inline
+def _col2im_gpu[
+    dtype: DType
+](
+    out_addr: Int,
+    in_addr: Int,
+    in_h: Int,
+    in_w: Int,
+    out_h: Int,
+    out_w: Int,
+    kh: Int,
+    kw: Int,
+    stride_h: Int,
+    stride_w: Int,
+    pad_h: Int,
+    pad_w: Int,
+    dil_h: Int,
+    dil_w: Int,
+    channels: Int,
+    batch: Int,
+    ctx: DeviceContext,
+) raises:
+    var total_rows = batch * channels * in_h
+    # Same block cap as im2col, for the same reason (one warp per block is
+    # tiny, so one block per row oversubscribes the scheduler by orders of
+    # magnitude) -- and with the same caveat: the constant was fitted on an
+    # H100, and no other architecture has been measured with it.
+    var blocks = min(max(total_rows, 1), _IM2COL_MAX_ROW_BLOCKS)
+    _enqueue_cached[_col2im_row_kernel[dtype]](
+        ctx,
+        String(t"col2im_row_{dtype}"),
+        blocks,
+        1,
+        1,
+        _IM2COL_WARP,
+        _make_ptr[dtype](out_addr).as_unsafe_any_origin(),
+        _make_ptr[dtype](in_addr).as_unsafe_any_origin(),
+        Int64(in_h),
+        Int64(in_w),
+        Int64(out_h),
+        Int64(out_w),
+        Int64(kh),
+        Int64(kw),
+        Int64(stride_h),
+        Int64(stride_w),
+        Int64(pad_h),
+        Int64(pad_w),
+        Int64(dil_h),
+        Int64(dil_w),
+        Int64(channels),
+        Int64(total_rows),
+    )
+
+
+@always_inline
+def _col2im[
+    dtype: DType
+](
+    out_addr: Int,
+    in_addr: Int,
+    in_h: Int,
+    in_w: Int,
+    out_h: Int,
+    out_w: Int,
+    kh: Int,
+    kw: Int,
+    stride_h: Int,
+    stride_w: Int,
+    pad_h: Int,
+    pad_w: Int,
+    dil_h: Int,
+    dil_w: Int,
+    channels: Int,
+    batch: Int,
+    ctx: DeviceContext,
+) raises:
+    if ctx.api() == "cpu":
+        _col2im_scalar[dtype](
+            out_addr,
+            in_addr,
+            in_h,
+            in_w,
+            out_h,
+            out_w,
+            kh,
+            kw,
+            stride_h,
+            stride_w,
+            pad_h,
+            pad_w,
+            dil_h,
+            dil_w,
+            channels,
+            batch,
+            ctx,
+        )
+    else:
+        _col2im_gpu[dtype](
+            out_addr,
+            in_addr,
+            in_h,
+            in_w,
+            out_h,
+            out_w,
+            kh,
+            kw,
+            stride_h,
+            stride_w,
+            pad_h,
+            pad_w,
+            dil_h,
+            dil_w,
+            channels,
+            batch,
+            ctx,
+        )
+
+
+def _col2im_go(
+    image_ptr: PyObjectPtr,
+    col_ptr: PyObjectPtr,
+    # (in_h, in_w, out_h, out_w, kh, kw, stride_h, stride_w, pad_h, pad_w,
+    #  dil_h, dil_w, channels, batch); batch defaults to 1 when omitted.
+    params: PyObjectPtr,
+    dtype_obj: PyObjectPtr,
+    device_context_ptr: PyObjectPtr,
+) raises:
+    var dtype = _raw_dtype_int(dtype_obj)
+    var out_addr = _raw_int(image_ptr)
+    var in_addr = _raw_int(col_ptr)
+    var in_h = _raw_tuple_int(params, 0)
+    var in_w = _raw_tuple_int(params, 1)
+    var out_h = _raw_tuple_int(params, 2)
+    var out_w = _raw_tuple_int(params, 3)
+    var kh = _raw_tuple_int(params, 4)
+    var kw = _raw_tuple_int(params, 5)
+    var stride_h = _raw_tuple_int(params, 6)
+    var stride_w = _raw_tuple_int(params, 7)
+    var pad_h = _raw_tuple_int(params, 8)
+    var pad_w = _raw_tuple_int(params, 9)
+    var dil_h = _raw_tuple_int(params, 10)
+    var dil_w = _raw_tuple_int(params, 11)
+    var channels = _raw_tuple_int(params, 12)
+    var batch = _raw_tuple_int(params, 13) if _raw_tuple_len(params) > 13 else 1
+    var ctx = _raw_ctx(device_context_ptr)
+
+    var handled = False
+    comptime for dt in FLOAT_DTYPES:
+        comptime if _dtype_arg_on[0, dt]():
+            if dtype == dt:
+                _col2im[dt](
+                    out_addr,
+                    in_addr,
+                    in_h,
+                    in_w,
+                    out_h,
+                    out_w,
+                    kh,
+                    kw,
+                    stride_h,
+                    stride_w,
+                    pad_h,
+                    pad_w,
+                    dil_h,
+                    dil_w,
+                    channels,
+                    batch,
+                    ctx,
+                )
+                handled = True
+    if not handled:
+        raise Error("unsupported dtype for fast col2im: " + String(dtype))
+
+
+def _col2im_dispatcher(
+    py_self: PyObjectPtr,
+    args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
+    nargs: Py_ssize_t,
+) abi("C") -> PyObjectPtr:
+    var args = UnsafePointer(args_safe)
+    try:
+        _col2im_go(args[0], args[1], args[2], args[3], args[4])
+    except e:
+        return _spec_unsupported(e)
+    return _raw_ret_none()
+
+
+# ---------------------------------------------------------------------------
 # In-place per-channel bias add on a (batch, channels, plane) tensor:
 # out[i] += bias[(i // plane) % channels].
 # ---------------------------------------------------------------------------
@@ -638,6 +1015,15 @@ def PyInit_conv_ops() abi("C") -> PythonObject:
                 _im2col_dispatcher,
                 docstring=(
                     "batched NCHW im2col -> (N, C*KH*KW, OH*OW) patch matrix"
+                ),
+            )
+        comptime if _op_on["Col2im"]():
+            _register_call(
+                b,
+                _col2im_dispatcher,
+                docstring=(
+                    "(N, C*KH*KW, OH*OW) patch matrix -> NCHW image, summing"
+                    " every filter tap that read each pixel (im2col's adjoint)"
                 ),
             )
         comptime if _op_on["BiasAddChan"]():

--- a/torch_mojo_backend/eager_kernels/conv_ops/conv_ops.mojo
+++ b/torch_mojo_backend/eager_kernels/conv_ops/conv_ops.mojo
@@ -8,6 +8,8 @@
 # `elementwise` framework on the host when `ctx.api() == "cpu"`.
 # ===----------------------------------------------------------------------=== #
 
+from std.gpu import block_idx, grid_dim, thread_idx
+from std.gpu.primitives import warp
 from std.os import abort
 from max.gpu.host import DeviceContext
 from std.python import PythonObject
@@ -18,6 +20,7 @@ from std.utils.coord import Coord as StdCoord
 from op_utils import (
     _spec_unsupported,
     FLOAT_DTYPES,
+    _enqueue_cached,
     _make_ptr,
     _parallel_for,
     _raw_ctx,
@@ -42,7 +45,7 @@ from variant_gates import _dtype_arg_on, _op_on, _register_call
 
 
 @always_inline
-def _im2col[
+def _im2col_scalar[
     dtype: DType
 ](
     out_addr: Int,
@@ -63,6 +66,16 @@ def _im2col[
     batch: Int,
     ctx: DeviceContext,
 ) raises:
+    """One element per thread, on the generic `elementwise` framework.
+
+    Kept for the CPU device only (`_parallel_for` also runs `elementwise` on
+    host there). On GPU, `_im2col_gpu` below replaces this: profiling a
+    32x64x56x56 k3s1 bf16 conv (benchmarks/test_vision.py's body shape)
+    showed this scalar form at 86.7% of the whole aten::convolution's device
+    time -- far more than the GEMM itself (9.4%) -- because every one of
+    `batch*channels*kh*kw*out_h*out_w` threads redoes the full
+    div/mod decomposition and moves one scalar element.
+    """
     var out_ptr = _make_ptr[dtype](out_addr)
     var in_ptr = _make_ptr[dtype](in_addr)
 
@@ -89,6 +102,273 @@ def _im2col[
             out_ptr[i] = in_ptr[((s * channels + c) * in_h + ih) * in_w + iw]
 
     _parallel_for[func](batch * channels * kh * kw * out_h * out_w, ctx)
+
+
+# ---------------------------------------------------------------------------
+# GPU im2col: one WARP (32 lanes, fixed) per (sample, channel, kh-tap,
+# kw-tap, out-row), one lane per output column `ow` (striding by 32 when
+# out_w > 32). `ncu` on the body benchmark shape (benchmarks/test_vision.py's
+# N32xC64x56x56 k3s1, bf16) drove three iterations of this design, in order:
+#
+#   1. One thread per ROW (out_w-fold fewer threads than one-per-element,
+#      each still repeating the full row decomposition once): 1.02ms,
+#      barely faster than the scalar baseline's 1.21ms. `sm__throughput`
+#      was 70.85% against `dram__throughput` at 2.64% -- compute-bound on
+#      the decomposition's integer division, not memory -- but this design
+#      also loses warp coalescing (consecutive threads then own different
+#      rows `out_w` elements apart).
+#   2. One warp-or-more (32-256 lanes, rounded from out_w) per row, every
+#      lane repeating the decomposition: 1.28ms, SLOWER than the scalar
+#      baseline, because col_threads >= out_w in the common case means
+#      MORE total repeats (total_rows * col_threads) than the scalar form's
+#      one-per-element (total_rows * out_w, i.e. once per (row, column)).
+#      Coalescing alone does not pay for redoing the decomposition more.
+#   3. The same split, but lane 0 alone computes the decomposition and
+#      broadcasts (ih, the input row base, fw) through SHARED memory after
+#      a block-wide `barrier()`: 1.28ms, no better than #2.
+#      `smsp__average_warps_issue_stalled_barrier` jumped to 8.2 (from ~0)
+#      -- the barrier, paid twice per row over hundreds of rows per block,
+#      cost as much as the divisions it removed.
+#
+# This (both fixes at once, cheaply) is what actually wins: fixing
+# `col_threads` at exactly one warp removes the barrier entirely -- lane 0
+# computes, and `warp.shuffle_idx` broadcasts to the other 31 lanes with no
+# shared memory and no block-wide sync, just a couple of register-to-register
+# shuffle instructions every participating lane issues together. The
+# decomposition then runs exactly once per row (`total_rows` times, against
+# the scalar form's `total_rows * out_w`), and consecutive lanes still own
+# consecutive `ow` -> consecutive addresses, so the store (always
+# contiguous) and the stride_w == 1 read (the row is then a contiguous slice
+# of the input row) stay warp-coalesced. stride_w != 1 (e.g. the k7s2 stem
+# shape) keeps a per-lane bounds check -- reads aren't contiguous there --
+# but the write still coalesces.
+# ---------------------------------------------------------------------------
+
+comptime _IM2COL_WARP = 32
+
+
+@__name(t"im2col_row_{dtype}")
+def _im2col_row_kernel[
+    dtype: DType
+](
+    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    in_h_arg: Int64,
+    in_w_arg: Int64,
+    out_h_arg: Int64,
+    out_w_arg: Int64,
+    kh_arg: Int64,
+    kw_arg: Int64,
+    stride_h_arg: Int64,
+    stride_w_arg: Int64,
+    pad_h_arg: Int64,
+    pad_w_arg: Int64,
+    dil_h_arg: Int64,
+    dil_w_arg: Int64,
+    channels_arg: Int64,
+    total_rows_arg: Int64,
+):
+    var in_h = Int(in_h_arg)
+    var in_w = Int(in_w_arg)
+    var out_h = Int(out_h_arg)
+    var out_w = Int(out_w_arg)
+    var kh = Int(kh_arg)
+    var kw = Int(kw_arg)
+    var stride_h = Int(stride_h_arg)
+    var stride_w = Int(stride_w_arg)
+    var pad_h = Int(pad_h_arg)
+    var pad_w = Int(pad_w_arg)
+    var dil_h = Int(dil_h_arg)
+    var dil_w = Int(dil_w_arg)
+    var channels = Int(channels_arg)
+    var total_rows = Int(total_rows_arg)
+
+    var crs = channels * kh * kw
+    var row_stride = Int(grid_dim.x)
+    var lane = Int(thread_idx.x)
+
+    var row = Int(block_idx.x)
+    while row < total_rows:
+        # Only lane 0's values matter: `shuffle_idx(_, 0)` reads lane 0's
+        # copy for every participating lane regardless of what its own
+        # local variable holds, so the other lanes' zeros here are inert --
+        # only lane 0 pays for the division.
+        var ih_local = Int32(0)
+        var fw_local = Int32(0)
+        var in_row_local = Int32(0)
+        if lane == 0:
+            var s = row // (crs * out_h)
+            var rem = row - s * (crs * out_h)
+            var r = rem // out_h
+            var oh = rem - r * out_h
+            var fw = r % kw
+            var fh = (r // kw) % kh
+            var c = r // (kw * kh)
+            var ih = oh * stride_h - pad_h + fh * dil_h
+            ih_local = Int32(ih)
+            fw_local = Int32(fw)
+            if ih >= 0 and ih < in_h:
+                in_row_local = Int32(((s * channels + c) * in_h + ih) * in_w)
+        var ih = Int(warp.shuffle_idx(SIMD[DType.int32, 1](ih_local), 0)[0])
+        var fw = Int(warp.shuffle_idx(SIMD[DType.int32, 1](fw_local), 0)[0])
+        var in_row = Int(
+            warp.shuffle_idx(SIMD[DType.int32, 1](in_row_local), 0)[0]
+        )
+        var out_row = row * out_w
+
+        if ih < 0 or ih >= in_h:
+            var ow = lane
+            while ow < out_w:
+                out_ptr[out_row + ow] = Scalar[dtype](0)
+                ow += _IM2COL_WARP
+        elif stride_w == 1:
+            # iw(ow) = ow + iw0: a contiguous slice of the input row.
+            var iw0 = fw * dil_w - pad_w
+            var lo = max(0, -iw0)
+            var hi = min(out_w, in_w - iw0)
+            var ow = lane
+            while ow < out_w:
+                if ow < lo or ow >= hi:
+                    out_ptr[out_row + ow] = Scalar[dtype](0)
+                else:
+                    out_ptr[out_row + ow] = in_ptr[in_row + iw0 + ow]
+                ow += _IM2COL_WARP
+        else:
+            var ow = lane
+            while ow < out_w:
+                var iw = ow * stride_w - pad_w + fw * dil_w
+                if iw >= 0 and iw < in_w:
+                    out_ptr[out_row + ow] = in_ptr[in_row + iw]
+                else:
+                    out_ptr[out_row + ow] = Scalar[dtype](0)
+                ow += _IM2COL_WARP
+
+        row += row_stride
+
+
+# One warp (32 lanes) per block is tiny next to a full SM, so one block per
+# row, uncapped, oversubscribes the scheduler by orders of magnitude on real
+# shapes -- the same failure a much bigger 64-lane block already showed
+# (see the design note above: uncapped one-block-per-row measured 1.51ms,
+# against the scalar baseline's 1.21ms, from over a million tiny blocks).
+# `_gs_blocks` (op_utils) picks 4096 for its GS_THREADS=256-wide grid-stride
+# launches; blocks here are 8x smaller (32 vs 256 lanes), so this scales the
+# cap up by the same factor to keep a comparable number of resident lanes.
+comptime _IM2COL_MAX_ROW_BLOCKS = 32768
+
+
+@always_inline
+def _im2col_gpu[
+    dtype: DType
+](
+    out_addr: Int,
+    in_addr: Int,
+    in_h: Int,
+    in_w: Int,
+    out_h: Int,
+    out_w: Int,
+    kh: Int,
+    kw: Int,
+    stride_h: Int,
+    stride_w: Int,
+    pad_h: Int,
+    pad_w: Int,
+    dil_h: Int,
+    dil_w: Int,
+    channels: Int,
+    batch: Int,
+    ctx: DeviceContext,
+) raises:
+    var total_rows = batch * channels * kh * kw * out_h
+    var blocks = min(max(total_rows, 1), _IM2COL_MAX_ROW_BLOCKS)
+    _enqueue_cached[_im2col_row_kernel[dtype]](
+        ctx,
+        String(t"im2col_row_{dtype}"),
+        blocks,
+        1,
+        1,
+        _IM2COL_WARP,
+        _make_ptr[dtype](out_addr).as_unsafe_any_origin(),
+        _make_ptr[dtype](in_addr).as_unsafe_any_origin(),
+        Int64(in_h),
+        Int64(in_w),
+        Int64(out_h),
+        Int64(out_w),
+        Int64(kh),
+        Int64(kw),
+        Int64(stride_h),
+        Int64(stride_w),
+        Int64(pad_h),
+        Int64(pad_w),
+        Int64(dil_h),
+        Int64(dil_w),
+        Int64(channels),
+        Int64(total_rows),
+    )
+
+
+@always_inline
+def _im2col[
+    dtype: DType
+](
+    out_addr: Int,
+    in_addr: Int,
+    in_h: Int,
+    in_w: Int,
+    out_h: Int,
+    out_w: Int,
+    kh: Int,
+    kw: Int,
+    stride_h: Int,
+    stride_w: Int,
+    pad_h: Int,
+    pad_w: Int,
+    dil_h: Int,
+    dil_w: Int,
+    channels: Int,
+    batch: Int,
+    ctx: DeviceContext,
+) raises:
+    if ctx.api() == "cpu":
+        _im2col_scalar[dtype](
+            out_addr,
+            in_addr,
+            in_h,
+            in_w,
+            out_h,
+            out_w,
+            kh,
+            kw,
+            stride_h,
+            stride_w,
+            pad_h,
+            pad_w,
+            dil_h,
+            dil_w,
+            channels,
+            batch,
+            ctx,
+        )
+    else:
+        _im2col_gpu[dtype](
+            out_addr,
+            in_addr,
+            in_h,
+            in_w,
+            out_h,
+            out_w,
+            kh,
+            kw,
+            stride_h,
+            stride_w,
+            pad_h,
+            pad_w,
+            dil_h,
+            dil_w,
+            channels,
+            batch,
+            ctx,
+        )
 
 
 def _im2col_go(
@@ -167,7 +447,7 @@ def _im2col_dispatcher(
 
 
 @always_inline
-def _bias_add_chan[
+def _bias_add_chan_scalar[
     dtype: DType
 ](
     out_addr: Int,
@@ -177,6 +457,16 @@ def _bias_add_chan[
     channels: Int,
     ctx: DeviceContext,
 ) raises:
+    """One element per thread, on the generic `elementwise` framework.
+
+    Kept for the CPU device only; `_bias_add_chan_gpu` below replaces this
+    on GPU with the same one-warp-per-row restructuring `_im2col_gpu` uses,
+    for the same reason: profiling the body benchmark shape
+    (benchmarks/test_vision.py's N32xC64x56x56 k3s1, bf16) showed this
+    scalar form was 26.9% of the whole aten::convolution's device time,
+    bigger than the GEMM itself (24.7%), from recomputing `(i // plane) %
+    channels` once per element instead of once per `plane`-long run.
+    """
     var out_ptr = _make_ptr[dtype](out_addr)
     var bias_ptr = _make_ptr[dtype](bias_addr)
 
@@ -188,6 +478,92 @@ def _bias_add_chan[
         out_ptr[i] = out_ptr[i] + bias_ptr[(i // plane) % channels]
 
     _parallel_for[func](total, ctx)
+
+
+# One warp (32 lanes) per (sample, channel) row of `plane` contiguous
+# elements, one lane per element (striding by 32 when plane > 32) --
+# `plane`-fold fewer redundant `(i // plane) % channels` computations than
+# the scalar form, one per row instead of one per element. Unlike im2col's
+# row-invariant metadata, `row % channels` is one mod plus one small,
+# warp-uniform load (every lane reads the SAME `bias_ptr` element, which the
+# memory system broadcasts on its own), so every lane just recomputes it --
+# not worth a `warp.shuffle_idx` broadcast the way im2col's much heavier
+# multi-division decomposition was. Consecutive lanes still own consecutive
+# elements, so both the read and the write stay warp-coalesced.
+@__name(t"bias_add_chan_row_{dtype}")
+def _bias_add_chan_row_kernel[
+    dtype: DType
+](
+    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    bias_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    plane_arg: Int64,
+    channels_arg: Int64,
+    total_rows_arg: Int64,
+):
+    var plane = Int(plane_arg)
+    var channels = Int(channels_arg)
+    var total_rows = Int(total_rows_arg)
+    var row_stride = Int(grid_dim.x)
+    var lane = Int(thread_idx.x)
+
+    var row = Int(block_idx.x)
+    while row < total_rows:
+        var bias_val = bias_ptr[row % channels]
+        var base = row * plane
+        var i = lane
+        while i < plane:
+            out_ptr[base + i] = out_ptr[base + i] + bias_val
+            i += _IM2COL_WARP
+        row += row_stride
+
+
+@always_inline
+def _bias_add_chan_gpu[
+    dtype: DType
+](
+    out_addr: Int,
+    bias_addr: Int,
+    total: Int,
+    plane: Int,
+    channels: Int,
+    ctx: DeviceContext,
+) raises:
+    var total_rows = total // plane if plane > 0 else 0
+    var blocks = min(max(total_rows, 1), _IM2COL_MAX_ROW_BLOCKS)
+    _enqueue_cached[_bias_add_chan_row_kernel[dtype]](
+        ctx,
+        String(t"bias_add_chan_row_{dtype}"),
+        blocks,
+        1,
+        1,
+        _IM2COL_WARP,
+        _make_ptr[dtype](out_addr).as_unsafe_any_origin(),
+        _make_ptr[dtype](bias_addr).as_unsafe_any_origin(),
+        Int64(plane),
+        Int64(channels),
+        Int64(total_rows),
+    )
+
+
+@always_inline
+def _bias_add_chan[
+    dtype: DType
+](
+    out_addr: Int,
+    bias_addr: Int,
+    total: Int,
+    plane: Int,
+    channels: Int,
+    ctx: DeviceContext,
+) raises:
+    if ctx.api() == "cpu" or plane <= 0 or total % plane != 0:
+        _bias_add_chan_scalar[dtype](
+            out_addr, bias_addr, total, plane, channels, ctx
+        )
+    else:
+        _bias_add_chan_gpu[dtype](
+            out_addr, bias_addr, total, plane, channels, ctx
+        )
 
 
 def _bias_add_chan_go(

--- a/torch_mojo_backend/eager_kernels/conv_ops/conv_ops.mojo
+++ b/torch_mojo_backend/eager_kernels/conv_ops/conv_ops.mojo
@@ -441,6 +441,383 @@ def _im2col_dispatcher(
 
 
 # ---------------------------------------------------------------------------
+# col2im: the exact adjoint of the im2col above, used by the conv backward's
+# data gradient. `_im2col` GATHERS one input element per (patch row, output
+# column); its adjoint SCATTERS the same value back, so every input pixel
+# accumulates the columns of every filter tap that read it.
+#
+# Written as a gather over the OUTPUT (one thread owns one input pixel and
+# loops over the taps that could have read it) rather than as a scatter over
+# the input (one thread per column element, atomically adding into the image).
+# Two reasons, both structural: the gather needs no atomics at all, and it is
+# bit-for-bit deterministic -- an atomic scatter would sum the taps of a pixel
+# in launch order, so two runs of the same backward could return different
+# gradients. The tap loop is `kh * kw` iterations of integer arithmetic per
+# pixel, against `kh * kw` atomic round trips per pixel for the scatter.
+#
+# The tap condition inverts the forward index map
+#   ih = oh * stride_h - pad_h + r * dil_h
+# for a fixed `ih`: `oh` exists iff `th = ih + pad_h - r * dil_h` is
+# non-negative, divisible by `stride_h` and lands inside `[0, out_h)`.
+# `th >= 0` is tested BEFORE the modulo on purpose -- a negative dividend
+# makes `%` implementation-defined between languages, and every negative `th`
+# is out of range anyway.
+#
+# Accumulation is float32 for every supported dtype (FLOAT_DTYPES tops out at
+# f32), matching both torch's own accumulator and the fp32 accumulation of the
+# GEMM that produced the columns; a bf16 accumulator would lose the small taps
+# of a 7x7 filter outright.
+# ---------------------------------------------------------------------------
+
+
+@always_inline
+def _col2im_scalar[
+    dtype: DType
+](
+    out_addr: Int,
+    in_addr: Int,
+    in_h: Int,
+    in_w: Int,
+    out_h: Int,
+    out_w: Int,
+    kh: Int,
+    kw: Int,
+    stride_h: Int,
+    stride_w: Int,
+    pad_h: Int,
+    pad_w: Int,
+    dil_h: Int,
+    dil_w: Int,
+    channels: Int,
+    batch: Int,
+    ctx: DeviceContext,
+) raises:
+    """One input pixel per thread, on the generic `elementwise` framework.
+
+    The CPU device's only path (`_parallel_for` runs `elementwise` on host
+    there); `_col2im_gpu` below replaces it on GPU with the same
+    warp-per-row shape `_im2col_gpu` uses.
+    """
+    var out_ptr = _make_ptr[dtype](out_addr)
+    var in_ptr = _make_ptr[dtype](in_addr)
+
+    @always_inline
+    @parameter
+    @__copy_capture(out_ptr, in_ptr)
+    def func[width: Int, alignment: Int = 1](idx: StdCoord):
+        var i = Int(idx[0].value())
+        var cols = out_h * out_w
+        var iw = i % in_w
+        var ih = (i // in_w) % in_h
+        var c = (i // (in_w * in_h)) % channels
+        var s = i // (in_w * in_h * channels)
+        var col_base = (s * channels + c) * kh * kw * cols
+        var acc = Scalar[DType.float32](0)
+        for r in range(kh):
+            var th = ih + pad_h - r * dil_h
+            if th < 0 or th % stride_h != 0:
+                continue
+            var oh = th // stride_h
+            if oh >= out_h:
+                continue
+            var row_base = col_base + r * kw * cols + oh * out_w
+            for fw in range(kw):
+                var tw = iw + pad_w - fw * dil_w
+                if tw < 0 or tw % stride_w != 0:
+                    continue
+                var ow = tw // stride_w
+                if ow >= out_w:
+                    continue
+                acc += in_ptr[row_base + fw * cols + ow].cast[DType.float32]()
+        out_ptr[i] = acc.cast[dtype]()
+
+    _parallel_for[func](batch * channels * in_h * in_w, ctx)
+
+
+# One warp (32 lanes) per (sample, channel, input row), one lane per input
+# column (striding by 32 when in_w > 32) -- the same shape `_im2col_gpu`
+# settled on, for the same reasons: the `(s, c, ih)` decomposition is
+# computed once per row instead of once per pixel, and consecutive lanes own
+# consecutive `iw`, so the store is always warp-coalesced and the loads are
+# too whenever `stride_w == 1` (then `ow = iw + pad_w - fw * dil_w` is
+# consecutive across lanes as well). The per-row `r`-loop bookkeeping
+# (`th`, `oh`) is warp-uniform, so unlike im2col's much heavier
+# multi-division decomposition there is nothing worth broadcasting through
+# `warp.shuffle_idx`: every lane recomputes a couple of cheap integer ops
+# rather than paying a shuffle plus the register pressure of holding them.
+#
+# The grid is `batch * channels * in_h` rows, which is COARSER than im2col's
+# `batch * channels * kh * kw * out_h`: the tap loop is folded into each lane
+# instead of being spread across the grid, because a pixel's taps have to be
+# summed by ONE thread for the gather to stay atomic-free. That trades
+# parallelism for determinism deliberately; if a shape ever starves the
+# machine of blocks, the fix is a split over taps with a second reduce pass,
+# not an atomic scatter.
+@__name(t"col2im_row_{dtype}")
+def _col2im_row_kernel[
+    dtype: DType
+](
+    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    in_h_arg: Int64,
+    in_w_arg: Int64,
+    out_h_arg: Int64,
+    out_w_arg: Int64,
+    kh_arg: Int64,
+    kw_arg: Int64,
+    stride_h_arg: Int64,
+    stride_w_arg: Int64,
+    pad_h_arg: Int64,
+    pad_w_arg: Int64,
+    dil_h_arg: Int64,
+    dil_w_arg: Int64,
+    channels_arg: Int64,
+    total_rows_arg: Int64,
+):
+    var in_h = Int(in_h_arg)
+    var in_w = Int(in_w_arg)
+    var out_h = Int(out_h_arg)
+    var out_w = Int(out_w_arg)
+    var kh = Int(kh_arg)
+    var kw = Int(kw_arg)
+    var stride_h = Int(stride_h_arg)
+    var stride_w = Int(stride_w_arg)
+    var pad_h = Int(pad_h_arg)
+    var pad_w = Int(pad_w_arg)
+    var dil_h = Int(dil_h_arg)
+    var dil_w = Int(dil_w_arg)
+    var channels = Int(channels_arg)
+    var total_rows = Int(total_rows_arg)
+
+    var cols = out_h * out_w
+    var row_stride = Int(grid_dim.x)
+    var lane = Int(thread_idx.x)
+
+    var row = Int(block_idx.x)
+    while row < total_rows:
+        var ih = row % in_h
+        var sc = row // in_h
+        # `sc` is the flat (sample, channel) index and the column block of
+        # that pair starts at `sc * kh * kw * cols`, so the sample and the
+        # channel never need to be separated.
+        var col_base = sc * kh * kw * cols
+        var out_base = row * in_w
+
+        var iw = lane
+        while iw < in_w:
+            var acc = Scalar[DType.float32](0)
+            for r in range(kh):
+                var th = ih + pad_h - r * dil_h
+                if th < 0 or th % stride_h != 0:
+                    continue
+                var oh = th // stride_h
+                if oh >= out_h:
+                    continue
+                var row_base = col_base + r * kw * cols + oh * out_w
+                for fw in range(kw):
+                    var tw = iw + pad_w - fw * dil_w
+                    if tw < 0 or tw % stride_w != 0:
+                        continue
+                    var ow = tw // stride_w
+                    if ow >= out_w:
+                        continue
+                    acc += in_ptr[row_base + fw * cols + ow].cast[
+                        DType.float32
+                    ]()
+            out_ptr[out_base + iw] = acc.cast[dtype]()
+            iw += _IM2COL_WARP
+
+        row += row_stride
+
+
+@always_inline
+def _col2im_gpu[
+    dtype: DType
+](
+    out_addr: Int,
+    in_addr: Int,
+    in_h: Int,
+    in_w: Int,
+    out_h: Int,
+    out_w: Int,
+    kh: Int,
+    kw: Int,
+    stride_h: Int,
+    stride_w: Int,
+    pad_h: Int,
+    pad_w: Int,
+    dil_h: Int,
+    dil_w: Int,
+    channels: Int,
+    batch: Int,
+    ctx: DeviceContext,
+) raises:
+    var total_rows = batch * channels * in_h
+    # Same block cap as im2col, for the same reason (one warp per block is
+    # tiny, so one block per row oversubscribes the scheduler by orders of
+    # magnitude) -- and with the same caveat: the constant was fitted on an
+    # H100, and no other architecture has been measured with it.
+    var blocks = min(max(total_rows, 1), _IM2COL_MAX_ROW_BLOCKS)
+    _enqueue_cached[_col2im_row_kernel[dtype]](
+        ctx,
+        String(t"col2im_row_{dtype}"),
+        blocks,
+        1,
+        1,
+        _IM2COL_WARP,
+        _make_ptr[dtype](out_addr).as_unsafe_any_origin(),
+        _make_ptr[dtype](in_addr).as_unsafe_any_origin(),
+        Int64(in_h),
+        Int64(in_w),
+        Int64(out_h),
+        Int64(out_w),
+        Int64(kh),
+        Int64(kw),
+        Int64(stride_h),
+        Int64(stride_w),
+        Int64(pad_h),
+        Int64(pad_w),
+        Int64(dil_h),
+        Int64(dil_w),
+        Int64(channels),
+        Int64(total_rows),
+    )
+
+
+@always_inline
+def _col2im[
+    dtype: DType
+](
+    out_addr: Int,
+    in_addr: Int,
+    in_h: Int,
+    in_w: Int,
+    out_h: Int,
+    out_w: Int,
+    kh: Int,
+    kw: Int,
+    stride_h: Int,
+    stride_w: Int,
+    pad_h: Int,
+    pad_w: Int,
+    dil_h: Int,
+    dil_w: Int,
+    channels: Int,
+    batch: Int,
+    ctx: DeviceContext,
+) raises:
+    if ctx.api() == "cpu":
+        _col2im_scalar[dtype](
+            out_addr,
+            in_addr,
+            in_h,
+            in_w,
+            out_h,
+            out_w,
+            kh,
+            kw,
+            stride_h,
+            stride_w,
+            pad_h,
+            pad_w,
+            dil_h,
+            dil_w,
+            channels,
+            batch,
+            ctx,
+        )
+    else:
+        _col2im_gpu[dtype](
+            out_addr,
+            in_addr,
+            in_h,
+            in_w,
+            out_h,
+            out_w,
+            kh,
+            kw,
+            stride_h,
+            stride_w,
+            pad_h,
+            pad_w,
+            dil_h,
+            dil_w,
+            channels,
+            batch,
+            ctx,
+        )
+
+
+def _col2im_go(
+    image_ptr: PyObjectPtr,
+    col_ptr: PyObjectPtr,
+    # (in_h, in_w, out_h, out_w, kh, kw, stride_h, stride_w, pad_h, pad_w,
+    #  dil_h, dil_w, channels, batch); batch defaults to 1 when omitted.
+    params: PyObjectPtr,
+    dtype_obj: PyObjectPtr,
+    device_context_ptr: PyObjectPtr,
+) raises:
+    var dtype = _raw_dtype_int(dtype_obj)
+    var out_addr = _raw_int(image_ptr)
+    var in_addr = _raw_int(col_ptr)
+    var in_h = _raw_tuple_int(params, 0)
+    var in_w = _raw_tuple_int(params, 1)
+    var out_h = _raw_tuple_int(params, 2)
+    var out_w = _raw_tuple_int(params, 3)
+    var kh = _raw_tuple_int(params, 4)
+    var kw = _raw_tuple_int(params, 5)
+    var stride_h = _raw_tuple_int(params, 6)
+    var stride_w = _raw_tuple_int(params, 7)
+    var pad_h = _raw_tuple_int(params, 8)
+    var pad_w = _raw_tuple_int(params, 9)
+    var dil_h = _raw_tuple_int(params, 10)
+    var dil_w = _raw_tuple_int(params, 11)
+    var channels = _raw_tuple_int(params, 12)
+    var batch = _raw_tuple_int(params, 13) if _raw_tuple_len(params) > 13 else 1
+    var ctx = _raw_ctx(device_context_ptr)
+
+    var handled = False
+    comptime for dt in FLOAT_DTYPES:
+        comptime if _dtype_arg_on[0, dt]():
+            if dtype == dt:
+                _col2im[dt](
+                    out_addr,
+                    in_addr,
+                    in_h,
+                    in_w,
+                    out_h,
+                    out_w,
+                    kh,
+                    kw,
+                    stride_h,
+                    stride_w,
+                    pad_h,
+                    pad_w,
+                    dil_h,
+                    dil_w,
+                    channels,
+                    batch,
+                    ctx,
+                )
+                handled = True
+    if not handled:
+        raise Error("unsupported dtype for fast col2im: " + String(dtype))
+
+
+def _col2im_dispatcher(
+    py_self: PyObjectPtr,
+    args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
+    nargs: Py_ssize_t,
+) abi("C") -> PyObjectPtr:
+    var args = UnsafePointer(args_safe)
+    try:
+        _col2im_go(args[0], args[1], args[2], args[3], args[4])
+    except e:
+        return _spec_unsupported(e)
+    return _raw_ret_none()
+
+
+# ---------------------------------------------------------------------------
 # In-place per-channel bias add on a (batch, channels, plane) tensor:
 # out[i] += bias[(i // plane) % channels].
 # ---------------------------------------------------------------------------
@@ -621,6 +998,15 @@ def PyInit_conv_ops() abi("C") -> PythonObject:
                 _im2col_dispatcher,
                 docstring=(
                     "batched NCHW im2col -> (N, C*KH*KW, OH*OW) patch matrix"
+                ),
+            )
+        comptime if _op_on["Col2im"]():
+            _register_call(
+                b,
+                _col2im_dispatcher,
+                docstring=(
+                    "(N, C*KH*KW, OH*OW) patch matrix -> NCHW image, summing"
+                    " every filter tap that read each pixel (im2col's adjoint)"
                 ),
             )
         comptime if _op_on["BiasAddChan"]():

--- a/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_bmm_v5_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_bmm_v5_kernels.mojo
@@ -74,6 +74,7 @@ from layout.tensor_core_async import (
 from layout.tma_async import SharedMemBarrier, TMATensorTile
 
 from gemm16_dtype import _GEMM16_DT, _GEMM16_TAG
+from wgmma_c_epilogue import _wgmma_store_c_tile
 
 comptime _B5_DT = _GEMM16_DT
 comptime _B5_F32 = DType.float32
@@ -655,59 +656,22 @@ def _b5_bmm_nn_tiny[
                 issue_tile(t + stages)
             t += 1
 
-        var tid = Int(thread_idx.x)
-        var warp = tid // 32
-        var lane = tid % 32
-        var base_row = warp * 16 + lane // 4
-        var base_col = (lane % 4) * 2
-        comptime if tma_store:
-            comptime for q in range(CFRAG // 2):
-                var e = q * 2
-                var row = base_row + (q % 2) * 8
-                var col = base_col + (q // 2) * 8
-                var pair = SIMD[_B5_DT, 2](
-                    accum.ptr[e].cast[_B5_DT](),
-                    accum.ptr[e + 1].cast[_B5_DT](),
-                )
-                var lcol = col % 64
-                var elem = (
-                    (col // 64) * (bm * 64)
-                    + row * 64
-                    + ((lcol // 8) ^ (row % 8)) * 8
-                    + lcol % 8
-                )
-                c_smem.ptr.store[alignment=4](elem, pair)
-            fence_async_view_proxy()
-            barrier()
-            if thread_idx.x == 0:
-                comptime for chunk in range(bn // 64):
-                    var c_chunk = LayoutTensor[
-                        _B5_DT,
-                        Layout.row_major(bm, 64),
-                        MutAnyOrigin,
-                        address_space=AddressSpace.SHARED,
-                        alignment=128,
-                    ](c_smem.ptr + chunk * bm * 64)
-                    c_tma.async_store_3d(c_chunk, (n0 + chunk * 64, m0, bidx))
-                c_tma.commit_group()
-                c_tma.wait_group[0]()
-        else:
-            comptime for q in range(CFRAG // 2):
-                var e = q * 2
-                var row = base_row + (q % 2) * 8
-                var col = base_col + (q // 2) * 8
-                if m0 + row < m:
-                    var off = bidx * c_bs + (m0 + row) * n + n0 + col
-                    if n0 + col + 1 < n:
-                        output.store[alignment=2](
-                            off,
-                            SIMD[_B5_DT, 2](
-                                accum.ptr[e].cast[_B5_DT](),
-                                accum.ptr[e + 1].cast[_B5_DT](),
-                            ),
-                        )
-                    elif n0 + col < n:
-                        output[off] = accum.ptr[e].cast[_B5_DT]()
+        # Both epilogues (128 B-swizzled TMA store and the scalar 4 B
+        # fallback) are pure functions of the wgmma fragment layout, and the
+        # implicit-GEMM conv kernel writes exactly the same (batch, m, n)
+        # tile, so they live in wgmma_c_epilogue.mojo and are shared instead
+        # of copied.  `@always_inline`: verified via
+        # scripts/compare_kernel_asm.py (sm_90a) that this is a NEW-FUNCTION-
+        # BOUNDARY diff, not a logic change -- the scalar-epilogue kernels'
+        # PTX shifts by register renumbering and instruction reordering
+        # (param-load order), never a changed opcode/operand/immediate. Not
+        # byte-identical, so treat that script's "0 kernels changed" bar as
+        # not met here; the correctness net is the 140+ gemm16/bmm/conv unit
+        # tests plus benchmarks/test_vision.py's mid/awkward conv shapes
+        # (both route through this exact scalar-epilogue kernel), all green.
+        _wgmma_store_c_tile[_B5_DT, bm, bn, tma_store](
+            c_tma, c_smem.ptr, accum.ptr, output, m, n, c_bs, m0, n0, bidx
+        )
 
 
 def _b5_enqueue_tiny[

--- a/torch_mojo_backend/eager_kernels/wgmma_c_epilogue.mojo
+++ b/torch_mojo_backend/eager_kernels/wgmma_c_epilogue.mojo
@@ -1,0 +1,114 @@
+"""The shared C-tile epilogue of the 128-thread wgmma bodies.
+
+One 128-thread warp group holding a 64 x `bn` fp32 accumulator writes it out
+in exactly one of two ways, and both are pure functions of the accumulator
+fragment layout, so every kernel with that body shape wants the same code:
+
+  * `tma_store=True` — stage the tile into the 128 B-swizzled shared buffer
+    the TMA store expects, then `async_store_3d` it 64 columns at a time.
+    Needs a 16 B aligned output row pitch (the descriptor requirement), and
+    TMA clips the ragged edges against the descriptor's own extents.
+  * `tma_store=False` — the scalar fallback for an output row pitch a TMA
+    store descriptor cannot express: 4 B pairs straight to global, with the
+    row and column bounds tested in software.
+
+The accumulator element -> (row, col) mapping is the wgmma m64nNk16 fragment
+layout: lane l of warp w owns rows `w*16 + l/4` (+8) and column pairs
+`(l%4)*2 + 8*q`.  It is the one piece of this that is easy to get subtly
+wrong, which is why it lives in one place instead of once per kernel.
+
+The tile is addressed as one item of a rank-3 (batch, m, n) output:
+`out[bidx, m0 + row, n0 + col]`, with `c_bs` the element stride between
+batch items.  A conv fprop whose GEMM computes (out_c x pixels) per sample
+is exactly that with `m = out_c`, `n = OH*OW`, `c_bs = out_c*OH*OW`, which
+is why the implicit-GEMM conv kernel shares this epilogue verbatim rather
+than carrying a second copy.
+"""
+
+from std.gpu import thread_idx
+from max.gpu.memory import fence_async_view_proxy
+from max.gpu.sync import barrier
+from std.memory import AddressSpace
+from std.utils.index import Index
+
+from layout import Layout, LayoutTensor
+from layout.tma_async import TMATensorTile
+
+
+@always_inline
+def _wgmma_store_c_tile[
+    dtype: DType,
+    bm: Int,
+    bn: Int,
+    tma_store: Bool,
+](
+    c_tma: TMATensorTile[dtype, 3, Index(1, bm, 64), Index(1, bm, 64)],
+    c_smem: UnsafePointer[
+        Scalar[dtype], MutAnyOrigin, address_space=AddressSpace.SHARED
+    ],
+    accum: UnsafePointer[
+        Scalar[DType.float32], MutAnyOrigin, address_space=AddressSpace.LOCAL
+    ],
+    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    m: Int,
+    n: Int,
+    c_bs: Int,
+    m0: Int,
+    n0: Int,
+    bidx: Int,
+):
+    comptime assert bn % 64 == 0, "the C tile is stored 64 columns at a time"
+    comptime CFRAG = 64 * bn // 128
+    var tid = Int(thread_idx.x)
+    var warp = tid // 32
+    var lane = tid % 32
+    var base_row = warp * 16 + lane // 4
+    var base_col = (lane % 4) * 2
+    comptime if tma_store:
+        comptime for q in range(CFRAG // 2):
+            var e = q * 2
+            var row = base_row + (q % 2) * 8
+            var col = base_col + (q // 2) * 8
+            var pair = SIMD[dtype, 2](
+                accum[e].cast[dtype](),
+                accum[e + 1].cast[dtype](),
+            )
+            var lcol = col % 64
+            var elem = (
+                (col // 64) * (bm * 64)
+                + row * 64
+                + ((lcol // 8) ^ (row % 8)) * 8
+                + lcol % 8
+            )
+            c_smem.store[alignment=4](elem, pair)
+        fence_async_view_proxy()
+        barrier()
+        if thread_idx.x == 0:
+            comptime for chunk in range(bn // 64):
+                var c_chunk = LayoutTensor[
+                    dtype,
+                    Layout.row_major(bm, 64),
+                    MutAnyOrigin,
+                    address_space=AddressSpace.SHARED,
+                    alignment=128,
+                ](c_smem + chunk * bm * 64)
+                c_tma.async_store_3d(c_chunk, (n0 + chunk * 64, m0, bidx))
+            c_tma.commit_group()
+            c_tma.wait_group[0]()
+    else:
+        comptime for q in range(CFRAG // 2):
+            var e = q * 2
+            var row = base_row + (q % 2) * 8
+            var col = base_col + (q // 2) * 8
+            if m0 + row < m:
+                var off = bidx * c_bs + (m0 + row) * n + n0 + col
+                if n0 + col + 1 < n:
+                    output.store[alignment=2](
+                        off,
+                        SIMD[dtype, 2](
+                            accum[e].cast[dtype](),
+                            accum[e + 1].cast[dtype](),
+                        ),
+                    )
+                elif n0 + col < n:
+                    output[off] = accum[e].cast[dtype]()

--- a/torch_mojo_backend/mojo_device/aten_ops/autograd_preflight.py
+++ b/torch_mojo_backend/mojo_device/aten_ops/autograd_preflight.py
@@ -160,56 +160,6 @@ mojo_device_upsample_bilinear2d = _preflight_unsupported_backward(
 # ---------------------------------------------------------------------------
 
 
-def mojo_device_convolution(
-    input: torch.Tensor,
-    weight: torch.Tensor,
-    bias: torch.Tensor | None,
-    stride: Sequence[int],
-    padding: Sequence[int],
-    dilation: Sequence[int],
-    transposed: bool,
-    output_padding: Sequence[int],
-    groups: int,
-) -> TorchMojoTensor:
-    """Convolution with a forward-time preflight of its native autograd node.
-
-    The forward exists here; `aten::convolution_backward` does not (it needs
-    the im2col-transpose GEMM pair). Recording ConvolutionBackward0 anyway
-    would move the failure into the autograd engine, where an exception aborts
-    the process instead of raising — the unwind hazard
-    `_refuse_unsupported_backward` documents — so a call whose gradient the
-    engine would come back for is refused here, from the forward, with a
-    traceback that names the op.
-
-    Unlike batch norm this has no training-mode escape: a conv weight normally
-    requires grad, so in practice this refuses every conv in a training model,
-    and the honest message is that the backward kernel is missing rather than
-    that some flag is set wrong. Inference is unaffected under
-    `torch.no_grad()` / `torch.inference_mode()`.
-    """
-    _refuse_unsupported_backward(
-        "aten::convolution",
-        "aten::convolution_backward",
-        (input, weight, bias),
-        _GRAD_OFF_ONLY,
-    )
-    aten_fast = _fast()
-    result = aten_fast.fast_aten_convolution(
-        input,
-        weight,
-        bias,
-        stride,
-        padding,
-        dilation,
-        transposed,
-        output_padding,
-        groups,
-    )
-    if result is aten_fast.NOT_HANDLED:
-        raise _unsupported("aten::convolution", (input, weight, bias))
-    return result
-
-
 def mojo_device_embedding(
     weight, indices, padding_idx=-1, scale_grad_by_freq=False, sparse=False
 ):

--- a/torch_mojo_backend/mojo_device/mojo_device_aten_ops.py
+++ b/torch_mojo_backend/mojo_device/mojo_device_aten_ops.py
@@ -25,7 +25,6 @@ from .aten_ops.autograd_preflight import (
     mojo_device__scaled_dot_product_efficient_attention,
     mojo_device__softmax,
     mojo_device_avg_pool2d,
-    mojo_device_convolution,
     mojo_device_cumsum,
     mojo_device_embedding,
     mojo_device_index,
@@ -247,7 +246,8 @@ _register_fast("aten::cat", "fast_aten_cat")
 _register_fast("aten::ceil", "fast_aten_ceil")
 _register_fast("aten::clamp", "fast_aten_clamp")
 _register_fast("aten::clone", "fast_aten_clone")
-register_aten_op("aten::convolution")(mojo_device_convolution)
+_register_fast("aten::convolution", "fast_aten_convolution")
+_register_fast("aten::convolution_backward", "fast_aten_convolution_backward")
 _register_fast("aten::cos", "fast_aten_cos")
 _register_fast("aten::cosh", "fast_aten_cosh")
 register_aten_op("aten::cumsum")(mojo_device_cumsum)

--- a/torch_mojo_backend/mojo_device/mojo_device_aten_ops.py
+++ b/torch_mojo_backend/mojo_device/mojo_device_aten_ops.py
@@ -25,7 +25,6 @@ from .aten_ops.autograd_preflight import (
     mojo_device__scaled_dot_product_efficient_attention,
     mojo_device__softmax,
     mojo_device_avg_pool2d,
-    mojo_device_convolution,
     mojo_device_cumsum,
     mojo_device_embedding,
     mojo_device_index,
@@ -242,7 +241,8 @@ _register_fast("aten::cat", "fast_aten_cat")
 _register_fast("aten::ceil", "fast_aten_ceil")
 _register_fast("aten::clamp", "fast_aten_clamp")
 _register_fast("aten::clone", "fast_aten_clone")
-register_aten_op("aten::convolution")(mojo_device_convolution)
+_register_fast("aten::convolution", "fast_aten_convolution")
+_register_fast("aten::convolution_backward", "fast_aten_convolution_backward")
 _register_fast("aten::cos", "fast_aten_cos")
 _register_fast("aten::cosh", "fast_aten_cosh")
 register_aten_op("aten::cumsum")(mojo_device_cumsum)


### PR DESCRIPTION
Training a CNN on the mojo device fails today at the **forward**. #401 had to
refuse any grad-requiring `aten::convolution` from there, because
`aten::convolution_backward` did not exist and a raise from inside the autograd
engine aborts the process on this backend instead of propagating. A conv weight
normally requires grad, so that refusal is every conv in a training model: CNNs,
ViTs with a conv stem, and SD UNets are all blocked. This PR adds the kernel and
deletes the refusal.

To be clear about what that does and does not unblock: conv was **one of three**
forward-time refusals standing between this device and vision training. Batch /
group norm backward (backlog N2) and pooling backward (C4) are still missing, so
a ResNet training step still stops — just one op later. What this PR buys is
that conv itself is no longer the thing stopping it, and that any model whose
only conv-shaped blocker was this one now trains.

### Stacked on #387

**This branch starts from #387's head, so its six commits are included below.
Read only the last one, `Implement aten::convolution_backward on the mojo eager
device` — everything before it is #387 and is reviewed there.** GitHub cannot
target a cross-fork branch as a base, hence `main`; merge #387 first and this
diff collapses to the backward alone.

The stacking is not incidental: the weight gradient IS an im2col GEMM and reuses
#387's `Im2col` kernel and its tensor-core GEMM routes directly, so building on
`main` would have meant duplicating machinery already under review. (#399, the
conv1d *forward*, is also still open and is NOT in this base — see the rank-3
note below.)

### The three gradients

| | how it is computed | new code? |
|---|---|---|
| `grad_bias` | one reduction of `grad_output` over batch and space | no |
| `grad_weight` | transposed-B GEMM of `grad_output` against the im2col matrix, then a reduce over the batch | no |
| `grad_input` | shared-A GEMM of the transposed weight against `grad_output`, then `Col2im` | one Mojo kernel |

`grad_weight` is the forward's own GEMM with the two operands' roles swapped, so
the reduction runs over output pixels instead of over patch rows — it rides the
same Bmm16 (bf16/f16) / TF32 (f32) / SIMT routes the forward picks from.

`Col2im` is im2col's exact adjoint and is the only new kernel. It is written as
a **gather over the output image** — one thread owns one input pixel and loops
the taps that could have read it — rather than as a scatter with atomics. That
buys two things: no atomics at all, and bit-for-bit determinism, where an atomic
scatter would sum each pixel's taps in launch order and could return different
gradients on two runs of the same backward. It reuses the warp-per-row shape
`_im2col_gpu` settled on, and accumulates in fp32 like torch does.

Grouped convolutions slice each group's contiguous rows with offset GEMMs — the
same decomposition the forward's grouped path already uses. A 1x1 stride-1
convolution short-circuits both spatial kernels, since col2im is then the
identity. Transposed convolutions decline cleanly: the forward declines them
too, so nothing on this device can produce such a node.

**rank-3 (conv1d)** goes through the rank-4 path behind a size-1 H axis. Because
the rank-3 *forward* is #399 and is not in this base, nothing can reach this
backward through autograd yet, so it is tested at the aten level instead — the
lift has to be correct from the day the backward exists, not from the day
something can reach it.

### Compile backend

`aten::convolution_backward` reaches the MAX-graph backend un-decomposed and
failed there too, so it gets its own composition. Two findings drove its shape:

* **MAX has no convolution-gradient op of any kind** (checked across
  `/root/modular` and the installed 26.5.0 `max.graph.ops`).
* **`conv2d_transpose` is unusable on GPU here.** It is cuDNN-only, and on an
  H100 it does not raise — it **aborts the process**: `ABORT: symbol not found:
  cudnnCreate`. Under this project's "works with a CPU-only PyTorch install"
  rule it is off the table regardless.

So: `F.fold` IS col2im, so the data gradient folds a matmul; the weight gradient
is a convolution with the operand roles permuted (input channels become the
batch, `grad_output` becomes the filter, stride and dilation exchange).

One measured gotcha, documented in the code: **`F.fold`'s `padding` argument
does not match torch's `F.fold`** — it agrees at padding 0 and diverges for
every nonzero padding. The padded case therefore folds into the padded extent
and crops the border off, which is the same identity and keeps this path on the
one fold configuration that is verified against torch.

### Correctness

Every eager case is checked against an **fp64 CPU-autograd ground truth with a
per-element tolerance derived from the fp32 accumulation bound** (magnitude x
`(roundings * half_ulp + 4 * eps_f32 * sqrt(k))`), the same criterion #387's
implicit-GEMM test uses — not a flat `atol`, which on a reduction over
`N * OH * OW` terms would either pass wrong kernels on big shapes or fail right
ones on small. Coverage: stride 1/2/3, padding, dilation 2, groups 1/2/64
(depthwise), batch 1/32, bf16/f16/f32, every `output_mask` combination, a
channels-last `grad_output`, truncating extents, rectangular filters, 1x1, and
rank-3. Masked-off slots come back as `None`, matching ATen's undefined-tensor
binding.

The compile backend gets its own compiled comparison against stock torch on both
CPU and CUDA, including an end-to-end `.backward()`.

`test_fast_conv2d_refuses_autograd_in_the_forward` is replaced by
`test_fast_conv2d_trains_through_autograd`, which asserts the whole round trip.

### Performance: coverage-first, and the numbers are not good

New benchmark, **one node per gradient** so a later change to one of the three
kernels is attributable. On an H100 PCIe against cuDNN, ours/stock device time
(12 entries each):

| gradient | min | median | max |
|---|---|---|---|
| `dgrad` | 1.40 | 10.58 | 15.12 |
| `wgrad` | 3.27 | 11.71 | 23.25 |
| `bgrad` | 0.39 | 0.90 | 3.21 |

The bias gradient is usually **faster** than torch (it is a plain reduction).
The two spatial gradients are 10x off, and the reason is structural rather than
a tuning gap: they ride the **materialized** im2col route, because #387's
implicit-GEMM route is forward-only, so both pay a full column-buffer write and
read — the traffic that PR's own profiling measured at 89% of the materialized
route's device time. The weight gradient additionally materializes an
`(N, out_c, C*R*S)` partials buffer, since none of the GEMM routes here takes a
`beta=1` accumulator; that buffer is larger than the column buffer itself
whenever `out_c > OH*OW`, i.e. exactly in the deep stages where the worst ratios
sit.

Both are written up as follow-ups in `docs/optimization_backlog.md` (C3): a
patch-major im2col variant folds N into the weight GEMM's K, removing both the
partials buffer and the batch reduce; an implicit-GEMM dgrad/wgrad would remove
the column buffer entirely. Bar-chasing is a separate engagement.

### Also in here

* `_try_gemm16_conv_bmm` / `_try_tf32_conv_bmm` generalized into shared-A
  batched GEMM helpers plus `_conv_col_matrix`, now used by both convolution
  directions instead of duplicated.
* `matmul_tolerance` moved from `test_compiler.py` into `conftest.py` so the
  new compiled tests can use the house TF32 allowance instead of inventing one.

### CI on this PR is red, and every red test is inherited from #387

`conv_ops.mojo` does not **build** on a runner without a GPU:
`_im2col_gpu`'s `_enqueue_cached` instantiation fails inside
`gpu/host/info.mojo`, so the whole module fails to import and every conv test
errors with `ImportError: mojo build failed for conv_ops`. That is #387's GPU
im2col, and **#387's own CI fails the same way, at the same trace, on the same
`test_mojo_device.py::test_convolution_2d[cpu]`** — see run 32249078749. It is
not fixed here because the fix belongs in that PR, next to the code that
introduced it.

This is checkable rather than assertable. Listing the failing test names of
both runs and diffing them: **#387 fails 27 tests; this PR fails those same 27
plus exactly one**, `tests/test_aten_functions.py::test_aten_convolution_backward`
— a test added here, failing with the same `ImportError: mojo build failed for
conv_ops` as the other 27, because its mojo-CPU cases reach the same broken
build. Not one test fails here for a reason that does not already fail on the
base. (The 27 are the conv suite plus the `div_floor_rounding` /
`div_trunc_rounding` conformance entries that came in with #402.)

### Test status (locally, on a machine that has a GPU)

`tests/test_eager_kernels.py` (1848 passed), `tests/test_aten_functions.py` (622
passed), `tests/test_compiler.py` (67 passed, serially), `test_call_queue.py`,
`test_mojo_device.py`, `test_high_level_ops.py -k conv`, and
`benchmarks/test_coverage.py` are all green. The two conformance failures on
`nn_functional_conv2d` bf16/f16 are pre-existing — verified by re-running them
against this branch's base sources — and are a forward bf16 rounding difference
on one element of a `padding='same'`, `dilation=3` sample.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Co2wBC1UYzM4y9PEC92Af
