### PR TITLE
Honour dtype= in linalg_vector_norm

### DIFF
--- a/tests/test_mojo_device.py
+++ b/tests/test_mojo_device.py
@@ -1188,3 +1188,15 @@ def test_pointer_ordinal_identifies_the_owning_gpu(mojo_gpu):
     assert cuda_peer.device_ordinal(0) is None
     assert cuda_peer.device_ordinal(torch.zeros(8).data_ptr()) is None
     assert not cuda_peer.same_physical_device(on_mojo._ptr, 0)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_vector_norm_with_an_accumulation_dtype(mojo_gpu_available, dtype):
+    """FSDP1's clip_grad_norm_ asks for the norm in float32 explicitly."""
+    if not mojo_gpu_available:
+        pytest.skip("requires a MAX GPU")
+    cpu = torch.randn(4096, dtype=dtype)
+    expected = torch.linalg.vector_norm(cpu, 2.0, dtype=torch.float32)
+    got = torch.linalg.vector_norm(cpu.to("mojo:0"), 2.0, dtype=torch.float32)
+    assert got.dtype == torch.float32
+    torch.testing.assert_close(got.cpu(), expected, rtol=1e-5, atol=1e-4)

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -5635,17 +5635,29 @@ def fast_aten_linalg_vector_norm(self, ord=2, dim=None, keepdim=False, *, dtype=
     It used to be composed here as mul -> sum -> sqrt, which is three launches
     and a temporary the size of the input for a reduction that reads each
     element once.
+
+    ``dtype`` selects the accumulation type, so it is honoured by casting
+    first, the same way ``fast_aten_mean`` does. FSDP1's
+    ``clip_grad_norm_`` always passes ``dtype=torch.float32``.
     """
     a = _t(self)
     if (
         a is None
-        or a._dtype not in _FLOAT_DTYPES
         or not isinstance(ord, int | float)
         or isinstance(ord, bool)
         or ord != 2
-        or dtype is not None
         or not isinstance(keepdim, bool)
     ):
+        return NOT_HANDLED
+    if dtype is not None:
+        target = _torch_dtype_to_max(dtype)
+        if target is None or target not in _FLOAT_DTYPES:
+            return NOT_HANDLED
+        if a._dtype != target:
+            if a._dtype not in _CAST_DTYPES or target not in _CAST_DTYPES:
+                return NOT_HANDLED
+            a = _cast_tensor(a, target)
+    if a._dtype not in _FLOAT_DTYPES:
         return NOT_HANDLED
     rank = len(a._shape)
     rdims = _norm_reduce_dims(dim, rank, empty_is_all=True)


### PR DESCRIPTION
The `linalg_vector_norm` fast path declined any `dtype=`, so the op fell through to `NotImplementedError`. `dtype` selects the accumulation type; it is now honoured by casting first, the same way `fast_aten_mean` does. `clip_grad_norm_` passes `dtype=torch.float32`, so gradient clipping failed on the first step of most real training loops. Regression test included (f32 and bf16 inputs accumulating in f32).

Split out of #422. Note: the four bugfix PRs each append a regression test at the end of `tests/test_mojo_device.py`, so whichever merges later hits a trivial append conflict there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AbxaDeRuA7yywYEUuZV72
