### PR TITLE
Add aten::set_.source_Tensor (adopt another tensor's allocation in place)

### DIFF
--- a/benchmarks/test_coverage.py
+++ b/benchmarks/test_coverage.py
@@ -120,6 +120,11 @@ SKIPPED_OPS: dict[str, str] = {
         "reader (device_streams.record_use). No kernel launches, so there "
         "is no device time to measure"
     ),
+    # -- metadata-only mutation -------------------------------------------
+    "aten::set_.source_Tensor": (
+        "repoints a tensor at another's allocation in place: payload rebind "
+        "plus TensorImpl metadata, zero-copy and no kernel"
+    ),
     # -- out-variant plumbing --------------------------------------------
     "aten::addcdiv.out": _OUT,
     "aten::addcmul.out": _OUT,

--- a/tests/test_mojo_device.py
+++ b/tests/test_mojo_device.py
@@ -1309,3 +1309,17 @@ def test_as_strided_zero_copy_view(mojo_gpu_available):
     # A layout that would reach past the allocation must be refused.
     with pytest.raises(NotImplementedError):
         torch.as_strided(dev, (5, 4), (8, 2), 1)
+
+
+def test_set_source_tensor_adopts_the_allocation(mojo_gpu_available):
+    if not mojo_gpu_available:
+        pytest.skip("requires a MAX GPU")
+    destination = torch.zeros(8, device="mojo:0")
+    source = torch.arange(4, dtype=torch.float32, device="mojo:0") + 50
+    returned = destination.set_(source)  # ty: ignore[invalid-argument-type] -- torch's stub lacks the Tensor overload
+    assert returned is destination
+    assert tuple(destination.shape) == (4,)
+    assert destination.cpu().tolist() == [50.0, 51.0, 52.0, 53.0]
+    # Sharing the allocation, not a copy of it.
+    source.add_(1.0)
+    assert destination.cpu().tolist() == [51.0, 52.0, 53.0, 54.0]

--- a/torch_mojo_backend/mojo_device/aten_ops/inplace.py
+++ b/torch_mojo_backend/mojo_device/aten_ops/inplace.py
@@ -6,7 +6,10 @@ from torch_mojo_backend.mojo_device.aten_ops.support import (
     _refuse_unsupported_backward,
     _unsupported,
 )
-from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
+from torch_mojo_backend.mojo_device.torch_mojo_tensor import (
+    TorchMojoTensor,
+    _rebind_payload_exact,
+)
 
 
 def mojo_device_add_(
@@ -64,6 +67,30 @@ def mojo_device_relu_(self: TorchMojoTensor) -> TorchMojoTensor:
     if result is aten_fast.NOT_HANDLED:
         raise _unsupported("aten::relu_", (self,))
     _copy_into_tensor(self, result)
+    return self
+
+
+def mojo_device_set__source_tensor(
+    self: TorchMojoTensor, source: TorchMojoTensor
+) -> TorchMojoTensor:
+    """``self.set_(source)``: adopt source's allocation and layout in place.
+
+    ``set_`` is the one op that repoints a tensor at another tensor's
+    storage without copying, keeping the Python object's identity — which is
+    why FSDP1 uses it to turn a flat parameter into its own shard
+    (``FlatParamHandle.shard``). Views already sharing this tensor's holder
+    keep pointing at the old allocation, exactly as on a storage-backed
+    backend; the allocation itself survives while any of them holds a
+    reference.
+    """
+    if not isinstance(self, TorchMojoTensor) or not isinstance(source, TorchMojoTensor):
+        raise _unsupported("aten::set_.source_Tensor", (self, source))
+    if self._device != source._device:
+        raise RuntimeError(
+            "aten::set_.source_Tensor requires both tensors on the same mojo "
+            f"device (got {self.device} and {source.device})"
+        )
+    _rebind_payload_exact(self, source)
     return self
 
 

--- a/torch_mojo_backend/mojo_device/mojo_device_aten_ops.py
+++ b/torch_mojo_backend/mojo_device/mojo_device_aten_ops.py
@@ -71,6 +71,7 @@ from torch_mojo_backend.mojo_device.aten_ops.inplace import (
     mojo_device_masked_fill_,
     mojo_device_mul_,
     mojo_device_relu_,
+    mojo_device_set__source_tensor,
     mojo_device_zero_,
 )
 from torch_mojo_backend.mojo_device.aten_ops.reductions import (
@@ -395,6 +396,7 @@ _register_out(
 )
 _register_fast("aten::select_scatter", "fast_aten_select_scatter")
 _register_fast("aten::select.int", "fast_aten_select")
+register_aten_op("aten::set_.source_Tensor")(mojo_device_set__source_tensor)
 register_aten_op("aten::sigmoid")(mojo_device_sigmoid)
 _register_fast("aten::sign", "fast_aten_sign")
 _register_fast("aten::silu", "fast_aten_silu")


### PR DESCRIPTION
`set_` repoints self at source's allocation in place: the payload moves (holder, pointer, layout) and the TensorImpl metadata is restated to source's exact sizes/strides/offset via the `_rebind_payload_exact` helper that landed with #426 — zero-copy, sharing not copying. Regression test asserts the aliasing.

Slice of #421; independent of the other slices. Validated: eager + device suites green on an H100 (ptxas 13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AbxaDeRuA7yywYEUuZV72
