### PR TITLE
Fuse the bias into the direct WGMMA GEMM epilogue (addmm / linear)

### DIFF
--- a/benchmarks/baselines.html
+++ b/benchmarks/baselines.html
@@ -5617,7 +5617,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 "S1_4096x4096x4096": {
                   "layouts": {
                     "NN": 3.501,
-                    "NT": 4.187,
+                    "NT": 1.201,
                     "TN": 2.326,
                     "TT": 3.312
                   }
@@ -5625,7 +5625,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 "S2_8192x2048x2048": {
                   "layouts": {
                     "NN": 3.49,
-                    "NT": 4.143,
+                    "NT": 1.337,
                     "TN": 2.283,
                     "TT": 3.528
                   }
@@ -5633,7 +5633,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 "S3_2048x8192x2048": {
                   "layouts": {
                     "NN": 3.537,
-                    "NT": 4.387,
+                    "NT": 1.393,
                     "TN": 2.28,
                     "TT": 3.586
                   }
@@ -5641,7 +5641,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 "S4_1024x1024x8192": {
                   "layouts": {
                     "NN": 4.773,
-                    "NT": 5.195,
+                    "NT": 0.866,
                     "TN": 3.542,
                     "TT": 4.474
                   }
@@ -5657,7 +5657,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 "S6_32768x768x768": {
                   "layouts": {
                     "NN": 3.139,
-                    "NT": 4.264,
+                    "NT": 1.852,
                     "TN": 2.147,
                     "TT": 3.491
                   }
@@ -5665,7 +5665,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 "S7_768x50304x49152": {
                   "layouts": {
                     "NN": 2.81,
-                    "NT": 3.424,
+                    "NT": 0.968,
                     "TN": 2.246,
                     "TT": 2.555
                   }
@@ -7209,22 +7209,22 @@ document.addEventListener("DOMContentLoaded", boot);
               "shapes": {
                 "S1_4096x4096x4096": {
                   "layouts": {
-                    "contig": 4.252
+                    "contig": 1.187
                   }
                 },
                 "S2_8192x2048x2048": {
                   "layouts": {
-                    "contig": 4.177
+                    "contig": 1.323
                   }
                 },
                 "S3_2048x8192x2048": {
                   "layouts": {
-                    "contig": 4.271
+                    "contig": 1.369
                   }
                 },
                 "S4_1024x1024x8192": {
                   "layouts": {
-                    "contig": 5.215
+                    "contig": 0.879
                   }
                 },
                 "S5_357x789x333": {
@@ -7234,12 +7234,12 @@ document.addEventListener("DOMContentLoaded", boot);
                 },
                 "S6_32768x768x768": {
                   "layouts": {
-                    "contig": 4.318
+                    "contig": 1.83
                   }
                 },
                 "S7_768x50304x49152": {
                   "layouts": {
-                    "contig": 3.449
+                    "contig": 0.991
                   }
                 }
               }
@@ -8011,7 +8011,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 "S1_4096x4096x4096": {
                   "layouts": {
                     "NN": 3.419,
-                    "NT": 3.72,
+                    "NT": 1.068,
                     "TN": 2.485,
                     "TT": 3.936
                   }
@@ -8019,7 +8019,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 "S2_8192x2048x2048": {
                   "layouts": {
                     "NN": 3.503,
-                    "NT": 4.19,
+                    "NT": 1.065,
                     "TN": 2.392,
                     "TT": 3.523
                   }
@@ -8027,7 +8027,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 "S3_2048x8192x2048": {
                   "layouts": {
                     "NN": 3.456,
-                    "NT": 4.309,
+                    "NT": 1.125,
                     "TN": 2.394,
                     "TT": 3.579
                   }
@@ -8035,7 +8035,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 "S4_1024x1024x8192": {
                   "layouts": {
                     "NN": 5.459,
-                    "NT": 5.713,
+                    "NT": 0.86,
                     "TN": 3.793,
                     "TT": 5.226
                   }
@@ -8051,7 +8051,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 "S6_32768x768x768": {
                   "layouts": {
                     "NN": 3.101,
-                    "NT": 4.305,
+                    "NT": 1.131,
                     "TN": 2.31,
                     "TT": 3.46
                   }
@@ -8059,7 +8059,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 "S7_768x50304x49152": {
                   "layouts": {
                     "NN": 2.842,
-                    "NT": 3.137,
+                    "NT": 0.951,
                     "TN": 2.355,
                     "TT": 2.531
                   }

--- a/benchmarks/baselines.html
+++ b/benchmarks/baselines.html
@@ -5437,7 +5437,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 "S1_4096x4096x4096": {
                   "layouts": {
                     "NN": 1.179,
-                    "NT": 1.178,
+                    "NT": 1.056,
                     "TN": 1.171,
                     "TT": 1.179
                   }
@@ -5445,7 +5445,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 "S2_8192x2048x2048": {
                   "layouts": {
                     "NN": 1.359,
-                    "NT": 1.364,
+                    "NT": 1.082,
                     "TN": 1.324,
                     "TT": 1.327
                   }
@@ -5453,7 +5453,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 "S3_2048x8192x2048": {
                   "layouts": {
                     "NN": 1.333,
-                    "NT": 1.367,
+                    "NT": 1.104,
                     "TN": 1.334,
                     "TT": 1.384
                   }
@@ -5477,7 +5477,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 "S6_32768x768x768": {
                   "layouts": {
                     "NN": 2.027,
-                    "NT": 2.086,
+                    "NT": 1.095,
                     "TN": 2.001,
                     "TT": 2.046
                   }
@@ -5497,7 +5497,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 "S1_4096x4096x4096": {
                   "layouts": {
                     "NN": 1.149,
-                    "NT": 1.148,
+                    "NT": 1.047,
                     "TN": 1.176,
                     "TT": 1.184
                   }
@@ -5505,7 +5505,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 "S2_8192x2048x2048": {
                   "layouts": {
                     "NN": 1.305,
-                    "NT": 1.352,
+                    "NT": 1.085,
                     "TN": 1.346,
                     "TT": 1.35
                   }
@@ -5513,7 +5513,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 "S3_2048x8192x2048": {
                   "layouts": {
                     "NN": 1.308,
-                    "NT": 1.319,
+                    "NT": 1.074,
                     "TN": 1.307,
                     "TT": 1.34
                   }
@@ -5537,7 +5537,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 "S6_32768x768x768": {
                   "layouts": {
                     "NN": 2.023,
-                    "NT": 2.093,
+                    "NT": 1.081,
                     "TN": 2.044,
                     "TT": 2.08
                   }
@@ -5617,7 +5617,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 "S1_4096x4096x4096": {
                   "layouts": {
                     "NN": 3.501,
-                    "NT": 1.201,
+                    "NT": 1.068,
                     "TN": 2.326,
                     "TT": 3.312
                   }
@@ -5625,7 +5625,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 "S2_8192x2048x2048": {
                   "layouts": {
                     "NN": 3.49,
-                    "NT": 1.337,
+                    "NT": 1.04,
                     "TN": 2.283,
                     "TT": 3.528
                   }
@@ -5633,7 +5633,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 "S3_2048x8192x2048": {
                   "layouts": {
                     "NN": 3.537,
-                    "NT": 1.393,
+                    "NT": 1.144,
                     "TN": 2.28,
                     "TT": 3.586
                   }
@@ -5657,7 +5657,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 "S6_32768x768x768": {
                   "layouts": {
                     "NN": 3.139,
-                    "NT": 1.852,
+                    "NT": 1.153,
                     "TN": 2.147,
                     "TT": 3.491
                   }
@@ -7092,17 +7092,17 @@ document.addEventListener("DOMContentLoaded", boot);
               "shapes": {
                 "S1_4096x4096x4096": {
                   "layouts": {
-                    "contig": 1.181
+                    "contig": 1.059
                   }
                 },
                 "S2_8192x2048x2048": {
                   "layouts": {
-                    "contig": 1.359
+                    "contig": 1.086
                   }
                 },
                 "S3_2048x8192x2048": {
                   "layouts": {
-                    "contig": 1.369
+                    "contig": 1.111
                   }
                 },
                 "S4_1024x1024x8192": {
@@ -7117,7 +7117,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 },
                 "S6_32768x768x768": {
                   "layouts": {
-                    "contig": 2.101
+                    "contig": 1.095
                   }
                 },
                 "S7_768x50304x49152": {
@@ -7131,17 +7131,17 @@ document.addEventListener("DOMContentLoaded", boot);
               "shapes": {
                 "S1_4096x4096x4096": {
                   "layouts": {
-                    "contig": 1.166
+                    "contig": 1.034
                   }
                 },
                 "S2_8192x2048x2048": {
                   "layouts": {
-                    "contig": 1.343
+                    "contig": 1.087
                   }
                 },
                 "S3_2048x8192x2048": {
                   "layouts": {
-                    "contig": 1.29
+                    "contig": 1.069
                   }
                 },
                 "S4_1024x1024x8192": {
@@ -7156,7 +7156,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 },
                 "S6_32768x768x768": {
                   "layouts": {
-                    "contig": 2.107
+                    "contig": 1.071
                   }
                 },
                 "S7_768x50304x49152": {
@@ -7209,17 +7209,17 @@ document.addEventListener("DOMContentLoaded", boot);
               "shapes": {
                 "S1_4096x4096x4096": {
                   "layouts": {
-                    "contig": 1.187
+                    "contig": 1.072
                   }
                 },
                 "S2_8192x2048x2048": {
                   "layouts": {
-                    "contig": 1.323
+                    "contig": 1.049
                   }
                 },
                 "S3_2048x8192x2048": {
                   "layouts": {
-                    "contig": 1.369
+                    "contig": 1.117
                   }
                 },
                 "S4_1024x1024x8192": {
@@ -7234,7 +7234,7 @@ document.addEventListener("DOMContentLoaded", boot);
                 },
                 "S6_32768x768x768": {
                   "layouts": {
-                    "contig": 1.83
+                    "contig": 1.15
                   }
                 },
                 "S7_768x50304x49152": {

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -6391,11 +6391,17 @@ def test_bf16_v3_source_dependency_and_kernel_contract():
     for kernel_name in (
         "gemm_v3_nn_ws_m64n128_tma_s3",
         "gemm_v3_nn_ws_m128n256_tma_s3",
-        "gemm_v3_nt_ws_m128n256_tma_s3",
         "gemm_v3_tn_ws_m64n128_tma_col_a_s3",
         "gemm_v3_tn_ws_m128n256_tma_col_a_s3",
     ):
         assert f'@__name(t"{{_GEMM16_TAG}}_{kernel_name}")' in v3_source
+    # The NT kernel carries a second interpolation: it is specialized on a
+    # fused-bias epilogue, and the two specializations must be tellable apart
+    # in a profile (`..._tma_s3` vs `..._tma_s3_bias`).
+    assert (
+        't"{_GEMM16_TAG}_gemm_v3_nt_ws_m128n256_tma_s3'
+        '{_gemm16_bias_tag[has_bias]()}"' in v3_source
+    )
 
     for helper_name in (
         "_v3_enqueue_nn_ws_m64n128_tma_s3",
@@ -6403,9 +6409,7 @@ def test_bf16_v3_source_dependency_and_kernel_contract():
     ):
         assert v3_source.count(f"{helper_name}(") == 2
 
-    nt_kernel_start = v3_source.index(
-        '@__name(t"{_GEMM16_TAG}_gemm_v3_nt_ws_m128n256_tma_s3")'
-    )
+    nt_kernel_start = v3_source.index('t"{_GEMM16_TAG}_gemm_v3_nt_ws_m128n256_tma_s3')
     nt_kernel_end = v3_source.index(
         '@__name(t"{_GEMM16_TAG}_gemm_v3_tn_ws_m64n128_tma_col_a_s3")'
     )
@@ -6625,10 +6629,22 @@ def test_addmm_tries_split_for_aligned_shapes(monkeypatch):
     route -- see _gemm16_alignment_favors_split."""
     from torch_mojo_backend.eager_kernels import aten_fast
 
-    def tensor(shape):
-        return SimpleNamespace(_shape=tuple(shape))
+    device = SimpleNamespace(label="gpu", api="cuda", architecture_name="sm_90a")
 
-    lhs, rhs, bias = tensor((128, 128)), tensor((128, 128)), object()
+    def tensor(shape):
+        shape = tuple(shape)
+        return SimpleNamespace(
+            _shape=shape,
+            _strides=aten_fast._row_major_strides(shape),
+            _dtype=aten_fast.DType.bfloat16,
+            _device=device,
+            _ptr=4096,
+            _is_contiguous=True,
+        )
+
+    # NN, so no fused-bias route exists for it whatever the alignment: the
+    # bias-free mm plus a separate add is still the best available pair.
+    lhs, rhs, bias = tensor((128, 128)), tensor((128, 128)), tensor((128,))
     mm_result, biased_result = object(), object()
     gemm_calls = []
     add_calls = []
@@ -7131,29 +7147,35 @@ def test_tf32_wgmma_nt_runs_the_named_wgmma_kernels(mojo_h100: torch.device) -> 
         assert not any("bf16" in name or "f16_gemm" in name for name in names)
 
 
-def test_tf32_linear_and_addmm_split_bias_off_the_wgmma_route(
+def test_tf32_linear_and_addmm_fuse_bias_into_the_wgmma_route(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A biased NT float32 call splits into mm + add exactly when the WGMMA
-    route serves the mm.
+    """A biased NT float32 call carries its bias to the direct WGMMA kernel,
+    and splits it off only where that kernel is not the route.
 
-    Those kernels have no fused-bias epilogue and decline a biased call, so a
-    fused call would land on the SM80-class kernel; when the WGMMA route would
-    not serve the mm anyway, the split only pays for an extra launch (the S5
-    regression `_gemm16_alignment_favors_split` documents).
+    The direct kernel adds the bias inside its accumulator epilogue, so the
+    bias travels with the call: one launch, and no second full pass over C.
+    Two exceptions keep the old mm-then-add composition -- the deep-K shapes
+    the split-K arm claims (it reduces through an FP32 workspace and has no
+    accumulator epilogue to fuse into), and a bias whose pointer the fused
+    epilogue's naturally-aligned pair load cannot use.
     """
     from torch_mojo_backend.eager_kernels import aten_fast
 
     device = SimpleNamespace(label="gpu", api="cuda", architecture_name="sm_90a")
 
-    def tensor(shape: tuple[int, int], strides: tuple[int, int]) -> SimpleNamespace:
+    def tensor(
+        shape: tuple[int, ...], strides: tuple[int, ...], ptr: int = 4096
+    ) -> SimpleNamespace:
         return SimpleNamespace(
             _shape=tuple(shape),
             _strides=tuple(strides),
             _dtype=aten_fast.DType.float32,
             _device=device,
-            _ptr=4096,
-            _is_contiguous=strides == (shape[1], 1),
+            _ptr=ptr,
+            _is_contiguous=strides == tuple(shape[1:]) + (1,)
+            if len(shape) == 2
+            else True,
         )
 
     gemm_calls = []
@@ -7178,19 +7200,20 @@ def test_tf32_linear_and_addmm_split_bias_off_the_wgmma_route(
     monkeypatch.setattr(aten_fast, "_try_gemm16_linear", lambda *a, **k: None)
 
     weight = tensor((790, 336), (336, 1))  # (n, k): linear's NT weight
-    bias = object()
+    bias = tensor((790,), (1,))
 
     with _tf32_precision("high"):
-        # Admitted: k % 4 == 0 and n even -> split.
+        # Admitted, direct arm (a 357x790 output is far too large for split-K
+        # to claim): the bias rides along, no separate add.
         assert (
             aten_fast._try_tf32_linear(tensor((357, 336), (336, 1)), weight, bias)
-            is biased_result
+            is mm_result
         )
-        assert gemm_calls == [None]
-        assert add_calls == [(mm_result, bias)]
-        # Declined (k * 4 not 16B-aligned) -> one fused-bias call, no add.
+        assert gemm_calls == [bias]
+        assert add_calls == []
+        # Declined (k * 4 not 16B-aligned): one fused-bias call, no add, as
+        # before -- the SM80-class kernel takes the bias itself.
         gemm_calls.clear()
-        add_calls.clear()
         assert (
             aten_fast._try_tf32_linear(
                 tensor((357, 333), (333, 1)), tensor((790, 333), (333, 1)), bias
@@ -7199,17 +7222,170 @@ def test_tf32_linear_and_addmm_split_bias_off_the_wgmma_route(
         )
         assert gemm_calls == [bias]
         assert add_calls == []
-        # addmm's NT case splits on the same predicate.
+        # Deep K with few output tiles: the split-K arm claims this shape and
+        # cannot fuse, so the bias is split off exactly as it used to be.
+        gemm_calls.clear()
+        deep_bias = tensor((1024,), (1,))
+        assert (
+            aten_fast._try_tf32_linear(
+                tensor((1024, 8192), (8192, 1)),
+                tensor((1024, 8192), (8192, 1)),
+                deep_bias,
+            )
+            is biased_result
+        )
+        assert gemm_calls == [None]
+        assert add_calls == [(mm_result, deep_bias)]
+        # A bias the fused epilogue cannot read as a contiguous n-vector --
+        # a scalar, an expanded view -- keeps the split, whose elementwise
+        # add broadcasts.  Getting this wrong does not fault: the bridge
+        # declines the biased call and the projection falls past BOTH fast
+        # paths.
+        gemm_calls.clear()
+        add_calls.clear()
+        assert (
+            aten_fast._try_tf32_linear(
+                tensor((357, 336), (336, 1)), weight, tensor((), ())
+            )
+            is biased_result
+        )
+        assert gemm_calls == [None]
+        assert add_calls[0][0] is mm_result
+        # A bias reached through an offset view is not 8B-aligned, which the
+        # fused epilogue's pair load requires: split rather than fault.
+        gemm_calls.clear()
+        add_calls.clear()
+        odd_bias = tensor((790,), (1,), ptr=4100)
+        assert (
+            aten_fast._try_tf32_linear(tensor((357, 336), (336, 1)), weight, odd_bias)
+            is biased_result
+        )
+        assert gemm_calls == [None]
+        assert add_calls == [(mm_result, odd_bias)]
+        # addmm's NT case decides on the same predicates.
         gemm_calls.clear()
         add_calls.clear()
         assert (
             aten_fast.fast_aten_addmm(
                 bias, tensor((357, 336), (336, 1)), tensor((336, 790), (1, 336))
             )
-            is biased_result
+            is mm_result
         )
-        assert gemm_calls == [None]
-        assert add_calls == [(mm_result, bias)]
+        assert gemm_calls == [bias]
+        assert add_calls == []
+
+
+def test_gemm16_linear_and_addmm_fuse_bias_into_the_nt_wgmma_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The 16-bit twin of the float32 case above.
+
+    `linear` IS the NT regime by construction, and the persistent v4 NT kernel
+    fuses the bias, so a biased 16-bit projection is one launch.  Non-NT
+    layouts have no fused-bias route and keep the mm-then-add split, which is
+    the whole reason `_gemm16_alignment_favors_split` exists.
+    """
+    from torch_mojo_backend.eager_kernels import aten_fast
+
+    device = SimpleNamespace(label="gpu", api="cuda", architecture_name="sm_90a")
+
+    def tensor(
+        shape: tuple[int, ...], strides: tuple[int, ...], ptr: int = 4096
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            _shape=tuple(shape),
+            _strides=tuple(strides),
+            _dtype=aten_fast.DType.bfloat16,
+            _device=device,
+            _ptr=ptr,
+            _is_contiguous=True,
+        )
+
+    gemm_calls = []
+    add_calls = []
+    mm_result, biased_result = object(), object()
+
+    def try_gemm16_mm(
+        a: object, b: object, bias: object = None, **kwargs: object
+    ) -> object:
+        gemm_calls.append(bias)
+        return mm_result
+
+    def fast_add(value: object, bias: object) -> object:
+        add_calls.append((value, bias))
+        return biased_result
+
+    monkeypatch.setattr(aten_fast, "_t", lambda value: value)
+    monkeypatch.setattr(aten_fast, "_try_gemm16_mm", try_gemm16_mm)
+    monkeypatch.setattr(aten_fast, "fast_aten_add", fast_add)
+
+    x = tensor((4096, 4096), (4096, 1))
+    weight = tensor((4096, 4096), (4096, 1))  # (n, k)
+    bias = tensor((4096,), (1,))
+
+    # NT (linear): fused, one call.
+    assert aten_fast._try_gemm16_linear(x, weight, bias) is mm_result
+    assert gemm_calls == [bias]
+    assert add_calls == []
+
+    # Deep K, few output tiles: split-K claims it, so the bias is split off.
+    gemm_calls.clear()
+    deep_bias = tensor((1024,), (1,))
+    assert (
+        aten_fast._try_gemm16_linear(
+            tensor((1024, 8192), (8192, 1)), tensor((1024, 8192), (8192, 1)), deep_bias
+        )
+        is biased_result
+    )
+    assert gemm_calls == [None]
+    assert add_calls == [(mm_result, deep_bias)]
+
+    # A scalar bias cannot be read as a contiguous n-vector: split.
+    gemm_calls.clear()
+    add_calls.clear()
+    assert aten_fast._try_gemm16_linear(x, weight, tensor((), ())) is biased_result
+    assert gemm_calls == [None]
+    assert add_calls[0][0] is mm_result
+
+    # An NN addmm has no fused-bias route: the mm-then-add split stands.
+    gemm_calls.clear()
+    add_calls.clear()
+    gemm_calls.clear()
+    add_calls.clear()
+    assert (
+        aten_fast.fast_aten_addmm(bias, x, tensor((4096, 4096), (4096, 1)))
+        is biased_result
+    )
+    assert gemm_calls == [None]
+    assert add_calls == [(mm_result, bias)]
+
+
+def test_gemm16_splitk_nt_may_fire_mirrors_the_split_k_gate() -> None:
+    """The host mirror that keeps deep-K shapes on the split-the-bias path.
+
+    It has to claim every shape the Mojo split-K arm could claim (claiming one
+    it cannot only costs an extra elementwise-add launch, while MISSING one
+    would push a deep-K shape onto the direct kernel, measured 85us -> 197us
+    on 1024x1024x8192 tf32).  The multiprocessor count it cannot query is
+    replaced by its architectural upper bound, in that same direction.
+    """
+    from torch_mojo_backend.eager_kernels import aten_fast
+
+    may_fire = aten_fast._gemm16_splitk_nt_may_fire
+    # The deep-K regime split-K exists for.
+    assert may_fire(1024, 1024, 8192)
+    # The four shapes the eight above-bar addmm/linear cells live on: their
+    # outputs are far too many tiles for a 2-way split to be reachable.
+    assert not may_fire(4096, 4096, 4096)
+    assert not may_fire(8192, 2048, 2048)
+    assert not may_fire(2048, 8192, 2048)
+    assert not may_fire(32768, 768, 768)
+    # Hard gates: the split-K tile is 128 x 256, exactly divided, and a 2-way
+    # split needs 32 k-tiles of 64.
+    assert not may_fire(1000, 1024, 8192)
+    assert not may_fire(1024, 1000, 8192)
+    assert not may_fire(1024, 1024, 8200)
+    assert not may_fire(1024, 1024, 1024)
 
 
 def test_matmul_spec_device_oom_is_not_disguised_as_unsupported(

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -6838,6 +6838,13 @@ _TF32_WGMMA_SHAPES = {
     "ragged_357x790x336": (357, 790, 336),
     # deep K, few output tiles: the split-K workspace + reduce route
     "deep_k_256x256x8192": (256, 256, 8192),
+    # k = 4 is the SMALLEST k the gate can admit at a 4-byte operand: the TMA
+    # rule is (k * 4) % 16 == 0, so k must be a multiple of 4, and k = 4 is one
+    # eighth of a single BK = 32 tile.  The whole mainloop is then one k-tile
+    # whose tail TMA zero-fills, which is exact because zeros contribute
+    # nothing to a dot product -- the boundary where that reasoning either
+    # holds or the kernel reads garbage.
+    "min_k_128x256x4": (128, 256, 4),
 }
 
 # k = 333 makes the row pitch k * 4 = 1332 bytes, not a multiple of 16, so no
@@ -7116,7 +7123,9 @@ def test_tf32_wgmma_nt_runs_the_named_wgmma_kernels(mojo_h100: torch.device) -> 
     ), deep_k
     assert any(name.startswith("tf32_gemm_tn_v4_splitk_reduce") for name in deep_k)
     # The declined shape stays on the SM80-class kernel and never reaches a
-    # WGMMA one.
+    # WGMMA one.  Assert the positive too: "no WGMMA kernel ran" would also be
+    # satisfied by a decomposition that never reached tf32_matmul_ops at all.
+    assert any(name.startswith("tf32_gemm_tile") for name in declined), declined
     assert not any("_v3_nt_ws_" in name or "_v4_splitk_" in name for name in declined)
     for names in (ragged, deep_k):
         assert not any("bf16" in name or "f16_gemm" in name for name in names)

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -1,8 +1,11 @@
 """Tests for the Mojo-extension fast path used by mojo eager mode."""
 
+import contextlib
+import fcntl
 import functools
 import math
 import weakref
+from collections.abc import Iterator
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
@@ -6380,8 +6383,11 @@ def test_bf16_v3_source_dependency_and_kernel_contract():
     assert "from gemm16_tn_v4_kernels import" in v3_source
     # Kernel names carry the dtype the build was specialized for, so the
     # literal in the source is the tag interpolation, not "bf16".  A user
-    # profiling a float16 model must read "f16_gemm_..." there.
-    assert "from gemm16_dtype import _GEMM16_DT, _GEMM16_TAG" in v3_source
+    # profiling a float16 model must read "f16_gemm_..." there, and one
+    # profiling float32 under a TF32 matmul precision must read "tf32_gemm_...".
+    assert "from gemm16_dtype import (" in v3_source
+    for imported in ("_GEMM16_DT,", "_GEMM16_TAG,", "_GEMM16_TF32,", "_GEMM16_W,"):
+        assert imported in v3_source
     for kernel_name in (
         "gemm_v3_nn_ws_m64n128_tma_s3",
         "gemm_v3_nn_ws_m128n256_tma_s3",
@@ -6809,6 +6815,394 @@ def test_tf32_matmul_family_highest_retains_tensorspec_fallback(monkeypatch):
     assert tf32_import_calls == []
 
 
+# ---------------------------------------------------------------------------
+# float32 (TF32) WGMMA NT route: gemm16's warp-specialized Hopper kernels
+# compiled for a 4-byte operand.  WGMMA takes float32 operands directly and
+# computes them as TF32, so these are the same kernels the bf16/f16 builds use,
+# with the width-bound constants doubled.
+#
+# The oracle in these tests is EXACT, not a tolerance: operands are multiples of
+# 1/32 in [-1, 1), which are exact in TF32's 10 mantissa bits, so every product
+# is a multiple of 1/1024 and a k-deep sum of them stays inside FP32's
+# exactly-representable integer range (|sum| * 1024 <= 2^24 for every k used
+# here).  A TF32 GEMM must therefore reproduce the FP64 reference BIT-exactly,
+# and any mantissa loss, misaddressed k-step or dropped tile shows up as a
+# nonzero error rather than as a tolerance judgement call.
+# ---------------------------------------------------------------------------
+_TF32_WGMMA_SHAPES = {
+    # aligned: the plain 128x256 WGMMA tile
+    "aligned_256x512x256": (256, 512, 256),
+    # ragged m AND ragged (even) n AND k not a multiple of BK=32: the three
+    # relaxations the float32 gate makes over the 16-bit routes' tile-multiple
+    # gate, all at once (A2 of the kernel harness)
+    "ragged_357x790x336": (357, 790, 336),
+    # deep K, few output tiles: the split-K workspace + reduce route
+    "deep_k_256x256x8192": (256, 256, 8192),
+}
+
+# k = 333 makes the row pitch k * 4 = 1332 bytes, not a multiple of 16, so no
+# TMA descriptor can be built for it; n = 257 is odd, so the epilogue's
+# two-element pair store would be misaligned.  Both must decline to the
+# SM80-class tf32_matmul_ops kernel rather than fault.
+_TF32_DECLINED_SHAPES = {
+    "unaligned_k_357x790x333": (357, 790, 333),
+    "odd_n_128x257x256": (128, 257, 256),
+}
+
+
+@contextlib.contextmanager
+def _gpu_lock(index: int = 0) -> Iterator[None]:
+    """AGENTS.md rule: hold flock /tmp/gpu_lock_{index}.lock around GPU work.
+
+    These few cases time nothing, but they run WGMMA kernels that saturate the
+    card, and this box shares one GPU between agents.  Do not wrap a whole
+    pytest run in an outer flock on the same file: this would then block on it
+    forever.
+    """
+    with open(f"/tmp/gpu_lock_{index}.lock", "w") as handle:
+        fcntl.flock(handle, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle, fcntl.LOCK_UN)
+
+
+def _tf32_exact_operand(shape: tuple[int, ...], seed: int) -> torch.Tensor:
+    """Multiples of 1/32 in [-1, 1): exact in TF32, so the reference is exact."""
+    generator = torch.Generator().manual_seed(seed)
+    return torch.randint(-31, 32, shape, generator=generator).float() / 32.0
+
+
+@contextlib.contextmanager
+def _tf32_precision(precision: str = "high") -> Iterator[None]:
+    previous = torch.get_float32_matmul_precision()
+    torch.set_float32_matmul_precision(precision)
+    try:
+        yield
+    finally:
+        torch.set_float32_matmul_precision(previous)
+
+
+def test_tf32_nt_wgmma_shape_admits_mirrors_the_kernel_gate() -> None:
+    """The host mirror of the two hardware constraints, with no GPU involved.
+
+    TMA needs a 16-BYTE global stride and both operands are k-minor, so k must
+    be a multiple of 4 at float32; the epilogue's pair store needs an even n.
+    m is free -- that is the whole point of the relaxation over the 16-bit
+    routes' tile-multiple gate.
+    """
+    from torch_mojo_backend.eager_kernels import aten_fast
+
+    admits = aten_fast._tf32_nt_wgmma_shape_admits
+    assert admits(357, 790, 336)  # ragged m, even n, k % 4 == 0
+    assert admits(1, 2, 4)  # every dimension at its minimum
+    assert not admits(357, 790, 333)  # k * 4 = 1332 is not 16B-aligned
+    assert not admits(357, 790, 334)
+    assert not admits(128, 257, 256)  # odd n misaligns the pair store
+    assert not admits(0, 256, 256)  # empty
+    # k a multiple of 4 but NOT of the 32-element tile: a partial trailing
+    # k-tile is legal (TMA zero-fills past the extent), unlike for the 16-bit
+    # routes.
+    assert admits(128, 256, 4)
+    # The two graceful-fallback bounds: past 2^31 the Mojo route declines on
+    # machine width, and the grid is one CTA per 128x256 tile.  Nothing that
+    # fits in device memory reaches either, but a shape that did must fall back
+    # rather than hit the bridge's raise.
+    assert not admits(2**31, 256, 256)
+    assert not admits(2**31 - 1, 2**31 - 2, 4)
+
+
+def test_tf32_nt_wgmma_admits_only_nt_layout_under_tf32_precision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Layout, dtype, architecture and precision gate the route, on the host.
+
+    Only NT is ported to a 4-byte operand, and "highest" means the user asked
+    for real FP32 -- neither may reach the WGMMA kernels.
+    """
+    from torch_mojo_backend.eager_kernels import aten_fast
+
+    device = SimpleNamespace(label="gpu", api="cuda", architecture_name="sm_90a")
+
+    def tensor(
+        shape: tuple[int, int],
+        strides: tuple[int, int],
+        dtype: object = None,
+        ptr: int = 4096,
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            _shape=tuple(shape),
+            _strides=tuple(strides),
+            _dtype=aten_fast.DType.float32 if dtype is None else dtype,
+            _device=device,
+            _ptr=ptr,
+        )
+
+    monkeypatch.setattr(aten_fast, "_t", lambda value: value)
+    monkeypatch.setattr(aten_fast, "_gemm16_bridge_available", lambda: True)
+
+    row_major_a = tensor((256, 256), (256, 1))
+    nt_b = tensor((256, 512), (1, 256))  # a .t() view of a (512, 256) buffer
+    nn_b = tensor((256, 512), (512, 1))
+
+    with _tf32_precision("high"):
+        assert aten_fast._tf32_nt_wgmma_admits(row_major_a, nt_b)
+        # NN, TN, TT stay on the SM80-class route.
+        assert not aten_fast._tf32_nt_wgmma_admits(row_major_a, nn_b)
+        assert not aten_fast._tf32_nt_wgmma_admits(tensor((256, 256), (1, 256)), nt_b)
+        # transpose_b flips which physical layout counts as NT.  With it set
+        # the RHS is the (n, k) buffer -- the shape torch.linear hands over --
+        # so it must be (512, 256) here, not nn_b's (256, 512), whose k would
+        # contradict A's.
+        nk_b = tensor((512, 256), (256, 1))
+        assert aten_fast._tf32_nt_wgmma_admits(row_major_a, nk_b, transpose_b=True)
+        # bfloat16 has its own, separately routed build of the same family.
+        assert not aten_fast._tf32_nt_wgmma_admits(
+            tensor((256, 256), (256, 1), dtype=aten_fast.DType.bfloat16),
+            tensor((256, 512), (1, 256), dtype=aten_fast.DType.bfloat16),
+        )
+        # An offset view's data pointer need not be 16B-aligned, and TMA
+        # descriptor creation requires it.
+        assert not aten_fast._tf32_nt_wgmma_admits(
+            tensor((256, 256), (256, 1), ptr=4100), nt_b
+        )
+        # Not an H100: these are WGMMA+TMA kernels and nothing else runs them.
+        other = SimpleNamespace(label="gpu", api="cuda", architecture_name="sm_80")
+        sm80_a = tensor((256, 256), (256, 1))
+        sm80_b = tensor((256, 512), (1, 256))
+        sm80_a._device = other
+        sm80_b._device = other
+        assert not aten_fast._tf32_nt_wgmma_admits(sm80_a, sm80_b)
+        # An absent bridge declines before anything is allocated.
+        monkeypatch.setattr(aten_fast, "_gemm16_bridge_available", lambda: False)
+        assert not aten_fast._tf32_nt_wgmma_admits(row_major_a, nt_b)
+
+    monkeypatch.setattr(aten_fast, "_gemm16_bridge_available", lambda: True)
+    with _tf32_precision("highest"):
+        assert not aten_fast._tf32_nt_wgmma_admits(row_major_a, nt_b)
+
+
+@pytest.mark.parametrize("shape_id", sorted(_TF32_WGMMA_SHAPES))
+def test_tf32_wgmma_nt_mm_is_bit_exact(mojo_h100: torch.device, shape_id: str) -> None:
+    """The WGMMA float32 route reproduces the FP64 reference bit for bit."""
+    _require_real_bf16_gemm_sources()
+    m, n, k = _TF32_WGMMA_SHAPES[shape_id]
+    host_a = _tf32_exact_operand((m, k), 20260819)
+    host_b = _tf32_exact_operand((n, k), 20260820)
+    expected = (host_a.double() @ host_b.double().t()).float()
+
+    with _tf32_precision("high"), _gpu_lock():
+        a = host_a.to(mojo_h100)
+        b = host_b.to(mojo_h100)
+        actual = (a @ b.t()).cpu()
+
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("shape_id", sorted(_TF32_DECLINED_SHAPES))
+def test_tf32_declined_shapes_stay_correct_on_the_sm80_route(
+    mojo_h100: torch.device, shape_id: str
+) -> None:
+    """A shape no TMA descriptor can describe must decline, not fault.
+
+    k * 4 not a multiple of 16 bytes fails descriptor creation outright, and an
+    odd n misaligns the epilogue's pair store; the SM80-class kernel serves
+    both, and is exact on the same operands.
+    """
+    _require_real_bf16_gemm_sources()
+    from torch_mojo_backend.eager_kernels import aten_fast
+
+    m, n, k = _TF32_DECLINED_SHAPES[shape_id]
+    assert not aten_fast._tf32_nt_wgmma_shape_admits(m, n, k)
+    host_a = _tf32_exact_operand((m, k), 20260821)
+    host_b = _tf32_exact_operand((n, k), 20260822)
+    expected = (host_a.double() @ host_b.double().t()).float()
+
+    with _tf32_precision("high"), _gpu_lock():
+        a = host_a.to(mojo_h100)
+        b = host_b.to(mojo_h100)
+        actual = (a @ b.t()).cpu()
+
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
+def test_tf32_wgmma_nt_writes_nothing_past_the_output(
+    mojo_h100: torch.device, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Guard cells immediately after C survive a doubly ragged output tile.
+
+    357x790 straddles the 128x256 tile in both dimensions, so the last CTA row
+    and column are partial and the epilogue's own bounds check is the only
+    thing keeping the stores inside C.  Handing the route a view into the head
+    of a larger buffer puts real, checkable memory right after that last
+    element.
+    """
+    _require_real_bf16_gemm_sources()
+    from torch_mojo_backend.eager_kernels import aten_fast
+
+    m, n, k = 357, 790, 336
+    guard_elements = 4096
+    sentinel = -12345.0
+    host_a = _tf32_exact_operand((m, k), 20260823)
+    host_b = _tf32_exact_operand((n, k), 20260824)
+    expected = (host_a.double() @ host_b.double().t()).float()
+    real_alloc = aten_fast._alloc
+
+    with _tf32_precision("high"), _gpu_lock():
+        buffer = torch.full(
+            (m * n + guard_elements,), sentinel, device=mojo_h100, dtype=torch.float32
+        )
+        head = aten_fast._view_of(buffer, (m, n), (n, 1), 0, contiguous=True)
+
+        def alloc_head(
+            shape: tuple[int, ...], dtype: object, device: object
+        ) -> torch.Tensor:
+            if tuple(shape) == (m, n) and dtype == head._dtype:
+                return head
+            return real_alloc(shape, dtype, device)
+
+        monkeypatch.setattr(aten_fast, "_alloc", alloc_head)
+        a = host_a.to(mojo_h100)
+        b = host_b.to(mojo_h100)
+        actual = a @ b.t()
+        # Aliasing, not identity: what matters is that the kernel wrote into the
+        # guarded buffer rather than into a fresh allocation of its own.
+        assert actual._ptr == head._ptr
+        result = head.cpu()
+        guard = buffer[m * n :].cpu()
+
+    torch.testing.assert_close(result, expected, atol=0, rtol=0)
+    assert torch.equal(guard, torch.full((guard_elements,), sentinel))
+
+
+def test_tf32_wgmma_nt_runs_the_named_wgmma_kernels(mojo_h100: torch.device) -> None:
+    """The route actually taken, read back from the profiler's kernel names.
+
+    The names are what CUPTI, Nsight and torch.profiler print, so this is also
+    the assertion that a user profiling a float32 model at TF32 precision reads
+    "tf32", never "bf16".  A silent fall back to the SM80-class kernel would
+    otherwise look exactly like success.
+    """
+    _require_real_bf16_gemm_sources()
+    from torch.profiler import ProfilerActivity, profile
+
+    device_event_types = ("DeviceType.CUDA", "DeviceType.PrivateUse1")
+
+    def kernel_names(m: int, n: int, k: int) -> set[str]:
+        a = torch.randn(m, k, device=mojo_h100)
+        b = torch.randn(n, k, device=mojo_h100)
+        for _ in range(2):  # build and warm the variant outside the profile
+            del_me = a @ b.t()
+            del del_me
+        with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:
+            out = a @ b.t()
+            del out
+        return {
+            event.name
+            for event in prof.events()
+            if str(event.device_type) in device_event_types
+            and "memc" not in event.name.lower()
+            and "memset" not in event.name.lower()
+        }
+
+    with _tf32_precision("high"), _gpu_lock():
+        ragged = kernel_names(357, 790, 336)
+        deep_k = kernel_names(256, 256, 8192)
+        declined = kernel_names(357, 790, 333)
+
+    assert any(name.startswith("tf32_gemm_v3_nt_ws_m128n256_tma_s3") for name in ragged)
+    assert any(
+        name.startswith("tf32_gemm_nt_v4_splitk_m128n256_s4") for name in deep_k
+    ), deep_k
+    assert any(name.startswith("tf32_gemm_tn_v4_splitk_reduce") for name in deep_k)
+    # The declined shape stays on the SM80-class kernel and never reaches a
+    # WGMMA one.
+    assert not any("_v3_nt_ws_" in name or "_v4_splitk_" in name for name in declined)
+    for names in (ragged, deep_k):
+        assert not any("bf16" in name or "f16_gemm" in name for name in names)
+
+
+def test_tf32_linear_and_addmm_split_bias_off_the_wgmma_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A biased NT float32 call splits into mm + add exactly when the WGMMA
+    route serves the mm.
+
+    Those kernels have no fused-bias epilogue and decline a biased call, so a
+    fused call would land on the SM80-class kernel; when the WGMMA route would
+    not serve the mm anyway, the split only pays for an extra launch (the S5
+    regression `_gemm16_alignment_favors_split` documents).
+    """
+    from torch_mojo_backend.eager_kernels import aten_fast
+
+    device = SimpleNamespace(label="gpu", api="cuda", architecture_name="sm_90a")
+
+    def tensor(shape: tuple[int, int], strides: tuple[int, int]) -> SimpleNamespace:
+        return SimpleNamespace(
+            _shape=tuple(shape),
+            _strides=tuple(strides),
+            _dtype=aten_fast.DType.float32,
+            _device=device,
+            _ptr=4096,
+            _is_contiguous=strides == (shape[1], 1),
+        )
+
+    gemm_calls = []
+    add_calls = []
+    mm_result, biased_result = object(), object()
+
+    def try_tf32_gemm(
+        a: object, b: object, bias: object = None, **kwargs: object
+    ) -> object:
+        gemm_calls.append(bias)
+        return mm_result
+
+    def fast_add(value: object, bias: object) -> object:
+        add_calls.append((value, bias))
+        return biased_result
+
+    monkeypatch.setattr(aten_fast, "_t", lambda value: value)
+    monkeypatch.setattr(aten_fast, "_gemm16_bridge_available", lambda: True)
+    monkeypatch.setattr(aten_fast, "_try_tf32_gemm", try_tf32_gemm)
+    monkeypatch.setattr(aten_fast, "fast_aten_add", fast_add)
+    monkeypatch.setattr(aten_fast, "_try_gemm16_mm", lambda *a, **k: None)
+    monkeypatch.setattr(aten_fast, "_try_gemm16_linear", lambda *a, **k: None)
+
+    weight = tensor((790, 336), (336, 1))  # (n, k): linear's NT weight
+    bias = object()
+
+    with _tf32_precision("high"):
+        # Admitted: k % 4 == 0 and n even -> split.
+        assert (
+            aten_fast._try_tf32_linear(tensor((357, 336), (336, 1)), weight, bias)
+            is biased_result
+        )
+        assert gemm_calls == [None]
+        assert add_calls == [(mm_result, bias)]
+        # Declined (k * 4 not 16B-aligned) -> one fused-bias call, no add.
+        gemm_calls.clear()
+        add_calls.clear()
+        assert (
+            aten_fast._try_tf32_linear(
+                tensor((357, 333), (333, 1)), tensor((790, 333), (333, 1)), bias
+            )
+            is mm_result
+        )
+        assert gemm_calls == [bias]
+        assert add_calls == []
+        # addmm's NT case splits on the same predicate.
+        gemm_calls.clear()
+        add_calls.clear()
+        assert (
+            aten_fast.fast_aten_addmm(
+                bias, tensor((357, 336), (336, 1)), tensor((336, 790), (1, 336))
+            )
+            is biased_result
+        )
+        assert gemm_calls == [None]
+        assert add_calls == [(mm_result, bias)]
+
+
 def test_matmul_spec_device_oom_is_not_disguised_as_unsupported(
     monkeypatch, fake_mojo_tensor
 ):
@@ -6888,7 +7282,16 @@ def test_tf32_linear_flattens_contiguous_gpt_input_as_zero_copy_view(monkeypatch
     gemm_calls = []
 
     def as_tensor(value):
-        return {input: input_metadata, weight: weight_metadata}.get(value)
+        # Identity lookup rather than a dict: `_try_tf32_linear` now offers the
+        # flattened matrix view to `_tf32_nt_wgmma_admits` before deciding
+        # whether to split the bias off, and that view is a SimpleNamespace,
+        # which is unhashable.  Returning None for it makes the predicate
+        # decline, which is the fused-bias path this test is about.
+        if value is input:
+            return input_metadata
+        if value is weight:
+            return weight_metadata
+        return None
 
     def view_of(*args, **kwargs):
         view_calls.append((args, kwargs))
@@ -6924,7 +7327,16 @@ def test_tf32_linear_noncontiguous_batch_retains_tensorspec_path(monkeypatch):
     fallback = object()
 
     def as_tensor(value):
-        return {input: input_metadata, weight: weight_metadata}.get(value)
+        # Identity lookup rather than a dict: `_try_tf32_linear` now offers the
+        # flattened matrix view to `_tf32_nt_wgmma_admits` before deciding
+        # whether to split the bias off, and that view is a SimpleNamespace,
+        # which is unhashable.  Returning None for it makes the predicate
+        # decline, which is the fused-bias path this test is about.
+        if value is input:
+            return input_metadata
+        if value is weight:
+            return weight_metadata
+        return None
 
     def fail_tf32_work(*_args, **_kwargs):
         raise AssertionError("non-contiguous batched linear entered the TF32 path")

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -1,8 +1,11 @@
 """Tests for the Mojo-extension fast path used by mojo eager mode."""
 
+import contextlib
+import fcntl
 import functools
 import math
 import weakref
+from collections.abc import Iterator
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
@@ -6352,8 +6355,11 @@ def test_bf16_v3_source_dependency_and_kernel_contract():
     assert "from gemm16_tn_v4_kernels import" in v3_source
     # Kernel names carry the dtype the build was specialized for, so the
     # literal in the source is the tag interpolation, not "bf16".  A user
-    # profiling a float16 model must read "f16_gemm_..." there.
-    assert "from gemm16_dtype import _GEMM16_DT, _GEMM16_TAG" in v3_source
+    # profiling a float16 model must read "f16_gemm_..." there, and one
+    # profiling float32 under a TF32 matmul precision must read "tf32_gemm_...".
+    assert "from gemm16_dtype import (" in v3_source
+    for imported in ("_GEMM16_DT,", "_GEMM16_TAG,", "_GEMM16_TF32,", "_GEMM16_W,"):
+        assert imported in v3_source
     for kernel_name in (
         "gemm_v3_nn_ws_m64n128_tma_s3",
         "gemm_v3_nn_ws_m128n256_tma_s3",
@@ -6781,6 +6787,394 @@ def test_tf32_matmul_family_highest_retains_tensorspec_fallback(monkeypatch):
     assert tf32_import_calls == []
 
 
+# ---------------------------------------------------------------------------
+# float32 (TF32) WGMMA NT route: gemm16's warp-specialized Hopper kernels
+# compiled for a 4-byte operand.  WGMMA takes float32 operands directly and
+# computes them as TF32, so these are the same kernels the bf16/f16 builds use,
+# with the width-bound constants doubled.
+#
+# The oracle in these tests is EXACT, not a tolerance: operands are multiples of
+# 1/32 in [-1, 1), which are exact in TF32's 10 mantissa bits, so every product
+# is a multiple of 1/1024 and a k-deep sum of them stays inside FP32's
+# exactly-representable integer range (|sum| * 1024 <= 2^24 for every k used
+# here).  A TF32 GEMM must therefore reproduce the FP64 reference BIT-exactly,
+# and any mantissa loss, misaddressed k-step or dropped tile shows up as a
+# nonzero error rather than as a tolerance judgement call.
+# ---------------------------------------------------------------------------
+_TF32_WGMMA_SHAPES = {
+    # aligned: the plain 128x256 WGMMA tile
+    "aligned_256x512x256": (256, 512, 256),
+    # ragged m AND ragged (even) n AND k not a multiple of BK=32: the three
+    # relaxations the float32 gate makes over the 16-bit routes' tile-multiple
+    # gate, all at once (A2 of the kernel harness)
+    "ragged_357x790x336": (357, 790, 336),
+    # deep K, few output tiles: the split-K workspace + reduce route
+    "deep_k_256x256x8192": (256, 256, 8192),
+}
+
+# k = 333 makes the row pitch k * 4 = 1332 bytes, not a multiple of 16, so no
+# TMA descriptor can be built for it; n = 257 is odd, so the epilogue's
+# two-element pair store would be misaligned.  Both must decline to the
+# SM80-class tf32_matmul_ops kernel rather than fault.
+_TF32_DECLINED_SHAPES = {
+    "unaligned_k_357x790x333": (357, 790, 333),
+    "odd_n_128x257x256": (128, 257, 256),
+}
+
+
+@contextlib.contextmanager
+def _gpu_lock(index: int = 0) -> Iterator[None]:
+    """AGENTS.md rule: hold flock /tmp/gpu_lock_{index}.lock around GPU work.
+
+    These few cases time nothing, but they run WGMMA kernels that saturate the
+    card, and this box shares one GPU between agents.  Do not wrap a whole
+    pytest run in an outer flock on the same file: this would then block on it
+    forever.
+    """
+    with open(f"/tmp/gpu_lock_{index}.lock", "w") as handle:
+        fcntl.flock(handle, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle, fcntl.LOCK_UN)
+
+
+def _tf32_exact_operand(shape: tuple[int, ...], seed: int) -> torch.Tensor:
+    """Multiples of 1/32 in [-1, 1): exact in TF32, so the reference is exact."""
+    generator = torch.Generator().manual_seed(seed)
+    return torch.randint(-31, 32, shape, generator=generator).float() / 32.0
+
+
+@contextlib.contextmanager
+def _tf32_precision(precision: str = "high") -> Iterator[None]:
+    previous = torch.get_float32_matmul_precision()
+    torch.set_float32_matmul_precision(precision)
+    try:
+        yield
+    finally:
+        torch.set_float32_matmul_precision(previous)
+
+
+def test_tf32_nt_wgmma_shape_admits_mirrors_the_kernel_gate() -> None:
+    """The host mirror of the two hardware constraints, with no GPU involved.
+
+    TMA needs a 16-BYTE global stride and both operands are k-minor, so k must
+    be a multiple of 4 at float32; the epilogue's pair store needs an even n.
+    m is free -- that is the whole point of the relaxation over the 16-bit
+    routes' tile-multiple gate.
+    """
+    from torch_mojo_backend.eager_kernels import aten_fast
+
+    admits = aten_fast._tf32_nt_wgmma_shape_admits
+    assert admits(357, 790, 336)  # ragged m, even n, k % 4 == 0
+    assert admits(1, 2, 4)  # every dimension at its minimum
+    assert not admits(357, 790, 333)  # k * 4 = 1332 is not 16B-aligned
+    assert not admits(357, 790, 334)
+    assert not admits(128, 257, 256)  # odd n misaligns the pair store
+    assert not admits(0, 256, 256)  # empty
+    # k a multiple of 4 but NOT of the 32-element tile: a partial trailing
+    # k-tile is legal (TMA zero-fills past the extent), unlike for the 16-bit
+    # routes.
+    assert admits(128, 256, 4)
+    # The two graceful-fallback bounds: past 2^31 the Mojo route declines on
+    # machine width, and the grid is one CTA per 128x256 tile.  Nothing that
+    # fits in device memory reaches either, but a shape that did must fall back
+    # rather than hit the bridge's raise.
+    assert not admits(2**31, 256, 256)
+    assert not admits(2**31 - 1, 2**31 - 2, 4)
+
+
+def test_tf32_nt_wgmma_admits_only_nt_layout_under_tf32_precision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Layout, dtype, architecture and precision gate the route, on the host.
+
+    Only NT is ported to a 4-byte operand, and "highest" means the user asked
+    for real FP32 -- neither may reach the WGMMA kernels.
+    """
+    from torch_mojo_backend.eager_kernels import aten_fast
+
+    device = SimpleNamespace(label="gpu", api="cuda", architecture_name="sm_90a")
+
+    def tensor(
+        shape: tuple[int, int],
+        strides: tuple[int, int],
+        dtype: object = None,
+        ptr: int = 4096,
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            _shape=tuple(shape),
+            _strides=tuple(strides),
+            _dtype=aten_fast.DType.float32 if dtype is None else dtype,
+            _device=device,
+            _ptr=ptr,
+        )
+
+    monkeypatch.setattr(aten_fast, "_t", lambda value: value)
+    monkeypatch.setattr(aten_fast, "_gemm16_bridge_available", lambda: True)
+
+    row_major_a = tensor((256, 256), (256, 1))
+    nt_b = tensor((256, 512), (1, 256))  # a .t() view of a (512, 256) buffer
+    nn_b = tensor((256, 512), (512, 1))
+
+    with _tf32_precision("high"):
+        assert aten_fast._tf32_nt_wgmma_admits(row_major_a, nt_b)
+        # NN, TN, TT stay on the SM80-class route.
+        assert not aten_fast._tf32_nt_wgmma_admits(row_major_a, nn_b)
+        assert not aten_fast._tf32_nt_wgmma_admits(tensor((256, 256), (1, 256)), nt_b)
+        # transpose_b flips which physical layout counts as NT.  With it set
+        # the RHS is the (n, k) buffer -- the shape torch.linear hands over --
+        # so it must be (512, 256) here, not nn_b's (256, 512), whose k would
+        # contradict A's.
+        nk_b = tensor((512, 256), (256, 1))
+        assert aten_fast._tf32_nt_wgmma_admits(row_major_a, nk_b, transpose_b=True)
+        # bfloat16 has its own, separately routed build of the same family.
+        assert not aten_fast._tf32_nt_wgmma_admits(
+            tensor((256, 256), (256, 1), dtype=aten_fast.DType.bfloat16),
+            tensor((256, 512), (1, 256), dtype=aten_fast.DType.bfloat16),
+        )
+        # An offset view's data pointer need not be 16B-aligned, and TMA
+        # descriptor creation requires it.
+        assert not aten_fast._tf32_nt_wgmma_admits(
+            tensor((256, 256), (256, 1), ptr=4100), nt_b
+        )
+        # Not an H100: these are WGMMA+TMA kernels and nothing else runs them.
+        other = SimpleNamespace(label="gpu", api="cuda", architecture_name="sm_80")
+        sm80_a = tensor((256, 256), (256, 1))
+        sm80_b = tensor((256, 512), (1, 256))
+        sm80_a._device = other
+        sm80_b._device = other
+        assert not aten_fast._tf32_nt_wgmma_admits(sm80_a, sm80_b)
+        # An absent bridge declines before anything is allocated.
+        monkeypatch.setattr(aten_fast, "_gemm16_bridge_available", lambda: False)
+        assert not aten_fast._tf32_nt_wgmma_admits(row_major_a, nt_b)
+
+    monkeypatch.setattr(aten_fast, "_gemm16_bridge_available", lambda: True)
+    with _tf32_precision("highest"):
+        assert not aten_fast._tf32_nt_wgmma_admits(row_major_a, nt_b)
+
+
+@pytest.mark.parametrize("shape_id", sorted(_TF32_WGMMA_SHAPES))
+def test_tf32_wgmma_nt_mm_is_bit_exact(mojo_h100: torch.device, shape_id: str) -> None:
+    """The WGMMA float32 route reproduces the FP64 reference bit for bit."""
+    _require_real_bf16_gemm_sources()
+    m, n, k = _TF32_WGMMA_SHAPES[shape_id]
+    host_a = _tf32_exact_operand((m, k), 20260819)
+    host_b = _tf32_exact_operand((n, k), 20260820)
+    expected = (host_a.double() @ host_b.double().t()).float()
+
+    with _tf32_precision("high"), _gpu_lock():
+        a = host_a.to(mojo_h100)
+        b = host_b.to(mojo_h100)
+        actual = (a @ b.t()).cpu()
+
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("shape_id", sorted(_TF32_DECLINED_SHAPES))
+def test_tf32_declined_shapes_stay_correct_on_the_sm80_route(
+    mojo_h100: torch.device, shape_id: str
+) -> None:
+    """A shape no TMA descriptor can describe must decline, not fault.
+
+    k * 4 not a multiple of 16 bytes fails descriptor creation outright, and an
+    odd n misaligns the epilogue's pair store; the SM80-class kernel serves
+    both, and is exact on the same operands.
+    """
+    _require_real_bf16_gemm_sources()
+    from torch_mojo_backend.eager_kernels import aten_fast
+
+    m, n, k = _TF32_DECLINED_SHAPES[shape_id]
+    assert not aten_fast._tf32_nt_wgmma_shape_admits(m, n, k)
+    host_a = _tf32_exact_operand((m, k), 20260821)
+    host_b = _tf32_exact_operand((n, k), 20260822)
+    expected = (host_a.double() @ host_b.double().t()).float()
+
+    with _tf32_precision("high"), _gpu_lock():
+        a = host_a.to(mojo_h100)
+        b = host_b.to(mojo_h100)
+        actual = (a @ b.t()).cpu()
+
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
+def test_tf32_wgmma_nt_writes_nothing_past_the_output(
+    mojo_h100: torch.device, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Guard cells immediately after C survive a doubly ragged output tile.
+
+    357x790 straddles the 128x256 tile in both dimensions, so the last CTA row
+    and column are partial and the epilogue's own bounds check is the only
+    thing keeping the stores inside C.  Handing the route a view into the head
+    of a larger buffer puts real, checkable memory right after that last
+    element.
+    """
+    _require_real_bf16_gemm_sources()
+    from torch_mojo_backend.eager_kernels import aten_fast
+
+    m, n, k = 357, 790, 336
+    guard_elements = 4096
+    sentinel = -12345.0
+    host_a = _tf32_exact_operand((m, k), 20260823)
+    host_b = _tf32_exact_operand((n, k), 20260824)
+    expected = (host_a.double() @ host_b.double().t()).float()
+    real_alloc = aten_fast._alloc
+
+    with _tf32_precision("high"), _gpu_lock():
+        buffer = torch.full(
+            (m * n + guard_elements,), sentinel, device=mojo_h100, dtype=torch.float32
+        )
+        head = aten_fast._view_of(buffer, (m, n), (n, 1), 0, contiguous=True)
+
+        def alloc_head(
+            shape: tuple[int, ...], dtype: object, device: object
+        ) -> torch.Tensor:
+            if tuple(shape) == (m, n) and dtype == head._dtype:
+                return head
+            return real_alloc(shape, dtype, device)
+
+        monkeypatch.setattr(aten_fast, "_alloc", alloc_head)
+        a = host_a.to(mojo_h100)
+        b = host_b.to(mojo_h100)
+        actual = a @ b.t()
+        # Aliasing, not identity: what matters is that the kernel wrote into the
+        # guarded buffer rather than into a fresh allocation of its own.
+        assert actual._ptr == head._ptr
+        result = head.cpu()
+        guard = buffer[m * n :].cpu()
+
+    torch.testing.assert_close(result, expected, atol=0, rtol=0)
+    assert torch.equal(guard, torch.full((guard_elements,), sentinel))
+
+
+def test_tf32_wgmma_nt_runs_the_named_wgmma_kernels(mojo_h100: torch.device) -> None:
+    """The route actually taken, read back from the profiler's kernel names.
+
+    The names are what CUPTI, Nsight and torch.profiler print, so this is also
+    the assertion that a user profiling a float32 model at TF32 precision reads
+    "tf32", never "bf16".  A silent fall back to the SM80-class kernel would
+    otherwise look exactly like success.
+    """
+    _require_real_bf16_gemm_sources()
+    from torch.profiler import ProfilerActivity, profile
+
+    device_event_types = ("DeviceType.CUDA", "DeviceType.PrivateUse1")
+
+    def kernel_names(m: int, n: int, k: int) -> set[str]:
+        a = torch.randn(m, k, device=mojo_h100)
+        b = torch.randn(n, k, device=mojo_h100)
+        for _ in range(2):  # build and warm the variant outside the profile
+            del_me = a @ b.t()
+            del del_me
+        with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:
+            out = a @ b.t()
+            del out
+        return {
+            event.name
+            for event in prof.events()
+            if str(event.device_type) in device_event_types
+            and "memc" not in event.name.lower()
+            and "memset" not in event.name.lower()
+        }
+
+    with _tf32_precision("high"), _gpu_lock():
+        ragged = kernel_names(357, 790, 336)
+        deep_k = kernel_names(256, 256, 8192)
+        declined = kernel_names(357, 790, 333)
+
+    assert any(name.startswith("tf32_gemm_v3_nt_ws_m128n256_tma_s3") for name in ragged)
+    assert any(
+        name.startswith("tf32_gemm_nt_v4_splitk_m128n256_s4") for name in deep_k
+    ), deep_k
+    assert any(name.startswith("tf32_gemm_tn_v4_splitk_reduce") for name in deep_k)
+    # The declined shape stays on the SM80-class kernel and never reaches a
+    # WGMMA one.
+    assert not any("_v3_nt_ws_" in name or "_v4_splitk_" in name for name in declined)
+    for names in (ragged, deep_k):
+        assert not any("bf16" in name or "f16_gemm" in name for name in names)
+
+
+def test_tf32_linear_and_addmm_split_bias_off_the_wgmma_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A biased NT float32 call splits into mm + add exactly when the WGMMA
+    route serves the mm.
+
+    Those kernels have no fused-bias epilogue and decline a biased call, so a
+    fused call would land on the SM80-class kernel; when the WGMMA route would
+    not serve the mm anyway, the split only pays for an extra launch (the S5
+    regression `_gemm16_alignment_favors_split` documents).
+    """
+    from torch_mojo_backend.eager_kernels import aten_fast
+
+    device = SimpleNamespace(label="gpu", api="cuda", architecture_name="sm_90a")
+
+    def tensor(shape: tuple[int, int], strides: tuple[int, int]) -> SimpleNamespace:
+        return SimpleNamespace(
+            _shape=tuple(shape),
+            _strides=tuple(strides),
+            _dtype=aten_fast.DType.float32,
+            _device=device,
+            _ptr=4096,
+            _is_contiguous=strides == (shape[1], 1),
+        )
+
+    gemm_calls = []
+    add_calls = []
+    mm_result, biased_result = object(), object()
+
+    def try_tf32_gemm(
+        a: object, b: object, bias: object = None, **kwargs: object
+    ) -> object:
+        gemm_calls.append(bias)
+        return mm_result
+
+    def fast_add(value: object, bias: object) -> object:
+        add_calls.append((value, bias))
+        return biased_result
+
+    monkeypatch.setattr(aten_fast, "_t", lambda value: value)
+    monkeypatch.setattr(aten_fast, "_gemm16_bridge_available", lambda: True)
+    monkeypatch.setattr(aten_fast, "_try_tf32_gemm", try_tf32_gemm)
+    monkeypatch.setattr(aten_fast, "fast_aten_add", fast_add)
+    monkeypatch.setattr(aten_fast, "_try_gemm16_mm", lambda *a, **k: None)
+    monkeypatch.setattr(aten_fast, "_try_gemm16_linear", lambda *a, **k: None)
+
+    weight = tensor((790, 336), (336, 1))  # (n, k): linear's NT weight
+    bias = object()
+
+    with _tf32_precision("high"):
+        # Admitted: k % 4 == 0 and n even -> split.
+        assert (
+            aten_fast._try_tf32_linear(tensor((357, 336), (336, 1)), weight, bias)
+            is biased_result
+        )
+        assert gemm_calls == [None]
+        assert add_calls == [(mm_result, bias)]
+        # Declined (k * 4 not 16B-aligned) -> one fused-bias call, no add.
+        gemm_calls.clear()
+        add_calls.clear()
+        assert (
+            aten_fast._try_tf32_linear(
+                tensor((357, 333), (333, 1)), tensor((790, 333), (333, 1)), bias
+            )
+            is mm_result
+        )
+        assert gemm_calls == [bias]
+        assert add_calls == []
+        # addmm's NT case splits on the same predicate.
+        gemm_calls.clear()
+        add_calls.clear()
+        assert (
+            aten_fast.fast_aten_addmm(
+                bias, tensor((357, 336), (336, 1)), tensor((336, 790), (1, 336))
+            )
+            is biased_result
+        )
+        assert gemm_calls == [None]
+        assert add_calls == [(mm_result, bias)]
+
+
 def test_matmul_spec_device_oom_is_not_disguised_as_unsupported(
     monkeypatch, fake_mojo_tensor
 ):
@@ -6860,7 +7254,16 @@ def test_tf32_linear_flattens_contiguous_gpt_input_as_zero_copy_view(monkeypatch
     gemm_calls = []
 
     def as_tensor(value):
-        return {input: input_metadata, weight: weight_metadata}.get(value)
+        # Identity lookup rather than a dict: `_try_tf32_linear` now offers the
+        # flattened matrix view to `_tf32_nt_wgmma_admits` before deciding
+        # whether to split the bias off, and that view is a SimpleNamespace,
+        # which is unhashable.  Returning None for it makes the predicate
+        # decline, which is the fused-bias path this test is about.
+        if value is input:
+            return input_metadata
+        if value is weight:
+            return weight_metadata
+        return None
 
     def view_of(*args, **kwargs):
         view_calls.append((args, kwargs))
@@ -6896,7 +7299,16 @@ def test_tf32_linear_noncontiguous_batch_retains_tensorspec_path(monkeypatch):
     fallback = object()
 
     def as_tensor(value):
-        return {input: input_metadata, weight: weight_metadata}.get(value)
+        # Identity lookup rather than a dict: `_try_tf32_linear` now offers the
+        # flattened matrix view to `_tf32_nt_wgmma_admits` before deciding
+        # whether to split the bias off, and that view is a SimpleNamespace,
+        # which is unhashable.  Returning None for it makes the predicate
+        # decline, which is the fused-bias path this test is about.
+        if value is input:
+            return input_metadata
+        if value is weight:
+            return weight_metadata
+        return None
 
     def fail_tf32_work(*_args, **_kwargs):
         raise AssertionError("non-contiguous batched linear entered the TF32 path")

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -6363,11 +6363,17 @@ def test_bf16_v3_source_dependency_and_kernel_contract():
     for kernel_name in (
         "gemm_v3_nn_ws_m64n128_tma_s3",
         "gemm_v3_nn_ws_m128n256_tma_s3",
-        "gemm_v3_nt_ws_m128n256_tma_s3",
         "gemm_v3_tn_ws_m64n128_tma_col_a_s3",
         "gemm_v3_tn_ws_m128n256_tma_col_a_s3",
     ):
         assert f'@__name(t"{{_GEMM16_TAG}}_{kernel_name}")' in v3_source
+    # The NT kernel carries a second interpolation: it is specialized on a
+    # fused-bias epilogue, and the two specializations must be tellable apart
+    # in a profile (`..._tma_s3` vs `..._tma_s3_bias`).
+    assert (
+        't"{_GEMM16_TAG}_gemm_v3_nt_ws_m128n256_tma_s3'
+        '{_gemm16_bias_tag[has_bias]()}"' in v3_source
+    )
 
     for helper_name in (
         "_v3_enqueue_nn_ws_m64n128_tma_s3",
@@ -6375,9 +6381,7 @@ def test_bf16_v3_source_dependency_and_kernel_contract():
     ):
         assert v3_source.count(f"{helper_name}(") == 2
 
-    nt_kernel_start = v3_source.index(
-        '@__name(t"{_GEMM16_TAG}_gemm_v3_nt_ws_m128n256_tma_s3")'
-    )
+    nt_kernel_start = v3_source.index('t"{_GEMM16_TAG}_gemm_v3_nt_ws_m128n256_tma_s3')
     nt_kernel_end = v3_source.index(
         '@__name(t"{_GEMM16_TAG}_gemm_v3_tn_ws_m64n128_tma_col_a_s3")'
     )
@@ -6597,10 +6601,22 @@ def test_addmm_tries_split_for_aligned_shapes(monkeypatch):
     route -- see _gemm16_alignment_favors_split."""
     from torch_mojo_backend.eager_kernels import aten_fast
 
-    def tensor(shape):
-        return SimpleNamespace(_shape=tuple(shape))
+    device = SimpleNamespace(label="gpu", api="cuda", architecture_name="sm_90a")
 
-    lhs, rhs, bias = tensor((128, 128)), tensor((128, 128)), object()
+    def tensor(shape):
+        shape = tuple(shape)
+        return SimpleNamespace(
+            _shape=shape,
+            _strides=aten_fast._row_major_strides(shape),
+            _dtype=aten_fast.DType.bfloat16,
+            _device=device,
+            _ptr=4096,
+            _is_contiguous=True,
+        )
+
+    # NN, so no fused-bias route exists for it whatever the alignment: the
+    # bias-free mm plus a separate add is still the best available pair.
+    lhs, rhs, bias = tensor((128, 128)), tensor((128, 128)), tensor((128,))
     mm_result, biased_result = object(), object()
     gemm_calls = []
     add_calls = []
@@ -7103,29 +7119,35 @@ def test_tf32_wgmma_nt_runs_the_named_wgmma_kernels(mojo_h100: torch.device) -> 
         assert not any("bf16" in name or "f16_gemm" in name for name in names)
 
 
-def test_tf32_linear_and_addmm_split_bias_off_the_wgmma_route(
+def test_tf32_linear_and_addmm_fuse_bias_into_the_wgmma_route(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A biased NT float32 call splits into mm + add exactly when the WGMMA
-    route serves the mm.
+    """A biased NT float32 call carries its bias to the direct WGMMA kernel,
+    and splits it off only where that kernel is not the route.
 
-    Those kernels have no fused-bias epilogue and decline a biased call, so a
-    fused call would land on the SM80-class kernel; when the WGMMA route would
-    not serve the mm anyway, the split only pays for an extra launch (the S5
-    regression `_gemm16_alignment_favors_split` documents).
+    The direct kernel adds the bias inside its accumulator epilogue, so the
+    bias travels with the call: one launch, and no second full pass over C.
+    Two exceptions keep the old mm-then-add composition -- the deep-K shapes
+    the split-K arm claims (it reduces through an FP32 workspace and has no
+    accumulator epilogue to fuse into), and a bias whose pointer the fused
+    epilogue's naturally-aligned pair load cannot use.
     """
     from torch_mojo_backend.eager_kernels import aten_fast
 
     device = SimpleNamespace(label="gpu", api="cuda", architecture_name="sm_90a")
 
-    def tensor(shape: tuple[int, int], strides: tuple[int, int]) -> SimpleNamespace:
+    def tensor(
+        shape: tuple[int, ...], strides: tuple[int, ...], ptr: int = 4096
+    ) -> SimpleNamespace:
         return SimpleNamespace(
             _shape=tuple(shape),
             _strides=tuple(strides),
             _dtype=aten_fast.DType.float32,
             _device=device,
-            _ptr=4096,
-            _is_contiguous=strides == (shape[1], 1),
+            _ptr=ptr,
+            _is_contiguous=strides == tuple(shape[1:]) + (1,)
+            if len(shape) == 2
+            else True,
         )
 
     gemm_calls = []
@@ -7150,19 +7172,20 @@ def test_tf32_linear_and_addmm_split_bias_off_the_wgmma_route(
     monkeypatch.setattr(aten_fast, "_try_gemm16_linear", lambda *a, **k: None)
 
     weight = tensor((790, 336), (336, 1))  # (n, k): linear's NT weight
-    bias = object()
+    bias = tensor((790,), (1,))
 
     with _tf32_precision("high"):
-        # Admitted: k % 4 == 0 and n even -> split.
+        # Admitted, direct arm (a 357x790 output is far too large for split-K
+        # to claim): the bias rides along, no separate add.
         assert (
             aten_fast._try_tf32_linear(tensor((357, 336), (336, 1)), weight, bias)
-            is biased_result
+            is mm_result
         )
-        assert gemm_calls == [None]
-        assert add_calls == [(mm_result, bias)]
-        # Declined (k * 4 not 16B-aligned) -> one fused-bias call, no add.
+        assert gemm_calls == [bias]
+        assert add_calls == []
+        # Declined (k * 4 not 16B-aligned): one fused-bias call, no add, as
+        # before -- the SM80-class kernel takes the bias itself.
         gemm_calls.clear()
-        add_calls.clear()
         assert (
             aten_fast._try_tf32_linear(
                 tensor((357, 333), (333, 1)), tensor((790, 333), (333, 1)), bias
@@ -7171,17 +7194,170 @@ def test_tf32_linear_and_addmm_split_bias_off_the_wgmma_route(
         )
         assert gemm_calls == [bias]
         assert add_calls == []
-        # addmm's NT case splits on the same predicate.
+        # Deep K with few output tiles: the split-K arm claims this shape and
+        # cannot fuse, so the bias is split off exactly as it used to be.
+        gemm_calls.clear()
+        deep_bias = tensor((1024,), (1,))
+        assert (
+            aten_fast._try_tf32_linear(
+                tensor((1024, 8192), (8192, 1)),
+                tensor((1024, 8192), (8192, 1)),
+                deep_bias,
+            )
+            is biased_result
+        )
+        assert gemm_calls == [None]
+        assert add_calls == [(mm_result, deep_bias)]
+        # A bias the fused epilogue cannot read as a contiguous n-vector --
+        # a scalar, an expanded view -- keeps the split, whose elementwise
+        # add broadcasts.  Getting this wrong does not fault: the bridge
+        # declines the biased call and the projection falls past BOTH fast
+        # paths.
+        gemm_calls.clear()
+        add_calls.clear()
+        assert (
+            aten_fast._try_tf32_linear(
+                tensor((357, 336), (336, 1)), weight, tensor((), ())
+            )
+            is biased_result
+        )
+        assert gemm_calls == [None]
+        assert add_calls[0][0] is mm_result
+        # A bias reached through an offset view is not 8B-aligned, which the
+        # fused epilogue's pair load requires: split rather than fault.
+        gemm_calls.clear()
+        add_calls.clear()
+        odd_bias = tensor((790,), (1,), ptr=4100)
+        assert (
+            aten_fast._try_tf32_linear(tensor((357, 336), (336, 1)), weight, odd_bias)
+            is biased_result
+        )
+        assert gemm_calls == [None]
+        assert add_calls == [(mm_result, odd_bias)]
+        # addmm's NT case decides on the same predicates.
         gemm_calls.clear()
         add_calls.clear()
         assert (
             aten_fast.fast_aten_addmm(
                 bias, tensor((357, 336), (336, 1)), tensor((336, 790), (1, 336))
             )
-            is biased_result
+            is mm_result
         )
-        assert gemm_calls == [None]
-        assert add_calls == [(mm_result, bias)]
+        assert gemm_calls == [bias]
+        assert add_calls == []
+
+
+def test_gemm16_linear_and_addmm_fuse_bias_into_the_nt_wgmma_route(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The 16-bit twin of the float32 case above.
+
+    `linear` IS the NT regime by construction, and the persistent v4 NT kernel
+    fuses the bias, so a biased 16-bit projection is one launch.  Non-NT
+    layouts have no fused-bias route and keep the mm-then-add split, which is
+    the whole reason `_gemm16_alignment_favors_split` exists.
+    """
+    from torch_mojo_backend.eager_kernels import aten_fast
+
+    device = SimpleNamespace(label="gpu", api="cuda", architecture_name="sm_90a")
+
+    def tensor(
+        shape: tuple[int, ...], strides: tuple[int, ...], ptr: int = 4096
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            _shape=tuple(shape),
+            _strides=tuple(strides),
+            _dtype=aten_fast.DType.bfloat16,
+            _device=device,
+            _ptr=ptr,
+            _is_contiguous=True,
+        )
+
+    gemm_calls = []
+    add_calls = []
+    mm_result, biased_result = object(), object()
+
+    def try_gemm16_mm(
+        a: object, b: object, bias: object = None, **kwargs: object
+    ) -> object:
+        gemm_calls.append(bias)
+        return mm_result
+
+    def fast_add(value: object, bias: object) -> object:
+        add_calls.append((value, bias))
+        return biased_result
+
+    monkeypatch.setattr(aten_fast, "_t", lambda value: value)
+    monkeypatch.setattr(aten_fast, "_try_gemm16_mm", try_gemm16_mm)
+    monkeypatch.setattr(aten_fast, "fast_aten_add", fast_add)
+
+    x = tensor((4096, 4096), (4096, 1))
+    weight = tensor((4096, 4096), (4096, 1))  # (n, k)
+    bias = tensor((4096,), (1,))
+
+    # NT (linear): fused, one call.
+    assert aten_fast._try_gemm16_linear(x, weight, bias) is mm_result
+    assert gemm_calls == [bias]
+    assert add_calls == []
+
+    # Deep K, few output tiles: split-K claims it, so the bias is split off.
+    gemm_calls.clear()
+    deep_bias = tensor((1024,), (1,))
+    assert (
+        aten_fast._try_gemm16_linear(
+            tensor((1024, 8192), (8192, 1)), tensor((1024, 8192), (8192, 1)), deep_bias
+        )
+        is biased_result
+    )
+    assert gemm_calls == [None]
+    assert add_calls == [(mm_result, deep_bias)]
+
+    # A scalar bias cannot be read as a contiguous n-vector: split.
+    gemm_calls.clear()
+    add_calls.clear()
+    assert aten_fast._try_gemm16_linear(x, weight, tensor((), ())) is biased_result
+    assert gemm_calls == [None]
+    assert add_calls[0][0] is mm_result
+
+    # An NN addmm has no fused-bias route: the mm-then-add split stands.
+    gemm_calls.clear()
+    add_calls.clear()
+    gemm_calls.clear()
+    add_calls.clear()
+    assert (
+        aten_fast.fast_aten_addmm(bias, x, tensor((4096, 4096), (4096, 1)))
+        is biased_result
+    )
+    assert gemm_calls == [None]
+    assert add_calls == [(mm_result, bias)]
+
+
+def test_gemm16_splitk_nt_may_fire_mirrors_the_split_k_gate() -> None:
+    """The host mirror that keeps deep-K shapes on the split-the-bias path.
+
+    It has to claim every shape the Mojo split-K arm could claim (claiming one
+    it cannot only costs an extra elementwise-add launch, while MISSING one
+    would push a deep-K shape onto the direct kernel, measured 85us -> 197us
+    on 1024x1024x8192 tf32).  The multiprocessor count it cannot query is
+    replaced by its architectural upper bound, in that same direction.
+    """
+    from torch_mojo_backend.eager_kernels import aten_fast
+
+    may_fire = aten_fast._gemm16_splitk_nt_may_fire
+    # The deep-K regime split-K exists for.
+    assert may_fire(1024, 1024, 8192)
+    # The four shapes the eight above-bar addmm/linear cells live on: their
+    # outputs are far too many tiles for a 2-way split to be reachable.
+    assert not may_fire(4096, 4096, 4096)
+    assert not may_fire(8192, 2048, 2048)
+    assert not may_fire(2048, 8192, 2048)
+    assert not may_fire(32768, 768, 768)
+    # Hard gates: the split-K tile is 128 x 256, exactly divided, and a 2-way
+    # split needs 32 k-tiles of 64.
+    assert not may_fire(1000, 1024, 8192)
+    assert not may_fire(1024, 1000, 8192)
+    assert not may_fire(1024, 1024, 8200)
+    assert not may_fire(1024, 1024, 1024)
 
 
 def test_matmul_spec_device_oom_is_not_disguised_as_unsupported(

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -6810,6 +6810,13 @@ _TF32_WGMMA_SHAPES = {
     "ragged_357x790x336": (357, 790, 336),
     # deep K, few output tiles: the split-K workspace + reduce route
     "deep_k_256x256x8192": (256, 256, 8192),
+    # k = 4 is the SMALLEST k the gate can admit at a 4-byte operand: the TMA
+    # rule is (k * 4) % 16 == 0, so k must be a multiple of 4, and k = 4 is one
+    # eighth of a single BK = 32 tile.  The whole mainloop is then one k-tile
+    # whose tail TMA zero-fills, which is exact because zeros contribute
+    # nothing to a dot product -- the boundary where that reasoning either
+    # holds or the kernel reads garbage.
+    "min_k_128x256x4": (128, 256, 4),
 }
 
 # k = 333 makes the row pitch k * 4 = 1332 bytes, not a multiple of 16, so no
@@ -7088,7 +7095,9 @@ def test_tf32_wgmma_nt_runs_the_named_wgmma_kernels(mojo_h100: torch.device) -> 
     ), deep_k
     assert any(name.startswith("tf32_gemm_tn_v4_splitk_reduce") for name in deep_k)
     # The declined shape stays on the SM80-class kernel and never reaches a
-    # WGMMA one.
+    # WGMMA one.  Assert the positive too: "no WGMMA kernel ran" would also be
+    # satisfied by a decomposition that never reached tf32_matmul_ops at all.
+    assert any(name.startswith("tf32_gemm_tile") for name in declined), declined
     assert not any("_v3_nt_ws_" in name or "_v4_splitk_" in name for name in declined)
     for names in (ragged, deep_k):
         assert not any("bf16" in name or "f16_gemm" in name for name in names)

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -191,11 +191,18 @@ _GEMM16_SOURCE_PATHS = (
     eager_kernels._PACKAGE_DIR / "gemm16_matmul_ops/gemm16_kernels.mojo",
 )
 
-# The dtypes that family serves.  bfloat16 and float16 are one and the same to
-# Hopper's tensor cores -- same operand width, same WGMMA tile shapes, same
-# FP32 accumulator, only the operand-type token of the instruction differs --
-# so every tile size, pipeline depth and TMA descriptor carries over unchanged
-# and the loader simply compiles the sources once per dtype.
+# The dtypes the `_try_gemm16_*` helpers here offer that family.  bfloat16 and
+# float16 are one and the same to Hopper's tensor cores -- same operand width,
+# same WGMMA tile shapes, same FP32 accumulator, only the operand-type token of
+# the instruction differs -- so every tile size, pipeline depth and TMA
+# descriptor carries over unchanged and the loader simply compiles the sources
+# once per dtype.
+#
+# float32 is deliberately NOT in this tuple even though the family compiles for
+# it (gemm16_dtype.mojo): using it is a numerics decision gated on
+# `torch.get_float32_matmul_precision()`, not a capability one, so that route is
+# reached only through `_try_tf32_gemm`, which owns the precision gate and picks
+# between the WGMMA kernels and the SM80-class `tf32_matmul_ops` fallback.
 _GEMM16_DTYPES = (DType.bfloat16, DType.float16)
 
 # The TF32 host route is useful before the separately profiled Fable kernel is
@@ -8449,8 +8456,95 @@ def _try_gemm16_mm(a, b, bias=None, *, transpose_b=False, output_shape=None):
     return out
 
 
+def _tf32_nt_wgmma_shape_admits(m: int, n: int, k: int) -> bool:
+    """The shape half of the gemm16 float32 NT gate, mirrored on the host.
+
+    It has to be mirrored rather than discovered, because the two bridges are
+    separate extensions and the host is what picks between them: whatever this
+    declines must reach the SM80-class ``tf32_matmul_ops`` route instead.  The
+    Mojo side (``_enqueue_gemm16_gemm_tf32``) raises rather than silently
+    no-op'ing if the two ever disagree, so a drift is loud.
+
+    The two conditions are hardware, not tuning (``_try_enqueue_gemm16_nt_v3_tf32``
+    in gemm16_v3_kernels.mojo carries the full derivation): TMA needs every
+    global stride to be a multiple of 16 BYTES and both operands are k-minor, so
+    the row pitch ``k * 4`` must be; and the epilogue stores a two-element pair
+    per lane at a row start of ``row * n * 4`` bytes, which needs an even ``n``.
+    ``m`` is unconstrained -- a partial edge tile in m is clipped by the
+    kernel's own bounds check.
+
+    The 2^31 bound and the grid bound are the Mojo route's remaining two
+    declines, mirrored here only so an absurd shape falls back gracefully
+    instead of hitting that raise; both are far beyond anything that fits in
+    device memory.  Every machine-width product guard the Mojo side also checks
+    (k * m, k * n, m * n against INT64_MAX) is implied by the 2^31 bound.
+    """
+    if min(m, n, k) < 1 or max(m, n, k) > 2**31 - 1:
+        return False
+    if (k * 4) % 16 or n % 2:
+        return False
+    # One CTA per 128x256 output tile, and grid.x is capped at 2^31 - 1 on
+    # every CUDA device of the compute capability this route already requires.
+    blocks_m = (m + 127) // 128
+    blocks_n = (n + 255) // 256
+    return blocks_m * blocks_n <= 2**31 - 1
+
+
+def _tf32_nt_wgmma_admits(a, b, *, transpose_b: bool = False) -> bool:
+    """Whether the float32 (TF32) WGMMA route serves this bias-free 2-D mm.
+
+    True only for the NT layout, which is the one layout of the gemm16 family
+    that has been ported and measured at a 4-byte operand: A row-major (m, k)
+    and B reached k-minor, i.e. a ``.t()`` view of an (n, k) buffer or an
+    explicit ``transpose_b``.  Every other float32 layout keeps the
+    SM80-class route, so this predicate is also what a caller consults before
+    splitting a fused bias off a matmul: splitting is only worth an extra
+    elementwise-add launch when the mm itself lands on the faster route.
+    """
+    if torch.get_float32_matmul_precision() == "highest":
+        return False
+    lhs = _t(a)
+    rhs = _t(b)
+    if (
+        lhs is None
+        or rhs is None
+        or lhs._dtype != DType.float32
+        or rhs._dtype != DType.float32
+        or lhs._device != rhs._device
+        or lhs._device.label != "gpu"
+        or lhs._device.api != "cuda"
+        or lhs._device.architecture_name != "sm_90a"
+    ):
+        return False
+    lhs_layout = _tf32_dense_2d_layout(lhs)
+    rhs_layout = _tf32_dense_2d_layout(rhs)
+    if lhs_layout is None or rhs_layout is None:
+        return False
+    # NT only: A untransposed, B effectively transposed.
+    if lhs_layout or not (rhs_layout ^ bool(transpose_b)):
+        return False
+    m, k = lhs._shape
+    rhs_k = rhs._shape[1] if transpose_b else rhs._shape[0]
+    n = rhs._shape[0] if transpose_b else rhs._shape[1]
+    if min(m, n, k) <= 0 or rhs_k != k:
+        return False
+    # An offset view's data pointer need not be 16B-aligned, and TMA
+    # descriptor creation requires it.
+    if lhs._ptr % 16 or rhs._ptr % 16:
+        return False
+    return _tf32_nt_wgmma_shape_admits(m, n, k) and _gemm16_bridge_available()
+
+
 def _try_tf32_gemm(a, b, bias=None, *, transpose_b=False, output_shape=None):
     """Enqueue the opt-in dense H100 TF32 GEMM, or return ``None``.
+
+    Two device routes hide behind this one helper, both consuming and producing
+    float32 while accumulating in FP32.  The NT layout goes to the gemm16
+    family's warp-specialized WGMMA kernels compiled for a 4-byte operand --
+    WGMMA takes float32 operands directly and computes them as TF32 -- which
+    took the benchmark's NT tf32 nodes from 3.1-5.7x stock cuBLAS to 0.85-1.07x
+    on an H100 PCIe.  Every other layout, and every NT shape the WGMMA gate
+    declines, keeps the SM80-class ``mma.m16n8k8`` route in ``tf32_matmul_ops``.
 
     This helper owns only host validation/allocation and the raw bridge call;
     the Fable-owned module owns every device-kernel body.  Unsupported layouts
@@ -8508,9 +8602,24 @@ def _try_tf32_gemm(a, b, bias=None, *, transpose_b=False, output_shape=None):
     if not _tf32_bridge_available():
         return None
     out = _alloc(logical_output_shape, DType.float32, lhs._device)
+    # Route selection, not capability: both bridges accept this exact 11-tuple,
+    # so the only difference is which extension compiles it.  The WGMMA leg
+    # takes the NT no-bias regimes it was measured on; everything else stays on
+    # the SM80-class kernel.  A fresh allocation is always 16B-aligned, but the
+    # gemm16 gate requires that of the OUTPUT too and it raises rather than
+    # declining, so check rather than assume.
+    extension = _Tf32MatmulExtension
+    op_name = "Tf32GemmF32"
+    if (
+        bias_tensor is None
+        and out._ptr % 16 == 0
+        and _tf32_nt_wgmma_admits(lhs, rhs, transpose_b=transpose_b)
+    ):
+        extension = _Gemm16MatmulExtension
+        op_name = "Gemm16"
     _call_mojo(
-        _Tf32MatmulExtension,
-        "Tf32GemmF32",
+        extension,
+        op_name,
         (
             out._ptr,
             lhs._ptr,
@@ -8724,6 +8833,13 @@ def _try_tf32_linear(input, weight, bias=None):
     input is already the same row-major matrix after its leading dimensions
     are flattened, so only a metadata view is needed.  Non-contiguous inputs
     retain the TensorSpec path, which owns any required materialization.
+
+    A bias is split off exactly when the bias-free mm reaches the WGMMA route
+    (`_tf32_nt_wgmma_admits`), for the reason spelled out in
+    `_try_gemm16_linear`: those kernels have no fused-bias epilogue and decline
+    a biased call outright, so a fused-bias call would land on the much slower
+    SM80-class kernel.  When the WGMMA route would not serve the mm anyway,
+    the fused-bias call is at worst identical and saves a launch.
     """
     if torch.get_float32_matmul_precision() == "highest":
         return None
@@ -8750,6 +8866,14 @@ def _try_tf32_linear(input, weight, bias=None):
             a._offset,
             contiguous=True,
         )
+    if bias is not None and _tf32_nt_wgmma_admits(matrix, weight, transpose_b=True):
+        mm_out = _try_tf32_gemm(
+            matrix, weight, transpose_b=True, output_shape=output_shape
+        )
+        if mm_out is not None:
+            biased = fast_aten_add(mm_out, bias)
+            if biased is not NOT_HANDLED:
+                return biased
     return _try_tf32_gemm(
         matrix, weight, bias, transpose_b=True, output_shape=output_shape
     )
@@ -8778,6 +8902,15 @@ def fast_aten_addmm(input, mat1, mat2, *, beta=1.0, alpha=1.0):
         # elementwise add instead.
         if _gemm16_alignment_favors_split(mat1, mat2):
             mm_out = _try_gemm16_mm(mat1, mat2)
+            if mm_out is not None:
+                biased = fast_aten_add(mm_out, input)
+                if biased is not NOT_HANDLED:
+                    return biased
+        # The float32 (TF32) WGMMA route has no fused-bias epilogue either, and
+        # declines a biased call the same way; split the bias off it too, but
+        # only where that route would actually serve the mm.
+        if _tf32_nt_wgmma_admits(mat1, mat2):
+            mm_out = _try_tf32_gemm(mat1, mat2)
             if mm_out is not None:
                 biased = fast_aten_add(mm_out, input)
                 if biased is not NOT_HANDLED:

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -8375,6 +8375,126 @@ def _gemm16_alignment_favors_split(a, b, *, transpose_b: bool = False) -> bool:
     return m % 64 == 0 and n % 64 == 0 and k % 64 == 0
 
 
+# The largest multiprocessor count of any sm_90a part (H100 PCIe 114, H100
+# SXM / H200 / GH200 132).  Used only as an UPPER bound below, where
+# over-estimating it is the safe direction: it can only make
+# `_gemm16_splitk_nt_may_fire` claim more shapes, i.e. keep more of them on
+# today's split-the-bias path.
+_SM90_MAX_MULTIPROCESSORS = 160
+
+
+def _gemm16_splitk_nt_may_fire(m: int, n: int, k: int) -> bool:
+    """Whether the deep-K split-K NT route could claim this shape.
+
+    The split-K kernels write an FP32 workspace and reduce it in a SECOND
+    kernel, so they have no accumulator epilogue to fuse a bias into (that
+    bias belongs in the reduce kernel, which is a different change).  A
+    biased call therefore skips them and takes the direct WGMMA kernel --
+    the right trade everywhere except in the regime split-K exists for,
+    where it is a large loss: 1024x1024x8192 tf32 measures 85us split-K
+    against 197us direct on an H100 PCIe.  So the caller keeps splitting the
+    bias off exactly the shapes this returns True for, and fuses the rest.
+
+    This mirrors `try_enqueue_gemm16_gemm_splitk_rm_v4`'s hard gates
+    (gemm16_tn_v4_kernels.mojo) and the cheapest of its regime conditions,
+    deliberately in the CONSERVATIVE direction: every condition dropped here
+    can only make the Mojo side decline where this says "may", which costs
+    an extra elementwise-add launch on a shape whose C is small by
+    construction -- never the reverse, which would be the 2x loss above.
+    The dropped conditions are the ones needing a device query (the exact
+    multiprocessor count, replaced by its architectural upper bound) or the
+    workspace-size and marginal-split refinements.
+    """
+    # Hard gates: the split-K tile is 128 x 256 with an exact division, and a
+    # 2-way split needs _V4_MIN_CHUNK_TILES = 16 k-tiles of 64 per part.
+    if m % 128 or n % 256 or k % 64 or k // 64 < 2 * 16:
+        return False
+    tiles = (m // 128) * (n // 256)
+    # cap = sm_count // tiles must reach _V4_SPLITK_RM_MIN_SPLITS = 2.
+    return tiles > 0 and 2 * tiles <= _SM90_MAX_MULTIPROCESSORS
+
+
+def _fused_bias_vector_ok(bias, reference, n: int) -> bool:
+    """Whether the fused WGMMA epilogue can consume this bias as it stands.
+
+    It reads one contiguous row of `n` values in the operand dtype through a
+    naturally-aligned two-element load.  Everything else -- a scalar or
+    otherwise broadcast bias, a strided or expanded view, a different dtype,
+    an offset view whose pointer is not pair-aligned -- keeps the separate
+    elementwise add, which broadcasts and does not care.
+
+    The shape/contiguity half is deliberately the same check `_try_gemm16_mm`
+    and `_try_tf32_gemm` already apply before handing a bias to a bridge at
+    all: if this were the looser of the two, a caller would skip the split,
+    the bridge would then decline the biased call, and the whole projection
+    would fall past both fast paths.  That is exactly what a scalar bias did.
+    """
+    bias_tensor = _t(bias)
+    return (
+        bias_tensor is not None
+        and bias_tensor._dtype == reference._dtype
+        and bias_tensor._device == reference._device
+        and tuple(bias_tensor._shape) == (n,)
+        and bias_tensor._is_contiguous
+        and bias_tensor._ptr % (2 * bias_tensor._dtype.size_in_bytes) == 0
+    )
+
+
+def _gemm16_nt_wgmma_fuses_bias(a, b, bias, *, transpose_b: bool = False) -> bool:
+    """Whether a BIASED 16-bit NT call lands on a kernel that fuses the bias.
+
+    True exactly when the persistent v4 NT kernel
+    (`maybe_enqueue_gemm16_nt_v4`, gemm16_nt_v4_kernels.mojo) will serve the
+    call: it is the first fused-bias route the NT ladder offers once the
+    split-K arm is out of the way, and its gate is looser than the v3 NT
+    fallback's, so mirroring it alone is both sufficient and conservative --
+    a shape it declines and v3 NT would have taken merely keeps today's
+    split, at the cost of one elementwise-add launch.
+
+    This is the 16-bit twin of `_tf32_nt_wgmma_admits`, and it exists for
+    the same reason that one does: the routing decision is made on the host,
+    before the bridge is called, so the condition has to be legible here.
+
+    The bias itself is checked too, by `_fused_bias_vector_ok`: the fused
+    epilogue consumes one contiguous, pair-aligned row of `n` values and
+    nothing else.
+    """
+    lhs = _t(a)
+    rhs = _t(b)
+    if (
+        lhs is None
+        or rhs is None
+        or lhs._dtype not in _GEMM16_DTYPES
+        or rhs._dtype != lhs._dtype
+        or lhs._device != rhs._device
+        or lhs._device.label != "gpu"
+        or lhs._device.api != "cuda"
+        or lhs._device.architecture_name != "sm_90a"
+    ):
+        return False
+    lhs_layout = _tf32_dense_2d_layout(lhs)
+    rhs_layout = _tf32_dense_2d_layout(rhs)
+    if lhs_layout is None or rhs_layout is None:
+        return False
+    # NT only: A untransposed, B effectively transposed.
+    if lhs_layout or not (rhs_layout ^ bool(transpose_b)):
+        return False
+    m, k = lhs._shape
+    rhs_k = rhs._shape[1] if transpose_b else rhs._shape[0]
+    n = rhs._shape[0] if transpose_b else rhs._shape[1]
+    if min(m, n, k) <= 0 or rhs_k != k:
+        return False
+    # TMA descriptor creation needs 16B-aligned bases; an offset view's data
+    # pointer need not be one.  The output is freshly allocated and is.
+    if lhs._ptr % 16 or rhs._ptr % 16:
+        return False
+    if n % 8 or k % 64 or n < 64 or m > 2**31 - 1 or n > 2**31 - 1 or k > 2**31 - 1:
+        return False
+    if not _fused_bias_vector_ok(bias, lhs, n):
+        return False
+    return not _gemm16_splitk_nt_may_fire(m, n, k)
+
+
 def _try_gemm16_mm(a, b, bias=None, *, transpose_b=False, output_shape=None):
     """Enqueue the dense H100 16-bit tensor-core GEMM, or return ``None``.
 
@@ -8535,6 +8655,30 @@ def _tf32_nt_wgmma_admits(a, b, *, transpose_b: bool = False) -> bool:
     return _tf32_nt_wgmma_shape_admits(m, n, k) and _gemm16_bridge_available()
 
 
+def _tf32_nt_wgmma_splits_bias(a, b, bias, *, transpose_b: bool = False) -> bool:
+    """For an operand pair `_tf32_nt_wgmma_admits` accepted: must its bias
+    still be added by a separate kernel?
+
+    True for the deep-K shapes the split-K arm claims, which has no
+    accumulator epilogue to fuse into (see `_gemm16_splitk_nt_may_fire`), and
+    for any bias the fused epilogue cannot consume as it stands (see
+    `_fused_bias_vector_ok`).  Everywhere else the direct WGMMA kernel adds
+    the bias for free, and this returns False so the caller passes the bias
+    straight to the bridge.
+
+    Split from `_tf32_nt_wgmma_admits` rather than folded into it so the two
+    together cost one admission check plus a handful of integer reads, not two
+    admission checks, on the eager `addmm`/`linear` hot path.
+    """
+    lhs = _t(a)
+    rhs = _t(b)
+    m, k = lhs._shape
+    n = rhs._shape[0] if transpose_b else rhs._shape[1]
+    if not _fused_bias_vector_ok(bias, lhs, n):
+        return True
+    return _gemm16_splitk_nt_may_fire(m, n, k)
+
+
 def _try_tf32_gemm(a, b, bias=None, *, transpose_b=False, output_shape=None):
     """Enqueue the opt-in dense H100 TF32 GEMM, or return ``None``.
 
@@ -8604,16 +8748,23 @@ def _try_tf32_gemm(a, b, bias=None, *, transpose_b=False, output_shape=None):
     out = _alloc(logical_output_shape, DType.float32, lhs._device)
     # Route selection, not capability: both bridges accept this exact 11-tuple,
     # so the only difference is which extension compiles it.  The WGMMA leg
-    # takes the NT no-bias regimes it was measured on; everything else stays on
-    # the SM80-class kernel.  A fresh allocation is always 16B-aligned, but the
-    # gemm16 gate requires that of the OUTPUT too and it raises rather than
-    # declining, so check rather than assume.
+    # takes the NT regimes it was measured on; everything else stays on the
+    # SM80-class kernel.  A bias comes along only where the DIRECT WGMMA kernel
+    # serves the call and fuses it into its epilogue: the split-K arm has no
+    # such epilogue, and `_enqueue_gemm16_gemm_tf32` skips that arm entirely in
+    # a biased build, which would push a deep-K shape onto the much slower
+    # direct kernel (see `_tf32_nt_wgmma_splits_bias`).  A fresh allocation is
+    # always 16B-aligned, but the gemm16 gate requires that of the OUTPUT too
+    # and it raises rather than declining, so check rather than assume.
     extension = _Tf32MatmulExtension
     op_name = "Tf32GemmF32"
     if (
-        bias_tensor is None
-        and out._ptr % 16 == 0
+        out._ptr % 16 == 0
         and _tf32_nt_wgmma_admits(lhs, rhs, transpose_b=transpose_b)
+        and (
+            bias_tensor is None
+            or not _tf32_nt_wgmma_splits_bias(lhs, rhs, bias, transpose_b=transpose_b)
+        )
     ):
         extension = _Gemm16MatmulExtension
         op_name = "Gemm16"
@@ -8772,15 +8923,21 @@ def _try_tf32_bmm(a, b, *, transpose_b=False):
 def _try_gemm16_linear(input, weight, bias=None):
     """Route a dense rank >= 2 16-bit projection through GEMM without copies.
 
-    Every gemm16 tensor-core route (the v3/v4 warp-specialized, TMA, and
-    split-K kernels in gemm16_v3_kernels.mojo) declines outright whenever a
-    bias is present, so a fused-bias call here would silently fall back to
-    the far slower "accepted" mma.sync kernel -- measured 3.6-7.4x slower
-    than stock PyTorch on deep-K shapes, versus ~1.3x for the identical
-    unbiased mm.  Compute the bias-free mm on the fast path instead and add
-    the bias afterward with the existing broadcasting elementwise add: the
-    same mm-then-add composition `aten_addmm` already uses for the
-    torch.compile backend, and microseconds next to the GEMM itself.
+    `linear` IS the NT regime by construction (the weight is stored
+    (out_features, in_features) and reached k-minor), and the NT direct WGMMA
+    kernels now add the bias inside their accumulator epilogue, so the bias
+    travels with the call whenever `_gemm16_nt_wgmma_fuses_bias` accepts the
+    operands -- one launch instead of two, and no second pass over C.
+
+    Everything it declines keeps the older two-step composition, because the
+    remaining tensor-core routes (the v3 NN/TN kernels, the split-K arm) still
+    decline a biased call outright and a fused-bias call would silently fall
+    back to the far slower "accepted" mma.sync kernel -- measured 3.6-7.4x
+    slower than stock PyTorch on deep-K shapes, versus ~1.3x for the identical
+    unbiased mm.  So the bias-free mm runs on the fast path and the bias is
+    added afterward with the existing broadcasting elementwise add: the same
+    mm-then-add composition `aten_addmm` already uses for the torch.compile
+    backend.
     """
     a = _t(input)
     w = _t(weight)
@@ -8809,7 +8966,9 @@ def _try_gemm16_linear(input, weight, bias=None):
         return _try_gemm16_mm(
             matrix, weight, transpose_b=True, output_shape=output_shape
         )
-    if _gemm16_alignment_favors_split(matrix, weight, transpose_b=True):
+    if _gemm16_alignment_favors_split(
+        matrix, weight, transpose_b=True
+    ) and not _gemm16_nt_wgmma_fuses_bias(matrix, weight, bias, transpose_b=True):
         mm_out = _try_gemm16_mm(
             matrix, weight, transpose_b=True, output_shape=output_shape
         )
@@ -8834,12 +8993,11 @@ def _try_tf32_linear(input, weight, bias=None):
     are flattened, so only a metadata view is needed.  Non-contiguous inputs
     retain the TensorSpec path, which owns any required materialization.
 
-    A bias is split off exactly when the bias-free mm reaches the WGMMA route
-    (`_tf32_nt_wgmma_admits`), for the reason spelled out in
-    `_try_gemm16_linear`: those kernels have no fused-bias epilogue and decline
-    a biased call outright, so a fused-bias call would land on the much slower
-    SM80-class kernel.  When the WGMMA route would not serve the mm anyway,
-    the fused-bias call is at worst identical and saves a launch.
+    A bias is split off only where the WGMMA route serves the mm but cannot
+    fuse the bias -- the deep-K split-K arm, see `_tf32_nt_wgmma_splits_bias`.
+    The direct WGMMA kernel adds the bias in its epilogue, so it takes the
+    bias directly; and when no WGMMA route would serve the mm anyway, the
+    fused-bias call is at worst identical and saves a launch.
     """
     if torch.get_float32_matmul_precision() == "highest":
         return None
@@ -8866,7 +9024,11 @@ def _try_tf32_linear(input, weight, bias=None):
             a._offset,
             contiguous=True,
         )
-    if bias is not None and _tf32_nt_wgmma_admits(matrix, weight, transpose_b=True):
+    if (
+        bias is not None
+        and _tf32_nt_wgmma_admits(matrix, weight, transpose_b=True)
+        and _tf32_nt_wgmma_splits_bias(matrix, weight, bias, transpose_b=True)
+    ):
         mm_out = _try_tf32_gemm(
             matrix, weight, transpose_b=True, output_shape=output_shape
         )
@@ -8893,23 +9055,28 @@ def fast_aten_mm(x, y):
 def fast_aten_addmm(input, mat1, mat2, *, beta=1.0, alpha=1.0):
     # beta/alpha scaling isn't implemented by the fast path (falls through).
     if beta == 1 and alpha == 1:
-        # See _try_gemm16_linear: every gemm16 tensor-core route declines
-        # outright whenever a bias is present, so calling it WITH the bias
-        # would silently fall back to the much slower "accepted" mma.sync
-        # kernel.  When the shape could plausibly reach a fast route (see
-        # _gemm16_alignment_favors_split), compute the bias-free mm on the
-        # fast path and add the bias with the existing broadcasting
-        # elementwise add instead.
-        if _gemm16_alignment_favors_split(mat1, mat2):
+        # See _try_gemm16_linear.  The NT direct WGMMA kernels fuse the bias
+        # into their accumulator epilogue, so those calls carry it straight
+        # through (the `_try_gemm16_mm(..., input)` below).  Every other
+        # tensor-core route still declines a biased call outright, so calling
+        # one WITH the bias would silently fall back to the much slower
+        # "accepted" mma.sync kernel; when the shape could plausibly reach
+        # such a route (see _gemm16_alignment_favors_split), compute the
+        # bias-free mm on the fast path and add the bias with the existing
+        # broadcasting elementwise add instead.
+        if _gemm16_alignment_favors_split(
+            mat1, mat2
+        ) and not _gemm16_nt_wgmma_fuses_bias(mat1, mat2, input):
             mm_out = _try_gemm16_mm(mat1, mat2)
             if mm_out is not None:
                 biased = fast_aten_add(mm_out, input)
                 if biased is not NOT_HANDLED:
                     return biased
-        # The float32 (TF32) WGMMA route has no fused-bias epilogue either, and
-        # declines a biased call the same way; split the bias off it too, but
-        # only where that route would actually serve the mm.
-        if _tf32_nt_wgmma_admits(mat1, mat2):
+        # Same for float32 (TF32): its direct WGMMA kernel fuses the bias, so
+        # only the deep-K split-K arm still needs the bias split off it.
+        if _tf32_nt_wgmma_admits(mat1, mat2) and _tf32_nt_wgmma_splits_bias(
+            mat1, mat2, input
+        ):
             mm_out = _try_tf32_gemm(mat1, mat2)
             if mm_out is not None:
                 biased = fast_aten_add(mm_out, input)

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -8547,8 +8547,8 @@ def _try_tf32_gemm(a, b, bias=None, *, transpose_b=False, output_shape=None):
     declines, keeps the SM80-class ``mma.m16n8k8`` route in ``tf32_matmul_ops``.
 
     This helper owns only host validation/allocation and the raw bridge call;
-    the Fable-owned module owns every device-kernel body.  Unsupported layouts
-    and strict FP32 retain the existing pure-Mojo SIMT path.
+    the Mojo module owns every device-kernel body.  Unsupported layouts and
+    strict FP32 retain the existing pure-Mojo SIMT path.
     """
     # This gate is a numerics decision, not a capability one: TF32 drops
     # mantissa bits, and "highest" (PyTorch's default) is the user asking for

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -8502,8 +8502,8 @@ def _try_tf32_gemm(a, b, bias=None, *, transpose_b=False, output_shape=None):
     declines, keeps the SM80-class ``mma.m16n8k8`` route in ``tf32_matmul_ops``.
 
     This helper owns only host validation/allocation and the raw bridge call;
-    the Fable-owned module owns every device-kernel body.  Unsupported layouts
-    and strict FP32 retain the existing pure-Mojo SIMT path.
+    the Mojo module owns every device-kernel body.  Unsupported layouts and
+    strict FP32 retain the existing pure-Mojo SIMT path.
     """
     # This gate is a numerics decision, not a capability one: TF32 drops
     # mantissa bits, and "highest" (PyTorch's default) is the user asking for

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -8330,6 +8330,126 @@ def _gemm16_alignment_favors_split(a, b, *, transpose_b: bool = False) -> bool:
     return m % 64 == 0 and n % 64 == 0 and k % 64 == 0
 
 
+# The largest multiprocessor count of any sm_90a part (H100 PCIe 114, H100
+# SXM / H200 / GH200 132).  Used only as an UPPER bound below, where
+# over-estimating it is the safe direction: it can only make
+# `_gemm16_splitk_nt_may_fire` claim more shapes, i.e. keep more of them on
+# today's split-the-bias path.
+_SM90_MAX_MULTIPROCESSORS = 160
+
+
+def _gemm16_splitk_nt_may_fire(m: int, n: int, k: int) -> bool:
+    """Whether the deep-K split-K NT route could claim this shape.
+
+    The split-K kernels write an FP32 workspace and reduce it in a SECOND
+    kernel, so they have no accumulator epilogue to fuse a bias into (that
+    bias belongs in the reduce kernel, which is a different change).  A
+    biased call therefore skips them and takes the direct WGMMA kernel --
+    the right trade everywhere except in the regime split-K exists for,
+    where it is a large loss: 1024x1024x8192 tf32 measures 85us split-K
+    against 197us direct on an H100 PCIe.  So the caller keeps splitting the
+    bias off exactly the shapes this returns True for, and fuses the rest.
+
+    This mirrors `try_enqueue_gemm16_gemm_splitk_rm_v4`'s hard gates
+    (gemm16_tn_v4_kernels.mojo) and the cheapest of its regime conditions,
+    deliberately in the CONSERVATIVE direction: every condition dropped here
+    can only make the Mojo side decline where this says "may", which costs
+    an extra elementwise-add launch on a shape whose C is small by
+    construction -- never the reverse, which would be the 2x loss above.
+    The dropped conditions are the ones needing a device query (the exact
+    multiprocessor count, replaced by its architectural upper bound) or the
+    workspace-size and marginal-split refinements.
+    """
+    # Hard gates: the split-K tile is 128 x 256 with an exact division, and a
+    # 2-way split needs _V4_MIN_CHUNK_TILES = 16 k-tiles of 64 per part.
+    if m % 128 or n % 256 or k % 64 or k // 64 < 2 * 16:
+        return False
+    tiles = (m // 128) * (n // 256)
+    # cap = sm_count // tiles must reach _V4_SPLITK_RM_MIN_SPLITS = 2.
+    return tiles > 0 and 2 * tiles <= _SM90_MAX_MULTIPROCESSORS
+
+
+def _fused_bias_vector_ok(bias, reference, n: int) -> bool:
+    """Whether the fused WGMMA epilogue can consume this bias as it stands.
+
+    It reads one contiguous row of `n` values in the operand dtype through a
+    naturally-aligned two-element load.  Everything else -- a scalar or
+    otherwise broadcast bias, a strided or expanded view, a different dtype,
+    an offset view whose pointer is not pair-aligned -- keeps the separate
+    elementwise add, which broadcasts and does not care.
+
+    The shape/contiguity half is deliberately the same check `_try_gemm16_mm`
+    and `_try_tf32_gemm` already apply before handing a bias to a bridge at
+    all: if this were the looser of the two, a caller would skip the split,
+    the bridge would then decline the biased call, and the whole projection
+    would fall past both fast paths.  That is exactly what a scalar bias did.
+    """
+    bias_tensor = _t(bias)
+    return (
+        bias_tensor is not None
+        and bias_tensor._dtype == reference._dtype
+        and bias_tensor._device == reference._device
+        and tuple(bias_tensor._shape) == (n,)
+        and bias_tensor._is_contiguous
+        and bias_tensor._ptr % (2 * bias_tensor._dtype.size_in_bytes) == 0
+    )
+
+
+def _gemm16_nt_wgmma_fuses_bias(a, b, bias, *, transpose_b: bool = False) -> bool:
+    """Whether a BIASED 16-bit NT call lands on a kernel that fuses the bias.
+
+    True exactly when the persistent v4 NT kernel
+    (`maybe_enqueue_gemm16_nt_v4`, gemm16_nt_v4_kernels.mojo) will serve the
+    call: it is the first fused-bias route the NT ladder offers once the
+    split-K arm is out of the way, and its gate is looser than the v3 NT
+    fallback's, so mirroring it alone is both sufficient and conservative --
+    a shape it declines and v3 NT would have taken merely keeps today's
+    split, at the cost of one elementwise-add launch.
+
+    This is the 16-bit twin of `_tf32_nt_wgmma_admits`, and it exists for
+    the same reason that one does: the routing decision is made on the host,
+    before the bridge is called, so the condition has to be legible here.
+
+    The bias itself is checked too, by `_fused_bias_vector_ok`: the fused
+    epilogue consumes one contiguous, pair-aligned row of `n` values and
+    nothing else.
+    """
+    lhs = _t(a)
+    rhs = _t(b)
+    if (
+        lhs is None
+        or rhs is None
+        or lhs._dtype not in _GEMM16_DTYPES
+        or rhs._dtype != lhs._dtype
+        or lhs._device != rhs._device
+        or lhs._device.label != "gpu"
+        or lhs._device.api != "cuda"
+        or lhs._device.architecture_name != "sm_90a"
+    ):
+        return False
+    lhs_layout = _tf32_dense_2d_layout(lhs)
+    rhs_layout = _tf32_dense_2d_layout(rhs)
+    if lhs_layout is None or rhs_layout is None:
+        return False
+    # NT only: A untransposed, B effectively transposed.
+    if lhs_layout or not (rhs_layout ^ bool(transpose_b)):
+        return False
+    m, k = lhs._shape
+    rhs_k = rhs._shape[1] if transpose_b else rhs._shape[0]
+    n = rhs._shape[0] if transpose_b else rhs._shape[1]
+    if min(m, n, k) <= 0 or rhs_k != k:
+        return False
+    # TMA descriptor creation needs 16B-aligned bases; an offset view's data
+    # pointer need not be one.  The output is freshly allocated and is.
+    if lhs._ptr % 16 or rhs._ptr % 16:
+        return False
+    if n % 8 or k % 64 or n < 64 or m > 2**31 - 1 or n > 2**31 - 1 or k > 2**31 - 1:
+        return False
+    if not _fused_bias_vector_ok(bias, lhs, n):
+        return False
+    return not _gemm16_splitk_nt_may_fire(m, n, k)
+
+
 def _try_gemm16_mm(a, b, bias=None, *, transpose_b=False, output_shape=None):
     """Enqueue the dense H100 16-bit tensor-core GEMM, or return ``None``.
 
@@ -8490,6 +8610,30 @@ def _tf32_nt_wgmma_admits(a, b, *, transpose_b: bool = False) -> bool:
     return _tf32_nt_wgmma_shape_admits(m, n, k) and _gemm16_bridge_available()
 
 
+def _tf32_nt_wgmma_splits_bias(a, b, bias, *, transpose_b: bool = False) -> bool:
+    """For an operand pair `_tf32_nt_wgmma_admits` accepted: must its bias
+    still be added by a separate kernel?
+
+    True for the deep-K shapes the split-K arm claims, which has no
+    accumulator epilogue to fuse into (see `_gemm16_splitk_nt_may_fire`), and
+    for any bias the fused epilogue cannot consume as it stands (see
+    `_fused_bias_vector_ok`).  Everywhere else the direct WGMMA kernel adds
+    the bias for free, and this returns False so the caller passes the bias
+    straight to the bridge.
+
+    Split from `_tf32_nt_wgmma_admits` rather than folded into it so the two
+    together cost one admission check plus a handful of integer reads, not two
+    admission checks, on the eager `addmm`/`linear` hot path.
+    """
+    lhs = _t(a)
+    rhs = _t(b)
+    m, k = lhs._shape
+    n = rhs._shape[0] if transpose_b else rhs._shape[1]
+    if not _fused_bias_vector_ok(bias, lhs, n):
+        return True
+    return _gemm16_splitk_nt_may_fire(m, n, k)
+
+
 def _try_tf32_gemm(a, b, bias=None, *, transpose_b=False, output_shape=None):
     """Enqueue the opt-in dense H100 TF32 GEMM, or return ``None``.
 
@@ -8559,16 +8703,23 @@ def _try_tf32_gemm(a, b, bias=None, *, transpose_b=False, output_shape=None):
     out = _alloc(logical_output_shape, DType.float32, lhs._device)
     # Route selection, not capability: both bridges accept this exact 11-tuple,
     # so the only difference is which extension compiles it.  The WGMMA leg
-    # takes the NT no-bias regimes it was measured on; everything else stays on
-    # the SM80-class kernel.  A fresh allocation is always 16B-aligned, but the
-    # gemm16 gate requires that of the OUTPUT too and it raises rather than
-    # declining, so check rather than assume.
+    # takes the NT regimes it was measured on; everything else stays on the
+    # SM80-class kernel.  A bias comes along only where the DIRECT WGMMA kernel
+    # serves the call and fuses it into its epilogue: the split-K arm has no
+    # such epilogue, and `_enqueue_gemm16_gemm_tf32` skips that arm entirely in
+    # a biased build, which would push a deep-K shape onto the much slower
+    # direct kernel (see `_tf32_nt_wgmma_splits_bias`).  A fresh allocation is
+    # always 16B-aligned, but the gemm16 gate requires that of the OUTPUT too
+    # and it raises rather than declining, so check rather than assume.
     extension = _Tf32MatmulExtension
     op_name = "Tf32GemmF32"
     if (
-        bias_tensor is None
-        and out._ptr % 16 == 0
+        out._ptr % 16 == 0
         and _tf32_nt_wgmma_admits(lhs, rhs, transpose_b=transpose_b)
+        and (
+            bias_tensor is None
+            or not _tf32_nt_wgmma_splits_bias(lhs, rhs, bias, transpose_b=transpose_b)
+        )
     ):
         extension = _Gemm16MatmulExtension
         op_name = "Gemm16"
@@ -8727,15 +8878,21 @@ def _try_tf32_bmm(a, b, *, transpose_b=False):
 def _try_gemm16_linear(input, weight, bias=None):
     """Route a dense rank >= 2 16-bit projection through GEMM without copies.
 
-    Every gemm16 tensor-core route (the v3/v4 warp-specialized, TMA, and
-    split-K kernels in gemm16_v3_kernels.mojo) declines outright whenever a
-    bias is present, so a fused-bias call here would silently fall back to
-    the far slower "accepted" mma.sync kernel -- measured 3.6-7.4x slower
-    than stock PyTorch on deep-K shapes, versus ~1.3x for the identical
-    unbiased mm.  Compute the bias-free mm on the fast path instead and add
-    the bias afterward with the existing broadcasting elementwise add: the
-    same mm-then-add composition `aten_addmm` already uses for the
-    torch.compile backend, and microseconds next to the GEMM itself.
+    `linear` IS the NT regime by construction (the weight is stored
+    (out_features, in_features) and reached k-minor), and the NT direct WGMMA
+    kernels now add the bias inside their accumulator epilogue, so the bias
+    travels with the call whenever `_gemm16_nt_wgmma_fuses_bias` accepts the
+    operands -- one launch instead of two, and no second pass over C.
+
+    Everything it declines keeps the older two-step composition, because the
+    remaining tensor-core routes (the v3 NN/TN kernels, the split-K arm) still
+    decline a biased call outright and a fused-bias call would silently fall
+    back to the far slower "accepted" mma.sync kernel -- measured 3.6-7.4x
+    slower than stock PyTorch on deep-K shapes, versus ~1.3x for the identical
+    unbiased mm.  So the bias-free mm runs on the fast path and the bias is
+    added afterward with the existing broadcasting elementwise add: the same
+    mm-then-add composition `aten_addmm` already uses for the torch.compile
+    backend.
     """
     a = _t(input)
     w = _t(weight)
@@ -8764,7 +8921,9 @@ def _try_gemm16_linear(input, weight, bias=None):
         return _try_gemm16_mm(
             matrix, weight, transpose_b=True, output_shape=output_shape
         )
-    if _gemm16_alignment_favors_split(matrix, weight, transpose_b=True):
+    if _gemm16_alignment_favors_split(
+        matrix, weight, transpose_b=True
+    ) and not _gemm16_nt_wgmma_fuses_bias(matrix, weight, bias, transpose_b=True):
         mm_out = _try_gemm16_mm(
             matrix, weight, transpose_b=True, output_shape=output_shape
         )
@@ -8789,12 +8948,11 @@ def _try_tf32_linear(input, weight, bias=None):
     are flattened, so only a metadata view is needed.  Non-contiguous inputs
     retain the TensorSpec path, which owns any required materialization.
 
-    A bias is split off exactly when the bias-free mm reaches the WGMMA route
-    (`_tf32_nt_wgmma_admits`), for the reason spelled out in
-    `_try_gemm16_linear`: those kernels have no fused-bias epilogue and decline
-    a biased call outright, so a fused-bias call would land on the much slower
-    SM80-class kernel.  When the WGMMA route would not serve the mm anyway,
-    the fused-bias call is at worst identical and saves a launch.
+    A bias is split off only where the WGMMA route serves the mm but cannot
+    fuse the bias -- the deep-K split-K arm, see `_tf32_nt_wgmma_splits_bias`.
+    The direct WGMMA kernel adds the bias in its epilogue, so it takes the
+    bias directly; and when no WGMMA route would serve the mm anyway, the
+    fused-bias call is at worst identical and saves a launch.
     """
     if torch.get_float32_matmul_precision() == "highest":
         return None
@@ -8821,7 +8979,11 @@ def _try_tf32_linear(input, weight, bias=None):
             a._offset,
             contiguous=True,
         )
-    if bias is not None and _tf32_nt_wgmma_admits(matrix, weight, transpose_b=True):
+    if (
+        bias is not None
+        and _tf32_nt_wgmma_admits(matrix, weight, transpose_b=True)
+        and _tf32_nt_wgmma_splits_bias(matrix, weight, bias, transpose_b=True)
+    ):
         mm_out = _try_tf32_gemm(
             matrix, weight, transpose_b=True, output_shape=output_shape
         )
@@ -8848,23 +9010,28 @@ def fast_aten_mm(x, y):
 def fast_aten_addmm(input, mat1, mat2, *, beta=1.0, alpha=1.0):
     # beta/alpha scaling isn't implemented by the fast path (falls through).
     if beta == 1 and alpha == 1:
-        # See _try_gemm16_linear: every gemm16 tensor-core route declines
-        # outright whenever a bias is present, so calling it WITH the bias
-        # would silently fall back to the much slower "accepted" mma.sync
-        # kernel.  When the shape could plausibly reach a fast route (see
-        # _gemm16_alignment_favors_split), compute the bias-free mm on the
-        # fast path and add the bias with the existing broadcasting
-        # elementwise add instead.
-        if _gemm16_alignment_favors_split(mat1, mat2):
+        # See _try_gemm16_linear.  The NT direct WGMMA kernels fuse the bias
+        # into their accumulator epilogue, so those calls carry it straight
+        # through (the `_try_gemm16_mm(..., input)` below).  Every other
+        # tensor-core route still declines a biased call outright, so calling
+        # one WITH the bias would silently fall back to the much slower
+        # "accepted" mma.sync kernel; when the shape could plausibly reach
+        # such a route (see _gemm16_alignment_favors_split), compute the
+        # bias-free mm on the fast path and add the bias with the existing
+        # broadcasting elementwise add instead.
+        if _gemm16_alignment_favors_split(
+            mat1, mat2
+        ) and not _gemm16_nt_wgmma_fuses_bias(mat1, mat2, input):
             mm_out = _try_gemm16_mm(mat1, mat2)
             if mm_out is not None:
                 biased = fast_aten_add(mm_out, input)
                 if biased is not NOT_HANDLED:
                     return biased
-        # The float32 (TF32) WGMMA route has no fused-bias epilogue either, and
-        # declines a biased call the same way; split the bias off it too, but
-        # only where that route would actually serve the mm.
-        if _tf32_nt_wgmma_admits(mat1, mat2):
+        # Same for float32 (TF32): its direct WGMMA kernel fuses the bias, so
+        # only the deep-K split-K arm still needs the bias split off it.
+        if _tf32_nt_wgmma_admits(mat1, mat2) and _tf32_nt_wgmma_splits_bias(
+            mat1, mat2, input
+        ):
             mm_out = _try_tf32_gemm(mat1, mat2)
             if mm_out is not None:
                 biased = fast_aten_add(mm_out, input)

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -191,11 +191,18 @@ _GEMM16_SOURCE_PATHS = (
     eager_kernels._PACKAGE_DIR / "gemm16_matmul_ops/gemm16_kernels.mojo",
 )
 
-# The dtypes that family serves.  bfloat16 and float16 are one and the same to
-# Hopper's tensor cores -- same operand width, same WGMMA tile shapes, same
-# FP32 accumulator, only the operand-type token of the instruction differs --
-# so every tile size, pipeline depth and TMA descriptor carries over unchanged
-# and the loader simply compiles the sources once per dtype.
+# The dtypes the `_try_gemm16_*` helpers here offer that family.  bfloat16 and
+# float16 are one and the same to Hopper's tensor cores -- same operand width,
+# same WGMMA tile shapes, same FP32 accumulator, only the operand-type token of
+# the instruction differs -- so every tile size, pipeline depth and TMA
+# descriptor carries over unchanged and the loader simply compiles the sources
+# once per dtype.
+#
+# float32 is deliberately NOT in this tuple even though the family compiles for
+# it (gemm16_dtype.mojo): using it is a numerics decision gated on
+# `torch.get_float32_matmul_precision()`, not a capability one, so that route is
+# reached only through `_try_tf32_gemm`, which owns the precision gate and picks
+# between the WGMMA kernels and the SM80-class `tf32_matmul_ops` fallback.
 _GEMM16_DTYPES = (DType.bfloat16, DType.float16)
 
 # The TF32 host route is useful before the separately profiled Fable kernel is
@@ -8404,8 +8411,95 @@ def _try_gemm16_mm(a, b, bias=None, *, transpose_b=False, output_shape=None):
     return out
 
 
+def _tf32_nt_wgmma_shape_admits(m: int, n: int, k: int) -> bool:
+    """The shape half of the gemm16 float32 NT gate, mirrored on the host.
+
+    It has to be mirrored rather than discovered, because the two bridges are
+    separate extensions and the host is what picks between them: whatever this
+    declines must reach the SM80-class ``tf32_matmul_ops`` route instead.  The
+    Mojo side (``_enqueue_gemm16_gemm_tf32``) raises rather than silently
+    no-op'ing if the two ever disagree, so a drift is loud.
+
+    The two conditions are hardware, not tuning (``_try_enqueue_gemm16_nt_v3_tf32``
+    in gemm16_v3_kernels.mojo carries the full derivation): TMA needs every
+    global stride to be a multiple of 16 BYTES and both operands are k-minor, so
+    the row pitch ``k * 4`` must be; and the epilogue stores a two-element pair
+    per lane at a row start of ``row * n * 4`` bytes, which needs an even ``n``.
+    ``m`` is unconstrained -- a partial edge tile in m is clipped by the
+    kernel's own bounds check.
+
+    The 2^31 bound and the grid bound are the Mojo route's remaining two
+    declines, mirrored here only so an absurd shape falls back gracefully
+    instead of hitting that raise; both are far beyond anything that fits in
+    device memory.  Every machine-width product guard the Mojo side also checks
+    (k * m, k * n, m * n against INT64_MAX) is implied by the 2^31 bound.
+    """
+    if min(m, n, k) < 1 or max(m, n, k) > 2**31 - 1:
+        return False
+    if (k * 4) % 16 or n % 2:
+        return False
+    # One CTA per 128x256 output tile, and grid.x is capped at 2^31 - 1 on
+    # every CUDA device of the compute capability this route already requires.
+    blocks_m = (m + 127) // 128
+    blocks_n = (n + 255) // 256
+    return blocks_m * blocks_n <= 2**31 - 1
+
+
+def _tf32_nt_wgmma_admits(a, b, *, transpose_b: bool = False) -> bool:
+    """Whether the float32 (TF32) WGMMA route serves this bias-free 2-D mm.
+
+    True only for the NT layout, which is the one layout of the gemm16 family
+    that has been ported and measured at a 4-byte operand: A row-major (m, k)
+    and B reached k-minor, i.e. a ``.t()`` view of an (n, k) buffer or an
+    explicit ``transpose_b``.  Every other float32 layout keeps the
+    SM80-class route, so this predicate is also what a caller consults before
+    splitting a fused bias off a matmul: splitting is only worth an extra
+    elementwise-add launch when the mm itself lands on the faster route.
+    """
+    if torch.get_float32_matmul_precision() == "highest":
+        return False
+    lhs = _t(a)
+    rhs = _t(b)
+    if (
+        lhs is None
+        or rhs is None
+        or lhs._dtype != DType.float32
+        or rhs._dtype != DType.float32
+        or lhs._device != rhs._device
+        or lhs._device.label != "gpu"
+        or lhs._device.api != "cuda"
+        or lhs._device.architecture_name != "sm_90a"
+    ):
+        return False
+    lhs_layout = _tf32_dense_2d_layout(lhs)
+    rhs_layout = _tf32_dense_2d_layout(rhs)
+    if lhs_layout is None or rhs_layout is None:
+        return False
+    # NT only: A untransposed, B effectively transposed.
+    if lhs_layout or not (rhs_layout ^ bool(transpose_b)):
+        return False
+    m, k = lhs._shape
+    rhs_k = rhs._shape[1] if transpose_b else rhs._shape[0]
+    n = rhs._shape[0] if transpose_b else rhs._shape[1]
+    if min(m, n, k) <= 0 or rhs_k != k:
+        return False
+    # An offset view's data pointer need not be 16B-aligned, and TMA
+    # descriptor creation requires it.
+    if lhs._ptr % 16 or rhs._ptr % 16:
+        return False
+    return _tf32_nt_wgmma_shape_admits(m, n, k) and _gemm16_bridge_available()
+
+
 def _try_tf32_gemm(a, b, bias=None, *, transpose_b=False, output_shape=None):
     """Enqueue the opt-in dense H100 TF32 GEMM, or return ``None``.
+
+    Two device routes hide behind this one helper, both consuming and producing
+    float32 while accumulating in FP32.  The NT layout goes to the gemm16
+    family's warp-specialized WGMMA kernels compiled for a 4-byte operand --
+    WGMMA takes float32 operands directly and computes them as TF32 -- which
+    took the benchmark's NT tf32 nodes from 3.1-5.7x stock cuBLAS to 0.85-1.07x
+    on an H100 PCIe.  Every other layout, and every NT shape the WGMMA gate
+    declines, keeps the SM80-class ``mma.m16n8k8`` route in ``tf32_matmul_ops``.
 
     This helper owns only host validation/allocation and the raw bridge call;
     the Fable-owned module owns every device-kernel body.  Unsupported layouts
@@ -8463,9 +8557,24 @@ def _try_tf32_gemm(a, b, bias=None, *, transpose_b=False, output_shape=None):
     if not _tf32_bridge_available():
         return None
     out = _alloc(logical_output_shape, DType.float32, lhs._device)
+    # Route selection, not capability: both bridges accept this exact 11-tuple,
+    # so the only difference is which extension compiles it.  The WGMMA leg
+    # takes the NT no-bias regimes it was measured on; everything else stays on
+    # the SM80-class kernel.  A fresh allocation is always 16B-aligned, but the
+    # gemm16 gate requires that of the OUTPUT too and it raises rather than
+    # declining, so check rather than assume.
+    extension = _Tf32MatmulExtension
+    op_name = "Tf32GemmF32"
+    if (
+        bias_tensor is None
+        and out._ptr % 16 == 0
+        and _tf32_nt_wgmma_admits(lhs, rhs, transpose_b=transpose_b)
+    ):
+        extension = _Gemm16MatmulExtension
+        op_name = "Gemm16"
     _call_mojo(
-        _Tf32MatmulExtension,
-        "Tf32GemmF32",
+        extension,
+        op_name,
         (
             out._ptr,
             lhs._ptr,
@@ -8679,6 +8788,13 @@ def _try_tf32_linear(input, weight, bias=None):
     input is already the same row-major matrix after its leading dimensions
     are flattened, so only a metadata view is needed.  Non-contiguous inputs
     retain the TensorSpec path, which owns any required materialization.
+
+    A bias is split off exactly when the bias-free mm reaches the WGMMA route
+    (`_tf32_nt_wgmma_admits`), for the reason spelled out in
+    `_try_gemm16_linear`: those kernels have no fused-bias epilogue and decline
+    a biased call outright, so a fused-bias call would land on the much slower
+    SM80-class kernel.  When the WGMMA route would not serve the mm anyway,
+    the fused-bias call is at worst identical and saves a launch.
     """
     if torch.get_float32_matmul_precision() == "highest":
         return None
@@ -8705,6 +8821,14 @@ def _try_tf32_linear(input, weight, bias=None):
             a._offset,
             contiguous=True,
         )
+    if bias is not None and _tf32_nt_wgmma_admits(matrix, weight, transpose_b=True):
+        mm_out = _try_tf32_gemm(
+            matrix, weight, transpose_b=True, output_shape=output_shape
+        )
+        if mm_out is not None:
+            biased = fast_aten_add(mm_out, bias)
+            if biased is not NOT_HANDLED:
+                return biased
     return _try_tf32_gemm(
         matrix, weight, bias, transpose_b=True, output_shape=output_shape
     )
@@ -8733,6 +8857,15 @@ def fast_aten_addmm(input, mat1, mat2, *, beta=1.0, alpha=1.0):
         # elementwise add instead.
         if _gemm16_alignment_favors_split(mat1, mat2):
             mm_out = _try_gemm16_mm(mat1, mat2)
+            if mm_out is not None:
+                biased = fast_aten_add(mm_out, input)
+                if biased is not NOT_HANDLED:
+                    return biased
+        # The float32 (TF32) WGMMA route has no fused-bias epilogue either, and
+        # declines a biased call the same way; split the bias off it too, but
+        # only where that route would actually serve the mm.
+        if _tf32_nt_wgmma_admits(mat1, mat2):
+            mm_out = _try_tf32_gemm(mat1, mat2)
             if mm_out is not None:
                 biased = fast_aten_add(mm_out, input)
                 if biased is not NOT_HANDLED:

--- a/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_bias.mojo
+++ b/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_bias.mojo
@@ -1,0 +1,135 @@
+# ===----------------------------------------------------------------------=== #
+# The fused-bias epilogue term, shared by every direct WGMMA route here.
+#
+# `addmm` and `linear` are a GEMM plus a row-broadcast bias.  Adding that bias
+# with a separate elementwise kernel is a SECOND FULL PASS over C, and C is the
+# largest tensor in the problem: on an H100 PCIe it measured 67us next to a
+# 296us GEMM (S2/S3 4096-class) and 108us next to a 189us GEMM (S6, tall-skinny
+# 32768x768) -- i.e. up to +56% device time for an operation that costs nothing
+# when it happens where the accumulator already lives, in registers.
+#
+# So the bias is added to the WGMMA accumulator, in place, immediately before
+# whatever the route's store path is.  That placement is deliberate: it is the
+# ONE point every direct route has in common (the v3 warp-specialized kernels
+# store pairs straight to global, the v4 persistent kernel stages through
+# `st.matrix` into a swizzled tile and TMA-stores it), so a single helper serves
+# both without either store path knowing a bias exists.  It also composes with
+# the TMA-store epilogue by construction rather than by luck: the bias is gone
+# from the picture before the first store instruction of either kind.
+#
+# Numerics: the bias is added to the FP32 accumulator, so the result is
+# round(acc + bias) rather than the split path's round(round(acc) + bias).  At
+# float32/TF32 that is bit-identical; at bfloat16/float16 it is one rounding
+# step FEWER, which is also what cuBLAS's fused epilogue does.
+# ===----------------------------------------------------------------------=== #
+
+from std.memory import AddressSpace
+from std.sys.defines import get_defined_string
+
+from layout import Layout, LayoutTensor
+
+from gemm16_dtype import _GEMM16_DT, _GEMM16_W
+
+
+# Whether this specialization carries the fused-bias kernels.
+#
+# The loader already compiles one .so per (OP, dtype, flags) tuple and the
+# `HAS_BIAS` flag is ALREADY part of that tuple -- `_try_gemm16_mm` and
+# `_try_tf32_gemm` have always passed it -- so reading it here costs no extra
+# build: it only stops the unused specialization from being instantiated into a
+# build that can never call it.
+#
+# The same value ALSO arrives at runtime through the bridge ABI, and
+# `enqueue_gemm16_gemm` raises when the two disagree.  That check is the whole
+# safety argument for gating a CORRECTNESS property on a define: a define that
+# silently reads back as "" would otherwise drop the bias and return a wrong
+# answer, which is far worse than the usual define-gating failure of declining
+# a call.  A standalone `mojo build` with no `-D HAS_BIAS=1` (the asm-compare
+# script, a harness binary) therefore gets exactly the bias-free kernels, which
+# is what makes those kernels' assembly comparable across trees at all.
+comptime _GEMM16_HAS_BIAS = get_defined_string["HAS_BIAS", ""]() == "1"
+
+
+@always_inline
+def _gemm16_add_bias_to_accum[
+    CFRAG: Int
+](
+    accum: LayoutTensor[
+        DType.float32,
+        Layout.row_major(1, CFRAG),
+        MutAnyOrigin,
+        address_space=AddressSpace.LOCAL,
+    ],
+    bias: UnsafePointer[Scalar[_GEMM16_DT], MutAnyOrigin],
+    n0: Int,
+    n: Int,
+    lane: Int,
+):
+    """Add `bias[n0 + column(i)]` to every accumulator element `i`, in place.
+
+    One warp group of a WGMMA `m64nNk*` instruction holds the N-half of a
+    64-row output tile in `CFRAG = N // 2` registers per thread, laid out by
+    the hardware as
+
+        row(i)    = warp * 16 + lane // 4 + 8 * ((i % 4) // 2)
+        column(i) = 8 * (i // 4) + 2 * (lane % 4) + (i % 2)
+
+    (the same mapping the v3 store loop walks with `q = i // 2`).  The bias is
+    a function of the COLUMN only, and the column depends on `i` solely through
+    `i // 4` and `i % 2`, so the four elements `4c .. 4c + 3` need exactly one
+    two-element bias load: elements `4c` and `4c + 2` share column `8c + 2L`,
+    elements `4c + 1` and `4c + 3` share `8c + 2L + 1`.  That is `CFRAG // 4`
+    loads per thread instead of `CFRAG`, and it is why the loop is nested.
+
+    Out-of-range columns are CLAMPED, not branched: `min(col, n - 2)` reads a
+    valid, in-bounds bias pair whose result is then discarded by the store
+    path, which clips the partial edge tile anyway (v3 with its explicit
+    `n0 + col + 1 < n` guard, v4 through the TMA store's global extent).  A
+    branch per load would cost more than the wasted add.  Both callers gate on
+    an even `n` (v3 tf32 requires `n % 2`, v4 requires `n % 8`), so the clamped
+    index stays EVEN -- but that only makes the load naturally aligned relative
+    to the BASE, so every route that reaches here must also have checked
+    `_gemm16_bias_ptr_ok`.  A bias reached through an offset view (`w.bias[1:]`)
+    has an odd element offset and would fault the pair load outright.
+    """
+    var base = n0 + (lane % 4) * 2
+    comptime for c in range(CFRAG // 4):
+        var pair = bias.load[width=2, alignment=2 * _GEMM16_W](
+            min(base + c * 8, n - 2)
+        )
+        var b0 = pair[0].cast[DType.float32]()
+        var b1 = pair[1].cast[DType.float32]()
+        comptime for r in range(2):
+            accum.ptr[c * 4 + r * 2] += b0
+            accum.ptr[c * 4 + r * 2 + 1] += b1
+
+
+@always_inline
+def _gemm16_bias_ptr_ok(
+    bias: UnsafePointer[Scalar[_GEMM16_DT], MutAnyOrigin]
+) -> Bool:
+    """Whether `_gemm16_add_bias_to_accum` may read this bias pointer.
+
+    Its two-element load is naturally aligned, which a bias tensor satisfies
+    unless it is an offset view onto a larger buffer -- legal in torch, and a
+    hard CUDA_ERROR_MISALIGNED_ADDRESS here.  Every fused-bias route checks
+    this and declines, so the fault is unreachable regardless of what the
+    host-side routing in aten_fast.py believes; the host has the matching
+    check only so such a bias keeps a FAST route instead of falling all the
+    way to the accepted kernel.
+    """
+    return Int(bias) % (2 * _GEMM16_W) == 0
+
+
+@always_inline
+def _gemm16_bias_tag[has_bias: Bool]() -> StaticString:
+    """Kernel-name suffix marking the fused-bias specialization.
+
+    Kernel names are what CUPTI, Nsight and torch.profiler print, and the two
+    specializations are genuinely different code, so a user profiling `addmm`
+    has to be able to tell which one ran.
+    """
+    comptime if has_bias:
+        return "_bias"
+    else:
+        return ""

--- a/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_dtype.mojo
+++ b/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_dtype.mojo
@@ -1,12 +1,29 @@
 # ===----------------------------------------------------------------------=== #
-# Which 16-bit tensor-core dtype this build of the GEMM family carries.
+# Which tensor-core operand dtype this build of the GEMM family carries.
 #
 # bfloat16 and float16 are the same thing to Hopper's tensor cores: identical
 # operand width, identical WGMMA tile shapes, identical FP32 accumulator, and
 # only the operand-type token of the instruction differs.  Every tile size,
 # pipeline depth, TMA descriptor and wave-aware grid in this directory is a
-# function of the operand WIDTH, so one source serves both dtypes and the
-# choice is made once, here, at compile time.
+# function of the operand WIDTH, so one source serves every dtype of the family
+# and the choice is made once, here, at compile time.
+#
+# float32 joins them as a THIRD operand dtype, and it is the same thesis one
+# step further out: WGMMA takes float32 operands directly and computes them as
+# TF32 -- max/mojo/max/gpu/compute/mma.mojo's `_dtype_to_nvvm_wgmma_type` maps
+# `DType.float32` to `#nvvm.wgmma_type<tf32>`, and `tensor_core_async.mojo`'s
+# `_supported_mma_shape` accepts the m64/k8 shape that a 4-byte operand needs.
+# So the tf32 kernel IS the 16-bit kernel with the width doubled, and the only
+# constants that move are the byte-quantity ones below plus the WGMMA
+# shared-memory descriptor strides in `_v4_mma_tile`.  Smem per pipeline stage
+# (BM * BK * width) and WGMMA steps per stage (BK / wgmma_k) are both invariant
+# when the width doubles and BK halves, which is why nothing structural moves.
+#
+# NOT every route in this directory is float32-verified, and the dispatcher says
+# so: `enqueue_gemm16_gemm` serves only the NT split-K and NT 128x256 WGMMA
+# routes at float32 and never instantiates the rest, so a widened-but-unmeasured
+# kernel cannot reach a user.  Everything else float32 keeps the SM80-class
+# `tf32_matmul_ops/` route, chosen on the host in `aten_fast.py`.
 #
 # The selector is a compile-time define, the same mechanism every other kernel
 # family in this package uses: the loader already compiles one .so per
@@ -14,21 +31,27 @@
 # of the call, so nothing new travels at runtime.
 #
 # bfloat16 is the default for EVERY other value of the define, including the
-# absent one.  That is deliberate rather than incidental: it is what makes a
-# build that never heard of this define -- `mojo build` with no `-D`, or
-# scripts/compare_kernel_asm.py's float32 pass -- emit exactly the bfloat16
-# kernels it emitted before this family was parametrized, which is how the
-# bfloat16 half of the family stays byte-invariant under the parametrization.
+# absent one, so a build that never heard of this define -- `mojo build` with no
+# `-D` -- emits the bfloat16 kernels.  Note for scripts/compare_kernel_asm.py:
+# its float32 pass USED to land on that default and re-emit the bfloat16
+# kernels, which is no longer true now that float32 selects its own kernels.
+# The bfloat16/float16 byte-invariance check is therefore
+# `--dtypes bfloat16 float16`, and the float32 pass is where the new tf32
+# kernels appear as additions.
 # ===----------------------------------------------------------------------=== #
+
+from std.sys import size_of
 
 from variant_gates import _dtype_arg_on
 
 
 @always_inline
 def _gemm16_dtype() -> DType:
-    """The 16-bit operand dtype this specialization was compiled for."""
+    """The tensor-core operand dtype this specialization was compiled for."""
     comptime if _dtype_arg_on[0, DType.float16]():
         return DType.float16
+    elif _dtype_arg_on[0, DType.float32]():
+        return DType.float32
     else:
         return DType.bfloat16
 
@@ -38,13 +61,37 @@ def _gemm16_tag() -> StaticString:
     """The dtype token every kernel of this family carries in its name.
 
     Kernel names are what CUPTI, Nsight and torch.profiler print, so a user
-    profiling a float16 model has to read "f16" there and never "bf16".
+    profiling a float16 model has to read "f16" there and never "bf16", and a
+    user profiling a float32 model under a TF32 matmul precision has to read
+    "tf32" -- the operand dtype is float32 but the instruction is TF32, and
+    "tf32" is the name of the arithmetic they are paying for.
     """
     comptime if _gemm16_dtype() == DType.float16:
         return "f16"
+    elif _gemm16_dtype() == DType.float32:
+        return "tf32"
     else:
         return "bf16"
 
 
 comptime _GEMM16_DT = _gemm16_dtype()
 comptime _GEMM16_TAG = _gemm16_tag()
+
+# The operand width in bytes, and the two tile quantities derived from it.
+# Both are BYTE quantities in the hardware, which is the whole reason one
+# source serves 2-byte and 4-byte operands:
+#
+#   * one SWIZZLE_128B shared-memory row is 128 BYTES, so a k-major tile is
+#     `128 // width` elements deep: BK = 64 at bfloat16/float16, 32 at float32.
+#   * WGMMA_K_BYTES (layout/tensor_core_async.mojo) is 32, so one WGMMA step
+#     covers `32 // width` k-elements: 16 at bfloat16/float16, 8 at float32.
+#
+# Their ratio -- WGMMA steps per BK tile -- is 4 either way, and smem per stage
+# (BM * BK * width) is identical either way.
+comptime _GEMM16_W = size_of[Scalar[_GEMM16_DT]]()
+comptime _GEMM16_BK = 128 // _GEMM16_W
+comptime _GEMM16_WGMMA_K = 32 // _GEMM16_W
+# float32 operands, i.e. TF32 tensor-core arithmetic. Selects the reduced
+# route ladder in `enqueue_gemm16_gemm` and the partial-k-tile arithmetic that
+# the 16-bit routes' stricter admission gates make unnecessary for them.
+comptime _GEMM16_TF32 = _GEMM16_DT == DType.float32

--- a/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_nn_v4_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_nn_v4_kernels.mojo
@@ -30,10 +30,14 @@ clips the trailing partial column of tiles the same way); everything else
 must be routed to the existing v3 dispatcher by the caller
 (`maybe_enqueue_...` returns False in that case).
 
-The operand dtype is bfloat16 or float16, chosen at compile time by
-`_GEMM16_DT` (gemm16_dtype.mojo); every tile size and pipeline constant
-here is a function of the 2-byte operand width, not of the exponent
-layout, so one source serves both.
+The operand dtype is bfloat16, float16 or float32, chosen at compile time
+by `_GEMM16_DT` (gemm16_dtype.mojo); every tile size and pipeline constant
+here is a function of the operand WIDTH.  One exception, and it is why the
+float32 ladder never selects this route: the `tma_store` epilogue's
+128B-swizzle arithmetic treats a 64-element row as one swizzle row, which
+holds only for a 2-byte operand.  `_v4_mma_tile` below IS width-generic --
+it is shared with the float32 NT split-K route in
+gemm16_tn_v4_kernels.mojo.
 """
 
 from std.gpu import (
@@ -78,12 +82,18 @@ from layout.tensor_core_async import (
 from layout.tma_async import SharedMemBarrier, TMATensorTile
 
 from gemm16_kernels import _pick_regime
-from gemm16_dtype import _GEMM16_DT, _GEMM16_TAG
+from gemm16_dtype import (
+    _GEMM16_BK,
+    _GEMM16_DT,
+    _GEMM16_TAG,
+    _GEMM16_W,
+    _GEMM16_WGMMA_K,
+)
 
 comptime _V4_DT = _GEMM16_DT
 comptime _V4_F32 = DType.float32
 comptime _V4_PTR = UnsafePointer[Scalar[_V4_DT], MutAnyOrigin]
-comptime _V4_BK = 64
+comptime _V4_BK = _GEMM16_BK
 # Macro-rows per rasterization group: consecutive work indices cover
 # _V4_GROUP macro rows before advancing one BN column, keeping the in-flight
 # A slab and the current B column resident in L2.
@@ -138,10 +148,15 @@ def _v4_mma_tile[
     comptime a_stride01 = a_canonical_layout[0].stride[1].value()
     comptime a_stride11 = a_canonical_layout[1].stride[1].value()
     comptime b_stride11 = b_canonical_layout[1].stride[1].value()
-    comptime a_m_stride = a_stride01 * (64 // a_shape00) * 2
-    comptime a_k_stride = a_stride11 * 2 * 2
-    comptime b_k_stride = b_stride11 * 2 * 2
-    comptime NUM_K_MMAS = _V4_BK // 16
+    # Only the TRAILING factor of each stride is the operand width.  The
+    # leading 2 of a_k_stride/b_k_stride is modular's own core-matrix
+    # factor (layout/tensor_core_async.mojo, `TensorCoreAsync.wgmma`), and
+    # scaling it by the width too would mis-address every k-step past the
+    # first.
+    comptime a_m_stride = a_stride01 * (64 // a_shape00) * _GEMM16_W
+    comptime a_k_stride = a_stride11 * 2 * _GEMM16_W
+    comptime b_k_stride = b_stride11 * 2 * _GEMM16_W
+    comptime NUM_K_MMAS = _V4_BK // _GEMM16_WGMMA_K
     var a_desc = _wgmma_descriptor[a_canonical_layout, not COL_A, _V4_SWIZZLE](
         a_smem
     )
@@ -157,7 +172,7 @@ def _v4_mma_tile[
         var c_out = wgmma_async[
             64,
             BN,
-            16,
+            _GEMM16_WGMMA_K,
             a_type=_V4_DT,
             b_type=_V4_DT,
             layout_a="col" if COL_A else "row",
@@ -346,7 +361,7 @@ def _v4_nn_persistent_ws[
 
         comptime CFRAG = 64 * bn // 128
         comptime MACRO_BM = bm * cluster_m
-        comptime TMA_BYTES = (bm + bn) * _V4_BK * 2
+        comptime TMA_BYTES = (bm + bn) * _V4_BK * _GEMM16_W
         comptime MCAST_MASK = UInt16((1 << cluster_m) - 1)
         comptime B_CHUNKS = bn // 64
         var warp_group_idx = Int(thread_idx.x) // 128
@@ -483,7 +498,7 @@ def _v4_nn_persistent_ws[
                 _V4_F32,
                 _V4_DT,
                 _V4_DT,
-                Index(64, bn, 16),
+                Index(64, bn, _GEMM16_WGMMA_K),
                 a_swizzle=_V4_SWIZZLE,
                 b_swizzle=_V4_SWIZZLE,
                 transpose_b=False,
@@ -571,6 +586,10 @@ def _v4_nn_persistent_ws[
                         )
                         # 128B-swizzled staging layout: 16B units within
                         # each 64-element row are XORed with (row % 8).
+                        # A 64-element row is one 128-byte swizzle row only
+                        # at a 2-byte operand, so this arithmetic -- alone in
+                        # this file -- is 16-bit-only, and the float32 ladder
+                        # never selects a tma_store route.
                         var lcol = col % 64
                         var elem = (
                             (col // 64) * (bm * 64)
@@ -578,7 +597,7 @@ def _v4_nn_persistent_ws[
                             + ((lcol // 8) ^ (row % 8)) * 8
                             + lcol % 8
                         )
-                        c_smem.ptr.store[alignment=4](elem, pair)
+                        c_smem.ptr.store[alignment=2 * _GEMM16_W](elem, pair)
                     fence_async_view_proxy()
                     named_barrier[NCONS](1)
                     if warp_group_idx == 1 and warp_group_thread_idx == 0:
@@ -604,7 +623,7 @@ def _v4_nn_persistent_ws[
                             accum.ptr[e + 1].cast[_V4_DT](),
                         )
                         if m0 + row < m and n0 + col + 1 < n:
-                            output.store[alignment=4](
+                            output.store[alignment=2 * _GEMM16_W](
                                 (m0 + row) * n + n0 + col, pair
                             )
                 w += num_clusters

--- a/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_nt_v4_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_nt_v4_kernels.mojo
@@ -62,6 +62,11 @@ from layout.tensor_core_async import (
     warpgroup_fence,
 )
 from layout.tma_async import SharedMemBarrier, TMATensorTile
+from gemm16_bias import (
+    _gemm16_add_bias_to_accum,
+    _gemm16_bias_ptr_ok,
+    _gemm16_bias_tag,
+)
 from gemm16_dtype import _GEMM16_DT, _GEMM16_TAG
 
 comptime _V4_DT = _GEMM16_DT
@@ -191,10 +196,14 @@ def _v4c_nt_defer_tag[defer_release: Bool]() -> StaticString:
 # a 16-hex hash that moves on any refactor -- which is both unreadable and,
 # once this family serves float16 too, wrong about the dtype.
 @__name(
-    t"{_GEMM16_TAG}_gemm_nt_v4_persistent_m{_V4_BM}n{bn}_s{stages}g{raster_h}{_v4c_nt_defer_tag[defer_release]()}"
+    t"{_GEMM16_TAG}_gemm_nt_v4_persistent_m{_V4_BM}n{bn}_s{stages}g{raster_h}{_v4c_nt_defer_tag[defer_release]()}{_gemm16_bias_tag[has_bias]()}"
 )
 def _v4c_nt_persistent[
-    bn: Int, stages: Int, raster_h: Int, defer_release: Bool = False
+    bn: Int,
+    stages: Int,
+    raster_h: Int,
+    defer_release: Bool = False,
+    has_bias: Bool = False,
 ](
     a_tma: _V4_A_TMA,
     b_tma: TMATensorTile[
@@ -209,6 +218,7 @@ def _v4c_nt_persistent[
     m_arg: Int64,
     n_arg: Int64,
     k_arg: Int64,
+    bias: _V4_PTR,
 ):
     """Clustered persistent NT kernel with TMA multicast of B.
 
@@ -493,6 +503,9 @@ def _v4c_nt_persistent[
                     c_tma.wait_group[0]()
                 named_barrier[Int32(128)](Int32(warp_group_idx))
 
+                comptime if has_bias:
+                    _gemm16_add_bias_to_accum[CFRAG](accum, bias, n0, n, lane)
+
                 _v4_store_accum_stmatrix[bn](wg_half, accum, warp, lane)
 
                 # Make generic-proxy smem writes visible to the async proxy,
@@ -525,11 +538,16 @@ def _v4c_nt_persistent[
 
 
 def _v4c_enqueue_nt_persistent[
-    bn: Int, stages: Int, raster_h: Int, defer_release: Bool = False
+    bn: Int,
+    stages: Int,
+    raster_h: Int,
+    defer_release: Bool = False,
+    has_bias: Bool = False,
 ](
     output: _V4_PTR,
     a: _V4_PTR,
     b: _V4_PTR,
+    bias: _V4_PTR,
     m: Int,
     n: Int,
     k: Int,
@@ -580,7 +598,7 @@ def _v4c_enqueue_nt_persistent[
         _V4_DT, 2, Index(_V4_WG_ROWS, bn), Index(_V4_WG_ROWS, _V4_C_BOX_N)
     ](c_desc)
     ctx.enqueue_function[
-        _v4c_nt_persistent[bn, stages, raster_h, defer_release]
+        _v4c_nt_persistent[bn, stages, raster_h, defer_release, has_bias]
     ](
         a_tma,
         b_tma,
@@ -588,15 +606,19 @@ def _v4c_enqueue_nt_persistent[
         Int64(m),
         Int64(n),
         Int64(k),
+        bias,
         grid_dim=(grid_x,),
         block_dim=(_V4_THREADS,),
     )
 
 
-def maybe_enqueue_gemm16_nt_v4(
+def maybe_enqueue_gemm16_nt_v4[
+    has_bias: Bool = False
+](
     output: _V4_PTR,
     a: _V4_PTR,
     b: _V4_PTR,
+    bias: _V4_PTR,
     m: Int,
     n: Int,
     k: Int,
@@ -610,6 +632,12 @@ def maybe_enqueue_gemm16_nt_v4(
     pipeline, and TMA descriptor dimension limits.  m and n need NOT be
     tile-aligned: TMA clips partial edge tiles on load and store.
     """
+    comptime if has_bias:
+        # The fused epilogue's two-element bias load is naturally aligned;
+        # an offset bias view is not, and would fault.  Decline so the
+        # caller's ladder serves it some other way.
+        if not _gemm16_bias_ptr_ok(bias):
+            return False
     comptime if _has_sm_9x():
         if ctx.api() == "cuda":
             var cc_major = ctx.get_attribute(
@@ -673,13 +701,13 @@ def maybe_enqueue_gemm16_nt_v4(
                     ) * (192 + 32)
                     if cost_192 * 102 < cost_256 * 100:
                         var grid_x = min(pairs_192, grid_pairs) * _V4_CLUSTER
-                        _v4c_enqueue_nt_persistent[192, 4, 16](
-                            output, a, b, m, n, k, grid_x, ctx
+                        _v4c_enqueue_nt_persistent[192, 4, 16, False, has_bias](
+                            output, a, b, bias, m, n, k, grid_x, ctx
                         )
                         return True
                     var grid_x = min(pairs_256, grid_pairs) * _V4_CLUSTER
-                    _v4c_enqueue_nt_persistent[256, 3, 16](
-                        output, a, b, m, n, k, grid_x, ctx
+                    _v4c_enqueue_nt_persistent[256, 3, 16, False, has_bias](
+                        output, a, b, bias, m, n, k, grid_x, ctx
                     )
                     return True
     return False

--- a/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_nt_v4_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_nt_v4_kernels.mojo
@@ -70,6 +70,12 @@ comptime _V4_PTR = UnsafePointer[Scalar[_V4_DT], MutAnyOrigin]
 comptime _V4_SWIZZLE = TensorMapSwizzle.SWIZZLE_128B
 
 comptime _V4_BM = 128
+# NOT derived from the family's operand width (gemm16_dtype.mojo's
+# _GEMM16_BK), unlike its siblings in gemm16_v3/nn_v4/tn_v4: this file's
+# epilogue stages C through `st.matrix`, a 16-bit-only instruction, so the
+# whole route is 16-bit by construction and the float32 ladder never calls
+# it.  Widening the tile alone would produce a kernel that compiles and
+# cannot be correct.
 comptime _V4_BK = 64
 comptime _V4_THREADS = 384
 comptime _V4_CONSUMERS = 2

--- a/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_tn_v4_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_tn_v4_kernels.mojo
@@ -1,4 +1,4 @@
-"""V4 H100 16-bit TN (wgrad) GEMM kernels: split-K and narrow-tile variants.
+"""V4 H100 TN (wgrad) GEMM kernels: split-K and narrow-tile variants.
 
 The nanogpt wgrad family C[m,n] = A[k,m]^T @ B[k,n] has a huge reduction
 dimension (K = tokens = 32768) and small outputs (m,n in the hundreds to a
@@ -10,8 +10,9 @@ Two remedies, both dispatched by regime (no model dims hardcoded):
 1. Split-K: when output tiles fill less than half the SMs, partition K
    across `splits` CTAs per tile (grid y).  Each CTA accumulates its K-chunk
    into an fp32 workspace slice; a small elementwise kernel reduces the
-   slices and casts to bf16.  A workspace + separate reduce is deterministic
-   and much faster than atomics on these deep-K shapes.
+   slices and casts back to the operand dtype.  A workspace + separate
+   reduce is deterministic and much faster than atomics on these deep-K
+   shapes.
 2. Narrow 128x192 tiles whenever the wave-quantized cost (waves x per-CTA
    work) beats 256-wide tiles.  That covers the one-wave underfilled case
    (72 CTAs of 128x256 on 114 SMs -> 96 fuller CTAs) and the multi-wave
@@ -25,10 +26,11 @@ Both kernels reuse the v3 warp-specialized TMA + WGMMA structure: A is
 physical row-major (K, M) and loaded directly into an MN-major shared tile,
 which is the column-major A representation accepted by SM90 WGMMA.
 
-The operand dtype is bfloat16 or float16, chosen at compile time by
-`_GEMM16_DT` (gemm16_dtype.mojo); every tile size and pipeline constant
-here is a function of the 2-byte operand width, not of the exponent
-layout, so one source serves both.
+The operand dtype is bfloat16, float16 or float32, chosen at compile time
+by `_GEMM16_DT` (gemm16_dtype.mojo); every tile size and pipeline constant
+here is a function of the operand WIDTH, not of the exponent layout, so one
+source serves all three.  At float32 only the NT split-K instantiation is
+reached (see `_enqueue_gemm16_gemm_tf32` in gemm16_v3_kernels.mojo).
 """
 
 from max.gpu.sync import barrier
@@ -56,7 +58,12 @@ from gemm16_nn_v4_kernels import (
     _v4_mma_tile,
     maybe_enqueue_gemm16_tn_v4_persistent,
 )
-from gemm16_dtype import _GEMM16_DT, _GEMM16_TAG
+from gemm16_dtype import (
+    _GEMM16_BK,
+    _GEMM16_DT,
+    _GEMM16_TAG,
+    _GEMM16_W,
+)
 
 
 comptime _V4_DT = _GEMM16_DT
@@ -64,12 +71,19 @@ comptime _V4_F32 = DType.float32
 comptime _V4_PTR = UnsafePointer[Scalar[_V4_DT], MutAnyOrigin]
 comptime _V4_F32_PTR = UnsafePointer[Scalar[_V4_F32], MutAnyOrigin]
 comptime _V4_BM = 128
-comptime _V4_BK = 64
+comptime _V4_BK = _GEMM16_BK
 comptime _V4_SWIZZLE = TensorMapSwizzle.SWIZZLE_128B
 comptime _V4_THREADS = 384
 comptime _V4_CONSUMERS = 2
 # Split-K sizing: never split below this many BK-tiles per chunk (pipeline
 # ramp-up dominates below that), and cap the workspace size.
+#
+# This floor counts BK-TILES, and BK halves with a 4-byte operand, so the same
+# 16 tiles are 1024 k-elements at bfloat16/float16 and 512 at float32.  Kept in
+# tiles rather than restated in k-elements because that is the configuration the
+# float32 split-K route was measured in (1024x1024x8192 at 3 splits, 84.8us vs
+# cuBLAS 95.4us on H100 PCIe @1395MHz); expressing it in k-elements would make
+# it width-invariant but would also cap float32's splits at half, unmeasured.
 comptime _V4_MIN_CHUNK_TILES = 16
 comptime _V4_MAX_SPLITS = 8
 comptime _V4_MAX_WS_BYTES = 256 * 1024 * 1024
@@ -103,7 +117,8 @@ def _v4_b_smem_layout[BN: Int, KMAJ_B: Bool]() -> Layout:
 #
 # SPLITK=True : accumulates BK-tiles [tile_start, tile_start + chunk) and
 #               stores the fp32 partial tile into ws at slice block_idx.y.
-# SPLITK=False: accumulates the whole K range and stores bf16 into out.
+# SPLITK=False: accumulates the whole K range and stores the operand dtype
+#               into out.
 #
 # The TMA tile/descriptor shapes are infer-only: each concrete entry point
 # passes descriptors matching its operand majorness (built by the enqueue
@@ -200,7 +215,7 @@ def _v4_tn_ws_body[
             my_tiles = min(chunk_tiles, k // _V4_BK - tile_start)
             if my_tiles < 0:
                 my_tiles = 0
-        comptime TMA_BYTES = (BM + BN) * _V4_BK * 2
+        comptime TMA_BYTES = (BM + BN) * _V4_BK * _GEMM16_W
 
         # Initially release every pipeline slot to the producer.  Thereafter
         # both consumer warp groups arrive only after their WGMMA reads
@@ -297,6 +312,10 @@ def _v4_tn_ws_body[
                     var col = base_col + (q // 2) * 8
                     var pair = SIMD[_V4_F32, 2](accum.ptr[e], accum.ptr[e + 1])
                     if m0 + row < m and n0 + col + 1 < n:
+                        # The split-K workspace is FP32 whatever the operands
+                        # are, so this pair is 8 bytes for every dtype of the
+                        # family -- unlike the output store below, whose
+                        # alignment tracks the operand width.
                         ws_base.store[alignment=8](
                             (m0 + row) * n + n0 + col, pair
                         )
@@ -310,7 +329,7 @@ def _v4_tn_ws_body[
                         accum.ptr[e + 1].cast[_V4_DT](),
                     )
                     if m0 + row < m and n0 + col + 1 < n:
-                        output.store[alignment=4](
+                        output.store[alignment=2 * _GEMM16_W](
                             (m0 + row) * n + n0 + col, pair
                         )
 
@@ -541,8 +560,8 @@ def _v4_tt_direct_m64n128_s3(
     )
 
 
-# Elementwise reduction of the split-K fp32 workspace slices into the bf16
-# output: out[i] = bf16(sum_s ws[s * count + i]).  Each thread owns
+# Elementwise reduction of the split-K fp32 workspace slices into the output:
+# out[i] = operand_dtype(sum_s ws[s * count + i]).  Each thread owns
 # _V4_RED_GROUPS independent vec4 chains so enough loads are in flight to
 # saturate DRAM (a single chain per thread measured only ~53% of peak).
 comptime _V4_RED_THREADS = 256
@@ -579,7 +598,7 @@ def _v4_tn_splitk_reduce(
                     slice_base + g * _V4_RED_THREADS * 4
                 )
         comptime for g in range(_V4_RED_GROUPS):
-            output.store[alignment=8](
+            output.store[alignment=4 * _GEMM16_W](
                 base + g * _V4_RED_THREADS * 4, acc[g].cast[_V4_DT]()
             )
     else:
@@ -589,7 +608,7 @@ def _v4_tn_splitk_reduce(
                 var acc4 = ws.load[width=4, alignment=16](i)
                 for s in range(1, splits):
                     acc4 += ws.load[width=4, alignment=16](s * count + i)
-                output.store[alignment=8](i, acc4.cast[_V4_DT]())
+                output.store[alignment=4 * _GEMM16_W](i, acc4.cast[_V4_DT]())
             else:
                 while i < count:
                     var acc1 = ws[i]

--- a/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_v3_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_v3_kernels.mojo
@@ -54,6 +54,12 @@ from gemm16_tn_v4_kernels import (
     try_enqueue_gemm16_gemm_tn_v4,
     try_enqueue_gemm16_gemm_tt_v4,
 )
+from gemm16_bias import (
+    _GEMM16_HAS_BIAS,
+    _gemm16_add_bias_to_accum,
+    _gemm16_bias_ptr_ok,
+    _gemm16_bias_tag,
+)
 from gemm16_dtype import (
     _GEMM16_BK,
     _GEMM16_DT,
@@ -678,14 +684,19 @@ def _v3_enqueue_nn_ws_m64n128_tma_s3(
 @__llvm_metadata(
     MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(_V3_NT_THREADS))
 )
-@__name(t"{_GEMM16_TAG}_gemm_v3_nt_ws_m128n256_tma_s3")
-def _v3_nt_ws_m128n256_tma_s3(
+@__name(
+    t"{_GEMM16_TAG}_gemm_v3_nt_ws_m128n256_tma_s3{_gemm16_bias_tag[has_bias]()}"
+)
+def _v3_nt_ws_m128n256_tma_s3[
+    has_bias: Bool = False
+](
     a_tma: _V3_NT_A_TMA,
     b_tma: _V3_B_K_TMA,
     output: _V3_PTR,
     m_arg: Int64,
     n_arg: Int64,
     k_arg: Int64,
+    bias: _V3_PTR,
 ):
     # Int is not device-passable (host/device width mismatch); scalars cross
     # the launch ABI as Int64 and index math stays in Int.
@@ -839,6 +850,8 @@ def _v3_nt_ws_m128n256_tma_s3(
             var lane = tid % 32
             var base_row = warp * 16 + lane // 4
             var base_col = (lane % 4) * 2
+            comptime if has_bias:
+                _gemm16_add_bias_to_accum[CFRAG](accum, bias, n0, n, lane)
             comptime for q in range(CFRAG // 2):
                 var e = q * 2
                 var row = (warp_group_idx - 1) * 64 + base_row + (q % 2) * 8
@@ -853,10 +866,13 @@ def _v3_nt_ws_m128n256_tma_s3(
                     )
 
 
-def _v3_enqueue_nt_ws_m128n256_tma_s3(
+def _v3_enqueue_nt_ws_m128n256_tma_s3[
+    has_bias: Bool = False
+](
     output: _V3_PTR,
     a: _V3_PTR,
     b: _V3_PTR,
+    bias: _V3_PTR,
     m: Int,
     n: Int,
     k: Int,
@@ -887,13 +903,14 @@ def _v3_enqueue_nt_ws_m128n256_tma_s3(
     )
     var a_tma = _V3_NT_A_TMA(a_desc)
     var b_tma = _V3_B_K_TMA(b_desc)
-    ctx.enqueue_function[_v3_nt_ws_m128n256_tma_s3](
+    ctx.enqueue_function[_v3_nt_ws_m128n256_tma_s3[has_bias]](
         a_tma,
         b_tma,
         output,
         Int64(m),
         Int64(n),
         Int64(k),
+        bias,
         grid_dim=(grid_x,),
         block_dim=(_V3_NT_THREADS,),
     )
@@ -1545,10 +1562,13 @@ def _try_enqueue_gemm16_tn_route(
 #
 # So ragged m and any even n are served, and k needs only 4-element alignment.
 # ============================================================================
-def _try_enqueue_gemm16_nt_v3_tf32(
+def _try_enqueue_gemm16_nt_v3_tf32[
+    has_bias: Bool = False
+](
     output: _V3_PTR,
     a: _V3_PTR,
     b: _V3_PTR,
+    bias: _V3_PTR,
     m: Int,
     n: Int,
     k: Int,
@@ -1558,6 +1578,9 @@ def _try_enqueue_gemm16_nt_v3_tf32(
         return False
     if ctx.api() != "cuda":
         return False
+    comptime if has_bias:
+        if not _gemm16_bias_ptr_ok(bias):
+            return False
     # _has_sm_9x() is a comptime FAMILY check; on a mixed-architecture box the
     # DeviceContext can still be bound to a non-Hopper device, and this kernel
     # is WGMMA+TMA-only.  Every sibling route checks the runtime compute
@@ -1593,8 +1616,8 @@ def _try_enqueue_gemm16_nt_v3_tf32(
         or blocks_m > max_grid_x // blocks_n
     ):
         return False
-    _v3_enqueue_nt_ws_m128n256_tma_s3(
-        output, a, b, m, n, k, blocks_m * blocks_n, ctx
+    _v3_enqueue_nt_ws_m128n256_tma_s3[has_bias](
+        output, a, b, bias, m, n, k, blocks_m * blocks_n, ctx
     )
     return True
 
@@ -1622,26 +1645,37 @@ def _enqueue_gemm16_gemm_tf32(
     output: _V3_PTR,
     a: _V3_PTR,
     b: _V3_PTR,
+    bias: _V3_PTR,
     m: Int,
     n: Int,
     k: Int,
     transpose_a: Bool,
     transpose_b: Bool,
-    has_bias: Bool,
     ctx: DeviceContext,
 ) raises:
-    if not transpose_a and transpose_b and not has_bias:
-        if try_enqueue_gemm16_gemm_splitk_rm_v4[True](
-            output, a, b, m, n, k, ctx
+    if not transpose_a and transpose_b:
+        # The split-K arm has no fused-bias epilogue (its bias would belong in
+        # the separate reduce kernel, not here), so a biased call skips it and
+        # takes the direct kernel, whose epilogue does fuse.  That would be the
+        # wrong trade for the deep-K shapes split-K exists for -- measured on
+        # an H100 PCIe, 1024x1024x8192 tf32 costs 85us split-K versus 197us
+        # direct -- which is why the host keeps splitting the bias off exactly
+        # those shapes (`_gemm16_splitk_nt_may_fire` in aten_fast.py) and only
+        # sends a fused bias here when the direct kernel is the route anyway.
+        comptime if not _GEMM16_HAS_BIAS:
+            if try_enqueue_gemm16_gemm_splitk_rm_v4[True](
+                output, a, b, m, n, k, ctx
+            ):
+                return
+        if _try_enqueue_gemm16_nt_v3_tf32[_GEMM16_HAS_BIAS](
+            output, a, b, bias, m, n, k, ctx
         ):
             return
-        if _try_enqueue_gemm16_nt_v3_tf32(output, a, b, m, n, k, ctx):
-            return
     raise Error(
-        t"gemm16 float32 (tf32) carries the NT no-bias route only, and only"
-        t" for (k * 4) % 16 == 0 and even n on sm_90a; got m={m} n={n} k={k}"
+        t"gemm16 float32 (tf32) carries the NT route only, and only for"
+        t" (k * 4) % 16 == 0 and even n on sm_90a; got m={m} n={n} k={k}"
         t" transpose_a={transpose_a} transpose_b={transpose_b}"
-        t" has_bias={has_bias}. The host gate in aten_fast.py"
+        t" has_bias={_GEMM16_HAS_BIAS}. The host gate in aten_fast.py"
         t" (_tf32_nt_wgmma_admits) must not offer this call to this bridge."
     )
 
@@ -1659,17 +1693,28 @@ def enqueue_gemm16_gemm(
     has_bias: Bool,
     ctx: DeviceContext,
 ) raises:
+    # The compiled-in HAS_BIAS flag selects which kernels this .so carries, so
+    # it MUST agree with the bias the caller actually passed.  Disagreement can
+    # only come from a loader/bridge bug, and its silent form would be a wrong
+    # answer (a dropped or a garbage bias), so it is checked once per call --
+    # host-side integer compare, next to a GEMM.
+    if has_bias != _GEMM16_HAS_BIAS:
+        raise Error(
+            t"gemm16 was built with HAS_BIAS={_GEMM16_HAS_BIAS} but called"
+            t" with has_bias={has_bias}: the specialization defines and the"
+            t" call ABI have drifted apart."
+        )
     comptime if _GEMM16_TF32:
         _enqueue_gemm16_gemm_tf32(
             output,
             a,
             b,
+            bias,
             m,
             n,
             k,
             transpose_a,
             transpose_b,
-            has_bias,
             ctx,
         )
     else:
@@ -1706,17 +1751,24 @@ def _enqueue_gemm16_gemm_16bit(
     # helper enqueues only for regimes it fully supports (SM90, aligned
     # n/k, TMA-compatible sizes) and returns False otherwise, in which case
     # the pre-existing NT path below remains the fallback.
-    if not transpose_a and transpose_b and not has_bias:
+    if not transpose_a and transpose_b:
         # Deep-K split-K route first: the persistent kernel below keeps all
         # SMs resident but cannot parallelize over K, so an output with few
         # macro-tiles and a deep reduction leaves most of the GPU idle.
         # The helper gates itself on that regime (see
         # gemm16_tn_v4_kernels.mojo) and returns False otherwise.
-        if try_enqueue_gemm16_gemm_splitk_rm_v4[True](
-            output, a, b, m, n, k, ctx
+        comptime if not _GEMM16_HAS_BIAS:
+            # See _enqueue_gemm16_gemm_tf32: split-K has no fused-bias
+            # epilogue, and the host keeps splitting the bias off the deep-K
+            # shapes that reach it rather than pushing them onto the direct
+            # kernel, which is much slower there.
+            if try_enqueue_gemm16_gemm_splitk_rm_v4[True](
+                output, a, b, m, n, k, ctx
+            ):
+                return
+        if maybe_enqueue_gemm16_nt_v4[_GEMM16_HAS_BIAS](
+            output, a, b, bias, m, n, k, ctx
         ):
-            return
-        if maybe_enqueue_gemm16_nt_v4(output, a, b, m, n, k, ctx):
             return
     comptime if _has_sm_9x():
         if ctx.api() == "cuda":
@@ -1893,7 +1945,7 @@ def _enqueue_gemm16_gemm_16bit(
                 if (
                     not transpose_a
                     and transpose_b
-                    and not has_bias
+                    and (not _GEMM16_HAS_BIAS or _gemm16_bias_ptr_ok(bias))
                     and m >= _V3_BM
                     and n >= _V3_BN
                     and k >= _V3_BK
@@ -1923,8 +1975,8 @@ def _enqueue_gemm16_gemm_16bit(
                     ):
                         var grid_x = blocks_m * blocks_n
                         if grid_x > 0:
-                            _v3_enqueue_nt_ws_m128n256_tma_s3(
-                                output, a, b, m, n, k, grid_x, ctx
+                            _v3_enqueue_nt_ws_m128n256_tma_s3[_GEMM16_HAS_BIAS](
+                                output, a, b, bias, m, n, k, grid_x, ctx
                             )
                             return
                 # The remaining TN regimes (underfilled small-tile and large

--- a/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_v3_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_v3_kernels.mojo
@@ -1,12 +1,15 @@
-"""Dynamically routed H100 16-bit tensor-core GEMM kernels.
+"""Dynamically routed H100 tensor-core GEMM kernels (16-bit and TF32).
 
 The accepted-v2 implementation remains the fallback for every regime not
 handled by the optimized NN, NT, and TN routes in this module.
 
-The operand dtype is bfloat16 or float16, chosen at compile time by
-`_GEMM16_DT` (gemm16_dtype.mojo); every tile size and pipeline constant
-here is a function of the 2-byte operand width, not of the exponent
-layout, so one source serves both.
+The operand dtype is bfloat16, float16 or float32, chosen at compile time
+by `_GEMM16_DT` (gemm16_dtype.mojo); every tile size and pipeline constant
+here is a function of the operand WIDTH, not of the exponent layout, so one
+source serves all three -- float32 operands are what WGMMA computes as TF32.
+float32 reaches only the NT routes (`_enqueue_gemm16_gemm_tf32`), which is
+also what keeps the unwidened ones out of a float32 build: Mojo instantiates
+only what is called.
 """
 
 from max.gpu.sync import barrier
@@ -51,7 +54,14 @@ from gemm16_tn_v4_kernels import (
     try_enqueue_gemm16_gemm_tn_v4,
     try_enqueue_gemm16_gemm_tt_v4,
 )
-from gemm16_dtype import _GEMM16_DT, _GEMM16_TAG
+from gemm16_dtype import (
+    _GEMM16_BK,
+    _GEMM16_DT,
+    _GEMM16_TAG,
+    _GEMM16_TF32,
+    _GEMM16_W,
+    _GEMM16_WGMMA_K,
+)
 
 
 comptime _V3_DT = _GEMM16_DT
@@ -59,15 +69,15 @@ comptime _V3_F32 = DType.float32
 comptime _V3_PTR = UnsafePointer[Scalar[_V3_DT], MutAnyOrigin]
 comptime _V3_BM = 64
 comptime _V3_BN = 128
-comptime _V3_BK = 64
+comptime _V3_BK = _GEMM16_BK
 comptime _V3_SWIZZLE = TensorMapSwizzle.SWIZZLE_128B
 comptime _V3_NN_BM = 128
 comptime _V3_NN_BN = 256
-comptime _V3_NN_BK = 64
+comptime _V3_NN_BK = _GEMM16_BK
 comptime _V3_NN_STAGES = 3
 comptime _V3_NN_THREADS = 384
 comptime _V3_NN_CONSUMERS = 2
-comptime _V3_NN_WGMMA_SHAPE = Index(64, 256, 16)
+comptime _V3_NN_WGMMA_SHAPE = Index(64, 256, _GEMM16_WGMMA_K)
 comptime _V3_NN_A_LAYOUT = tile_layout_k_major[
     _V3_DT, _V3_NN_BM, _V3_NN_BK, _V3_SWIZZLE
 ]()
@@ -94,11 +104,11 @@ comptime _V3_NN_B_PIPE_LAYOUT = Layout.row_major(
 )
 comptime _V3_NN_SMALL_BM = 64
 comptime _V3_NN_SMALL_BN = 128
-comptime _V3_NN_SMALL_BK = 64
+comptime _V3_NN_SMALL_BK = _GEMM16_BK
 comptime _V3_NN_SMALL_STAGES = 3
 comptime _V3_NN_SMALL_THREADS = 256
 comptime _V3_NN_SMALL_CONSUMERS = 1
-comptime _V3_NN_SMALL_WGMMA_SHAPE = Index(64, 128, 16)
+comptime _V3_NN_SMALL_WGMMA_SHAPE = Index(64, 128, _GEMM16_WGMMA_K)
 comptime _V3_NN_SMALL_A_LAYOUT = tile_layout_k_major[
     _V3_DT, _V3_NN_SMALL_BM, _V3_NN_SMALL_BK, _V3_SWIZZLE
 ]()
@@ -125,11 +135,11 @@ comptime _V3_NN_SMALL_B_PIPE_LAYOUT = Layout.row_major(
 )
 comptime _V3_NT_BM = 128
 comptime _V3_NT_BN = 256
-comptime _V3_NT_BK = 64
+comptime _V3_NT_BK = _GEMM16_BK
 comptime _V3_NT_STAGES = 3
 comptime _V3_NT_THREADS = 384
 comptime _V3_NT_CONSUMERS = 2
-comptime _V3_NT_WGMMA_SHAPE = Index(64, 256, 16)
+comptime _V3_NT_WGMMA_SHAPE = Index(64, 256, _GEMM16_WGMMA_K)
 comptime _V3_NT_A_LAYOUT = tile_layout_k_major[
     _V3_DT, _V3_NT_BM, _V3_NT_BK, _V3_SWIZZLE
 ]()
@@ -156,11 +166,11 @@ comptime _V3_NT_B_PIPE_LAYOUT = Layout.row_major(
 )
 comptime _V3_TN_WS_BM = 128
 comptime _V3_TN_WS_BN = 256
-comptime _V3_TN_WS_BK = 64
+comptime _V3_TN_WS_BK = _GEMM16_BK
 comptime _V3_TN_WS_STAGES = 3
 comptime _V3_TN_WS_THREADS = 384
 comptime _V3_TN_WS_CONSUMERS = 2
-comptime _V3_TN_WS_WGMMA_SHAPE = Index(64, 256, 16)
+comptime _V3_TN_WS_WGMMA_SHAPE = Index(64, 256, _GEMM16_WGMMA_K)
 comptime _V3_TN_WS_A_LAYOUT = tile_layout_mn_major[
     _V3_DT, _V3_TN_WS_BM, _V3_TN_WS_BK, _V3_SWIZZLE
 ]()
@@ -187,11 +197,11 @@ comptime _V3_TN_WS_B_PIPE_LAYOUT = Layout.row_major(
 )
 comptime _V3_TN_SMALL_BM = 64
 comptime _V3_TN_SMALL_BN = 128
-comptime _V3_TN_SMALL_BK = 64
+comptime _V3_TN_SMALL_BK = _GEMM16_BK
 comptime _V3_TN_SMALL_STAGES = 3
 comptime _V3_TN_SMALL_THREADS = 256
 comptime _V3_TN_SMALL_CONSUMERS = 1
-comptime _V3_TN_SMALL_WGMMA_SHAPE = Index(64, 128, 16)
+comptime _V3_TN_SMALL_WGMMA_SHAPE = Index(64, 128, _GEMM16_WGMMA_K)
 comptime _V3_TN_SMALL_A_LAYOUT = tile_layout_mn_major[
     _V3_DT, _V3_TN_SMALL_BM, _V3_TN_SMALL_BK, _V3_SWIZZLE
 ]()
@@ -288,7 +298,7 @@ def _v3_nn_ws_m128n256_tma_s3(
         var m0 = (group * 8 + rem % rows_in_group) * _V3_NN_BM
         var n0 = (rem // rows_in_group) * _V3_NN_BN
         var num_tiles = k // _V3_NN_BK
-        comptime TMA_BYTES = (_V3_NN_BM + _V3_NN_BN) * _V3_NN_BK * 2
+        comptime TMA_BYTES = (_V3_NN_BM + _V3_NN_BN) * _V3_NN_BK * _GEMM16_W
 
         if warp_group_idx > 0 and warp_group_thread_idx == 0:
             comptime for stage in range(_V3_NN_STAGES):
@@ -386,7 +396,9 @@ def _v3_nn_ws_m128n256_tma_s3(
                     accum.ptr[e + 1].cast[_V3_DT](),
                 )
                 if m0 + row < m and n0 + col + 1 < n:
-                    output.store[alignment=4]((m0 + row) * n + n0 + col, pair)
+                    output.store[alignment=2 * _GEMM16_W](
+                        (m0 + row) * n + n0 + col, pair
+                    )
 
 
 def _v3_enqueue_nn_ws_m128n256_tma_s3(
@@ -506,7 +518,7 @@ def _v3_nn_ws_m64n128_tma_s3(
         var num_tiles = k // _V3_NN_SMALL_BK
         comptime TMA_BYTES = (
             _V3_NN_SMALL_BM + _V3_NN_SMALL_BN
-        ) * _V3_NN_SMALL_BK * 2
+        ) * _V3_NN_SMALL_BK * _GEMM16_W
 
         if warp_group_idx > 0 and warp_group_thread_idx == 0:
             comptime for stage in range(_V3_NN_SMALL_STAGES):
@@ -610,7 +622,9 @@ def _v3_nn_ws_m64n128_tma_s3(
                     accum.ptr[e + 1].cast[_V3_DT](),
                 )
                 if m0 + row < m and n0 + col + 1 < n:
-                    output.store[alignment=4]((m0 + row) * n + n0 + col, pair)
+                    output.store[alignment=2 * _GEMM16_W](
+                        (m0 + row) * n + n0 + col, pair
+                    )
 
 
 def _v3_enqueue_nn_ws_m64n128_tma_s3(
@@ -726,7 +740,16 @@ def _v3_nt_ws_m128n256_tma_s3(
         var m0 = (group * 8 + rem % rows_in_group) * _V3_NT_BM
         var n0 = (rem // rows_in_group) * _V3_NT_BN
         var num_tiles = k // _V3_NT_BK
-        comptime TMA_BYTES = (_V3_NT_BM + _V3_NT_BN) * _V3_NT_BK * 2
+        comptime if _GEMM16_TF32:
+            # The 16-bit dispatcher admits this route only at k % BK == 0, so
+            # the exact division above is the whole K range for it and stays
+            # byte-identical.  The tf32 dispatcher admits any k whose ROW PITCH
+            # is TMA-legal ((k * width) % 16 == 0, i.e. k % 4 here), which
+            # leaves a partial trailing k-tile: TMA zero-fills a box that runs
+            # past the global extent and zeros do not contribute to a dot
+            # product, so one extra tile is exactly right.
+            num_tiles = (k + _V3_NT_BK - 1) // _V3_NT_BK
+        comptime TMA_BYTES = (_V3_NT_BM + _V3_NT_BN) * _V3_NT_BK * _GEMM16_W
 
         if warp_group_idx > 0 and warp_group_thread_idx == 0:
             comptime for stage in range(_V3_NT_STAGES):
@@ -825,7 +848,9 @@ def _v3_nt_ws_m128n256_tma_s3(
                     accum.ptr[e + 1].cast[_V3_DT](),
                 )
                 if m0 + row < m and n0 + col + 1 < n:
-                    output.store[alignment=4]((m0 + row) * n + n0 + col, pair)
+                    output.store[alignment=2 * _GEMM16_W](
+                        (m0 + row) * n + n0 + col, pair
+                    )
 
 
 def _v3_enqueue_nt_ws_m128n256_tma_s3(
@@ -948,7 +973,7 @@ def _v3_tn_ws_m64n128_tma_col_a_s3(
         var num_tiles = k // _V3_TN_SMALL_BK
         comptime TMA_BYTES = (
             _V3_TN_SMALL_BM + _V3_TN_SMALL_BN
-        ) * _V3_TN_SMALL_BK * 2
+        ) * _V3_TN_SMALL_BK * _GEMM16_W
 
         if warp_group_idx > 0 and warp_group_thread_idx == 0:
             comptime for stage in range(_V3_TN_SMALL_STAGES):
@@ -1078,7 +1103,9 @@ def _v3_tn_ws_m64n128_tma_col_a_s3(
                     accum.ptr[e + 1].cast[_V3_DT](),
                 )
                 if m0 + row < m and n0 + col + 1 < n:
-                    output.store[alignment=4]((m0 + row) * n + n0 + col, pair)
+                    output.store[alignment=2 * _GEMM16_W](
+                        (m0 + row) * n + n0 + col, pair
+                    )
 
 
 def _v3_enqueue_tn_ws_m64n128_tma_col_a_s3(
@@ -1201,7 +1228,9 @@ def _v3_tn_ws_m128n256_tma_col_a_s3(
         var m0 = (group * 8 + rem % rows_in_group) * _V3_TN_WS_BM
         var n0 = (rem // rows_in_group) * _V3_TN_WS_BN
         var num_tiles = k // _V3_TN_WS_BK
-        comptime TMA_BYTES = (_V3_TN_WS_BM + _V3_TN_WS_BN) * _V3_TN_WS_BK * 2
+        comptime TMA_BYTES = (
+            _V3_TN_WS_BM + _V3_TN_WS_BN
+        ) * _V3_TN_WS_BK * _GEMM16_W
 
         # Initially release every pipeline slot to the producer.  Thereafter
         # both consumer warp groups arrive only after their WGMMA reads finish.
@@ -1336,7 +1365,9 @@ def _v3_tn_ws_m128n256_tma_col_a_s3(
                     accum.ptr[e + 1].cast[_V3_DT](),
                 )
                 if m0 + row < m and n0 + col + 1 < n:
-                    output.store[alignment=4]((m0 + row) * n + n0 + col, pair)
+                    output.store[alignment=2 * _GEMM16_W](
+                        (m0 + row) * n + n0 + col, pair
+                    )
 
 
 def _v3_enqueue_tn_ws_m128n256_tma_col_a_s3(
@@ -1494,7 +1525,170 @@ def _try_enqueue_gemm16_tn_route(
     return False
 
 
+# ============================================================================
+# float32 (TF32) NT route: the 128x256 warp-specialized WGMMA kernel above at
+# the 4-byte tile.  Its admission gate is NOT the 16-bit NT route's
+# tile-multiple gate; it is the two real hardware constraints, which are looser:
+#
+#   * TMA requires every global stride to be a multiple of 16 BYTES.  A is
+#     (m, k) row-major and B is (n, k) row-major, so both row pitches are
+#     k * width and the constraint on k is (k * width) % 16 == 0 -- k % 4 at
+#     float32.  It is NOT k % BK: a partial trailing k-tile is fine because TMA
+#     zero-fills a box past the global extent and zeros do not contribute to a
+#     dot product (that is what the ceil-div `num_tiles` above is for).
+#     Violating it fails descriptor creation with CUDA_ERROR_INVALID_VALUE, so
+#     it has to be a gate rather than a hope.
+#   * the epilogue stores a 2-element pair per lane at a row start of
+#     row * n * width, so n must be EVEN for that to be 2*width-aligned.  m is
+#     unconstrained: it only picks the row, and the epilogue's bounds check
+#     already clips a partial edge tile.
+#
+# So ragged m and any even n are served, and k needs only 4-element alignment.
+# ============================================================================
+def _try_enqueue_gemm16_nt_v3_tf32(
+    output: _V3_PTR,
+    a: _V3_PTR,
+    b: _V3_PTR,
+    m: Int,
+    n: Int,
+    k: Int,
+    ctx: DeviceContext,
+) raises -> Bool:
+    comptime if not _has_sm_9x():
+        return False
+    if ctx.api() != "cuda":
+        return False
+    # _has_sm_9x() is a comptime FAMILY check; on a mixed-architecture box the
+    # DeviceContext can still be bound to a non-Hopper device, and this kernel
+    # is WGMMA+TMA-only.  Every sibling route checks the runtime compute
+    # capability for exactly this reason.
+    var cc_major = ctx.get_attribute(DeviceAttribute.COMPUTE_CAPABILITY_MAJOR)
+    var cc_minor = ctx.get_attribute(DeviceAttribute.COMPUTE_CAPABILITY_MINOR)
+    if cc_major != 9 or cc_minor != 0:
+        return False
+    if (
+        m < 1
+        or n < 1
+        or k < 1
+        or (k * _GEMM16_W) % 16 != 0
+        or n % 2 != 0
+        or Int(output) % 16 != 0
+        or Int(a) % 16 != 0
+        or Int(b) % 16 != 0
+        or m > 2_147_483_647
+        or n > 2_147_483_647
+        or k > 2_147_483_647
+        or k > 9_223_372_036_854_775_807 // m
+        or k > 9_223_372_036_854_775_807 // n
+        or n > 9_223_372_036_854_775_807 // m
+    ):
+        return False
+    var blocks_m = (m + _V3_NT_BM - 1) // _V3_NT_BM
+    var blocks_n = (n + _V3_NT_BN - 1) // _V3_NT_BN
+    var max_grid_x = ctx.get_attribute(DeviceAttribute.MAX_GRID_DIM_X)
+    if (
+        blocks_m <= 0
+        or blocks_n <= 0
+        or max_grid_x <= 0
+        or blocks_m > max_grid_x // blocks_n
+    ):
+        return False
+    _v3_enqueue_nt_ws_m128n256_tma_s3(
+        output, a, b, m, n, k, blocks_m * blocks_n, ctx
+    )
+    return True
+
+
+# ============================================================================
+# The float32 (TF32) route ladder.
+#
+# Deliberately much shorter than the 16-bit one: only the NT split-K kernel and
+# the NT 128x256 WGMMA kernel above have been measured at float32 (H100 PCIe,
+# 1395MHz, versus cuBLAS's sm90 warpgroup tf32 kernels: 0.85-1.07x on
+# 4096^3 / 8192x2048x2048 / 2048x8192x2048 / 32768x768x768, and 0.89x on the
+# deep-K 1024x1024x8192 through split-K).  The routes NOT reachable here are
+# not merely unmeasured, two of them are structurally 16-bit:
+# gemm16_nt_v4_kernels.mojo's persistent kernel and the `tma_store` epilogue of
+# gemm16_nn_v4_kernels.mojo stage C through `st.matrix` / a hand-written
+# 128B-swizzle whose 64-element row is one swizzle row only at a 2-byte
+# operand.  Since Mojo instantiates only what is called, gating here is also
+# what keeps those out of a float32 build entirely.
+#
+# Everything this ladder declines keeps the SM80-class mma.m16n8k8 route in
+# tf32_matmul_ops/, which aten_fast.py picks on the host with the same
+# arithmetic; reaching the raise below means those two gates disagree.
+# ============================================================================
+def _enqueue_gemm16_gemm_tf32(
+    output: _V3_PTR,
+    a: _V3_PTR,
+    b: _V3_PTR,
+    m: Int,
+    n: Int,
+    k: Int,
+    transpose_a: Bool,
+    transpose_b: Bool,
+    has_bias: Bool,
+    ctx: DeviceContext,
+) raises:
+    if not transpose_a and transpose_b and not has_bias:
+        if try_enqueue_gemm16_gemm_splitk_rm_v4[True](
+            output, a, b, m, n, k, ctx
+        ):
+            return
+        if _try_enqueue_gemm16_nt_v3_tf32(output, a, b, m, n, k, ctx):
+            return
+    raise Error(
+        t"gemm16 float32 (tf32) carries the NT no-bias route only, and only"
+        t" for (k * 4) % 16 == 0 and even n on sm_90a; got m={m} n={n} k={k}"
+        t" transpose_a={transpose_a} transpose_b={transpose_b}"
+        t" has_bias={has_bias}. The host gate in aten_fast.py"
+        t" (_tf32_nt_wgmma_admits) must not offer this call to this bridge."
+    )
+
+
 def enqueue_gemm16_gemm(
+    output: UnsafePointer[Scalar[_V3_DT], MutAnyOrigin],
+    a: UnsafePointer[Scalar[_V3_DT], MutAnyOrigin],
+    b: UnsafePointer[Scalar[_V3_DT], MutAnyOrigin],
+    bias: UnsafePointer[Scalar[_V3_DT], MutAnyOrigin],
+    m: Int,
+    n: Int,
+    k: Int,
+    transpose_a: Bool,
+    transpose_b: Bool,
+    has_bias: Bool,
+    ctx: DeviceContext,
+) raises:
+    comptime if _GEMM16_TF32:
+        _enqueue_gemm16_gemm_tf32(
+            output,
+            a,
+            b,
+            m,
+            n,
+            k,
+            transpose_a,
+            transpose_b,
+            has_bias,
+            ctx,
+        )
+    else:
+        _enqueue_gemm16_gemm_16bit(
+            output,
+            a,
+            b,
+            bias,
+            m,
+            n,
+            k,
+            transpose_a,
+            transpose_b,
+            has_bias,
+            ctx,
+        )
+
+
+def _enqueue_gemm16_gemm_16bit(
     output: UnsafePointer[Scalar[_V3_DT], MutAnyOrigin],
     a: UnsafePointer[Scalar[_V3_DT], MutAnyOrigin],
     b: UnsafePointer[Scalar[_V3_DT], MutAnyOrigin],
@@ -1754,6 +1948,50 @@ def enqueue_gemm16_gemm(
 
 
 def enqueue_gemm16_bmm(
+    output: UnsafePointer[Scalar[_V3_DT], MutAnyOrigin],
+    a: UnsafePointer[Scalar[_V3_DT], MutAnyOrigin],
+    b: UnsafePointer[Scalar[_V3_DT], MutAnyOrigin],
+    batch_count: Int,
+    m: Int,
+    n: Int,
+    k: Int,
+    output_batch_stride: Int,
+    a_batch_stride: Int,
+    b_batch_stride: Int,
+    transpose_a: Bool,
+    transpose_b: Bool,
+    ctx: DeviceContext,
+) raises:
+    # No float32 (TF32) BMM here: the batched routes below are the pre-wgmma
+    # accepted kernel and gemm16_bmm_v5_kernels.mojo, neither of which has been
+    # widened or measured at a 4-byte operand.  A float32 BMM keeps the
+    # SM80-class route in tf32_matmul_ops/, which is what aten_fast.py calls,
+    # so this raise is unreachable from the eager path and exists only so a
+    # float32 specialization of this module compiles and says why.
+    comptime if _GEMM16_TF32:
+        raise Error(
+            "gemm16 carries no float32 (tf32) BMM route; float32 batched"
+            " matmuls use the tf32_matmul_ops bridge."
+        )
+    else:
+        _enqueue_gemm16_bmm_16bit(
+            output,
+            a,
+            b,
+            batch_count,
+            m,
+            n,
+            k,
+            output_batch_stride,
+            a_batch_stride,
+            b_batch_stride,
+            transpose_a,
+            transpose_b,
+            ctx,
+        )
+
+
+def _enqueue_gemm16_bmm_16bit(
     output: UnsafePointer[Scalar[_V3_DT], MutAnyOrigin],
     a: UnsafePointer[Scalar[_V3_DT], MutAnyOrigin],
     b: UnsafePointer[Scalar[_V3_DT], MutAnyOrigin],


### PR DESCRIPTION
Bias is a row vector added to C. Adding it with a separate elementwise kernel
is a **second full pass over C**, and C is the largest tensor in the problem.
On an H100 PCIe that pass measured 67us next to a 296us GEMM (`S2`/`S3`) and
108us next to a 189us GEMM (`S6`, tall-skinny 32768x768) — up to **+56% device
time** for an operation that costs nothing where the accumulator already lives.

This adds a fused-bias epilogue to the direct WGMMA GEMM kernels, which fixes
the eight above-bar `addmm`/`linear` tf32 cells named in #410 and brings
sixteen bf16/f16 cells with it.

> **Stacked on #410** (`kernel/tf32-gemm-wgmma`, 033feb7), which is still open —
> the tf32 kernel this fuses into only exists there, so this branches from its
> head rather than from main. GitHub will not take a fork branch as a base, so
> the diff below includes #410's two commits; **this change is the last commit
> only** (`Fuse the bias into the direct WGMMA GEMM epilogue`). Review after
> #410 merges, or review that commit alone.
>
> Independent of #395, which fuses the bias into the *split-K reduce* epilogue:
> different site, no overlap, see "What is not covered".

## What changed

A comptime `has_bias` parameter on the two direct routes, with the bias added
to the **FP32 accumulator** immediately before whatever store path the route
uses:

| kernel | serves | store path |
|---|---|---|
| `_v3_nt_ws_m128n256_tma_s3` | tf32 NT | pair stores straight to global |
| `_v4c_nt_persistent` | bf16/f16 NT | `st.matrix` into swizzled smem, TMA store |

The accumulator is the one point both have in common, so a single helper
(`gemm16_bias.mojo`) serves both and neither store path learns that a bias
exists. It also means the fusion **composes with the TMA-store epilogue by
construction** rather than by luck: the bias is gone from the picture before
the first store instruction of either kind.

The helper walks the WGMMA `m64nN` register mapping — `column(i) = 8*(i//4) +
2*(lane%4) + (i%2)` — so the four elements `4c..4c+3` share one two-element
bias load: `CFRAG//4` loads per thread, not `CFRAG`. Out-of-range columns are
clamped rather than branched, since the store path clips the partial edge tile
anyway.

Which specialization is built is selected by the `HAS_BIAS` define **that the
loader already put in the cache key** — `_try_gemm16_mm` and `_try_tf32_gemm`
have always passed it — so this costs no extra builds; it only stops the unused
variant from being instantiated into a build that cannot call it. Because that
gates a *correctness* property, `enqueue_gemm16_gemm` raises if the define and
the runtime ABI bool ever disagree.

## Measured (H100 PCIe, 1395MHz, `benchmarks/`, ABBA-interleaved)

The eight cells #410 named:

| case | addmm/tf32/NT | linear/tf32 |
|---|---|---|
| S1 4096³ | 1.201 → **1.068** | 1.187 → **1.072** |
| S2 8192x2048x2048 | 1.337 → **1.040** | 1.323 → **1.049** |
| S3 2048x8192x2048 | 1.393 → **1.144** | 1.369 → **1.117** |
| S6 32768x768x768 | 1.852 → **1.153** | 1.830 → **1.150** |

Sixteen more, for free, because `linear` IS the NT regime and bf16/f16 were
splitting their bias the same way:

| case | addmm/bf16 | linear/bf16 | addmm/f16 | linear/f16 |
|---|---|---|---|---|
| S1 | 1.178 → **1.056** | 1.181 → **1.059** | 1.148 → **1.047** | 1.166 → **1.034** |
| S2 | 1.364 → **1.082** | 1.359 → **1.086** | 1.352 → **1.085** | 1.343 → **1.087** |
| S3 | 1.367 → **1.104** | 1.369 → **1.111** | 1.319 → **1.074** | 1.290 → **1.069** |
| S6 | 2.086 → **1.095** | 2.101 → **1.095** | 2.093 → **1.081** | 2.107 → **1.071** |

S3 and S6 tf32 stay a little over 1.10, and that residual is **not** the bias:
the standalone harness measures the fused epilogue at `fused/nobias` = 0.99-1.03
on every shape and dtype, while the old two-launch path cost 1.04-2.80x.

```
dtype=tf32            nobias_us     split_us     fused_us  fused/nobias  split/nobias
S1_4096x4096x4096       532.16       636.45       537.36          1.01          1.20
S2_8192x2048x2048       291.75       393.91       294.14          1.01          1.35
S3_2048x8192x2048       291.14       394.42       293.23          1.01          1.35
S6_32768x768x768        189.13       355.93       193.40          1.02          1.88
S4_1024x1024x8192       197.82       206.33       198.54          1.00          1.04
A2_357x790x336           20.33        25.10        20.68          1.02          1.23

dtype=bf16
S1_4096x4096x4096       291.25       410.15       299.07          1.03          1.41
S2_8192x2048x2048       159.40       270.47       158.41          0.99          1.70
S3_2048x8192x2048       156.26       262.24       156.98          1.00          1.68
S6_32768x768x768         98.21       272.37        97.92          1.00          2.77
S4_1024x1024x8192        83.89        92.47        84.68          1.01          1.10
```

So `addmm`/`linear` now track their `mm` counterparts (`mm/tf32/NT` reads 1.125
on S3 and 1.131 on S6) to within 0.2-3%, and what is left is NOTES.md's open
item #2, "mm S3/S6 at 1.12-1.13 — tuning".

## What is not covered, and why

**Deep-K keeps the split.** The split-K arm reduces through an FP32 workspace
in a second kernel and has no accumulator epilogue to fuse into. A biased call
skips it and lands on the direct kernel, which is the wrong trade exactly where
split-K exists: 1024x1024x8192 tf32 is 85us split-K against 197us direct. So
`_gemm16_splitk_nt_may_fire` keeps those shapes on today's mm-then-add path.
It mirrors split-K's hard gates and replaces the multiprocessor count it cannot
query with that count's architectural upper bound — **conservative on purpose**:
claiming a shape split-K would decline costs one extra elementwise-add launch on
an output that is small by construction, while missing one would cost the 2.3x
above. #395 fuses the bias into that reduce kernel; when it lands, this mirror
can go.

**NN / TN / TT keep the split.** Only the NT direct routes have a fused-bias
epilogue, and `linear` is NT by construction. `_gemm16_alignment_favors_split`
still decides for the rest, unchanged.

**Anything that is not a plain bias vector.** The fused epilogue reads one
contiguous, pair-aligned row of `n` values in the operand dtype. A scalar or
otherwise broadcast bias, an expanded view, a bias reached through an offset
view (`b[1:]`, not pair-aligned) — all keep the separate add, which
broadcasts. `_fused_bias_vector_ok` is deliberately the *same* check the
bridges already apply before accepting a bias at all: when it was looser, a
scalar bias skipped the split, the bridge then declined the biased call, and
the projection fell past **both** fast paths. Eight `*_bias_broadcast_*` tests
caught exactly that. Separately, the Mojo routes check the pointer alignment
themselves and decline, so the misaligned-load fault is unreachable regardless
of what host routing believes.

## Numerics

The fused path computes `round(acc + bias)` where the split path computed
`round(round(acc) + bias)` — one rounding step **fewer**, and what cuBLAS's
fused epilogue does. At float32/TF32 the two are bit-identical; at bf16/f16
the fused result is strictly closer to the exact value. The harness models
both roundings explicitly rather than hiding the difference in a tolerance.

## Blast radius

- **Kernels changed:** `_v3_nt_ws_m128n256_tma_s3` and `_v4c_nt_persistent`
  gain a `_bias` specialization. sm_90a cross-compile against 033feb7: of 175
  device kernels, **4 differ and every one differs by exactly one line** — an
  appended, unused `.param .u64` — and by **zero instructions**. The other 171,
  including all 105 `Bmm16` kernels, are byte-identical. With `-D HAS_BIAS=1`
  the diff is `0 changed, +4 new, -7 gone` (the biased build correctly stops
  instantiating the split-K arm).
- **Routing changed:** `addmm`/`linear` on NT operands only.
- **`mm` and `bmm`:** untouched. `bmm` does not call any modified function;
  `mm` passes `has_bias = False`, which reduces to the previous control flow
  exactly.
- **Suite:** `pytest benchmarks/test_gemm.py -k "not bmm"` — 279 passed, 1
  failed. The failure is `addmm[S7_768x50304x49152-NN-tf32]`, a *measurement
  noise* refusal on the largest case in the suite (stock leg spread 9-15%); it
  fails identically on 033feb7 with our leg within 0.4%, so it is pre-existing.
- **Baselines:** 24 entries re-recorded, all improvements, all `addmm`/`linear`.
  Fifteen badly stale `mm/bf16` entries (NN/TT at ~5.0) also surfaced as
  improvements and were deliberately **not** recorded — `mm` has no bias, and
  one of them reproduces the same value on 033feb7.

## Tests

- `tests/test_eager_kernels.py`: **1773 passed, 22 skipped, 0 failed.** The
  routing test now asserts the fused behaviour and its four exceptions (deep-K,
  non-vector bias, unaligned bias, non-NT), plus a 16-bit twin and a mirror
  test for `_gemm16_splitk_nt_may_fire`. The kernel-name contract test learned
  the NT kernel's second interpolation, so `..._tma_s3` and `..._tma_s3_bias`
  stay tellable apart in a profile.
- The new `gemm16_bias.mojo` was verified to be in the extension's import
  closure: editing it forces a rebuild, leaving it alone is a cache hit.
- Standalone harness: exact-oracle correctness on six shapes x three dtypes x
  three legs, **zero** mismatches. Operands are multiples of 1/32, exact in
  TF32/bf16/f16, so every product is an exact multiple of 1/1024 and the FP32
  accumulator holds the k-sum exactly — the only rounding is the final store,
  which the fp64 reference reproduces. A mismatch would be a kernel bug, not a
  precision artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Co2wBC1UYzM4y9PEC92Af
