### PR TITLE
Fix four standalone bugs: wrapper attribute collision, .data assignment, ENOLCK, vector_norm dtype

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -159,7 +159,7 @@ def fake_mojo_tensor() -> Callable[..., torch.Tensor]:
         tensor._device = device
         tensor._dtype = dtype
         tensor._shape = shape
-        tensor._strides = strides
+        tensor._mojo_strides = strides
         tensor._offset = 0
         tensor._itemsize = dtype.size_in_bytes
         tensor._numel = math.prod(shape)

--- a/tests/test_eager_kernel_loader.py
+++ b/tests/test_eager_kernel_loader.py
@@ -472,7 +472,7 @@ def test_spec_descriptor_canonical_defines_match_make_defines() -> None:
     class _FakePayload:
         _dtype: DType
         _shape: tuple[int, ...] = (2, 3)
-        _strides: tuple[int, ...] = (3, 1)
+        _mojo_strides: tuple[int, ...] = (3, 1)
         _device: object = field(default_factory=lambda: cpu)
 
     a = _FakePayload(DType.float32)

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -421,7 +421,7 @@ def test_wrapper_subclass_preserves_native_saved_output(mojo_device):
     assert saved._holder is output._holder
     assert saved._ptr == output._ptr
     assert saved._shape == output._shape
-    assert saved._strides == output._strides
+    assert saved._mojo_strides == output._mojo_strides
     assert saved._device == output._device
 
     output.backward(host_gradient.to(mojo_device))
@@ -1388,7 +1388,7 @@ def test_fast_native_layer_norm_gpu_prologue_runs_without_a_gpu(
         shape = tuple(shape)
         return SimpleNamespace(
             _shape=shape,
-            _strides=aten_fast._row_major_strides(shape),
+            _mojo_strides=aten_fast._row_major_strides(shape),
             _offset=0,
             _dtype=aten_fast.DType.float32 if dtype is None else dtype,
             _device=device,
@@ -6421,7 +6421,7 @@ def test_bf16_unavailable_bridge_falls_back_before_allocation(
         shape = tuple(shape)
         return SimpleNamespace(
             _shape=shape,
-            _strides=aten_fast._row_major_strides(shape),
+            _mojo_strides=aten_fast._row_major_strides(shape),
             _dtype=aten_fast.DType.bfloat16,
             _device=device,
             _ptr=1234,
@@ -6631,7 +6631,7 @@ def test_tf32_unavailable_bridge_falls_back_before_allocation(
         shape = tuple(shape)
         return SimpleNamespace(
             _shape=shape,
-            _strides=aten_fast._row_major_strides(shape),
+            _mojo_strides=aten_fast._row_major_strides(shape),
             _dtype=aten_fast.DType.float32,
             _device=device,
             _ptr=1234,
@@ -6928,7 +6928,7 @@ def test_sdpa_forward_tf32_bmm_routing_preserves_raw_fallback(
         shape = tuple(shape)
         return SimpleNamespace(
             _shape=shape,
-            _strides=aten_fast._row_major_strides(shape),
+            _mojo_strides=aten_fast._row_major_strides(shape),
             _offset=0,
             _dtype=aten_fast.DType.float32 if dtype is None else dtype,
             _device=device,
@@ -7065,7 +7065,7 @@ def test_bf16_gemm_host_bridge_layouts_offsets_context_and_highest(
         rows, cols = shape
         return SimpleNamespace(
             _shape=shape,
-            _strides=(1, rows) if transposed else (cols, 1),
+            _mojo_strides=(1, rows) if transposed else (cols, 1),
             _offset=offset,
             _dtype=aten_fast.DType.bfloat16,
             _device=device,
@@ -7081,7 +7081,7 @@ def test_bf16_gemm_host_bridge_layouts_offsets_context_and_highest(
     rhs = matrix(rhs_shape, rhs_transposed, 2000, 5)
     bias = SimpleNamespace(
         _shape=(n,),
-        _strides=(1,),
+        _mojo_strides=(1,),
         _offset=2,
         _dtype=aten_fast.DType.bfloat16,
         _device=device,
@@ -7102,7 +7102,7 @@ def test_bf16_gemm_host_bridge_layouts_offsets_context_and_highest(
         allocations.append(shape)
         return SimpleNamespace(
             _shape=shape,
-            _strides=aten_fast._row_major_strides(shape),
+            _mojo_strides=aten_fast._row_major_strides(shape),
             _offset=0,
             _dtype=dtype,
             _device=actual_device,
@@ -7173,7 +7173,7 @@ def test_bf16_gemm_no_bias_uses_ignored_output_pointer(monkeypatch):
         shape = tuple(shape)
         return SimpleNamespace(
             _shape=shape,
-            _strides=aten_fast._row_major_strides(shape),
+            _mojo_strides=aten_fast._row_major_strides(shape),
             _dtype=aten_fast.DType.bfloat16,
             _device=device,
             _ptr=ptr,
@@ -7400,7 +7400,7 @@ def test_bf16_gemm_rejects_invalid_metadata_before_resolve_or_allocation(
         shape = tuple(shape)
         return SimpleNamespace(
             _shape=shape,
-            _strides=(
+            _mojo_strides=(
                 aten_fast._row_major_strides(shape) if strides is None else strides
             ),
             _dtype=dtype,
@@ -7531,7 +7531,7 @@ def test_bf16_bmm_host_bridge_padded_layouts_offsets_and_logical_transpose(
         return (
             SimpleNamespace(
                 _shape=shape,
-                _strides=(batch_stride, 1, rows)
+                _mojo_strides=(batch_stride, 1, rows)
                 if transposed
                 else (batch_stride, cols, 1),
                 _offset=offset,
@@ -7562,7 +7562,7 @@ def test_bf16_bmm_host_bridge_padded_layouts_offsets_and_logical_transpose(
         allocations.append((shape, dtype, actual_device))
         return SimpleNamespace(
             _shape=shape,
-            _strides=aten_fast._row_major_strides(shape),
+            _mojo_strides=aten_fast._row_major_strides(shape),
             _offset=0,
             _dtype=dtype,
             _device=actual_device,
@@ -7642,7 +7642,7 @@ def test_bf16_bmm_rejects_invalid_metadata_before_resolve_or_allocation(
         shape = tuple(shape)
         return SimpleNamespace(
             _shape=shape,
-            _strides=(
+            _mojo_strides=(
                 aten_fast._row_major_strides(shape) if strides is None else strides
             ),
             _dtype=dtype,
@@ -7699,7 +7699,7 @@ def test_bf16_bridge_error_propagates_without_retry(monkeypatch, operation):
         shape = tuple(shape)
         return SimpleNamespace(
             _shape=shape,
-            _strides=aten_fast._row_major_strides(shape),
+            _mojo_strides=aten_fast._row_major_strides(shape),
             _dtype=aten_fast.DType.bfloat16,
             _device=device,
             _ptr=ptr,
@@ -7749,7 +7749,7 @@ def test_bf16_helpers_reject_cross_device_before_resolve_or_allocation(
         shape = tuple(shape)
         return SimpleNamespace(
             _shape=shape,
-            _strides=aten_fast._row_major_strides(shape),
+            _mojo_strides=aten_fast._row_major_strides(shape),
             _offset=0,
             _dtype=aten_fast.DType.bfloat16,
             _device=device,
@@ -7807,7 +7807,7 @@ def test_tf32_helpers_route_each_fake_device_context_and_reject_cross_device(
         shape = tuple(shape)
         return SimpleNamespace(
             _shape=shape,
-            _strides=aten_fast._row_major_strides(shape),
+            _mojo_strides=aten_fast._row_major_strides(shape),
             _offset=0,
             _dtype=aten_fast.DType.float32,
             _device=device,
@@ -8759,7 +8759,7 @@ def test_tf32_dense_batched_layout_accepts_broadcast_stride_zero():
     def tensor(shape, strides):
         return SimpleNamespace(
             _shape=tuple(shape),
-            _strides=tuple(strides),
+            _mojo_strides=tuple(strides),
             _dtype=aten_fast.DType.bfloat16,
             _device=h100,
         )

--- a/tests/test_eager_optimizer_ops.py
+++ b/tests/test_eager_optimizer_ops.py
@@ -195,8 +195,8 @@ def test_fused_adamw_accepts_contiguous_singleton_stride_variants(
     cpu_groups = groups("cpu")
     mojo_groups = groups(mojo_gpu)
     parameter, gradient = mojo_groups[0][0], mojo_groups[1][0]
-    assert parameter._strides == (1, 1)
-    assert gradient._strides == (1, 2)
+    assert parameter._mojo_strides == (1, 1)
+    assert gradient._mojo_strides == (1, 2)
     assert parameter._is_contiguous and gradient._is_contiguous
     kwargs = {
         "lr": 0.01,

--- a/tests/test_fa4_host_wiring.py
+++ b/tests/test_fa4_host_wiring.py
@@ -32,7 +32,7 @@ def _tensor(
     return SimpleNamespace(
         name=name,
         _shape=shape,
-        _strides=strides,
+        _mojo_strides=strides,
         _offset=0,
         _dtype=dtype or aten_fast.DType.bfloat16,
         _device=device or _device(),
@@ -307,11 +307,11 @@ def test_fa4_strided_layout_contract_is_strict() -> None:
         {"_ptr": eligible._ptr + 2},
         {"_shape": (2, 255, 12, 64)},
         {"_shape": (2, 256, 12, 32)},
-        {"_strides": (strides[0], strides[1], 128, 1)},
-        {"_strides": (strides[0], 12 * 64 - 8, 64, 1)},
-        {"_strides": (strides[0] + 8, strides[1], 64, 1)},
-        {"_strides": (strides[0], strides[1], 64, 2)},
-        {"_strides": (strides[0], strides[1] + 2, 64, 1)},
+        {"_mojo_strides": (strides[0], strides[1], 128, 1)},
+        {"_mojo_strides": (strides[0], 12 * 64 - 8, 64, 1)},
+        {"_mojo_strides": (strides[0] + 8, strides[1], 64, 1)},
+        {"_mojo_strides": (strides[0], strides[1], 64, 2)},
+        {"_mojo_strides": (strides[0], strides[1] + 2, 64, 1)},
         {"_dtype": aten_fast.DType.float32, "_itemsize": 4},
     ):
         candidate = SimpleNamespace(**vars(eligible))
@@ -360,7 +360,7 @@ def test_fa4_canonical_fused_qkv_uses_zero_copy_strided_forward_bridge(
     def transpose(tensor, dim0, dim1):
         assert (dim0, dim1) == (1, 2)
         shape = list(tensor._shape)
-        strides = list(tensor._strides)
+        strides = list(tensor._mojo_strides)
         shape[dim0], shape[dim1] = shape[dim1], shape[dim0]
         strides[dim0], strides[dim1] = strides[dim1], strides[dim0]
         return _tensor(
@@ -402,7 +402,8 @@ def test_fa4_canonical_fused_qkv_uses_zero_copy_strided_forward_bridge(
     assert logsumexp._shape == (batch, heads, seqlen)
     assert tuple(tensor._ptr for tensor in (q_native, k_native, v_native)) == pointers
     assert all(
-        tensor._strides == physical_strides for tensor in (q_native, k_native, v_native)
+        tensor._mojo_strides == physical_strides
+        for tensor in (q_native, k_native, v_native)
     )
     assert strided_calls == [
         (
@@ -448,7 +449,7 @@ def test_fa4_offset_view_public_layout_copies_and_uses_contiguous_fallback(
 
     def transpose(tensor, dim0, dim1):
         shape = list(tensor._shape)
-        strides = list(tensor._strides)
+        strides = list(tensor._mojo_strides)
         shape[dim0], shape[dim1] = shape[dim1], shape[dim0]
         strides[dim0], strides[dim1] = strides[dim1], strides[dim0]
         return _tensor(
@@ -997,7 +998,7 @@ def test_fa4_canonical_fused_qkv_uses_strided_backward_bridge(
 
     def transpose(tensor, dim0, dim1):
         shape = list(tensor._shape)
-        strides = list(tensor._strides)
+        strides = list(tensor._mojo_strides)
         shape[dim0], shape[dim1] = shape[dim1], shape[dim0]
         strides[dim0], strides[dim1] = strides[dim1], strides[dim0]
         return _tensor(

--- a/tests/test_mojo_device.py
+++ b/tests/test_mojo_device.py
@@ -1188,3 +1188,59 @@ def test_pointer_ordinal_identifies_the_owning_gpu(mojo_gpu):
     assert cuda_peer.device_ordinal(0) is None
     assert cuda_peer.device_ordinal(torch.zeros(8).data_ptr()) is None
     assert not cuda_peer.same_physical_device(on_mojo._ptr, 0)
+
+
+def test_data_assignment_moves_the_payload(mojo_gpu_available):
+    """``x.data = y`` has to move the allocation, not just TensorImpl metadata.
+
+    The C++ setter shallow-copies the TensorImpl and stops; for this
+    storage-less wrapper that left every kernel reading the OLD buffer with
+    no error at all. FSDP1 swaps a flat parameter between its sharded and
+    unsharded buffers with exactly this assignment.
+    """
+    if not mojo_gpu_available:
+        pytest.skip("requires a MAX GPU")
+    destination = torch.zeros(8, device="mojo:0")
+    source = torch.arange(8, dtype=torch.float32, device="mojo:0") + 100
+    destination.data = source
+    assert destination.cpu().tolist() == source.cpu().tolist()
+
+    # A strided view at a non-zero offset must survive intact: FSDP hands
+    # every original parameter a slice of the flat parameter this way.
+    base = torch.arange(16, dtype=torch.float32, device="mojo:0")
+    view = base[4:12].reshape(2, 4)
+    holder = torch.zeros(1, device="mojo:0")
+    holder.data = view
+    assert tuple(holder.shape) == (2, 4)
+    assert holder.stride() == view.stride()
+    assert holder.cpu().tolist() == [[4.0, 5.0, 6.0, 7.0], [8.0, 9.0, 10.0, 11.0]]
+
+
+def test_library_attributes_do_not_clobber_the_payload(mojo_gpu_available):
+    """A mojo Parameter IS the wrapper object, so torch's own bookkeeping
+    attributes land in the payload's namespace.
+    ``FlatParameter._init_metadata`` writes ``_strides``/``_shapes``/
+    ``_numels``; none of those may disturb the layout metadata."""
+    if not mojo_gpu_available:
+        pytest.skip("requires a MAX GPU")
+    tensor = torch.arange(8, dtype=torch.float32, device="mojo:0")
+    strides = tensor._mojo_strides
+    tensor._strides = ((1,), (1,))
+    tensor._shapes = (torch.Size([4]), torch.Size([4]))
+    tensor._numels = (4, 4)
+    assert tensor._mojo_strides == strides
+    first, second = torch.split(tensor, [4, 4])
+    assert second.cpu().tolist() == [4.0, 5.0, 6.0, 7.0]
+    assert first.cpu().tolist() == [0.0, 1.0, 2.0, 3.0]
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_vector_norm_with_an_accumulation_dtype(mojo_gpu_available, dtype):
+    """FSDP1's clip_grad_norm_ asks for the norm in float32 explicitly."""
+    if not mojo_gpu_available:
+        pytest.skip("requires a MAX GPU")
+    cpu = torch.randn(4096, dtype=dtype)
+    expected = torch.linalg.vector_norm(cpu, 2.0, dtype=torch.float32)
+    got = torch.linalg.vector_norm(cpu.to("mojo:0"), 2.0, dtype=torch.float32)
+    assert got.dtype == torch.float32
+    torch.testing.assert_close(got.cpu(), expected, rtol=1e-5, atol=1e-4)

--- a/torch_mojo_backend/eager_kernels/__init__.py
+++ b/torch_mojo_backend/eager_kernels/__init__.py
@@ -35,6 +35,7 @@ process), so it is always built complete and never escalated — which also
 means direct references to its functions stay valid forever.
 """
 
+import errno
 import fcntl
 import hashlib
 import importlib.machinery
@@ -460,6 +461,25 @@ def _announce_build() -> None:
     )
 
 
+def _flock_or_none(lock: object) -> bool:
+    """Take the build lock; False when this filesystem cannot lock at all.
+
+    The lock only DEDUPES concurrent identical builds — correctness never
+    depends on it, because every builder writes a per-pid temp file and
+    installs it with an atomic os.replace. On NFS home directories without a
+    lock manager, flock raises ENOLCK (seen with 8 torchrun ranks sharing one
+    __mojocache__ over NFS); building redundantly is the right fallback.
+    """
+    try:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        return True
+    except OSError as e:
+        if e.errno in (errno.ENOLCK, errno.ENOSYS, errno.EOPNOTSUPP):
+            _trace(f"build lock unavailable ({e}); building without dedupe")
+            return False
+        raise
+
+
 def _build_extension(src: Path, defines: CanonicalDefines | None) -> Path:
     """Compile one immutable defined extension and return its cache path."""
     out = _extension_path(src, defines)
@@ -467,7 +487,7 @@ def _build_extension(src: Path, defines: CanonicalDefines | None) -> Path:
         return out
     _CACHE_DIR.mkdir(exist_ok=True)
     with open(_CACHE_DIR / f".{out.stem}.lock", "w") as lock:
-        fcntl.flock(lock, fcntl.LOCK_EX)
+        _flock_or_none(lock)
         if out.is_file():
             return out
         # An ungated build gets named as what it is rather than as

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -3,7 +3,7 @@
 Each function here is registered in `mojo_device_aten_ops.py` (through
 `_eager_impl`). Tensors are `TorchMojoTensor`s: a Mojo `TensorHolder`
 ownership token plus Python-side layout metadata (`_ptr`, `_shape`,
-`_strides` in elements, `_offset`, `_dtype`, `_device`, `_is_contiguous`).
+`_mojo_strides` in elements, `_offset`, `_dtype`, `_device`, `_is_contiguous`).
 An op runs as one or a few Mojo kernel calls — no graph building, no MLIR
 passes, no interpreter, and *no graph fallback*: when a function returns
 the `NOT_HANDLED` sentinel, the registration raises `NotImplementedError`
@@ -403,7 +403,7 @@ def _reduce_ready_operand(
     view = _view_of(
         a,
         tuple(a._shape[d] for d in perm),
-        tuple(a._strides[d] for d in perm),
+        tuple(a._mojo_strides[d] for d in perm),
         a._offset,
     )
     return view._contig(), trailing
@@ -628,7 +628,7 @@ def _foreach_scalar_overlap_kind(tensor, scalar) -> str:
     if (
         tensor._device != scalar._device
         or tensor._numel == 0
-        or not _is_non_overlapping_and_dense(tensor._shape, tensor._strides)
+        or not _is_non_overlapping_and_dense(tensor._shape, tensor._mojo_strides)
     ):
         return "none"
     tensor_begin = tensor._ptr
@@ -640,7 +640,7 @@ def _foreach_scalar_overlap_kind(tensor, scalar) -> str:
     if (
         tensor_begin == scalar_begin
         and tensor_end == scalar_end
-        and tensor._strides == scalar._strides
+        and tensor._mojo_strides == scalar._mojo_strides
     ):
         return "full"
     return "partial"
@@ -1182,7 +1182,7 @@ def _spec_of(t):
             t._ptr,
             len(t._shape),
             _pad8(t._shape, 1),
-            _pad8(t._strides, 0),
+            _pad8(t._mojo_strides, 0),
             t._offset,
             t._dtype.value,
             t._itemsize,
@@ -2357,7 +2357,7 @@ def _bcast_meta(*tensors):
             if j < 0 or t._shape[j] == 1:
                 st.append(0)
             else:
-                st.append(t._strides[j])
+                st.append(t._mojo_strides[j])
         all_strides.append([0] * (4 - rank) + st)
     return out, dims, all_strides
 
@@ -2786,7 +2786,7 @@ def fast_aten_fill__scalar(input, value):
             a._ptr,
             float(value),
             _pad8(a._shape, 1),
-            _pad8(a._strides, 0),
+            _pad8(a._mojo_strides, 0),
             a._dtype.value,
             _ctx_ptr(a._device),
             keepalive=(a,),
@@ -3603,7 +3603,7 @@ def fast_aten_addr(
     # at dim 0 / dim 1 respectively regardless of rank (see the kernel-side
     # comment in logic_ops.mojo above `_addr_bcast`).
     a_shape = (1,) * (2 - len(a._shape)) + tuple(a._shape)
-    a_strides = (0,) * (2 - len(a._strides)) + tuple(a._strides)
+    a_strides = (0,) * (2 - len(a._mojo_strides)) + tuple(a._mojo_strides)
     if a_shape[0] not in (1, n) or a_shape[1] not in (1, m):
         return NOT_HANDLED
     as0 = a_strides[0] if a_shape[0] != 1 else 0
@@ -3618,7 +3618,7 @@ def fast_aten_addr(
                 a._ptr,
                 b._ptr,
                 c._ptr,
-                (n, m, as0, as1, b._strides[0], c._strides[0]),
+                (n, m, as0, as1, b._mojo_strides[0], c._mojo_strides[0]),
                 float(beta),
                 float(alpha),
                 dtype.value,
@@ -3872,7 +3872,7 @@ def _fast_view(tensor, shape):
         return NOT_HANDLED
     if t._is_contiguous:
         return _view_of(t, sizes, _row_major_strides(sizes), t._offset, contiguous=True)
-    new_strides = _compute_view_strides(t._shape, t._strides, sizes)
+    new_strides = _compute_view_strides(t._shape, t._mojo_strides, sizes)
     if new_strides is None:
         # PyTorch's reshape reads the TensorImpl's (fake-contiguous) strides
         # and routes copy-requiring reshapes here too — materialize.
@@ -3899,8 +3899,8 @@ def fast_aten_unsqueeze(tensor, dim):
     if dim < 0:
         dim += rank + 1
     new_shape = t._shape[:dim] + (1,) + t._shape[dim:]
-    inserted = t._shape[dim] * t._strides[dim] if dim < rank else 1
-    new_strides = t._strides[:dim] + (inserted,) + t._strides[dim:]
+    inserted = t._shape[dim] * t._mojo_strides[dim] if dim < rank else 1
+    new_strides = t._mojo_strides[:dim] + (inserted,) + t._mojo_strides[dim:]
     return _view_of(t, new_shape, new_strides, t._offset)
 
 
@@ -3913,9 +3913,9 @@ def fast_aten_squeeze_dim(tensor, dim):
         return NOT_HANDLED
     dim %= rank
     if t._shape[dim] != 1:
-        return _view_of(t, t._shape, t._strides, t._offset)
+        return _view_of(t, t._shape, t._mojo_strides, t._offset)
     new_shape = t._shape[:dim] + t._shape[dim + 1 :]
-    new_strides = t._strides[:dim] + t._strides[dim + 1 :]
+    new_strides = t._mojo_strides[:dim] + t._mojo_strides[dim + 1 :]
     return _view_of(t, new_shape, new_strides, t._offset)
 
 
@@ -3936,7 +3936,7 @@ def fast_aten_alias(tensor):
             "a TorchMojoTensor allocation holder; its unpack hook must "
             "return a complete TorchMojoTensor or a host tensor"
         )
-    return _view_of(t, t._shape, t._strides, t._offset)
+    return _view_of(t, t._shape, t._mojo_strides, t._offset)
 
 
 fast_aten_detach = fast_aten_alias
@@ -3953,7 +3953,7 @@ def fast_aten_permute(input, dims):
     if None in perm or len(set(perm)) != rank:
         return NOT_HANDLED
     new_shape = tuple(t._shape[p] for p in perm)
-    new_strides = tuple(t._strides[p] for p in perm)
+    new_strides = tuple(t._mojo_strides[p] for p in perm)
     return _view_of(t, new_shape, new_strides, t._offset)
 
 
@@ -3962,7 +3962,7 @@ def fast_aten_t(input):
     if t is None or len(t._shape) > 2:
         return NOT_HANDLED
     if len(t._shape) < 2:
-        return _view_of(t, t._shape, t._strides, t._offset)
+        return _view_of(t, t._shape, t._mojo_strides, t._offset)
     return fast_aten_transpose(input, 0, 1)
 
 
@@ -3972,13 +3972,13 @@ def fast_aten_transpose(input, dim0, dim1):
         return NOT_HANDLED
     rank = len(t._shape)
     if rank == 0:
-        return _view_of(t, t._shape, t._strides, t._offset)
+        return _view_of(t, t._shape, t._mojo_strides, t._offset)
     if not (-rank <= dim0 < rank and -rank <= dim1 < rank):
         return NOT_HANDLED
     dim0 %= rank
     dim1 %= rank
     shape = list(t._shape)
-    strides = list(t._strides)
+    strides = list(t._mojo_strides)
     shape[dim0], shape[dim1] = shape[dim1], shape[dim0]
     strides[dim0], strides[dim1] = strides[dim1], strides[dim0]
     return _view_of(t, shape, strides, t._offset)
@@ -4006,7 +4006,7 @@ def fast_aten_expand(tensor, sizes, *, implicit=False):
             old_size = t._shape[j]
             if s == -1 or s == old_size:
                 new_shape.append(old_size)
-                new_strides.append(t._strides[j])
+                new_strides.append(t._mojo_strides[j])
             elif old_size == 1:
                 new_shape.append(s)
                 new_strides.append(0)
@@ -4037,8 +4037,12 @@ def fast_aten_slice(input, dim=0, start=None, end=None, step=1):
     length = max(end - start, 0)
     length = -(-length // step)  # ceil div for step > 1
     new_shape = t._shape[:dim] + (length,) + t._shape[dim + 1 :]
-    new_strides = t._strides[:dim] + (t._strides[dim] * step,) + t._strides[dim + 1 :]
-    new_offset = t._offset + start * t._strides[dim]
+    new_strides = (
+        t._mojo_strides[:dim]
+        + (t._mojo_strides[dim] * step,)
+        + t._mojo_strides[dim + 1 :]
+    )
+    new_offset = t._offset + start * t._mojo_strides[dim]
     return _view_of(t, new_shape, new_strides, new_offset)
 
 
@@ -4056,8 +4060,8 @@ def fast_aten_select(input, dim, index):
     if not 0 <= index < size:
         return NOT_HANDLED
     new_shape = t._shape[:dim] + t._shape[dim + 1 :]
-    new_strides = t._strides[:dim] + t._strides[dim + 1 :]
-    new_offset = t._offset + index * t._strides[dim]
+    new_strides = t._mojo_strides[:dim] + t._mojo_strides[dim + 1 :]
+    new_offset = t._offset + index * t._mojo_strides[dim]
     return _view_of(t, new_shape, new_strides, new_offset)
 
 
@@ -4260,7 +4264,7 @@ def fast_aten_cat(tensors, dim=0):
                 # instead of materializing a contiguous copy first. The slot
                 # is out[..., pos:pos+len, ...]: same strides as out, offset
                 # pos * out_strides[dim] == the accumulated flat offset.
-                slot = _view_of(out, b._shape, out._strides, offset)
+                slot = _view_of(out, b._shape, out._mojo_strides, offset)
                 _copy_strided_into(slot, b)
         offset += copy_len
     return out
@@ -4589,8 +4593,8 @@ def _fast_scatter(input, dim, index, src, value):
             value_f = float(value)
 
     dims4 = [1] * (4 - rank) + list(idx_c._shape)
-    out_strides4 = [0] * (4 - rank) + list(out._strides)
-    idx_strides4 = [0] * (4 - rank) + list(idx_c._strides)
+    out_strides4 = [0] * (4 - rank) + list(out._mojo_strides)
+    idx_strides4 = [0] * (4 - rank) + list(idx_c._mojo_strides)
     dim_padded = dim + (4 - rank)
     params = (
         tuple(dims4)
@@ -5635,17 +5639,29 @@ def fast_aten_linalg_vector_norm(self, ord=2, dim=None, keepdim=False, *, dtype=
     It used to be composed here as mul -> sum -> sqrt, which is three launches
     and a temporary the size of the input for a reduction that reads each
     element once.
+
+    ``dtype`` selects the accumulation type, so it is honoured by casting
+    first, the same way ``fast_aten_mean`` does. FSDP1's
+    ``clip_grad_norm_`` always passes ``dtype=torch.float32``.
     """
     a = _t(self)
     if (
         a is None
-        or a._dtype not in _FLOAT_DTYPES
         or not isinstance(ord, int | float)
         or isinstance(ord, bool)
         or ord != 2
-        or dtype is not None
         or not isinstance(keepdim, bool)
     ):
+        return NOT_HANDLED
+    if dtype is not None:
+        target = _torch_dtype_to_max(dtype)
+        if target is None or target not in _FLOAT_DTYPES:
+            return NOT_HANDLED
+        if a._dtype != target:
+            if a._dtype not in _CAST_DTYPES or target not in _CAST_DTYPES:
+                return NOT_HANDLED
+            a = _cast_tensor(a, target)
+    if a._dtype not in _FLOAT_DTYPES:
         return NOT_HANDLED
     rank = len(a._shape)
     rdims = _norm_reduce_dims(dim, rank, empty_is_all=True)
@@ -7058,11 +7074,11 @@ def _fa4_strided_bthd_layout(tensor) -> bool:
         or tensor._dtype not in (DType.bfloat16, DType.float16)
         or tensor._itemsize != tensor._dtype.size_in_bytes
         or len(tensor._shape) != 4
-        or len(tensor._strides) != 4
+        or len(tensor._mojo_strides) != 4
     ):
         return False
     batch, seqlen, heads, head_dim = tensor._shape
-    b_stride, s_stride, h_stride, d_stride = tensor._strides
+    b_stride, s_stride, h_stride, d_stride = tensor._mojo_strides
     if (
         batch <= 0
         or seqlen <= 0
@@ -7249,11 +7265,11 @@ def fast_fa4_16bit_d64_causal_forward(
         _device_call(
             forward_fn,
             q_native._ptr,
-            *q_native._strides,
+            *q_native._mojo_strides,
             k_native._ptr,
-            *k_native._strides,
+            *k_native._mojo_strides,
             v_native._ptr,
-            *v_native._strides,
+            *v_native._mojo_strides,
             out_native._ptr,
             logsumexp._ptr,
             batch,
@@ -7327,11 +7343,11 @@ def fast_fa4_16bit_d64_causal_backward(
         _device_call(
             backward_fn,
             q_native._ptr,
-            *q_native._strides,
+            *q_native._mojo_strides,
             k_native._ptr,
-            *k_native._strides,
+            *k_native._mojo_strides,
             v_native._ptr,
-            *v_native._strides,
+            *v_native._mojo_strides,
             out_native._ptr,
             dout_native._ptr,
             logsumexp._ptr,
@@ -7426,7 +7442,7 @@ def _fa_strides(t: MojoTensorLike) -> tuple[int, int, int]:
     The head_dim stride is not passed: it must be 1, and ``_fused_fa_inputs`` is
     what guarantees that.
     """
-    strides = t._strides
+    strides = t._mojo_strides
     return (strides[0], strides[1], strides[2])
 
 
@@ -7519,7 +7535,7 @@ def _fused_fa_inputs(
     ):
         return None
     # The innermost axis must be contiguous; every other stride is free.
-    if q._strides[3] != 1 or k._strides[3] != 1 or v._strides[3] != 1:
+    if q._mojo_strides[3] != 1 or k._mojo_strides[3] != 1 or v._mojo_strides[3] != 1:
         return None
     if scale is not None and (
         not isinstance(scale, int | float)
@@ -7612,15 +7628,15 @@ def fast_fused_flash_attention_backward(
         return NOT_HANDLED
     if g._dtype != q._dtype or tuple(g._shape) != tuple(q._shape):
         return NOT_HANDLED
-    if g._strides[3] != 1:
+    if g._mojo_strides[3] != 1:
         g = _tc(g)
         if g is None:
             return NOT_HANDLED
     if (
-        q._strides[3] != 1
-        or k._strides[3] != 1
-        or v._strides[3] != 1
-        or o._strides[3] != 1
+        q._mojo_strides[3] != 1
+        or k._mojo_strides[3] != 1
+        or v._mojo_strides[3] != 1
+        or o._mojo_strides[3] != 1
     ):
         return NOT_HANDLED
     batch, heads, seq_q, head_dim = q._shape
@@ -8243,7 +8259,7 @@ def _tf32_dense_2d_layout(tensor: MojoTensorLike) -> bool | None:
     if len(tensor._shape) != 2:
         return None
     rows, cols = tensor._shape
-    strides = tuple(tensor._strides)
+    strides = tuple(tensor._mojo_strides)
     if strides == (cols, 1):
         return False
     if strides == (1, rows):
@@ -8272,7 +8288,7 @@ def _tf32_dense_batched_layout(tensor: MojoTensorLike) -> tuple[bool, int] | Non
     if len(tensor._shape) != 3:
         return None
     batch, rows, cols = tensor._shape
-    batch_stride, row_stride, col_stride = tuple(tensor._strides)
+    batch_stride, row_stride, col_stride = tuple(tensor._mojo_strides)
     row_major = col_stride == 1 and (rows == 1 or row_stride == cols)
     transposed = row_stride == 1 and (cols == 1 or col_stride == rows)
     if row_major:
@@ -9176,9 +9192,9 @@ def fast_aten_scaled_dot_product_attention(
             and head_dim % 4 == 0
             and head_dim <= 256
             and kv_len <= 4096
-            and q._strides[3] == 1
-            and k._strides[3] == v._strides[3] == 1
-            and k._strides[2] == v._strides[2] == head_dim
+            and q._mojo_strides[3] == 1
+            and k._mojo_strides[3] == v._mojo_strides[3] == 1
+            and k._mojo_strides[2] == v._mojo_strides[2] == head_dim
         ):
             # Decode step: one fused kernel instead of bmm+softmax+bmm
             # (single launch, no scratch buffers, coalesced K/V reads).

--- a/torch_mojo_backend/mojo_device/mojo_device_autograd.py
+++ b/torch_mojo_backend/mojo_device/mojo_device_autograd.py
@@ -74,7 +74,7 @@ class _SavedMojoPayload:
         self.holder = None if _saved_tensor_hooks_active() else tensor._holder
         self.ptr = tensor._ptr
         self.shape = tensor._shape
-        self.strides = tensor._strides
+        self.strides = tensor._mojo_strides
         self.offset = tensor._offset
         self.dtype = tensor._dtype
         self.itemsize = tensor._itemsize
@@ -127,7 +127,7 @@ class _SavedMojoPayload:
             "_holder",
             "_ptr",
             "_shape",
-            "_strides",
+            "_mojo_strides",
             "_offset",
             "_dtype",
             "_itemsize",

--- a/torch_mojo_backend/mojo_device/torch_mojo_tensor.py
+++ b/torch_mojo_backend/mojo_device/torch_mojo_tensor.py
@@ -180,7 +180,15 @@ class MojoTensorLike(Protocol):
     """
 
     _shape: tuple[int, ...]
-    _strides: tuple[int, ...]
+    # Namespaced on purpose. PyTorch library code assigns its own bookkeeping
+    # onto parameter objects, and because a mojo Parameter *is* the wrapper
+    # instance (nn.Parameter.__new__ takes the custom-tensor path and returns
+    # `data.detach()`), such a write lands directly in this payload. FSDP1's
+    # `FlatParameter._init_metadata` sets `_strides` to the per-parameter
+    # stride list, which silently replaced the layout strides here and made
+    # every later view op read a list of tuples. Keep payload names that torch
+    # could plausibly reuse under a `_mojo_` prefix.
+    _mojo_strides: tuple[int, ...]
     _dtype: DType
     _device: object
 
@@ -316,7 +324,7 @@ class TorchMojoTensor(torch.Tensor):
       ownership mechanism, and the last drop enqueues the stream-ordered
       free (see docs/strided_owning_tensors_design.md).
     - Layout metadata as plain Python attributes (`_ptr`, `_shape`,
-      `_strides` in elements, `_offset` in elements from the allocation
+      `_mojo_strides` in elements, `_offset` in elements from the allocation
       start, `_dtype` as a max DType, `_numel`, `_itemsize`, `_device`,
       `_is_contiguous`).
 
@@ -364,7 +372,7 @@ class TorchMojoTensor(torch.Tensor):
         res._holder = holder
         res._ptr = ptr
         res._shape = shape
-        res._strides = strides
+        res._mojo_strides = strides
         res._offset = offset
         res._dtype = dtype
         res._itemsize = dtype.size_in_bytes
@@ -609,6 +617,36 @@ class TorchMojoTensor(torch.Tensor):
             return self._torch_device
         return super().device
 
+    def _set_data(self, value: torch.Tensor) -> None:
+        """``tensor.data = other`` for a wrapper whose payload is in Python.
+
+        The C++ setter reaches ``Variable::set_data``, which shallow-copies
+        the *TensorImpl* metadata and stops there. For an ordinary backend
+        that moves the storage pointer too and is the whole story; here the
+        allocation lives in this object's ``_holder``/``_ptr``, so the C++
+        path left every kernel reading the old buffer — silently, with no
+        error and wrong numbers. (FSDP1 swaps a flat parameter between its
+        sharded and unsharded buffers with exactly this assignment on every
+        unshard and reshard.) Move the payload as well.
+        """
+        if (
+            isinstance(value, TorchMojoTensor)
+            and hasattr(self, "_holder")
+            and hasattr(value, "_holder")
+        ):
+            if value._device != self._device:
+                raise RuntimeError(
+                    "tensor.data = other requires both tensors on the same mojo "
+                    f"device (got {self.device} and {value.device})"
+                )
+            _rebind_payload_exact(self, value)
+            return
+        torch._C.TensorBase.data.__set__(self, value)
+
+    # Only the setter is overridden; reads keep going straight to the C++
+    # getset descriptor so nothing about `x.data` changes for dynamo.
+    data = property(torch._C.TensorBase.data.__get__, _set_data)
+
     __torch_function__ = torch._C._disabled_torch_function_impl
 
 
@@ -648,10 +686,63 @@ class _PermuteCopyExtension(
             out._ptr,
             tensor._ptr,
             (1,) * pad + tuple(tensor._shape),
-            (0,) * pad + tuple(tensor._strides),
+            (0,) * pad + tuple(tensor._mojo_strides),
             tensor._dtype.size_in_bytes,
             _ctx_ptr(tensor._device),
         )
+
+
+_CPU_KEYSET = torch._C.DispatchKeySet(torch._C.DispatchKey.CPU)
+
+_PAYLOAD_ATTRIBUTES = (
+    "_holder",
+    "_ptr",
+    "_shape",
+    "_mojo_strides",
+    "_offset",
+    "_dtype",
+    "_itemsize",
+    "_numel",
+    "_device",
+    "_torch_device",
+    "_is_contiguous",
+)
+
+
+def _resize_tensorimpl(dst: TorchMojoTensor, shape) -> None:
+    """Set dst's TensorImpl sizes (and grow its placeholder storage)."""
+    torch.ops.aten.resize_.default.redispatch(
+        _CPU_KEYSET, dst, shape, memory_format=None
+    )
+
+
+def _as_strided_tensorimpl(dst: TorchMojoTensor, shape, strides, offset: int) -> None:
+    """State dst's TensorImpl layout exactly. Metadata only, no data moved."""
+    torch.ops.aten.as_strided_.default.redispatch(
+        _CPU_KEYSET, dst, shape, strides, offset
+    )
+
+
+def _move_payload_attributes(dst: TorchMojoTensor, src: TorchMojoTensor) -> None:
+    for name in _PAYLOAD_ATTRIBUTES:
+        setattr(dst, name, getattr(src, name))
+    # Any cached spec describes the old allocation or layout. Rebuild it on
+    # the next spec operation instead of retaining stale pointer metadata.
+    dst.__dict__.pop("_spec", None)
+
+
+def _storage_extent(tensor: TorchMojoTensor) -> int:
+    """Elements from the allocation start that `tensor`'s layout reaches."""
+    if not all(tensor._shape):
+        return tensor._offset
+    return (
+        tensor._offset
+        + 1
+        + sum(
+            (size - 1) * stride
+            for size, stride in zip(tensor._shape, tensor._mojo_strides)
+        )
+    )
 
 
 def _rebind_payload(dst: TorchMojoTensor, src: TorchMojoTensor) -> None:
@@ -670,29 +761,40 @@ def _rebind_payload(dst: TorchMojoTensor, src: TorchMojoTensor) -> None:
     to retain the original TensorImpl, then move the authoritative Mojo
     payload. No CPU tensor data is allocated or read.
     """
-    torch.ops.aten.resize_.default.redispatch(
-        torch._C.DispatchKeySet(torch._C.DispatchKey.CPU),
-        dst,
-        src._shape,
-        memory_format=None,
-    )
-    for name in (
-        "_holder",
-        "_ptr",
-        "_shape",
-        "_strides",
-        "_offset",
-        "_dtype",
-        "_itemsize",
-        "_numel",
-        "_device",
-        "_torch_device",
-        "_is_contiguous",
-    ):
-        setattr(dst, name, getattr(src, name))
-    # Any cached spec describes the old allocation or layout. Rebuild it on
-    # the next spec operation instead of retaining stale pointer metadata.
-    dst.__dict__.pop("_spec", None)
+    _resize_tensorimpl(dst, src._shape)
+    _move_payload_attributes(dst, src)
+
+
+def _rebind_payload_exact(dst: TorchMojoTensor, src: TorchMojoTensor) -> None:
+    """``_rebind_payload`` that also reproduces src's strides and offset.
+
+    ``_rebind_payload`` moves the payload and resizes the TensorImpl, but
+    ``resize_`` can only give contiguous strides at the offset the
+    destination already had. That is enough for an ``out=`` kernel, and not
+    enough for ``set_`` / ``tensor.data = view``, where the source is
+    routinely a strided view at a non-zero offset (FSDP1 hands every
+    original parameter a slice of the flat parameter this way). ``as_strided_``
+    is a metadata-only composite kernel — it calls ``setStrided`` and touches
+    no data — so redispatching it below this backend's Python kernels states
+    the layout exactly.
+
+    ``setStrided`` does bounds-check the layout against the wrapper's
+    placeholder storage, which was sized for whatever the destination used to
+    hold, so the resize that precedes it asks for the source's full extent
+    rather than its element count. Nothing is allocated either way: the
+    placeholder storage is on the Meta allocator and only its recorded byte
+    count moves.
+    """
+    if src._mojo_strides == _row_major_strides(src._shape) and src._offset == 0:
+        _rebind_payload(dst, src)
+        return
+    # Rewind to offset zero before growing: `resize_` sizes the storage from
+    # the offset the destination already has, which after an earlier exact
+    # rebind need not be zero and need not be large enough.
+    _as_strided_tensorimpl(dst, (0,), (1,), 0)
+    _resize_tensorimpl(dst, (_storage_extent(src),))
+    _move_payload_attributes(dst, src)
+    _as_strided_tensorimpl(dst, src._shape, src._mojo_strides, src._offset)
 
 
 def _resize_payload(dst: TorchMojoTensor, shape) -> None:
@@ -742,8 +844,8 @@ def _copy_strided_enqueue(dst: TorchMojoTensor, src: TorchMojoTensor) -> None:
         dst._ptr,
         src._ptr,
         _pad8(dst._shape, 1),
-        _pad8(dst._strides, 0),
-        _pad8(src._strides, 0),
+        _pad8(dst._mojo_strides, 0),
+        _pad8(src._mojo_strides, 0),
         dst._itemsize,
         _ctx_ptr(dst._device),
     )
@@ -766,8 +868,8 @@ def _copy_strided_into(dst: TorchMojoTensor, src: TorchMojoTensor) -> None:
         dst._ptr,
         src._ptr,
         _pad8(dst._shape, 1),
-        _pad8(dst._strides, 0),
-        _pad8(src._strides, 0),
+        _pad8(dst._mojo_strides, 0),
+        _pad8(src._mojo_strides, 0),
         dst._itemsize,
         _ctx_ptr(dst._device),
     )


### PR DESCRIPTION
First slice of the `ddp` branch (#421): just the standalone bugfixes, no distributed or stream machinery. Four fixes, each with a regression test where one is possible.

1. **`_strides` attribute collision → silent layout corruption.** A mojo `nn.Parameter` IS the `TorchMojoTensor` (for a wrapper subclass, `Parameter.__new__` returns `data.detach()`), so any library that writes bookkeeping attributes onto a parameter lands in the payload's namespace. torch's own `FlatParameter._init_metadata` writes `self._strides` — replacing our layout strides with a tuple of tuples, silently. The payload attribute is renamed `_mojo_strides` (mechanical, repo-wide; rationale documented at the declaration), with a regression test that writes the colliding names and checks views still resolve.

2. **`tensor.data = other` silently did nothing.** The C++ setter reaches `Variable::set_data`, which shallow-copies TensorImpl metadata and stops; the allocation lives in the Python payload, so every kernel kept reading the old buffer — no error, wrong numbers. A setter-only property now moves the payload too (including strided views at non-zero offsets); reads still go straight to the C++ getset so dynamo sees no change.

3. **Kernel-build lock crashes on filesystems that cannot flock.** Eight processes sharing one `__mojocache__` over an NFS home directory raise `OSError: ENOLCK`. The lock only dedupes concurrent identical builds — every builder writes a per-pid temp file and installs it with an atomic `os.replace` — so on `ENOLCK`/`ENOSYS`/`EOPNOTSUPP` the loader now degrades to lockless (redundant builds, correct result).

4. **`linalg_vector_norm` declined any `dtype=`.** `dtype` selects the accumulation type; it is now honoured by casting first, the same way `fast_aten_mean` does (`clip_grad_norm_` passes `dtype=torch.float32`, so gradient clipping failed on step 1 of most real training loops).

Validation: full eager + device/loader/optimizer/FA4 suites on an H100 (native ptxas 13): main baseline 1932 passed, this branch 1936 passed (the +4 are the new regression tests), zero failures either side; ruff/format clean. Note: the matmul-family suites cannot run on ptxas-12.8-only machines on main at all (its big-shared-memory GEMMs do not assemble there) -- that is what the upcoming ptxas-gating PR fixes, and why validation ran on a ptxas-13 box.

The rest of #421 (NCCL process group, streams/events, ptxas-12 dual-mode kernels) will come as separate PRs on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AbxaDeRuA7yywYEUuZV72
