### PR TITLE
Gate >48KiB-static-smem GEMM routes on a ptxas capability probe

### DIFF
--- a/docs/kernel_call_queue.md
+++ b/docs/kernel_call_queue.md
@@ -112,38 +112,15 @@ it. An unsupported dtype or flag reported by Mojo indicates a bug in Python's
 definition mapping and is surfaced directly. There is no widening, dtype
 escalation, fallback build, or launch-time retry.
 
-That is also why a toolchain limit has to be answered before the build, not
-after it. ptxas caps a kernel's *static* shared memory at 48 KiB up to CUDA
-12.8 and lifts the cap in CUDA 13; it enforces that inside `mojo build`, and
-one over-limit kernel fails the whole `.so`, so on an older assembler the
-matmul families would not be slow, they would be unimportable. Python asks
-the real toolchain rather than guessing which assembler MAX will use:
-`_ptxas_supports_big_static_smem` builds `eager_kernels/ptxas_probe.mojo` --
-a GPU kernel whose only content is a static `.shared` array sized by a `-D
-PROBE_SIZE` define -- with the loader's own `mojo build`, once for a size
-over the ceiling and, only if that fails, once more for a control size at
-exactly the ceiling (a failing control means the toolchain itself is unusable
-for the probe, not that it is capped, so the answer stays the pre-probe
-default). `mojo build` only shells out to the binary
-`MODULAR_NVPTX_COMPILER_PATH` names when it auto-detects a real accelerator
-to build for -- an explicit `--target-accelerator`, or no accelerator
-attached at all, both make it defer to PTX-only embedding and never touch
-that binary -- so the probe is built the same way, and is only ever
-consulted in practice where a real accelerator already exists
-(`big_static_smem_flags` runs while building an actual GEMM/BMM extension for
-an actual mojo device). `_ptxas_supports_big_static_smem` sends
-`PTXAS_BIG_SMEM=1` only when the over-ceiling build succeeds. Absent, the
-`_big_static_smem_on()` gate compiles the wgmma/TMA GEMM routes out and the
-smaller routes that already serve those shapes take over. With no
-`MODULAR_NVPTX_COMPILER_PATH` set, MAX assembles in-process with the compiler
-it ships and the define is always sent, so a default install compiles
-exactly what it always did -- and no probe build ever runs, since that
-in-process compiler is never named by a binary path to fingerprint. A build's
-verdict is memoized on disk under `__mojocache__`, keyed by toolchain
-identity plus the named binary's path and size/mtime, so only the first
-process per (toolchain, compiler binary) pays the `mojo build` seconds.
-`TORCH_MOJO_BACKEND_PTXAS_BIG_SMEM=0`/`=1` overrides the probe, short-circuiting
-before either the build or the disk cache.
+A toolchain limit has to be answered before the build for the same reason.
+ptxas caps a kernel's *static* shared memory at 48 KiB through CUDA 12.8, and
+one over-limit kernel fails the whole `.so`. `_ptxas_supports_big_static_smem`
+(eager_kernels/__init__.py) builds `ptxas_probe.mojo` once per (toolchain,
+`MODULAR_NVPTX_COMPILER_PATH` binary) to find out, and sends `PTXAS_BIG_SMEM=1`
+only when the assembler accepts it; otherwise `_big_static_smem_on()` in
+variant_gates.mojo compiles the wgmma/TMA GEMM routes out and the smaller
+routes serve their shapes. `TORCH_MOJO_BACKEND_PTXAS_BIG_SMEM=0`/`=1`
+overrides the probe.
 
 Builds are protected by a per-identity file lock (`flock`) and written to a
 temporary file before an atomic rename. Concurrent requests for one identity,

--- a/docs/kernel_call_queue.md
+++ b/docs/kernel_call_queue.md
@@ -116,15 +116,34 @@ That is also why a toolchain limit has to be answered before the build, not
 after it. ptxas caps a kernel's *static* shared memory at 48 KiB up to CUDA
 12.8 and lifts the cap in CUDA 13; it enforces that inside `mojo build`, and
 one over-limit kernel fails the whole `.so`, so on an older assembler the
-matmul families would not be slow, they would be unimportable. Python probes
-the assembler `MODULAR_NVPTX_COMPILER_PATH` names (`big_static_smem_flags`,
-`_ptxas_supports_big_static_smem`) and sends `PTXAS_BIG_SMEM=1` only when it
-takes the larger allocation. Absent, the `_big_static_smem_on()` gate compiles
-the wgmma/TMA GEMM routes out and the smaller routes that already serve those
-shapes take over. With no such variable set, MAX assembles in-process with the
-compiler it ships and the define is always sent, so a default install compiles
-exactly what it always did. `TORCH_MOJO_BACKEND_PTXAS_BIG_SMEM=0`/`=1`
-overrides the probe.
+matmul families would not be slow, they would be unimportable. Python asks
+the real toolchain rather than guessing which assembler MAX will use:
+`_ptxas_supports_big_static_smem` builds `eager_kernels/ptxas_probe.mojo` --
+a GPU kernel whose only content is a static `.shared` array sized by a `-D
+PROBE_SIZE` define -- with the loader's own `mojo build`, once for a size
+over the ceiling and, only if that fails, once more for a control size at
+exactly the ceiling (a failing control means the toolchain itself is unusable
+for the probe, not that it is capped, so the answer stays the pre-probe
+default). `mojo build` only shells out to the binary
+`MODULAR_NVPTX_COMPILER_PATH` names when it auto-detects a real accelerator
+to build for -- an explicit `--target-accelerator`, or no accelerator
+attached at all, both make it defer to PTX-only embedding and never touch
+that binary -- so the probe is built the same way, and is only ever
+consulted in practice where a real accelerator already exists
+(`big_static_smem_flags` runs while building an actual GEMM/BMM extension for
+an actual mojo device). `_ptxas_supports_big_static_smem` sends
+`PTXAS_BIG_SMEM=1` only when the over-ceiling build succeeds. Absent, the
+`_big_static_smem_on()` gate compiles the wgmma/TMA GEMM routes out and the
+smaller routes that already serve those shapes take over. With no
+`MODULAR_NVPTX_COMPILER_PATH` set, MAX assembles in-process with the compiler
+it ships and the define is always sent, so a default install compiles
+exactly what it always did -- and no probe build ever runs, since that
+in-process compiler is never named by a binary path to fingerprint. A build's
+verdict is memoized on disk under `__mojocache__`, keyed by toolchain
+identity plus the named binary's path and size/mtime, so only the first
+process per (toolchain, compiler binary) pays the `mojo build` seconds.
+`TORCH_MOJO_BACKEND_PTXAS_BIG_SMEM=0`/`=1` overrides the probe, short-circuiting
+before either the build or the disk cache.
 
 Builds are protected by a per-identity file lock (`flock`) and written to a
 temporary file before an atomic rename. Concurrent requests for one identity,

--- a/docs/kernel_call_queue.md
+++ b/docs/kernel_call_queue.md
@@ -112,6 +112,20 @@ it. An unsupported dtype or flag reported by Mojo indicates a bug in Python's
 definition mapping and is surfaced directly. There is no widening, dtype
 escalation, fallback build, or launch-time retry.
 
+That is also why a toolchain limit has to be answered before the build, not
+after it. ptxas caps a kernel's *static* shared memory at 48 KiB up to CUDA
+12.8 and lifts the cap in CUDA 13; it enforces that inside `mojo build`, and
+one over-limit kernel fails the whole `.so`, so on an older assembler the
+matmul families would not be slow, they would be unimportable. Python probes
+the assembler `MODULAR_NVPTX_COMPILER_PATH` names (`big_static_smem_flags`,
+`_ptxas_supports_big_static_smem`) and sends `PTXAS_BIG_SMEM=1` only when it
+takes the larger allocation. Absent, the `_big_static_smem_on()` gate compiles
+the wgmma/TMA GEMM routes out and the smaller routes that already serve those
+shapes take over. With no such variable set, MAX assembles in-process with the
+compiler it ships and the define is always sent, so a default install compiles
+exactly what it always did. `TORCH_MOJO_BACKEND_PTXAS_BIG_SMEM=0`/`=1`
+overrides the probe.
+
 Builds are protected by a per-identity file lock (`flock`) and written to a
 temporary file before an atomic rename. Concurrent requests for one identity,
 in this process or another, compile it once, and an interrupted compiler

--- a/tests/test_ptxas_gating.py
+++ b/tests/test_ptxas_gating.py
@@ -12,7 +12,6 @@ import subprocess
 import sys
 from collections.abc import Iterator
 from pathlib import Path
-from typing import ClassVar
 
 import pytest
 from max.dtype import DType
@@ -246,10 +245,10 @@ def test_matmul_spec_defines_carry_the_flag_and_agree_with_the_cache_key(
 class _StubTensor:
     """A `MojoTensorLike` stand-in; the define hooks read only `_dtype`."""
 
-    _shape: ClassVar[tuple[int, ...]] = (4, 4)
-    _mojo_strides: ClassVar[tuple[int, ...]] = (4, 1)
-    _dtype: ClassVar[DType] = DType.float32
-    _device: ClassVar[object] = None
+    _shape: tuple[int, ...] = (4, 4)
+    _mojo_strides: tuple[int, ...] = (4, 1)
+    _dtype: DType = DType.float32
+    _device: object = None
 
 
 def test_gated_routes_leave_an_unconditional_fallback_behind() -> None:

--- a/tests/test_ptxas_gating.py
+++ b/tests/test_ptxas_gating.py
@@ -9,6 +9,15 @@ and the loader has no run-time fallback to soften that
 (docs/kernel_call_queue.md). `PTXAS_BIG_SMEM` compiles those routes out
 instead, leaving the ones that already fit.
 
+The probe itself works by actually building `ptxas_probe.mojo` with
+`mojo build` (see eager_kernels._ptxas_assembles): the fakes below stand in
+for the assembler that build shells out to, not for a compiler this test
+invokes directly. `mojo build` only shells out to it when auto-detecting a
+real, physically attached accelerator, so tests that need at least one leg to
+genuinely reach the fake are gated on `real_accelerator`; the two tests where
+both legs fail regardless of *why* (missing binary, no attached accelerator)
+are not.
+
 Two properties matter and are tested separately: the probe must answer for
 the assembler that will actually be used, and the gate must leave a correct
 kernel behind for every shape the removed routes used to claim.
@@ -25,6 +34,7 @@ from typing import ClassVar
 
 import pytest
 from max.dtype import DType
+from max.driver import accelerator_count
 
 from torch_mojo_backend import eager_kernels, get_accelerators
 
@@ -40,26 +50,54 @@ _BIG, _CONTROL = eager_kernels._PTXAS_PROBE_SIZES
 
 @pytest.fixture(autouse=True)
 def _clear_probe_cache() -> Iterator[None]:
-    """The probe is process-cached; every test here sets up its own answer."""
+    """The probe is process-cached; every test here sets up its own answer.
+
+    Only the in-process `functools.cache` layer: the on-disk verdict cache is
+    keyed by the fake assembler's own path plus its file's size+mtime
+    (`_ptxas_probe_cache_path`), and every test here builds its fake under
+    pytest's per-test `tmp_path`, so distinct tests never share an entry.
+    """
     eager_kernels._ptxas_supports_big_static_smem.cache_clear()
     yield
     eager_kernels._ptxas_supports_big_static_smem.cache_clear()
 
 
-def _fake_ptxas(tmp_path: Path, *, ceiling: int | None, exit_code: int = 1) -> str:
-    """A stand-in `ptxas` that accepts static shared memory up to `ceiling`.
+@pytest.fixture(scope="module")
+def real_accelerator() -> None:
+    """`mojo build` shells out to `MODULAR_NVPTX_COMPILER_PATH` only when it
+    auto-detects a real, physically attached accelerator to build for
+    (verified empirically: an explicit `--target-accelerator`, or none
+    attached at all, both make it defer to PTX-only embedding and never
+    touch that env var — see eager_kernels._ptxas_assembles). A test that
+    needs the fake to actually be reached and accept a leg needs one.
 
-    It reads the `.shared` request out of the probe PTX the way the real one
-    does, so a probe that stopped emitting a shared array (and therefore
-    stopped testing anything) fails here instead of silently passing.
-    `ceiling=None` refuses everything, standing in for an assembler that
-    cannot answer the question at all.
+    `get_accelerators()` always appends a CPU pseudo-device (so `mojo:0`
+    resolves somewhere even without one), so its list is truthy either way;
+    `accelerator_count()` is the actual "is a real accelerator attached?"
+    primitive it and `sm90_mojo_gpu` are both built from.
+    """
+    if accelerator_count() == 0:
+        pytest.skip("the build-based ptxas probe needs a real accelerator")
+
+
+def _fake_ptxas(tmp_path: Path, *, ceiling: int | None, exit_code: int = 1) -> str:
+    """A stand-in assembler `mojo build` shells out to, accepting static
+    shared memory up to `ceiling`.
+
+    It reads the `.shared` request out of the PTX `mojo build` hands it the
+    way the real ptxas does, so a probe kernel that stopped declaring a
+    shared array (and therefore stopped testing anything) fails here instead
+    of silently passing. `ceiling=None` refuses everything, standing in for
+    an assembler that cannot answer the question at all. It also writes the
+    `-o` output path on success, matching a real assembler closely enough
+    that a future `mojo build` which starts checking for it still works.
     """
     script = tmp_path / "fake_ptxas"
     script.write_text(
         "#!/usr/bin/env python3\n"
         "import re, sys\n"
-        "source = [a for a in sys.argv[1:] if a.endswith('.ptx')]\n"
+        "args = sys.argv[1:]\n"
+        "source = [a for a in args if a.endswith('.ptx')]\n"
         "if not source:\n"
         "    sys.exit(2)\n"
         "text = open(source[0]).read()\n"
@@ -71,6 +109,8 @@ def _fake_ptxas(tmp_path: Path, *, ceiling: int | None, exit_code: int = 1) -> s
         "if ceiling is None or max(sizes) > ceiling:\n"
         "    sys.stderr.write('ptxas error   : uses too much shared data\\n')\n"
         f"    sys.exit({exit_code})\n"
+        "if '-o' in args:\n"
+        "    open(args[args.index('-o') + 1], 'wb').close()\n"
         "sys.exit(0)\n"
     )
     script.chmod(0o755)
@@ -117,7 +157,7 @@ def test_env_override_beats_the_probe(
 
 
 def test_assembler_that_takes_the_big_request_keeps_the_fast_routes(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    real_accelerator: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     monkeypatch.delenv(eager_kernels._PTXAS_BIG_SMEM_ENV, raising=False)
     monkeypatch.setenv(
@@ -129,7 +169,7 @@ def test_assembler_that_takes_the_big_request_keeps_the_fast_routes(
 
 
 def test_assembler_capped_at_48kib_compiles_the_big_routes_out(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    real_accelerator: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """The CUDA 12.x case: the control leg passes, the big one does not.
 
@@ -169,22 +209,73 @@ def test_assembler_that_cannot_be_run_is_not_evidence_of_a_cap(
     assert eager_kernels._PTXAS_BIG_SMEM_ENV in capsys.readouterr().err
 
 
-def test_probe_ptx_declares_more_than_the_ceiling_and_uses_it() -> None:
+def test_disk_cache_reprobes_only_when_the_assembler_fingerprint_changes(
+    real_accelerator: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A warm process must read the on-disk verdict, not rebuild, unless the
+    binary `MODULAR_NVPTX_COMPILER_PATH` names actually changed.
+
+    The "changed" leg uses a second, distinct path rather than overwriting
+    the first path's file in place: `mojo build` turns out to keep its own
+    persistent compilation cache (under `MODULAR_HOME`, confirmed to survive
+    across separate processes) keyed on the compiler *path string*, not on
+    the bytes at that path, so replacing a binary in place while `mojo`
+    itself has already cached an answer for that exact path is not something
+    this probe -- or any caller of `mojo build` -- can observe. A distinct
+    install path (a different CUDA toolkit directory, the realistic trigger
+    for "the assembler changed") is exactly the case the size+mtime
+    fingerprint has to catch, and it is what this test exercises.
+    """
+    monkeypatch.delenv(eager_kernels._PTXAS_BIG_SMEM_ENV, raising=False)
+    path = _fake_ptxas(tmp_path, ceiling=_BIG)
+    monkeypatch.setenv("MODULAR_NVPTX_COMPILER_PATH", path)
+
+    assert eager_kernels._ptxas_supports_big_static_smem() is True
+    cache_file = eager_kernels._ptxas_probe_cache_path(path)
+    assert cache_file.is_file()
+
+    # A fresh functools.cache (a new process, in effect) with the same
+    # fingerprint must read the disk verdict and never call mojo build again.
+    eager_kernels._ptxas_supports_big_static_smem.cache_clear()
+    calls: list[int] = []
+    real_ptxas_assembles = eager_kernels._ptxas_assembles
+    monkeypatch.setattr(
+        eager_kernels,
+        "_ptxas_assembles",
+        lambda size: calls.append(size) or real_ptxas_assembles(size),
+    )
+    assert eager_kernels._ptxas_supports_big_static_smem() is True
+    assert calls == []
+
+    # A different assembler at a different path is a different fingerprint
+    # (different path string alone already changes the cache key; a fresh
+    # binary's distinct size/mtime is the part this test is really after),
+    # which must force a fresh probe with the new, correct answer.
+    eager_kernels._ptxas_supports_big_static_smem.cache_clear()
+    other_dir = tmp_path / "other"
+    other_dir.mkdir()
+    other_path = _fake_ptxas(other_dir, ceiling=_CONTROL)
+    monkeypatch.setenv("MODULAR_NVPTX_COMPILER_PATH", other_path)
+    assert eager_kernels._ptxas_probe_cache_path(other_path) != cache_file
+    assert eager_kernels._ptxas_supports_big_static_smem() is False
+    assert calls, "a changed fingerprint must not be served from the stale entry"
+
+
+def test_probe_source_declares_more_than_the_ceiling_and_uses_it() -> None:
     """Guard rails on the probe source itself.
 
-    Assembling PTX that declares no shared memory, or whose array the
-    assembler can prove dead, would answer True everywhere — a probe that
-    always passes is worse than no probe, because it looks like evidence.
+    A kernel whose shared buffer the compiler can prove dead would assemble
+    everywhere regardless of size — a probe that always passes is worse than
+    no probe, because it looks like evidence.
     """
-    text = eager_kernels._PTXAS_PROBE_PTX
+    text = eager_kernels._PTXAS_PROBE_SOURCE.read_text()
     assert _BIG > _CONTROL == 49152
-    assert ".shared .align 16 .b8 probe_shared_buffer[__SIZE__];" in text
-    # Written, read back, and stored to a caller-visible pointer: nothing in
-    # that chain is removable.
-    assert "st.shared.u32" in text
-    assert "ld.shared.u32" in text
-    assert "st.global.u32" in text
-    assert ".target sm_90a" in text
+    assert "address_space=AddressSpace.SHARED" in text
+    assert "stack_allocation[" in text
+    # Written, barrier-synced, read back, and stored to a caller-visible
+    # pointer: nothing in that chain is provably dead.
+    assert "barrier()" in text
+    assert "out_ptr[0]" in text
 
 
 def test_only_the_two_families_with_big_smem_routes_send_the_define() -> None:

--- a/tests/test_ptxas_gating.py
+++ b/tests/test_ptxas_gating.py
@@ -14,8 +14,8 @@ from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
-from max.dtype import DType
 from max.driver import accelerator_count
+from max.dtype import DType
 
 from torch_mojo_backend import eager_kernels, get_accelerators
 
@@ -34,7 +34,7 @@ def _clear_probe_cache() -> Iterator[None]:
 
 
 @pytest.fixture(scope="module")
-def real_accelerator() -> None:
+def real_accelerator():
     # `get_accelerators()` is truthy even without one (CPU pseudo-device).
     if accelerator_count() == 0:
         pytest.skip("the build-based ptxas probe needs a real accelerator")
@@ -73,12 +73,12 @@ def _fake_ptxas(tmp_path: Path, *, ceiling: int | None, exit_code: int = 1) -> s
 
 def test_bundled_assembler_is_assumed_to_take_big_static_shared(
     monkeypatch: pytest.MonkeyPatch,
-) -> None:
+):
     """No compiler path set: MAX assembles in-process and nothing is probed."""
     monkeypatch.delenv("MODULAR_NVPTX_COMPILER_PATH", raising=False)
     monkeypatch.delenv(eager_kernels._PTXAS_BIG_SMEM_ENV, raising=False)
 
-    def fail(*args: object, **kwargs: object) -> None:
+    def fail(*args: object, **kwargs: object):
         raise AssertionError("the probe must not exec anything with no compiler set")
 
     monkeypatch.setattr(eager_kernels, "_ptxas_assembles", fail)
@@ -90,7 +90,7 @@ def test_bundled_assembler_is_assumed_to_take_big_static_shared(
 @pytest.mark.parametrize(("override", "expected"), [("0", False), ("1", True)])
 def test_env_override_beats_the_probe(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, override: str, expected: bool
-) -> None:
+):
     """The override wins in both directions over a live probe."""
     # The fake answers the opposite of the override, so an ignored override fails.
     monkeypatch.setenv(
@@ -105,7 +105,7 @@ def test_env_override_beats_the_probe(
 
 def test_assembler_that_takes_the_big_request_keeps_the_fast_routes(
     real_accelerator: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+):
     monkeypatch.delenv(eager_kernels._PTXAS_BIG_SMEM_ENV, raising=False)
     monkeypatch.setenv(
         "MODULAR_NVPTX_COMPILER_PATH", _fake_ptxas(tmp_path, ceiling=_BIG)
@@ -117,7 +117,7 @@ def test_assembler_that_takes_the_big_request_keeps_the_fast_routes(
 
 def test_assembler_capped_at_48kib_compiles_the_big_routes_out(
     real_accelerator: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+):
     """The CUDA 12.x case: the control leg passes, the big one does not."""
     monkeypatch.delenv(eager_kernels._PTXAS_BIG_SMEM_ENV, raising=False)
     monkeypatch.setenv(
@@ -130,7 +130,7 @@ def test_assembler_capped_at_48kib_compiles_the_big_routes_out(
 
 def test_assembler_that_fails_both_legs_is_not_evidence_of_a_cap(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
+):
     """An uninformative probe keeps the default rather than downgrading forever."""
     monkeypatch.delenv(eager_kernels._PTXAS_BIG_SMEM_ENV, raising=False)
     monkeypatch.setenv(
@@ -143,7 +143,7 @@ def test_assembler_that_fails_both_legs_is_not_evidence_of_a_cap(
 
 def test_assembler_that_cannot_be_run_is_not_evidence_of_a_cap(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
+):
     monkeypatch.delenv(eager_kernels._PTXAS_BIG_SMEM_ENV, raising=False)
     monkeypatch.setenv("MODULAR_NVPTX_COMPILER_PATH", str(tmp_path / "no-such-ptxas"))
 
@@ -153,7 +153,7 @@ def test_assembler_that_cannot_be_run_is_not_evidence_of_a_cap(
 
 def test_disk_cache_reprobes_only_when_the_assembler_fingerprint_changes(
     real_accelerator: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+):
     """A warm process reads the disk verdict; a different binary reprobes.
 
     The changed leg uses a second path, not an in-place overwrite: `mojo
@@ -191,7 +191,7 @@ def test_disk_cache_reprobes_only_when_the_assembler_fingerprint_changes(
     assert calls, "a changed fingerprint must not be served from the stale entry"
 
 
-def test_probe_source_declares_more_than_the_ceiling_and_uses_it() -> None:
+def test_probe_source_declares_more_than_the_ceiling_and_uses_it():
     """A probe whose buffer the compiler can prove dead would pass everywhere."""
     text = eager_kernels._PTXAS_PROBE_SOURCE.read_text()
     assert _BIG > _CONTROL == 49152
@@ -201,7 +201,7 @@ def test_probe_source_declares_more_than_the_ceiling_and_uses_it() -> None:
     assert "out_ptr[0]" in text
 
 
-def test_only_the_two_families_with_big_smem_routes_send_the_define() -> None:
+def test_only_the_two_families_with_big_smem_routes_send_the_define():
     """An unread define forks a byte-identical build, so senders must have readers."""
     aten_fast = (_KERNEL_DIR / "aten_fast.py").read_text()
     senders = aten_fast.count("big_static_smem_flags()")
@@ -222,7 +222,7 @@ def test_only_the_two_families_with_big_smem_routes_send_the_define() -> None:
 
 def test_matmul_spec_defines_carry_the_flag_and_agree_with_the_cache_key(
     monkeypatch: pytest.MonkeyPatch,
-) -> None:
+):
     """A flag on the compile line but not in the cache key would file a gated
     .so under the ungated name."""
     from torch_mojo_backend.eager_kernels import aten_fast
@@ -251,7 +251,7 @@ class _StubTensor:
     _device: object = None
 
 
-def test_gated_routes_leave_an_unconditional_fallback_behind() -> None:
+def test_gated_routes_leave_an_unconditional_fallback_behind():
     """The fallback call must sit outside every `comptime if`, or a gated
     build enqueues nothing for those shapes."""
     v3 = (_KERNEL_DIR / "gemm16_matmul_ops" / "gemm16_v3_kernels.mojo").read_text()
@@ -265,7 +265,7 @@ def test_gated_routes_leave_an_unconditional_fallback_behind() -> None:
 
 
 @pytest.fixture(scope="module")
-def sm90_mojo_gpu() -> None:
+def sm90_mojo_gpu():
     accelerators = list(get_accelerators())
     if not accelerators or accelerators[0].api != "cuda":
         pytest.skip("the gated routes are NVIDIA-only")
@@ -367,7 +367,7 @@ sys.exit(0)
 
 def test_gated_build_still_computes_the_right_answers(
     sm90_mojo_gpu: None, tmp_path: Path
-) -> None:
+):
     """With the fast routes compiled out, mm/bmm/linear/SDPA still match CPU.
     Compiles two extension families on first run."""
     worker = tmp_path / "ptxas_fallback_worker.py"

--- a/tests/test_ptxas_gating.py
+++ b/tests/test_ptxas_gating.py
@@ -1,26 +1,8 @@
-"""The ptxas static-shared-memory gate: probe, defines, and the fallback.
+"""The ptxas static-shared-memory gate (`_ptxas_supports_big_static_smem`).
 
-ptxas caps a kernel's *static* `.shared` at 48 KiB (0xc000) through CUDA 12.8
-and lifts the cap in CUDA 13. It enforces that at assembly time inside
-`mojo build`, and one over-limit kernel fails the whole shared library — so
-on a machine whose `MODULAR_NVPTX_COMPILER_PATH` names an older assembler the
-matmul extensions do not merely lose their fast routes, they stop importing,
-and the loader has no run-time fallback to soften that
-(docs/kernel_call_queue.md). `PTXAS_BIG_SMEM` compiles those routes out
-instead, leaving the ones that already fit.
-
-The probe itself works by actually building `ptxas_probe.mojo` with
-`mojo build` (see eager_kernels._ptxas_assembles): the fakes below stand in
-for the assembler that build shells out to, not for a compiler this test
-invokes directly. `mojo build` only shells out to it when auto-detecting a
-real, physically attached accelerator, so tests that need at least one leg to
-genuinely reach the fake are gated on `real_accelerator`; the two tests where
-both legs fail regardless of *why* (missing binary, no attached accelerator)
-are not.
-
-Two properties matter and are tested separately: the probe must answer for
-the assembler that will actually be used, and the gate must leave a correct
-kernel behind for every shape the removed routes used to claim.
+The fakes stand in for the assembler `mojo build` shells out to
+(`MODULAR_NVPTX_COMPILER_PATH`), which it only does with a real accelerator
+attached; tests where a leg must reach the fake need `real_accelerator`.
 """
 
 from __future__ import annotations
@@ -41,22 +23,12 @@ from torch_mojo_backend import eager_kernels, get_accelerators
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _KERNEL_DIR = _REPO_ROOT / "torch_mojo_backend" / "eager_kernels"
 
-# The probe asks for this many bytes of static shared memory, which is over
-# every ptxas's un-opted-in ceiling, and falls back to asking for exactly the
-# ceiling. Both numbers are part of the contract with the fake assemblers
-# below, so read them from the module rather than restating them.
 _BIG, _CONTROL = eager_kernels._PTXAS_PROBE_SIZES
 
 
 @pytest.fixture(autouse=True)
 def _clear_probe_cache() -> Iterator[None]:
-    """The probe is process-cached; every test here sets up its own answer.
-
-    Only the in-process `functools.cache` layer: the on-disk verdict cache is
-    keyed by the fake assembler's own path plus its file's size+mtime
-    (`_ptxas_probe_cache_path`), and every test here builds its fake under
-    pytest's per-test `tmp_path`, so distinct tests never share an entry.
-    """
+    """In-process layer only; the disk cache is per test via the fake's tmp_path."""
     eager_kernels._ptxas_supports_big_static_smem.cache_clear()
     yield
     eager_kernels._ptxas_supports_big_static_smem.cache_clear()
@@ -64,33 +36,16 @@ def _clear_probe_cache() -> Iterator[None]:
 
 @pytest.fixture(scope="module")
 def real_accelerator() -> None:
-    """`mojo build` shells out to `MODULAR_NVPTX_COMPILER_PATH` only when it
-    auto-detects a real, physically attached accelerator to build for
-    (verified empirically: an explicit `--target-accelerator`, or none
-    attached at all, both make it defer to PTX-only embedding and never
-    touch that env var — see eager_kernels._ptxas_assembles). A test that
-    needs the fake to actually be reached and accept a leg needs one.
-
-    `get_accelerators()` always appends a CPU pseudo-device (so `mojo:0`
-    resolves somewhere even without one), so its list is truthy either way;
-    `accelerator_count()` is the actual "is a real accelerator attached?"
-    primitive it and `sm90_mojo_gpu` are both built from.
-    """
+    # `get_accelerators()` is truthy even without one (CPU pseudo-device).
     if accelerator_count() == 0:
         pytest.skip("the build-based ptxas probe needs a real accelerator")
 
 
 def _fake_ptxas(tmp_path: Path, *, ceiling: int | None, exit_code: int = 1) -> str:
-    """A stand-in assembler `mojo build` shells out to, accepting static
-    shared memory up to `ceiling`.
+    """An assembler accepting static `.shared` up to `ceiling` (None: nothing).
 
-    It reads the `.shared` request out of the PTX `mojo build` hands it the
-    way the real ptxas does, so a probe kernel that stopped declaring a
-    shared array (and therefore stopped testing anything) fails here instead
-    of silently passing. `ceiling=None` refuses everything, standing in for
-    an assembler that cannot answer the question at all. It also writes the
-    `-o` output path on success, matching a real assembler closely enough
-    that a future `mojo build` which starts checking for it still works.
+    It parses the sizes out of the PTX, so a probe kernel that stopped
+    declaring shared memory fails here instead of passing everywhere.
     """
     script = tmp_path / "fake_ptxas"
     script.write_text(
@@ -120,13 +75,7 @@ def _fake_ptxas(tmp_path: Path, *, ceiling: int | None, exit_code: int = 1) -> s
 def test_bundled_assembler_is_assumed_to_take_big_static_shared(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """No `MODULAR_NVPTX_COMPILER_PATH` means MAX assembles in-process.
-
-    There is no external binary to interrogate, and the compiler MAX ships
-    is new enough — so the default install must compile exactly the kernels
-    it always did. Anything else would be a silent slowdown for every user
-    who never set the variable.
-    """
+    """No compiler path set: MAX assembles in-process and nothing is probed."""
     monkeypatch.delenv("MODULAR_NVPTX_COMPILER_PATH", raising=False)
     monkeypatch.delenv(eager_kernels._PTXAS_BIG_SMEM_ENV, raising=False)
 
@@ -143,9 +92,8 @@ def test_bundled_assembler_is_assumed_to_take_big_static_shared(
 def test_env_override_beats_the_probe(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, override: str, expected: bool
 ) -> None:
-    """The escape hatch wins in both directions, including over a live probe."""
-    # A fake assembler that answers the *opposite* of the override, so a test
-    # that passed by accident (probe consulted, override ignored) fails.
+    """The override wins in both directions over a live probe."""
+    # The fake answers the opposite of the override, so an ignored override fails.
     monkeypatch.setenv(
         "MODULAR_NVPTX_COMPILER_PATH",
         _fake_ptxas(tmp_path, ceiling=None if expected else _BIG),
@@ -171,11 +119,7 @@ def test_assembler_that_takes_the_big_request_keeps_the_fast_routes(
 def test_assembler_capped_at_48kib_compiles_the_big_routes_out(
     real_accelerator: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """The CUDA 12.x case: the control leg passes, the big one does not.
-
-    `_CONTROL` is exactly the ceiling and must be accepted; that is what
-    separates a real cap from an assembler that fails for its own reasons.
-    """
+    """The CUDA 12.x case: the control leg passes, the big one does not."""
     monkeypatch.delenv(eager_kernels._PTXAS_BIG_SMEM_ENV, raising=False)
     monkeypatch.setenv(
         "MODULAR_NVPTX_COMPILER_PATH", _fake_ptxas(tmp_path, ceiling=_CONTROL)
@@ -188,8 +132,7 @@ def test_assembler_capped_at_48kib_compiles_the_big_routes_out(
 def test_assembler_that_fails_both_legs_is_not_evidence_of_a_cap(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """An uninformative probe must keep today's behaviour, not silently
-    downgrade every matmul on the machine forever."""
+    """An uninformative probe keeps the default rather than downgrading forever."""
     monkeypatch.delenv(eager_kernels._PTXAS_BIG_SMEM_ENV, raising=False)
     monkeypatch.setenv(
         "MODULAR_NVPTX_COMPILER_PATH", _fake_ptxas(tmp_path, ceiling=None)
@@ -212,19 +155,11 @@ def test_assembler_that_cannot_be_run_is_not_evidence_of_a_cap(
 def test_disk_cache_reprobes_only_when_the_assembler_fingerprint_changes(
     real_accelerator: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """A warm process must read the on-disk verdict, not rebuild, unless the
-    binary `MODULAR_NVPTX_COMPILER_PATH` names actually changed.
+    """A warm process reads the disk verdict; a different binary reprobes.
 
-    The "changed" leg uses a second, distinct path rather than overwriting
-    the first path's file in place: `mojo build` turns out to keep its own
-    persistent compilation cache (under `MODULAR_HOME`, confirmed to survive
-    across separate processes) keyed on the compiler *path string*, not on
-    the bytes at that path, so replacing a binary in place while `mojo`
-    itself has already cached an answer for that exact path is not something
-    this probe -- or any caller of `mojo build` -- can observe. A distinct
-    install path (a different CUDA toolkit directory, the realistic trigger
-    for "the assembler changed") is exactly the case the size+mtime
-    fingerprint has to catch, and it is what this test exercises.
+    The changed leg uses a second path, not an in-place overwrite: `mojo
+    build`'s own cache is keyed on the compiler path string and would answer
+    stale for the same path (see `_ptxas_probe_cache_path`).
     """
     monkeypatch.delenv(eager_kernels._PTXAS_BIG_SMEM_ENV, raising=False)
     path = _fake_ptxas(tmp_path, ceiling=_BIG)
@@ -234,8 +169,7 @@ def test_disk_cache_reprobes_only_when_the_assembler_fingerprint_changes(
     cache_file = eager_kernels._ptxas_probe_cache_path(path)
     assert cache_file.is_file()
 
-    # A fresh functools.cache (a new process, in effect) with the same
-    # fingerprint must read the disk verdict and never call mojo build again.
+    # Same fingerprint, fresh process (in effect): served from disk, no build.
     eager_kernels._ptxas_supports_big_static_smem.cache_clear()
     calls: list[int] = []
     real_ptxas_assembles = eager_kernels._ptxas_assembles
@@ -247,10 +181,7 @@ def test_disk_cache_reprobes_only_when_the_assembler_fingerprint_changes(
     assert eager_kernels._ptxas_supports_big_static_smem() is True
     assert calls == []
 
-    # A different assembler at a different path is a different fingerprint
-    # (different path string alone already changes the cache key; a fresh
-    # binary's distinct size/mtime is the part this test is really after),
-    # which must force a fresh probe with the new, correct answer.
+    # A different binary is a different fingerprint and must reprobe.
     eager_kernels._ptxas_supports_big_static_smem.cache_clear()
     other_dir = tmp_path / "other"
     other_dir.mkdir()
@@ -262,29 +193,20 @@ def test_disk_cache_reprobes_only_when_the_assembler_fingerprint_changes(
 
 
 def test_probe_source_declares_more_than_the_ceiling_and_uses_it() -> None:
-    """Guard rails on the probe source itself.
-
-    A kernel whose shared buffer the compiler can prove dead would assemble
-    everywhere regardless of size — a probe that always passes is worse than
-    no probe, because it looks like evidence.
-    """
+    """A probe whose buffer the compiler can prove dead would pass everywhere."""
     text = eager_kernels._PTXAS_PROBE_SOURCE.read_text()
     assert _BIG > _CONTROL == 49152
     assert "address_space=AddressSpace.SHARED" in text
     assert "stack_allocation[" in text
-    # Written, barrier-synced, read back, and stored to a caller-visible
-    # pointer: nothing in that chain is provably dead.
     assert "barrier()" in text
     assert "out_ptr[0]" in text
 
 
 def test_only_the_two_families_with_big_smem_routes_send_the_define() -> None:
-    """A define no gate reads forks a second, byte-identical build of the
-    module that sends it (see the eager_kernels module docstring), so this
-    flag belongs at exactly the call sites whose Mojo reads it."""
+    """An unread define forks a byte-identical build, so senders must have readers."""
     aten_fast = (_KERNEL_DIR / "aten_fast.py").read_text()
     senders = aten_fast.count("big_static_smem_flags()")
-    # Gemm16, Bmm16, and the shared flag builder of _MatmulSpecExtension.
+    # Gemm16, Bmm16, _MatmulSpecExtension._flag_items.
     assert senders == 3, "a new sender must have a Mojo gate to justify it"
 
     readers = {
@@ -302,9 +224,8 @@ def test_only_the_two_families_with_big_smem_routes_send_the_define() -> None:
 def test_matmul_spec_defines_carry_the_flag_and_agree_with_the_cache_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """`make_defines` writes the compile line and `make_canonical_defines`
-    writes the cache name; a flag in one and not the other would build a
-    gated .so and remember it under the ungated key."""
+    """A flag on the compile line but not in the cache key would file a gated
+    .so under the ungated name."""
     from torch_mojo_backend.eager_kernels import aten_fast
 
     for supported in (True, False):
@@ -313,9 +234,7 @@ def test_matmul_spec_defines_carry_the_flag_and_agree_with_the_cache_key(
             "big_static_smem_flags",
             lambda supported=supported: {"PTXAS_BIG_SMEM": 1} if supported else {},
         )
-        tensors = tuple(
-            _StubTensor() for _ in range(2)
-        )  # only `_dtype` is read by either hook
+        tensors = tuple(_StubTensor() for _ in range(2))
         defines = aten_fast._MatmulSpecExtension.make_defines("MatmulSpec", tensors, 0)
         canonical = aten_fast._MatmulSpecExtension.make_canonical_defines(
             "MatmulSpec", tensors, 0
@@ -334,17 +253,11 @@ class _StubTensor:
 
 
 def test_gated_routes_leave_an_unconditional_fallback_behind() -> None:
-    """The gate removes routes; something must still serve their shapes.
-
-    Structural, because the alternative is a build on an old assembler that
-    enqueues nothing and returns a buffer of garbage. For the 16-bit GEMMs
-    the survivor is the mma.sync ladder, for fp32 the 64x64 TN core, and in
-    both files that call has to sit *outside* every `comptime if`.
-    """
+    """The fallback call must sit outside every `comptime if`, or a gated
+    build enqueues nothing for those shapes."""
     v3 = (_KERNEL_DIR / "gemm16_matmul_ops" / "gemm16_v3_kernels.mojo").read_text()
     for fallback in ("_enqueue_accepted_bf16_gemm(", "_enqueue_accepted_bf16_bmm("):
-        # Column 4 is the body of `enqueue_gemm16_gemm`/`enqueue_gemm16_bmm`
-        # itself; anything deeper is nested inside a branch.
+        # Column 4 is the function body; deeper is nested inside a branch.
         assert f"\n    {fallback}" in v3, fallback
 
     tn = (_KERNEL_DIR / "matmul_ops" / "tn_f32_gemm_kernels.mojo").read_text()
@@ -361,12 +274,10 @@ def sm90_mojo_gpu() -> None:
         pytest.skip("the gated routes are compiled only for sm_90a")
 
 
-# Runs out of process because the gate is answered once per process, behind
-# `functools.cache` and behind the loader's own memo of every specialization
-# key: flipping the environment variable inside a live session would leave
-# extensions already built under the other answer.
+# Out of process: the gate is answered once per process and the loader
+# memoizes every specialization key, so the env var cannot be flipped live.
 _FALLBACK_WORKER = '''
-"""Exercise every route the >48 KiB gate removes, against a CPU reference."""
+"""Exercise every shape the >48 KiB gate removes a route for, against CPU."""
 
 import sys
 
@@ -386,11 +297,8 @@ FP32, BF16, FP16 = 2e-5, 3e-2, 1e-2  # relative error each dtype is allowed
 
 
 def check(name, got, ref, rel):
-    # One relative tolerance, applied both element-wise and against the
-    # largest reference entry: a GEMM's error scales with the magnitude of
-    # the whole reduction, not with the element that happened to land near
-    # zero, and a fixed atol would mean something different on every shape
-    # below.
+    # atol scales with the largest reference entry: GEMM error follows the
+    # reduction's magnitude, not the element that landed near zero.
     ref = ref.float()
     torch.testing.assert_close(
         got.float().cpu(),
@@ -412,8 +320,7 @@ for dtype, rel in ((torch.float32, FP32), (torch.bfloat16, BF16), (torch.float16
         ref = a.float() @ b.float()
         check(f"mm {dtype} {m}x{n}x{k}", a.to(DEV) @ b.to(DEV), ref, rel)
 
-# Transposed-A mm: the weight-gradient layout, and the only shape that
-# reaches the gated fp32 128x128 TN cores.
+# Transposed-A mm: the only layout reaching the gated fp32 128x128 TN cores.
 for dtype, rel in ((torch.float32, FP32), (torch.bfloat16, BF16)):
     at, b = rand(512, 256, dtype=dtype), rand(512, 128, dtype=dtype)
     ref = at.float().t() @ b.float()
@@ -424,9 +331,7 @@ for dtype, rel in ((torch.bfloat16, BF16), (torch.float16, FP16)):
     ref = torch.bmm(a.float(), b.float())
     check(f"bmm {dtype}", torch.bmm(a.to(DEV), b.to(DEV)), ref, rel)
 
-# linear forward and backward under bf16 autocast: mm, addmm and both
-# gradient GEMMs (dX = dY @ W, dW = dY^T @ X) in one call. The reference is
-# the exact fp32 computation, so the bf16 tolerance covers the cast too.
+# linear fwd+bwd under bf16 autocast: addmm and both gradient GEMMs.
 x, w, bias = rand(256, 512), rand(384, 512), rand(384)
 for t in (x, w, bias):
     t.requires_grad_()
@@ -441,8 +346,7 @@ got_out.float().square().sum().backward()
 for name, got, want in (("x", xd, x), ("w", wd, w), ("bias", bd, bias)):
     check("linear bwd d" + name, got.grad, want.grad, BF16)
 
-# Causal SDPA, nanoGPT geometry (head_dim 64). Untouched by the gate, but
-# its math path reaches the same 16-bit BMM routes.
+# Causal SDPA: its math path reaches the same 16-bit BMM routes.
 q, k_, v = (rand(4, 6, 256, 64, dtype=torch.bfloat16) for _ in range(3))
 for t in (q, k_, v):
     t.requires_grad_()
@@ -465,13 +369,8 @@ sys.exit(0)
 def test_gated_build_still_computes_the_right_answers(
     sm90_mojo_gpu: None, tmp_path: Path
 ) -> None:
-    """End to end with the fast routes compiled out: mm, bmm, linear and
-    SDPA must still match a CPU reference.
-
-    This is the only check that the surviving routes actually *cover* the
-    shapes the removed ones claimed. It compiles two extension families the
-    first time it runs on a machine.
-    """
+    """With the fast routes compiled out, mm/bmm/linear/SDPA still match CPU.
+    Compiles two extension families on first run."""
     worker = tmp_path / "ptxas_fallback_worker.py"
     worker.write_text(_FALLBACK_WORKER)
     env = dict(os.environ)

--- a/tests/test_ptxas_gating.py
+++ b/tests/test_ptxas_gating.py
@@ -1,0 +1,398 @@
+"""The ptxas static-shared-memory gate: probe, defines, and the fallback.
+
+ptxas caps a kernel's *static* `.shared` at 48 KiB (0xc000) through CUDA 12.8
+and lifts the cap in CUDA 13. It enforces that at assembly time inside
+`mojo build`, and one over-limit kernel fails the whole shared library — so
+on a machine whose `MODULAR_NVPTX_COMPILER_PATH` names an older assembler the
+matmul extensions do not merely lose their fast routes, they stop importing,
+and the loader has no run-time fallback to soften that
+(docs/kernel_call_queue.md). `PTXAS_BIG_SMEM` compiles those routes out
+instead, leaving the ones that already fit.
+
+Two properties matter and are tested separately: the probe must answer for
+the assembler that will actually be used, and the gate must leave a correct
+kernel behind for every shape the removed routes used to claim.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+from typing import ClassVar
+
+import pytest
+from max.dtype import DType
+
+from torch_mojo_backend import eager_kernels, get_accelerators
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_KERNEL_DIR = _REPO_ROOT / "torch_mojo_backend" / "eager_kernels"
+
+# The probe asks for this many bytes of static shared memory, which is over
+# every ptxas's un-opted-in ceiling, and falls back to asking for exactly the
+# ceiling. Both numbers are part of the contract with the fake assemblers
+# below, so read them from the module rather than restating them.
+_BIG, _CONTROL = eager_kernels._PTXAS_PROBE_SIZES
+
+
+@pytest.fixture(autouse=True)
+def _clear_probe_cache() -> Iterator[None]:
+    """The probe is process-cached; every test here sets up its own answer."""
+    eager_kernels._ptxas_supports_big_static_smem.cache_clear()
+    yield
+    eager_kernels._ptxas_supports_big_static_smem.cache_clear()
+
+
+def _fake_ptxas(tmp_path: Path, *, ceiling: int | None, exit_code: int = 1) -> str:
+    """A stand-in `ptxas` that accepts static shared memory up to `ceiling`.
+
+    It reads the `.shared` request out of the probe PTX the way the real one
+    does, so a probe that stopped emitting a shared array (and therefore
+    stopped testing anything) fails here instead of silently passing.
+    `ceiling=None` refuses everything, standing in for an assembler that
+    cannot answer the question at all.
+    """
+    script = tmp_path / "fake_ptxas"
+    script.write_text(
+        "#!/usr/bin/env python3\n"
+        "import re, sys\n"
+        "source = [a for a in sys.argv[1:] if a.endswith('.ptx')]\n"
+        "if not source:\n"
+        "    sys.exit(2)\n"
+        "text = open(source[0]).read()\n"
+        "sizes = [int(n) for n in re.findall(r'\\.shared[^;]*\\[(\\d+)\\]', text)]\n"
+        "if not sizes:\n"
+        "    sys.stderr.write('probe declares no static shared memory\\n')\n"
+        "    sys.exit(3)\n"
+        f"ceiling = {ceiling!r}\n"
+        "if ceiling is None or max(sizes) > ceiling:\n"
+        "    sys.stderr.write('ptxas error   : uses too much shared data\\n')\n"
+        f"    sys.exit({exit_code})\n"
+        "sys.exit(0)\n"
+    )
+    script.chmod(0o755)
+    return str(script)
+
+
+def test_bundled_assembler_is_assumed_to_take_big_static_shared(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No `MODULAR_NVPTX_COMPILER_PATH` means MAX assembles in-process.
+
+    There is no external binary to interrogate, and the compiler MAX ships
+    is new enough — so the default install must compile exactly the kernels
+    it always did. Anything else would be a silent slowdown for every user
+    who never set the variable.
+    """
+    monkeypatch.delenv("MODULAR_NVPTX_COMPILER_PATH", raising=False)
+    monkeypatch.delenv(eager_kernels._PTXAS_BIG_SMEM_ENV, raising=False)
+
+    def fail(*args: object, **kwargs: object) -> None:
+        raise AssertionError("the probe must not exec anything with no compiler set")
+
+    monkeypatch.setattr(eager_kernels, "_ptxas_assembles", fail)
+
+    assert eager_kernels._ptxas_supports_big_static_smem() is True
+    assert eager_kernels.big_static_smem_flags() == {"PTXAS_BIG_SMEM": 1}
+
+
+@pytest.mark.parametrize(("override", "expected"), [("0", False), ("1", True)])
+def test_env_override_beats_the_probe(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, override: str, expected: bool
+) -> None:
+    """The escape hatch wins in both directions, including over a live probe."""
+    # A fake assembler that answers the *opposite* of the override, so a test
+    # that passed by accident (probe consulted, override ignored) fails.
+    monkeypatch.setenv(
+        "MODULAR_NVPTX_COMPILER_PATH",
+        _fake_ptxas(tmp_path, ceiling=None if expected else _BIG),
+    )
+    monkeypatch.setenv(eager_kernels._PTXAS_BIG_SMEM_ENV, override)
+
+    assert eager_kernels._ptxas_supports_big_static_smem() is expected
+    assert bool(eager_kernels.big_static_smem_flags()) is expected
+
+
+def test_assembler_that_takes_the_big_request_keeps_the_fast_routes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv(eager_kernels._PTXAS_BIG_SMEM_ENV, raising=False)
+    monkeypatch.setenv(
+        "MODULAR_NVPTX_COMPILER_PATH", _fake_ptxas(tmp_path, ceiling=_BIG)
+    )
+
+    assert eager_kernels._ptxas_supports_big_static_smem() is True
+    assert eager_kernels.big_static_smem_flags() == {"PTXAS_BIG_SMEM": 1}
+
+
+def test_assembler_capped_at_48kib_compiles_the_big_routes_out(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The CUDA 12.x case: the control leg passes, the big one does not.
+
+    `_CONTROL` is exactly the ceiling and must be accepted; that is what
+    separates a real cap from an assembler that fails for its own reasons.
+    """
+    monkeypatch.delenv(eager_kernels._PTXAS_BIG_SMEM_ENV, raising=False)
+    monkeypatch.setenv(
+        "MODULAR_NVPTX_COMPILER_PATH", _fake_ptxas(tmp_path, ceiling=_CONTROL)
+    )
+
+    assert eager_kernels._ptxas_supports_big_static_smem() is False
+    assert eager_kernels.big_static_smem_flags() == {}
+
+
+def test_assembler_that_fails_both_legs_is_not_evidence_of_a_cap(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """An uninformative probe must keep today's behaviour, not silently
+    downgrade every matmul on the machine forever."""
+    monkeypatch.delenv(eager_kernels._PTXAS_BIG_SMEM_ENV, raising=False)
+    monkeypatch.setenv(
+        "MODULAR_NVPTX_COMPILER_PATH", _fake_ptxas(tmp_path, ceiling=None)
+    )
+
+    assert eager_kernels._ptxas_supports_big_static_smem() is True
+    assert eager_kernels._PTXAS_BIG_SMEM_ENV in capsys.readouterr().err
+
+
+def test_assembler_that_cannot_be_run_is_not_evidence_of_a_cap(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.delenv(eager_kernels._PTXAS_BIG_SMEM_ENV, raising=False)
+    monkeypatch.setenv("MODULAR_NVPTX_COMPILER_PATH", str(tmp_path / "no-such-ptxas"))
+
+    assert eager_kernels._ptxas_supports_big_static_smem() is True
+    assert eager_kernels._PTXAS_BIG_SMEM_ENV in capsys.readouterr().err
+
+
+def test_probe_ptx_declares_more_than_the_ceiling_and_uses_it() -> None:
+    """Guard rails on the probe source itself.
+
+    Assembling PTX that declares no shared memory, or whose array the
+    assembler can prove dead, would answer True everywhere — a probe that
+    always passes is worse than no probe, because it looks like evidence.
+    """
+    text = eager_kernels._PTXAS_PROBE_PTX
+    assert _BIG > _CONTROL == 49152
+    assert ".shared .align 16 .b8 probe_shared_buffer[__SIZE__];" in text
+    # Written, read back, and stored to a caller-visible pointer: nothing in
+    # that chain is removable.
+    assert "st.shared.u32" in text
+    assert "ld.shared.u32" in text
+    assert "st.global.u32" in text
+    assert ".target sm_90a" in text
+
+
+def test_only_the_two_families_with_big_smem_routes_send_the_define() -> None:
+    """A define no gate reads forks a second, byte-identical build of the
+    module that sends it (see the eager_kernels module docstring), so this
+    flag belongs at exactly the call sites whose Mojo reads it."""
+    aten_fast = (_KERNEL_DIR / "aten_fast.py").read_text()
+    senders = aten_fast.count("big_static_smem_flags()")
+    # Gemm16, Bmm16, and the shared flag builder of _MatmulSpecExtension.
+    assert senders == 3, "a new sender must have a Mojo gate to justify it"
+
+    readers = {
+        path.relative_to(_KERNEL_DIR).as_posix()
+        for path in _KERNEL_DIR.rglob("*.mojo")
+        if "_big_static_smem_on" in path.read_text()
+    }
+    assert readers == {
+        "variant_gates.mojo",
+        "gemm16_matmul_ops/gemm16_v3_kernels.mojo",
+        "matmul_ops/tn_f32_gemm_kernels.mojo",
+    }
+
+
+def test_matmul_spec_defines_carry_the_flag_and_agree_with_the_cache_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`make_defines` writes the compile line and `make_canonical_defines`
+    writes the cache name; a flag in one and not the other would build a
+    gated .so and remember it under the ungated key."""
+    from torch_mojo_backend.eager_kernels import aten_fast
+
+    for supported in (True, False):
+        monkeypatch.setattr(
+            eager_kernels,
+            "big_static_smem_flags",
+            lambda supported=supported: {"PTXAS_BIG_SMEM": 1} if supported else {},
+        )
+        tensors = tuple(
+            _StubTensor() for _ in range(2)
+        )  # only `_dtype` is read by either hook
+        defines = aten_fast._MatmulSpecExtension.make_defines("MatmulSpec", tensors, 0)
+        canonical = aten_fast._MatmulSpecExtension.make_canonical_defines(
+            "MatmulSpec", tensors, 0
+        )
+        assert ("PTXAS_BIG_SMEM" in defines) is supported
+        assert eager_kernels.normalize_defines(defines) == canonical
+
+
+class _StubTensor:
+    """A `MojoTensorLike` stand-in; the define hooks read only `_dtype`."""
+
+    _shape: ClassVar[tuple[int, ...]] = (4, 4)
+    _mojo_strides: ClassVar[tuple[int, ...]] = (4, 1)
+    _dtype: ClassVar[DType] = DType.float32
+    _device: ClassVar[object] = None
+
+
+def test_gated_routes_leave_an_unconditional_fallback_behind() -> None:
+    """The gate removes routes; something must still serve their shapes.
+
+    Structural, because the alternative is a build on an old assembler that
+    enqueues nothing and returns a buffer of garbage. For the 16-bit GEMMs
+    the survivor is the mma.sync ladder, for fp32 the 64x64 TN core, and in
+    both files that call has to sit *outside* every `comptime if`.
+    """
+    v3 = (_KERNEL_DIR / "gemm16_matmul_ops" / "gemm16_v3_kernels.mojo").read_text()
+    for fallback in ("_enqueue_accepted_bf16_gemm(", "_enqueue_accepted_bf16_bmm("):
+        # Column 4 is the body of `enqueue_gemm16_gemm`/`enqueue_gemm16_bmm`
+        # itself; anything deeper is nested inside a branch.
+        assert f"\n    {fallback}" in v3, fallback
+
+    tn = (_KERNEL_DIR / "matmul_ops" / "tn_f32_gemm_kernels.mojo").read_text()
+    assert "comptime if not _big_static_smem_on():\n        use_t128 = False" in tn
+    assert "\n    if not use_t128:\n        _tn_core_launch[64, 64," in tn
+
+
+@pytest.fixture(scope="module")
+def sm90_mojo_gpu() -> None:
+    accelerators = list(get_accelerators())
+    if not accelerators or accelerators[0].api != "cuda":
+        pytest.skip("the gated routes are NVIDIA-only")
+    if accelerators[0].architecture_name != "sm_90a":
+        pytest.skip("the gated routes are compiled only for sm_90a")
+
+
+# Runs out of process because the gate is answered once per process, behind
+# `functools.cache` and behind the loader's own memo of every specialization
+# key: flipping the environment variable inside a live session would leave
+# extensions already built under the other answer.
+_FALLBACK_WORKER = '''
+"""Exercise every route the >48 KiB gate removes, against a CPU reference."""
+
+import sys
+
+import torch
+
+from torch_mojo_backend import eager_kernels, register_mojo_devices
+
+assert eager_kernels._ptxas_supports_big_static_smem() is False
+assert eager_kernels.big_static_smem_flags() == {}
+
+register_mojo_devices()
+DEV = "mojo:0"
+torch.manual_seed(0)
+
+
+FP32, BF16, FP16 = 2e-5, 3e-2, 1e-2  # relative error each dtype is allowed
+
+
+def check(name, got, ref, rel):
+    # One relative tolerance, applied both element-wise and against the
+    # largest reference entry: a GEMM's error scales with the magnitude of
+    # the whole reduction, not with the element that happened to land near
+    # zero, and a fixed atol would mean something different on every shape
+    # below.
+    ref = ref.float()
+    torch.testing.assert_close(
+        got.float().cpu(),
+        ref,
+        rtol=rel,
+        atol=rel * ref.abs().max().clamp(min=1e-6).item(),
+        msg=lambda m: name + ": " + m,
+    )
+    print("ok", name)
+
+
+def rand(*shape, dtype=torch.float32):
+    return torch.randn(*shape).to(dtype)
+
+
+for dtype, rel in ((torch.float32, FP32), (torch.bfloat16, BF16), (torch.float16, FP16)):
+    for m, n, k in ((256, 256, 256), (1024, 512, 2048)):
+        a, b = rand(m, k, dtype=dtype), rand(k, n, dtype=dtype)
+        ref = a.float() @ b.float()
+        check(f"mm {dtype} {m}x{n}x{k}", a.to(DEV) @ b.to(DEV), ref, rel)
+
+# Transposed-A mm: the weight-gradient layout, and the only shape that
+# reaches the gated fp32 128x128 TN cores.
+for dtype, rel in ((torch.float32, FP32), (torch.bfloat16, BF16)):
+    at, b = rand(512, 256, dtype=dtype), rand(512, 128, dtype=dtype)
+    ref = at.float().t() @ b.float()
+    check(f"mm TN {dtype}", at.to(DEV).t() @ b.to(DEV), ref, rel)
+
+for dtype, rel in ((torch.bfloat16, BF16), (torch.float16, FP16)):
+    a, b = rand(8, 128, 256, dtype=dtype), rand(8, 256, 192, dtype=dtype)
+    ref = torch.bmm(a.float(), b.float())
+    check(f"bmm {dtype}", torch.bmm(a.to(DEV), b.to(DEV)), ref, rel)
+
+# linear forward and backward under bf16 autocast: mm, addmm and both
+# gradient GEMMs (dX = dY @ W, dW = dY^T @ X) in one call. The reference is
+# the exact fp32 computation, so the bf16 tolerance covers the cast too.
+x, w, bias = rand(256, 512), rand(384, 512), rand(384)
+for t in (x, w, bias):
+    t.requires_grad_()
+xd, wd, bd = (t.detach().to(DEV).requires_grad_() for t in (x, w, bias))
+ref_out = torch.nn.functional.linear(x, w, bias)
+with torch.amp.autocast("mojo", dtype=torch.bfloat16):
+    got_out = torch.nn.functional.linear(xd, wd, bd)
+    assert got_out.dtype == torch.bfloat16, got_out.dtype
+check("linear fwd", got_out, ref_out, BF16)
+ref_out.float().square().sum().backward()
+got_out.float().square().sum().backward()
+for name, got, want in (("x", xd, x), ("w", wd, w), ("bias", bd, bias)):
+    check("linear bwd d" + name, got.grad, want.grad, BF16)
+
+# Causal SDPA, nanoGPT geometry (head_dim 64). Untouched by the gate, but
+# its math path reaches the same 16-bit BMM routes.
+q, k_, v = (rand(4, 6, 256, 64, dtype=torch.bfloat16) for _ in range(3))
+for t in (q, k_, v):
+    t.requires_grad_()
+qd, kd, vd = (t.detach().to(DEV).requires_grad_() for t in (q, k_, v))
+ref_att = torch.nn.functional.scaled_dot_product_attention(
+    q.float(), k_.float(), v.float(), is_causal=True
+)
+got_att = torch.nn.functional.scaled_dot_product_attention(qd, kd, vd, is_causal=True)
+check("sdpa causal fwd", got_att, ref_att, BF16)
+ref_att.square().sum().backward()
+got_att.float().square().sum().backward()
+for name, got, want in (("q", qd, q), ("k", kd, k_), ("v", vd, v)):
+    check("sdpa causal bwd d" + name, got.grad, want.grad, BF16)
+
+print("FALLBACK PASS")
+sys.exit(0)
+'''
+
+
+def test_gated_build_still_computes_the_right_answers(
+    sm90_mojo_gpu: None, tmp_path: Path
+) -> None:
+    """End to end with the fast routes compiled out: mm, bmm, linear and
+    SDPA must still match a CPU reference.
+
+    This is the only check that the surviving routes actually *cover* the
+    shapes the removed ones claimed. It compiles two extension families the
+    first time it runs on a machine.
+    """
+    worker = tmp_path / "ptxas_fallback_worker.py"
+    worker.write_text(_FALLBACK_WORKER)
+    env = dict(os.environ)
+    env[eager_kernels._PTXAS_BIG_SMEM_ENV] = "0"
+    result = subprocess.run(
+        [sys.executable, str(worker)],
+        cwd=str(_REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=1800,
+    )
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, f"gated-build worker failed:\n{output}"
+    assert "FALLBACK PASS" in output, f"worker did not reach the end:\n{output}"

--- a/torch_mojo_backend/eager_kernels/__init__.py
+++ b/torch_mojo_backend/eager_kernels/__init__.py
@@ -409,40 +409,21 @@ def _build_env() -> dict[str, str]:
     }
 
 
-# A ptxas capability probe, not a kernel: `ptxas_probe.mojo` declares one GPU
-# entry with a *static* `.shared` array of `PROBE_SIZE` bytes (a `-D` define)
-# and is built with `mojo build`, the same toolchain and (`_build_env`)
-# environment real extensions use, rather than by handing synthetic PTX to a
-# guessed assembler binary. ptxas rejects a static `.shared` allocation over
-# 48 KiB (0xc000) up to and including CUDA 12.8, and accepts it from CUDA 13
-# on; `mojo build` surfaces that as a nonzero exit and nothing is ever
-# launched.
-#
-# `mojo build` only shells out to the assembler `MODULAR_NVPTX_COMPILER_PATH`
-# names when it auto-detects a real, physically attached accelerator to build
-# for (confirmed empirically: passing an explicit `--target-accelerator`, or
-# building with none attached at all, both make it defer to PTX-only
-# embedding for later JIT and never touch that env var). `_ptxas_assembles`
-# therefore builds the same way `_extension_cmd` does -- no accelerator
-# override -- which also means the probe is only ever reachable in practice
-# where it matters: `big_static_smem_flags()` is only consulted while
-# building a real GEMM/BMM extension for an actual mojo device, which
-# requires an accelerator to exist in the first place.
 _PTXAS_PROBE_SOURCE = _PACKAGE_DIR / "ptxas_probe.mojo"
 
-# The static-shared ceiling every ptxas enforces without an opt-in, and the
-# smallest request above it. 49152 must assemble everywhere: it is the
-# control leg that tells a real ceiling apart from a probe that failed for
-# an unrelated reason (a sandboxed exec, a missing binary).
+# (over the 48 KiB ceiling, exactly at it). The control leg tells a capped
+# assembler apart from a probe that fails for unrelated reasons.
 _PTXAS_PROBE_SIZES = (131072, 49152)
 
 _PTXAS_BIG_SMEM_ENV = "TORCH_MOJO_BACKEND_PTXAS_BIG_SMEM"
 
 
 def _ptxas_assembles(size: int) -> bool:
-    """Whether `mojo build` compiles the probe kernel with `size` bytes of
-    static smem, under the active `MODULAR_NVPTX_COMPILER_PATH` (inherited
-    from `os.environ` through `_build_env`, exactly like a real build)."""
+    """Build the probe kernel with `size` bytes of static smem.
+
+    No `--target-accelerator`: given one, `mojo build` embeds PTX only and
+    never runs `MODULAR_NVPTX_COMPILER_PATH`.
+    """
     with tempfile.TemporaryDirectory() as tmpdir:
         out = Path(tmpdir) / "probe.so"
         proc = subprocess.run(
@@ -465,24 +446,10 @@ def _ptxas_assembles(size: int) -> bool:
 
 
 def _ptxas_probe_cache_path(compiler: str) -> Path:
-    """On-disk verdict location for one (toolchain, compiler-binary) pair.
-
-    `_TOOLCHAIN_IDENTITY` covers the mojo/max package versions and host ABI;
-    the compiler path plus its file's size+mtime cover the actual binary
-    `MODULAR_NVPTX_COMPILER_PATH` names, so pointing it at a different
-    install invalidates the entry -- the realistic way an assembler changes.
-    A path that cannot be stat'd (does not exist, no permission) still gets
-    a stable key -- probing it is cheap since `mojo build` fails immediately,
-    and the answer does not depend on a fingerprint that does not exist.
-
-    This can only invalidate what it can see. `mojo build` keeps its own
-    persistent compilation cache under `MODULAR_HOME`, and empirically (see
-    tests/test_ptxas_gating.py) that cache is keyed on the compiler *path
-    string*, not on the bytes at that path -- a ptxas binary replaced in
-    place at a path `mojo` has already built against can still answer from
-    its stale cache even in a brand new process. Nothing at this layer can
-    see that; it is a property of the toolchain, not of this probe.
-    """
+    """Keyed by toolchain identity plus the compiler binary's path and
+    size+mtime. `mojo build`'s own cache under `MODULAR_HOME` is keyed on the
+    path string alone, so a binary replaced in place can still be answered
+    stale from there; this layer cannot see that."""
     try:
         info = os.stat(compiler)
         fingerprint = f"{info.st_size}:{info.st_mtime_ns}"
@@ -516,14 +483,11 @@ def _write_ptxas_probe_cache(path: Path, verdict: bool) -> None:
 
 
 def _probe_ptxas_big_static_smem(compiler: str) -> bool:
-    """Run both probe legs and apply the broken-vs-capped fallback rule."""
     big, control = _PTXAS_PROBE_SIZES
     if _ptxas_assembles(big):
         return True
-    # The big leg failed. Only a passing control leg makes that a statement
-    # about the ceiling; if even 48 KiB fails, the probe itself is broken and
-    # gating the fast kernels out on that evidence would be a silent,
-    # permanent slowdown. Keep today's behaviour and say so.
+    # An assembler that fails the control leg too is broken, not capped;
+    # gating on that evidence would be a silent, permanent slowdown.
     if _ptxas_assembles(control):
         return False
     sys.stderr.write(
@@ -540,35 +504,16 @@ def _probe_ptxas_big_static_smem(compiler: str) -> bool:
 def _ptxas_supports_big_static_smem() -> bool:
     """Whether the active PTX assembler accepts >48 KiB of *static* shared memory.
 
-    Answering False compiles the sm_90 WGMMA/TMA GEMM routes out of the build
-    (see `_big_static_smem_on` in variant_gates.mojo): ptxas fails the whole
-    `mojo build`, not the one over-limit kernel, so an extension carrying such
-    a kernel is not slow on an old assembler, it is unimportable — and this
-    loader deliberately has no run-time fallback (docs/kernel_call_queue.md).
-    The routes that stay serve every shape those ones did, more slowly.
+    ptxas caps static `.shared` at 48 KiB through CUDA 12.8 and fails the
+    whole `mojo build` on one over-limit kernel, so the sm_90 wgmma/TMA GEMM
+    routes must be compiled out (`_big_static_smem_on` in variant_gates.mojo),
+    not merely left unselected; the smaller routes serve the same shapes.
 
-    The answer is a property of the assembler, so it is asked by actually
-    building `ptxas_probe.mojo` with `mojo build` rather than guessed from a
-    version string:
-
-    * `TORCH_MOJO_BACKEND_PTXAS_BIG_SMEM=0`/`=1` overrides everything, for
-      tests and for a machine whose probe is wrong. It short-circuits before
-      either the build or the disk cache below.
-    * With `MODULAR_NVPTX_COMPILER_PATH` unset, MAX assembles PTX in-process
-      with the PTX compiler it ships (CUDA 13 today, which accepts big static
-      smem) and there is no external binary to interrogate: answer True, so
-      the default install compiles exactly the kernels it always did.
-    * Otherwise that env var names the `ptxas` MAX will hand the PTX to, and
-      it is the one binary whose limits matter. A `mojo build` of the probe
-      costs real seconds, so the verdict is memoized on disk under
-      `_CACHE_DIR`, keyed by toolchain identity plus the compiler binary's
-      path and size+mtime fingerprint (`_ptxas_probe_cache_path`); this
-      `functools.cache` is only the in-process layer on top of that file.
-
-    Only NVIDIA is affected. AMD and Apple builds never consult
-    `MODULAR_NVPTX_COMPILER_PATH`, so they take the True branch above and
-    nothing about them changes; the routes gated on this flag are in any case
-    already behind an sm_9x comptime check.
+    `TORCH_MOJO_BACKEND_PTXAS_BIG_SMEM=0`/`=1` overrides the probe. With
+    `MODULAR_NVPTX_COMPILER_PATH` unset, MAX assembles with the CUDA 13
+    compiler it bundles and the answer is True. Otherwise `ptxas_probe.mojo`
+    is built once per (toolchain, compiler binary) and the verdict memoized
+    under `_CACHE_DIR`.
     """
     override = os.environ.get(_PTXAS_BIG_SMEM_ENV)
     if override in ("0", "1"):
@@ -586,14 +531,9 @@ def _ptxas_supports_big_static_smem() -> bool:
 
 
 def big_static_smem_flags() -> dict[str, DefineValue]:
-    """The `PTXAS_BIG_SMEM` define for a family that has >48 KiB-smem routes.
-
-    Empty when the assembler cannot take them, because every gate in
-    variant_gates.mojo is written so that an absent define reads back as ""
-    and selects nothing. Callers merge this into their `flags`; a family with
-    no such route must not, or it forks a second, byte-identical build of
-    itself for no reason (see this module's docstring).
-    """
+    """The `PTXAS_BIG_SMEM` define, empty when the assembler cannot take the
+    big routes (an absent define gates off). Only a family with such a route
+    may merge this in: an unread define forks a byte-identical build."""
     return {"PTXAS_BIG_SMEM": 1} if _ptxas_supports_big_static_smem() else {}
 
 

--- a/torch_mojo_backend/eager_kernels/__init__.py
+++ b/torch_mojo_backend/eager_kernels/__init__.py
@@ -411,8 +411,8 @@ def _build_env() -> dict[str, str]:
 
 _PTXAS_PROBE_SOURCE = _PACKAGE_DIR / "ptxas_probe.mojo"
 
-# (over the 48 KiB ceiling, exactly at it). The control leg tells a capped
-# assembler apart from a probe that fails for unrelated reasons.
+# Probe requests: over the 48 KiB ceiling, then exactly at it. The control leg
+# tells a capped assembler apart from a probe that fails for unrelated reasons.
 _PTXAS_PROBE_SIZES = (131072, 49152)
 
 _PTXAS_BIG_SMEM_ENV = "TORCH_MOJO_BACKEND_PTXAS_BIG_SMEM"

--- a/torch_mojo_backend/eager_kernels/__init__.py
+++ b/torch_mojo_backend/eager_kernels/__init__.py
@@ -409,62 +409,131 @@ def _build_env() -> dict[str, str]:
     }
 
 
-# A ptxas capability probe, not a kernel: one entry whose only body is a
-# store/load through a static `.shared` array of `__SIZE__` bytes. ptxas
-# rejects an entry function whose *static* shared memory exceeds 48 KiB
-# (0xc000) up to and including CUDA 12.8, and accepts it from CUDA 13 on;
-# the check happens before any device exists, so the probe assembles to
-# /dev/null and nothing is ever launched. `%tid.x` in and a global store out
-# keep the array live so the assembler cannot elide it. `.version 8.5` is the
-# ISA the Mojo toolchain emits for sm_90a (ptxas 12.6+ accepts it), so a
-# probe that assembles proves nothing about ISA support that the real build
-# does not already assume.
-_PTXAS_PROBE_PTX = """\
-.version 8.5
-.target sm_90a
-.address_size 64
-
-.shared .align 16 .b8 probe_shared_buffer[__SIZE__];
-
-.visible .entry probe_static_shared(
-\t.param .u64 .ptr .align 4 probe_static_shared_param_0
-)
-{
-\t.reg .b32 \t%r<4>;
-\t.reg .b64 \t%rd<4>;
-
-\tld.param.u64 \t%rd1, [probe_static_shared_param_0];
-\tcvta.to.global.u64 \t%rd2, %rd1;
-\tmov.u32 \t%r1, %tid.x;
-\tmov.u32 \t%r2, probe_shared_buffer;
-\tst.shared.u32 \t[%r2], %r1;
-\tbar.sync \t0;
-\tld.shared.u32 \t%r3, [%r2];
-\tst.global.u32 \t[%rd2], %r3;
-\tret;
-}
-"""
+# A ptxas capability probe, not a kernel: `ptxas_probe.mojo` declares one GPU
+# entry with a *static* `.shared` array of `PROBE_SIZE` bytes (a `-D` define)
+# and is built with `mojo build`, the same toolchain and (`_build_env`)
+# environment real extensions use, rather than by handing synthetic PTX to a
+# guessed assembler binary. ptxas rejects a static `.shared` allocation over
+# 48 KiB (0xc000) up to and including CUDA 12.8, and accepts it from CUDA 13
+# on; `mojo build` surfaces that as a nonzero exit and nothing is ever
+# launched.
+#
+# `mojo build` only shells out to the assembler `MODULAR_NVPTX_COMPILER_PATH`
+# names when it auto-detects a real, physically attached accelerator to build
+# for (confirmed empirically: passing an explicit `--target-accelerator`, or
+# building with none attached at all, both make it defer to PTX-only
+# embedding for later JIT and never touch that env var). `_ptxas_assembles`
+# therefore builds the same way `_extension_cmd` does -- no accelerator
+# override -- which also means the probe is only ever reachable in practice
+# where it matters: `big_static_smem_flags()` is only consulted while
+# building a real GEMM/BMM extension for an actual mojo device, which
+# requires an accelerator to exist in the first place.
+_PTXAS_PROBE_SOURCE = _PACKAGE_DIR / "ptxas_probe.mojo"
 
 # The static-shared ceiling every ptxas enforces without an opt-in, and the
 # smallest request above it. 49152 must assemble everywhere: it is the
 # control leg that tells a real ceiling apart from a probe that failed for
-# an unrelated reason (an sm_90a-unaware assembler, a sandboxed exec).
+# an unrelated reason (a sandboxed exec, a missing binary).
 _PTXAS_PROBE_SIZES = (131072, 49152)
 
 _PTXAS_BIG_SMEM_ENV = "TORCH_MOJO_BACKEND_PTXAS_BIG_SMEM"
 
 
-def _ptxas_assembles(compiler: str, size: int) -> bool:
-    """Whether `compiler` assembles the probe with `size` bytes of static smem."""
+def _ptxas_assembles(size: int) -> bool:
+    """Whether `mojo build` compiles the probe kernel with `size` bytes of
+    static smem, under the active `MODULAR_NVPTX_COMPILER_PATH` (inherited
+    from `os.environ` through `_build_env`, exactly like a real build)."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        source = Path(tmpdir) / f"probe_{size}.ptx"
-        source.write_text(_PTXAS_PROBE_PTX.replace("__SIZE__", str(size)))
+        out = Path(tmpdir) / "probe.so"
         proc = subprocess.run(
-            [compiler, "-arch=sm_90a", str(source), "-o", os.devnull],
+            [
+                str(_find_mojo()),
+                "build",
+                str(_PTXAS_PROBE_SOURCE),
+                "--emit",
+                "shared-lib",
+                "-D",
+                f"PROBE_SIZE={size}",
+                "-o",
+                str(out),
+            ],
             capture_output=True,
             text=True,
+            env=_build_env(),
         )
     return proc.returncode == 0
+
+
+def _ptxas_probe_cache_path(compiler: str) -> Path:
+    """On-disk verdict location for one (toolchain, compiler-binary) pair.
+
+    `_TOOLCHAIN_IDENTITY` covers the mojo/max package versions and host ABI;
+    the compiler path plus its file's size+mtime cover the actual binary
+    `MODULAR_NVPTX_COMPILER_PATH` names, so pointing it at a different
+    install invalidates the entry -- the realistic way an assembler changes.
+    A path that cannot be stat'd (does not exist, no permission) still gets
+    a stable key -- probing it is cheap since `mojo build` fails immediately,
+    and the answer does not depend on a fingerprint that does not exist.
+
+    This can only invalidate what it can see. `mojo build` keeps its own
+    persistent compilation cache under `MODULAR_HOME`, and empirically (see
+    tests/test_ptxas_gating.py) that cache is keyed on the compiler *path
+    string*, not on the bytes at that path -- a ptxas binary replaced in
+    place at a path `mojo` has already built against can still answer from
+    its stale cache even in a brand new process. Nothing at this layer can
+    see that; it is a property of the toolchain, not of this probe.
+    """
+    try:
+        info = os.stat(compiler)
+        fingerprint = f"{info.st_size}:{info.st_mtime_ns}"
+    except OSError:
+        fingerprint = "unavailable"
+    key = "|".join((_TOOLCHAIN_IDENTITY.decode(), compiler, fingerprint))
+    digest = hashlib.sha256(key.encode()).hexdigest()[:24]
+    return _CACHE_DIR / f"ptxas_big_smem.{digest}.json"
+
+
+def _read_ptxas_probe_cache(path: Path) -> bool | None:
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return None
+    verdict = data.get("supports_big_static_smem")
+    return verdict if isinstance(verdict, bool) else None
+
+
+def _write_ptxas_probe_cache(path: Path, verdict: bool) -> None:
+    """Best-effort: a write failure just costs the next process a re-probe."""
+    tmp = path.with_name(f".tmp{os.getpid()}.{path.name}")
+    try:
+        _CACHE_DIR.mkdir(exist_ok=True)
+        tmp.write_text(json.dumps({"supports_big_static_smem": verdict}))
+        os.replace(tmp, path)
+    except OSError:
+        pass
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+def _probe_ptxas_big_static_smem(compiler: str) -> bool:
+    """Run both probe legs and apply the broken-vs-capped fallback rule."""
+    big, control = _PTXAS_PROBE_SIZES
+    if _ptxas_assembles(big):
+        return True
+    # The big leg failed. Only a passing control leg makes that a statement
+    # about the ceiling; if even 48 KiB fails, the probe itself is broken and
+    # gating the fast kernels out on that evidence would be a silent,
+    # permanent slowdown. Keep today's behaviour and say so.
+    if _ptxas_assembles(control):
+        return False
+    sys.stderr.write(
+        f"torch-mojo-backend: {compiler!r} (MODULAR_NVPTX_COMPILER_PATH) "
+        "failed to build both probe kernels via `mojo build`, so its static "
+        "shared-memory limit could not be determined; assuming it accepts "
+        f"the large-shared-memory kernels. Set {_PTXAS_BIG_SMEM_ENV}=0 if "
+        "builds fail with 'uses too much shared data'.\n"
+    )
+    return True
 
 
 @functools.cache
@@ -478,17 +547,23 @@ def _ptxas_supports_big_static_smem() -> bool:
     loader deliberately has no run-time fallback (docs/kernel_call_queue.md).
     The routes that stay serve every shape those ones did, more slowly.
 
-    The answer is a property of the assembler, so it is probed rather than
-    guessed from a version string:
+    The answer is a property of the assembler, so it is asked by actually
+    building `ptxas_probe.mojo` with `mojo build` rather than guessed from a
+    version string:
 
     * `TORCH_MOJO_BACKEND_PTXAS_BIG_SMEM=0`/`=1` overrides everything, for
-      tests and for a machine whose probe is wrong.
+      tests and for a machine whose probe is wrong. It short-circuits before
+      either the build or the disk cache below.
     * With `MODULAR_NVPTX_COMPILER_PATH` unset, MAX assembles PTX in-process
       with the PTX compiler it ships (CUDA 13 today, which accepts big static
       smem) and there is no external binary to interrogate: answer True, so
       the default install compiles exactly the kernels it always did.
     * Otherwise that env var names the `ptxas` MAX will hand the PTX to, and
-      it is the one binary whose limits matter. Assemble the probe with it.
+      it is the one binary whose limits matter. A `mojo build` of the probe
+      costs real seconds, so the verdict is memoized on disk under
+      `_CACHE_DIR`, keyed by toolchain identity plus the compiler binary's
+      path and size+mtime fingerprint (`_ptxas_probe_cache_path`); this
+      `functools.cache` is only the in-process layer on top of that file.
 
     Only NVIDIA is affected. AMD and Apple builds never consult
     `MODULAR_NVPTX_COMPILER_PATH`, so they take the True branch above and
@@ -501,31 +576,13 @@ def _ptxas_supports_big_static_smem() -> bool:
     compiler = os.environ.get("MODULAR_NVPTX_COMPILER_PATH")
     if not compiler:
         return True
-    big, control = _PTXAS_PROBE_SIZES
-    try:
-        if _ptxas_assembles(compiler, big):
-            return True
-        # The big probe failed. Only a passing control leg makes that a
-        # statement about the ceiling; if even 48 KiB fails, the probe itself
-        # is broken and gating the fast kernels out on that evidence would be
-        # a silent, permanent slowdown. Keep today's behaviour and say so.
-        if _ptxas_assembles(compiler, control):
-            return False
-    except OSError as exc:
-        sys.stderr.write(
-            f"torch-mojo-backend: could not run {compiler!r} to probe its "
-            f"static shared-memory limit ({exc}); assuming it accepts the "
-            f"large-shared-memory kernels. Set {_PTXAS_BIG_SMEM_ENV}=0 if "
-            "builds fail with 'uses too much shared data'.\n"
-        )
-        return True
-    sys.stderr.write(
-        f"torch-mojo-backend: {compiler!r} failed to assemble both probes, so "
-        "its static shared-memory limit could not be determined; assuming it "
-        f"accepts the large-shared-memory kernels. Set {_PTXAS_BIG_SMEM_ENV}=0 "
-        "if builds fail with 'uses too much shared data'.\n"
-    )
-    return True
+    cache_path = _ptxas_probe_cache_path(compiler)
+    cached = _read_ptxas_probe_cache(cache_path)
+    if cached is not None:
+        return cached
+    verdict = _probe_ptxas_big_static_smem(compiler)
+    _write_ptxas_probe_cache(cache_path, verdict)
+    return verdict
 
 
 def big_static_smem_flags() -> dict[str, DefineValue]:

--- a/torch_mojo_backend/eager_kernels/__init__.py
+++ b/torch_mojo_backend/eager_kernels/__init__.py
@@ -469,7 +469,7 @@ def _read_ptxas_probe_cache(path: Path) -> bool | None:
     return verdict if isinstance(verdict, bool) else None
 
 
-def _write_ptxas_probe_cache(path: Path, verdict: bool) -> None:
+def _write_ptxas_probe_cache(path: Path, verdict: bool):
     """Best-effort: a write failure just costs the next process a re-probe."""
     tmp = path.with_name(f".tmp{os.getpid()}.{path.name}")
     try:

--- a/torch_mojo_backend/eager_kernels/__init__.py
+++ b/torch_mojo_backend/eager_kernels/__init__.py
@@ -37,6 +37,7 @@ means direct references to its functions stay valid forever.
 
 import errno
 import fcntl
+import functools
 import hashlib
 import importlib.machinery
 import importlib.metadata
@@ -47,6 +48,7 @@ import platform
 import re
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 from abc import ABC, abstractmethod
@@ -405,6 +407,137 @@ def _build_env() -> dict[str, str]:
             k.startswith("MODULAR_") and ("PACKAGE_ROOT" in k or "IMPORT_PATH" in k)
         )
     }
+
+
+# A ptxas capability probe, not a kernel: one entry whose only body is a
+# store/load through a static `.shared` array of `__SIZE__` bytes. ptxas
+# rejects an entry function whose *static* shared memory exceeds 48 KiB
+# (0xc000) up to and including CUDA 12.8, and accepts it from CUDA 13 on;
+# the check happens before any device exists, so the probe assembles to
+# /dev/null and nothing is ever launched. `%tid.x` in and a global store out
+# keep the array live so the assembler cannot elide it. `.version 8.5` is the
+# ISA the Mojo toolchain emits for sm_90a (ptxas 12.6+ accepts it), so a
+# probe that assembles proves nothing about ISA support that the real build
+# does not already assume.
+_PTXAS_PROBE_PTX = """\
+.version 8.5
+.target sm_90a
+.address_size 64
+
+.shared .align 16 .b8 probe_shared_buffer[__SIZE__];
+
+.visible .entry probe_static_shared(
+\t.param .u64 .ptr .align 4 probe_static_shared_param_0
+)
+{
+\t.reg .b32 \t%r<4>;
+\t.reg .b64 \t%rd<4>;
+
+\tld.param.u64 \t%rd1, [probe_static_shared_param_0];
+\tcvta.to.global.u64 \t%rd2, %rd1;
+\tmov.u32 \t%r1, %tid.x;
+\tmov.u32 \t%r2, probe_shared_buffer;
+\tst.shared.u32 \t[%r2], %r1;
+\tbar.sync \t0;
+\tld.shared.u32 \t%r3, [%r2];
+\tst.global.u32 \t[%rd2], %r3;
+\tret;
+}
+"""
+
+# The static-shared ceiling every ptxas enforces without an opt-in, and the
+# smallest request above it. 49152 must assemble everywhere: it is the
+# control leg that tells a real ceiling apart from a probe that failed for
+# an unrelated reason (an sm_90a-unaware assembler, a sandboxed exec).
+_PTXAS_PROBE_SIZES = (131072, 49152)
+
+_PTXAS_BIG_SMEM_ENV = "TORCH_MOJO_BACKEND_PTXAS_BIG_SMEM"
+
+
+def _ptxas_assembles(compiler: str, size: int) -> bool:
+    """Whether `compiler` assembles the probe with `size` bytes of static smem."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        source = Path(tmpdir) / f"probe_{size}.ptx"
+        source.write_text(_PTXAS_PROBE_PTX.replace("__SIZE__", str(size)))
+        proc = subprocess.run(
+            [compiler, "-arch=sm_90a", str(source), "-o", os.devnull],
+            capture_output=True,
+            text=True,
+        )
+    return proc.returncode == 0
+
+
+@functools.cache
+def _ptxas_supports_big_static_smem() -> bool:
+    """Whether the active PTX assembler accepts >48 KiB of *static* shared memory.
+
+    Answering False compiles the sm_90 WGMMA/TMA GEMM routes out of the build
+    (see `_big_static_smem_on` in variant_gates.mojo): ptxas fails the whole
+    `mojo build`, not the one over-limit kernel, so an extension carrying such
+    a kernel is not slow on an old assembler, it is unimportable — and this
+    loader deliberately has no run-time fallback (docs/kernel_call_queue.md).
+    The routes that stay serve every shape those ones did, more slowly.
+
+    The answer is a property of the assembler, so it is probed rather than
+    guessed from a version string:
+
+    * `TORCH_MOJO_BACKEND_PTXAS_BIG_SMEM=0`/`=1` overrides everything, for
+      tests and for a machine whose probe is wrong.
+    * With `MODULAR_NVPTX_COMPILER_PATH` unset, MAX assembles PTX in-process
+      with the PTX compiler it ships (CUDA 13 today, which accepts big static
+      smem) and there is no external binary to interrogate: answer True, so
+      the default install compiles exactly the kernels it always did.
+    * Otherwise that env var names the `ptxas` MAX will hand the PTX to, and
+      it is the one binary whose limits matter. Assemble the probe with it.
+
+    Only NVIDIA is affected. AMD and Apple builds never consult
+    `MODULAR_NVPTX_COMPILER_PATH`, so they take the True branch above and
+    nothing about them changes; the routes gated on this flag are in any case
+    already behind an sm_9x comptime check.
+    """
+    override = os.environ.get(_PTXAS_BIG_SMEM_ENV)
+    if override in ("0", "1"):
+        return override == "1"
+    compiler = os.environ.get("MODULAR_NVPTX_COMPILER_PATH")
+    if not compiler:
+        return True
+    big, control = _PTXAS_PROBE_SIZES
+    try:
+        if _ptxas_assembles(compiler, big):
+            return True
+        # The big probe failed. Only a passing control leg makes that a
+        # statement about the ceiling; if even 48 KiB fails, the probe itself
+        # is broken and gating the fast kernels out on that evidence would be
+        # a silent, permanent slowdown. Keep today's behaviour and say so.
+        if _ptxas_assembles(compiler, control):
+            return False
+    except OSError as exc:
+        sys.stderr.write(
+            f"torch-mojo-backend: could not run {compiler!r} to probe its "
+            f"static shared-memory limit ({exc}); assuming it accepts the "
+            f"large-shared-memory kernels. Set {_PTXAS_BIG_SMEM_ENV}=0 if "
+            "builds fail with 'uses too much shared data'.\n"
+        )
+        return True
+    sys.stderr.write(
+        f"torch-mojo-backend: {compiler!r} failed to assemble both probes, so "
+        "its static shared-memory limit could not be determined; assuming it "
+        f"accepts the large-shared-memory kernels. Set {_PTXAS_BIG_SMEM_ENV}=0 "
+        "if builds fail with 'uses too much shared data'.\n"
+    )
+    return True
+
+
+def big_static_smem_flags() -> dict[str, DefineValue]:
+    """The `PTXAS_BIG_SMEM` define for a family that has >48 KiB-smem routes.
+
+    Empty when the assembler cannot take them, because every gate in
+    variant_gates.mojo is written so that an absent define reads back as ""
+    and selects nothing. Callers merge this into their `flags`; a family with
+    no such route must not, or it forks a second, byte-identical build of
+    itself for no reason (see this module's docstring).
+    """
+    return {"PTXAS_BIG_SMEM": 1} if _ptxas_supports_big_static_smem() else {}
 
 
 def _extension_cmd(src: Path, defines: CanonicalDefines | None, out: Path) -> list[str]:

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -2179,14 +2179,29 @@ class _MatmulSpecExtension(
     MOJO_FILE: ClassVar[Path] = _MatmulExtension.MOJO_FILE
 
     @classmethod
+    def _flag_items(cls, transpose_b: int) -> tuple[tuple[str, bool | int | str], ...]:
+        """The non-dtype defines, in the one place both builders below read.
+
+        `PTXAS_BIG_SMEM` compiles the 128x128 fp32 TN tiles (>48 KiB of
+        static shared memory) in or out; the 64x64 core serves their shapes
+        without it. The two `make_*_defines` hooks must agree exactly — one
+        keys the cache, the other the compile line — so neither spells the
+        flag set itself.
+        """
+        return (
+            ("TRANSPOSE_B", bool(transpose_b)),
+            *eager_kernels.big_static_smem_flags().items(),
+        )
+
+    @classmethod
     def make_defines(
         cls, op: str, tensors: tuple[MojoTensorLike, ...], transpose_b: int
     ) -> dict[str, bool | int | str]:
-        defines = {
+        defines: dict[str, bool | int | str] = {
             "OP": op,
             "DTYPE_OUT": tensors[0]._dtype.name,
-            "TRANSPOSE_B": bool(transpose_b),
         }
+        defines.update(cls._flag_items(transpose_b))
         defines.update(
             (f"DTYPE_ARG_{index}", tensor._dtype.name)
             for index, tensor in enumerate(tensors)
@@ -2201,7 +2216,7 @@ class _MatmulSpecExtension(
             op,
             tuple(t._dtype for t in tensors),
             (tensors[0]._dtype,),
-            (("TRANSPOSE_B", bool(transpose_b)),),
+            cls._flag_items(transpose_b),
         )
 
     @classmethod
@@ -9036,7 +9051,15 @@ def _try_gemm16_mm(
         arg_dtypes=(lhs._dtype, rhs._dtype)
         + ((bias_tensor._dtype,) if bias_tensor is not None else ()),
         output_dtypes=(out._dtype,),
-        flags={"TRANSPOSE_B": bool(transpose_b), "HAS_BIAS": bias_tensor is not None},
+        # The >48 KiB static-smem WGMMA routes exist only where ptxas will
+        # assemble; the flag compiles them out where it cannot, leaving the
+        # mma.sync ladder that serves the same shapes. See
+        # `eager_kernels.big_static_smem_flags`.
+        flags={
+            "TRANSPOSE_B": bool(transpose_b),
+            "HAS_BIAS": bias_tensor is not None,
+            **eager_kernels.big_static_smem_flags(),
+        },
         keepalive=(out, lhs, rhs, bias_tensor),
     )
     return out
@@ -9189,7 +9212,12 @@ def _try_gemm16_bmm(
         ),
         arg_dtypes=(lhs._dtype, rhs._dtype),
         output_dtypes=(out._dtype,),
-        flags={"TRANSPOSE_B": bool(transpose_b)},
+        # Same >48 KiB static-smem gate as the Gemm16 call above: the batched
+        # WGMMA ladder is compiled out where ptxas will not take it.
+        flags={
+            "TRANSPOSE_B": bool(transpose_b),
+            **eager_kernels.big_static_smem_flags(),
+        },
         keepalive=(out, lhs, rhs),
     )
     return out

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -2180,14 +2180,8 @@ class _MatmulSpecExtension(
 
     @classmethod
     def _flag_items(cls, transpose_b: int) -> tuple[tuple[str, bool | int | str], ...]:
-        """The non-dtype defines, in the one place both builders below read.
-
-        `PTXAS_BIG_SMEM` compiles the 128x128 fp32 TN tiles (>48 KiB of
-        static shared memory) in or out; the 64x64 core serves their shapes
-        without it. The two `make_*_defines` hooks must agree exactly — one
-        keys the cache, the other the compile line — so neither spells the
-        flag set itself.
-        """
+        """Non-dtype defines. Both `make_*_defines` hooks must send the same
+        set: one keys the cache, the other the compile line."""
         return (
             ("TRANSPOSE_B", bool(transpose_b)),
             *eager_kernels.big_static_smem_flags().items(),
@@ -9051,10 +9045,6 @@ def _try_gemm16_mm(
         arg_dtypes=(lhs._dtype, rhs._dtype)
         + ((bias_tensor._dtype,) if bias_tensor is not None else ()),
         output_dtypes=(out._dtype,),
-        # The >48 KiB static-smem WGMMA routes exist only where ptxas will
-        # assemble; the flag compiles them out where it cannot, leaving the
-        # mma.sync ladder that serves the same shapes. See
-        # `eager_kernels.big_static_smem_flags`.
         flags={
             "TRANSPOSE_B": bool(transpose_b),
             "HAS_BIAS": bias_tensor is not None,
@@ -9212,8 +9202,6 @@ def _try_gemm16_bmm(
         ),
         arg_dtypes=(lhs._dtype, rhs._dtype),
         output_dtypes=(out._dtype,),
-        # Same >48 KiB static-smem gate as the Gemm16 call above: the batched
-        # WGMMA ladder is compiled out where ptxas will not take it.
         flags={
             "TRANSPOSE_B": bool(transpose_b),
             **eager_kernels.big_static_smem_flags(),

--- a/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_v3_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_v3_kernels.mojo
@@ -1513,18 +1513,9 @@ def enqueue_gemm16_gemm(
     # helper enqueues only for regimes it fully supports (SM90, aligned
     # n/k, TMA-compatible sizes) and returns False otherwise, in which case
     # the pre-existing NT path below remains the fallback.
-    # Every wgmma/TMA route in this ladder — the v4 kernels reached here and
-    # the v3 kernels defined in this file — stages its operand pipeline in
-    # *static* shared memory, 72 KiB to 208 KiB of it. ptxas caps a kernel's
-    # static `.shared` at 48 KiB before CUDA 13 and fails the whole
-    # `mojo build` on the first kernel over the line, so where the active
-    # assembler is an older one this module has to be compiled without those
-    # routes rather than merely stopped from choosing them. That is the only
-    # thing `_big_static_smem_on()` does here; the shapes they claim fall
-    # through to `_enqueue_accepted_bf16_gemm` at the bottom, the mma.sync
-    # ladder that already serves every layout, bias and dtype this family
-    # accepts (slower — restoring the fast routes under such an assembler
-    # means shrinking their tiles, which is a separate piece of work).
+    # The wgmma/TMA routes (v4 and the v3 kernels below) use 72-208 KiB of
+    # static smem; `_big_static_smem_on()` compiles them out where ptxas
+    # rejects that, and `_enqueue_accepted_bf16_gemm` serves their shapes.
     comptime if _big_static_smem_on():
         if not transpose_a and transpose_b and not has_bias:
             # Deep-K split-K route first: the persistent kernel below keeps
@@ -1820,12 +1811,8 @@ def enqueue_gemm16_bmm(
     # straight through, unlike `_tf32_dense_batched_layout` on the aten_fast
     # side which used to reject it (see that function's history).
     #
-    # Both routes below are wgmma/TMA kernels with 48 KiB-to-208 KiB static
-    # shared-memory pipelines, so `_big_static_smem_on()` compiles them out
-    # wherever ptxas would refuse to assemble them at all (see the matching
-    # comment in `enqueue_gemm16_gemm`). What remains is
-    # `_enqueue_accepted_bf16_bmm` at the bottom, which serves every layout
-    # unconditionally — the same kernel that already serves NT and TT here.
+    # Both wgmma/TMA routes are compiled out where ptxas rejects their static
+    # smem (see enqueue_gemm16_gemm); `_enqueue_accepted_bf16_bmm` remains.
     comptime if _big_static_smem_on():
         if not transpose_a and not transpose_b:
             if try_enqueue_bmm16_nn_batched(

--- a/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_v3_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_v3_kernels.mojo
@@ -52,6 +52,7 @@ from gemm16_tn_v4_kernels import (
     try_enqueue_gemm16_gemm_tt_v4,
 )
 from gemm16_dtype import _GEMM16_DT, _GEMM16_TAG
+from variant_gates import _big_static_smem_on
 
 
 comptime _V3_DT = _GEMM16_DT
@@ -1512,19 +1513,32 @@ def enqueue_gemm16_gemm(
     # helper enqueues only for regimes it fully supports (SM90, aligned
     # n/k, TMA-compatible sizes) and returns False otherwise, in which case
     # the pre-existing NT path below remains the fallback.
-    if not transpose_a and transpose_b and not has_bias:
-        # Deep-K split-K route first: the persistent kernel below keeps all
-        # SMs resident but cannot parallelize over K, so an output with few
-        # macro-tiles and a deep reduction leaves most of the GPU idle.
-        # The helper gates itself on that regime (see
-        # gemm16_tn_v4_kernels.mojo) and returns False otherwise.
-        if try_enqueue_gemm16_gemm_splitk_rm_v4[True](
-            output, a, b, m, n, k, ctx
-        ):
-            return
-        if maybe_enqueue_gemm16_nt_v4(output, a, b, m, n, k, ctx):
-            return
-    comptime if _has_sm_9x():
+    # Every wgmma/TMA route in this ladder — the v4 kernels reached here and
+    # the v3 kernels defined in this file — stages its operand pipeline in
+    # *static* shared memory, 72 KiB to 208 KiB of it. ptxas caps a kernel's
+    # static `.shared` at 48 KiB before CUDA 13 and fails the whole
+    # `mojo build` on the first kernel over the line, so where the active
+    # assembler is an older one this module has to be compiled without those
+    # routes rather than merely stopped from choosing them. That is the only
+    # thing `_big_static_smem_on()` does here; the shapes they claim fall
+    # through to `_enqueue_accepted_bf16_gemm` at the bottom, the mma.sync
+    # ladder that already serves every layout, bias and dtype this family
+    # accepts (slower — restoring the fast routes under such an assembler
+    # means shrinking their tiles, which is a separate piece of work).
+    comptime if _big_static_smem_on():
+        if not transpose_a and transpose_b and not has_bias:
+            # Deep-K split-K route first: the persistent kernel below keeps
+            # all SMs resident but cannot parallelize over K, so an output
+            # with few macro-tiles and a deep reduction leaves most of the
+            # GPU idle. The helper gates itself on that regime (see
+            # gemm16_tn_v4_kernels.mojo) and returns False otherwise.
+            if try_enqueue_gemm16_gemm_splitk_rm_v4[True](
+                output, a, b, m, n, k, ctx
+            ):
+                return
+            if maybe_enqueue_gemm16_nt_v4(output, a, b, m, n, k, ctx):
+                return
+    comptime if _has_sm_9x() and _big_static_smem_on():
         if ctx.api() == "cuda":
             var cc_major = ctx.get_attribute(
                 DeviceAttribute.COMPUTE_CAPABILITY_MAJOR
@@ -1805,23 +1819,31 @@ def enqueue_gemm16_bmm(
     # is a first-class input here, not a special case: the caller passes it
     # straight through, unlike `_tf32_dense_batched_layout` on the aten_fast
     # side which used to reject it (see that function's history).
-    if not transpose_a and not transpose_b:
-        if try_enqueue_bmm16_nn_batched(
-            output,
-            a,
-            b,
-            batch_count,
-            m,
-            n,
-            k,
-            output_batch_stride,
-            a_batch_stride,
-            b_batch_stride,
-            ctx,
-        ):
-            return
+    #
+    # Both routes below are wgmma/TMA kernels with 48 KiB-to-208 KiB static
+    # shared-memory pipelines, so `_big_static_smem_on()` compiles them out
+    # wherever ptxas would refuse to assemble them at all (see the matching
+    # comment in `enqueue_gemm16_gemm`). What remains is
+    # `_enqueue_accepted_bf16_bmm` at the bottom, which serves every layout
+    # unconditionally — the same kernel that already serves NT and TT here.
+    comptime if _big_static_smem_on():
+        if not transpose_a and not transpose_b:
+            if try_enqueue_bmm16_nn_batched(
+                output,
+                a,
+                b,
+                batch_count,
+                m,
+                n,
+                k,
+                output_batch_stride,
+                a_batch_stride,
+                b_batch_stride,
+                ctx,
+            ):
+                return
     if transpose_a and not transpose_b:
-        comptime if _has_sm_9x():
+        comptime if _has_sm_9x() and _big_static_smem_on():
             if ctx.api() == "cuda":
                 var cc_major = ctx.get_attribute(
                     DeviceAttribute.COMPUTE_CAPABILITY_MAJOR

--- a/torch_mojo_backend/eager_kernels/matmul_ops/tn_f32_gemm_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/matmul_ops/tn_f32_gemm_kernels.mojo
@@ -459,17 +459,9 @@ def try_enqueue_tn_f32_gemm(
     var vb4 = n % 4 == 0 and b_addr % 16 == 0
 
     var use_t128 = m >= 96 and n >= 96
-    # Both 128x128 cores stage their tiles in *static* shared memory —
-    # 0x10000 bytes for the quadrant core, up to 0x20000 for the warp-group
-    # split core — and ptxas caps a kernel's static `.shared` at 0xc000
-    # bytes before CUDA 13. It rejects the kernel at assembly time, which
-    # fails the whole `mojo build`, so an assembler with that cap needs a
-    # build these tiles are not *in*, not merely one that avoids selecting
-    # them. Forcing the choice here is the whole of the runtime effect; the
-    # matching `comptime if` on the launches below is what actually keeps
-    # them out of the module. The 64x64 core is correct for any m, n, k >= 1
-    # (see this function's docstring), so it serves these shapes instead,
-    # more slowly on the large ones.
+    # The 128x128 cores use 64-128 KiB of static smem, over ptxas's 48 KiB
+    # cap before CUDA 13; the `comptime if` below keeps them out of such a
+    # build and the 64x64 core (correct for any m, n, k >= 1) serves instead.
     comptime if not _big_static_smem_on():
         use_t128 = False
     var use_split = use_t128 and va4 and vb4
@@ -512,12 +504,8 @@ def try_enqueue_tn_f32_gemm(
         ws = ctx.enqueue_create_buffer[DType.float32](ksplits * m * n)
         c_target = Int(ws.value().unsafe_ptr())
 
-    # The `comptime if` is what keeps the 128x128 tiles out of a build whose
-    # assembler will not take their static shared memory: a runtime `if`
-    # would still elaborate the parametric launch and emit the kernel. Its
-    # partner is the `use_t128 = False` above, which is what makes the
-    # 64x64 launch below unconditional in that build — every path out of
-    # this function still enqueues exactly one GEMM.
+    # `comptime if`, not a runtime `if`: a runtime branch would still
+    # elaborate the parametric launch and emit the over-limit kernel.
     comptime if _big_static_smem_on():
         if use_split:
             # Deep splits mean short per-group chains (kchunk <= ~2 x

--- a/torch_mojo_backend/eager_kernels/matmul_ops/tn_f32_gemm_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/matmul_ops/tn_f32_gemm_kernels.mojo
@@ -61,6 +61,7 @@ from std.sys.info import _has_sm_9x
 from gemm_splitk_common import TARGET_BLOCKS, _ksplit_reduce_kernel
 from op_utils import _enqueue_cached, _make_ptr
 from tn_f32_gemm_core import _tn_core_kernel, _tn_split_kernel
+from variant_gates import _big_static_smem_on
 
 
 # Split-K workspace cap. 32 MB never binds for the tiny-MN deep-K regime it
@@ -458,6 +459,19 @@ def try_enqueue_tn_f32_gemm(
     var vb4 = n % 4 == 0 and b_addr % 16 == 0
 
     var use_t128 = m >= 96 and n >= 96
+    # Both 128x128 cores stage their tiles in *static* shared memory —
+    # 0x10000 bytes for the quadrant core, up to 0x20000 for the warp-group
+    # split core — and ptxas caps a kernel's static `.shared` at 0xc000
+    # bytes before CUDA 13. It rejects the kernel at assembly time, which
+    # fails the whole `mojo build`, so an assembler with that cap needs a
+    # build these tiles are not *in*, not merely one that avoids selecting
+    # them. Forcing the choice here is the whole of the runtime effect; the
+    # matching `comptime if` on the launches below is what actually keeps
+    # them out of the module. The 64x64 core is correct for any m, n, k >= 1
+    # (see this function's docstring), so it serves these shapes instead,
+    # more slowly on the large ones.
+    comptime if not _big_static_smem_on():
+        use_t128 = False
     var use_split = use_t128 and va4 and vb4
 
     var gx: Int
@@ -498,13 +512,52 @@ def try_enqueue_tn_f32_gemm(
         ws = ctx.enqueue_create_buffer[DType.float32](ksplits * m * n)
         c_target = Int(ws.value().unsafe_ptr())
 
-    if use_split:
-        # Deep splits mean short per-group chains (kchunk <= ~2 x
-        # KCHUNK_MIN_T128 slabs); STAGES=2's one-slab prologue amortizes
-        # better there (interleaved A/B on 128x128x131072 ks=114: s2
-        # 0.157 ms vs s4 0.158-0.159 ms). Long chains keep STAGES=4.
-        if ksplits > SPLITK_GENERIC_CAP:
-            _tn_split_launch[128, 128, 16, 2](
+    # The `comptime if` is what keeps the 128x128 tiles out of a build whose
+    # assembler will not take their static shared memory: a runtime `if`
+    # would still elaborate the parametric launch and emit the kernel. Its
+    # partner is the `use_t128 = False` above, which is what makes the
+    # 64x64 launch below unconditional in that build — every path out of
+    # this function still enqueues exactly one GEMM.
+    comptime if _big_static_smem_on():
+        if use_split:
+            # Deep splits mean short per-group chains (kchunk <= ~2 x
+            # KCHUNK_MIN_T128 slabs); STAGES=2's one-slab prologue amortizes
+            # better there (interleaved A/B on 128x128x131072 ks=114: s2
+            # 0.157 ms vs s4 0.158-0.159 ms). Long chains keep STAGES=4.
+            if ksplits > SPLITK_GENERIC_CAP:
+                _tn_split_launch[128, 128, 16, 2](
+                    ctx,
+                    gx,
+                    gy,
+                    ksplits,
+                    c_target,
+                    a_addr,
+                    b_addr,
+                    m,
+                    n,
+                    k,
+                    ksplits,
+                    va4,
+                    vb4,
+                )
+            else:
+                _tn_split_launch[128, 128, 16, 4](
+                    ctx,
+                    gx,
+                    gy,
+                    ksplits,
+                    c_target,
+                    a_addr,
+                    b_addr,
+                    m,
+                    n,
+                    k,
+                    ksplits,
+                    va4,
+                    vb4,
+                )
+        elif use_t128:
+            _tn_core_launch[128, 128, 16, 32, 64, 4, 4, 2](
                 ctx,
                 gx,
                 gy,
@@ -519,39 +572,7 @@ def try_enqueue_tn_f32_gemm(
                 va4,
                 vb4,
             )
-        else:
-            _tn_split_launch[128, 128, 16, 4](
-                ctx,
-                gx,
-                gy,
-                ksplits,
-                c_target,
-                a_addr,
-                b_addr,
-                m,
-                n,
-                k,
-                ksplits,
-                va4,
-                vb4,
-            )
-    elif use_t128:
-        _tn_core_launch[128, 128, 16, 32, 64, 4, 4, 2](
-            ctx,
-            gx,
-            gy,
-            ksplits,
-            c_target,
-            a_addr,
-            b_addr,
-            m,
-            n,
-            k,
-            ksplits,
-            va4,
-            vb4,
-        )
-    else:
+    if not use_t128:
         _tn_core_launch[64, 64, 16, 16, 32, 4, 4, 4](
             ctx,
             gx,

--- a/torch_mojo_backend/eager_kernels/ptxas_probe.mojo
+++ b/torch_mojo_backend/eager_kernels/ptxas_probe.mojo
@@ -1,0 +1,76 @@
+# ===----------------------------------------------------------------------=== #
+# ptxas static-shared-memory capability probe.
+#
+# Not a kernel: `_ptxas_probe_kernel` exists only so `mojo build` elaborates a
+# GPU entry with a *static* `.shared` buffer of `PROBE_SIZE` bytes (a `-D`
+# define, see eager_kernels/__init__.py) the same way a real gated GEMM
+# kernel would. Its thread-index write, barrier, and readback into a
+# caller-visible pointer keep the buffer live so no optimizer pass can prove
+# it dead and drop the `.shared` declaration before ptxas ever sees it.
+#
+# `_ptxas_probe_entry` is `@export`ed and never called (the address it hands
+# `DeviceContext`/`enqueue_function` is a placeholder, not a real buffer):
+# exporting it is what makes `mojo build` fully elaborate everything it
+# reaches, the same mechanism `scripts/compare_kernel_asm.py` relies on for
+# real entry modules. It deliberately is NOT named `PyInit_...` -- that name
+# is how `compare_kernel_asm.py` finds real Python-extension entry points,
+# and this file is neither loaded as an extension nor built by that script.
+#
+# Built with `--emit shared-lib` and no `--target-accelerator` override, the
+# same way `eager_kernels._extension_cmd` builds real kernels: passing an
+# explicit accelerator makes `mojo build` defer to PTX-only embedding and
+# skip assembling through the toolchain entirely (confirmed empirically --
+# see the probe's Python-side docstring), so this file always builds for
+# whatever accelerator is actually attached, exactly like a real kernel does.
+# ===----------------------------------------------------------------------=== #
+
+from max.gpu.host import DeviceContext
+from max.gpu.sync import barrier
+from std.gpu import thread_idx
+from std.memory import AddressSpace, OpaquePointer, UnsafePointer, stack_allocation
+from std.os import abort
+from std.sys.defines import get_defined_string
+
+comptime _PROBE_SIZE_STR = get_defined_string["PROBE_SIZE", "49152"]()
+
+
+@always_inline
+def _probe_size() -> Int:
+    # Only the two sizes eager_kernels._PTXAS_PROBE_SIZES ever sends are
+    # meaningful; anything else silently takes the control (always-must-pass)
+    # leg rather than failing this comptime binding.
+    comptime if _PROBE_SIZE_STR == "131072":
+        return 131072
+    else:
+        return 49152
+
+
+comptime _SIZE = _probe_size()
+
+
+def _ptxas_probe_kernel(
+    out_ptr: UnsafePointer[Scalar[DType.uint32], MutUntrackedOrigin]
+):
+    var tile = stack_allocation[
+        _SIZE, DType.uint8, address_space=AddressSpace.SHARED
+    ]()
+    tile[0] = thread_idx.x.cast[DType.uint8]()
+    barrier()
+    out_ptr[0] = tile[0].cast[DType.uint32]()
+
+
+@export
+def _ptxas_probe_entry() abi("C"):
+    try:
+        var ctx = DeviceContext(
+            OpaquePointer[MutUntrackedOrigin](unsafe_from_address=1)
+        )
+        ctx.enqueue_function[_ptxas_probe_kernel](
+            UnsafePointer[Scalar[DType.uint32], MutUntrackedOrigin](
+                unsafe_from_address=1
+            ),
+            grid_dim=(1,),
+            block_dim=(1,),
+        )
+    except e:
+        abort(t"unreachable: the ptxas probe entry is never executed ({e})")

--- a/torch_mojo_backend/eager_kernels/ptxas_probe.mojo
+++ b/torch_mojo_backend/eager_kernels/ptxas_probe.mojo
@@ -1,33 +1,18 @@
-# ===----------------------------------------------------------------------=== #
-# ptxas static-shared-memory capability probe.
-#
-# Not a kernel: `_ptxas_probe_kernel` exists only so `mojo build` elaborates a
-# GPU entry with a *static* `.shared` buffer of `PROBE_SIZE` bytes (a `-D`
-# define, see eager_kernels/__init__.py) the same way a real gated GEMM
-# kernel would. Its thread-index write, barrier, and readback into a
-# caller-visible pointer keep the buffer live so no optimizer pass can prove
-# it dead and drop the `.shared` declaration before ptxas ever sees it.
-#
-# `_ptxas_probe_entry` is `@export`ed and never called (the address it hands
-# `DeviceContext`/`enqueue_function` is a placeholder, not a real buffer):
-# exporting it is what makes `mojo build` fully elaborate everything it
-# reaches, the same mechanism `scripts/compare_kernel_asm.py` relies on for
-# real entry modules. It deliberately is NOT named `PyInit_...` -- that name
-# is how `compare_kernel_asm.py` finds real Python-extension entry points,
-# and this file is neither loaded as an extension nor built by that script.
-#
-# Built with `--emit shared-lib` and no `--target-accelerator` override, the
-# same way `eager_kernels._extension_cmd` builds real kernels: passing an
-# explicit accelerator makes `mojo build` defer to PTX-only embedding and
-# skip assembling through the toolchain entirely (confirmed empirically --
-# see the probe's Python-side docstring), so this file always builds for
-# whatever accelerator is actually attached, exactly like a real kernel does.
-# ===----------------------------------------------------------------------=== #
+# ptxas static-shared-memory probe, built by `_ptxas_supports_big_static_smem`
+# (eager_kernels/__init__.py). The kernel writes, barriers and reads back its
+# `PROBE_SIZE`-byte static `.shared` buffer so no pass can drop it. The entry
+# is never called; `@export` is what makes `mojo build` elaborate the kernel.
+# It is not named `PyInit_...` so compare_kernel_asm.py does not pick it up.
 
 from max.gpu.host import DeviceContext
 from max.gpu.sync import barrier
 from std.gpu import thread_idx
-from std.memory import AddressSpace, OpaquePointer, UnsafePointer, stack_allocation
+from std.memory import (
+    AddressSpace,
+    OpaquePointer,
+    UnsafePointer,
+    stack_allocation,
+)
 from std.os import abort
 from std.sys.defines import get_defined_string
 
@@ -36,9 +21,7 @@ comptime _PROBE_SIZE_STR = get_defined_string["PROBE_SIZE", "49152"]()
 
 @always_inline
 def _probe_size() -> Int:
-    # Only the two sizes eager_kernels._PTXAS_PROBE_SIZES ever sends are
-    # meaningful; anything else silently takes the control (always-must-pass)
-    # leg rather than failing this comptime binding.
+    # Any size other than the two in `_PTXAS_PROBE_SIZES` takes the control leg.
     comptime if _PROBE_SIZE_STR == "131072":
         return 131072
     else:

--- a/torch_mojo_backend/eager_kernels/variant_gates.mojo
+++ b/torch_mojo_backend/eager_kernels/variant_gates.mojo
@@ -16,6 +16,35 @@ def _op_on[name: StaticString]() -> Bool:
         return False
 
 
+comptime _PTXAS_BIG_SMEM = get_defined_string["PTXAS_BIG_SMEM", ""]()
+
+
+@always_inline
+def _big_static_smem_on() -> Bool:
+    """Whether this build may contain kernels using >48 KiB of *static* smem.
+
+    ptxas caps a kernel's static (non-opt-in) `.shared` at 0xc000 bytes on
+    every sm_90 part up to CUDA 12.8 and lifts the cap in CUDA 13, and it
+    fails the whole `mojo build` rather than the one over-limit kernel — so a
+    route that needs a bigger tile has to be compiled out, not merely left
+    unselected, wherever the active assembler is the older one. Python probes
+    that assembler once per process and passes `PTXAS_BIG_SMEM=1` only when
+    it accepts the larger allocation (`_ptxas_supports_big_static_smem` in
+    eager_kernels/__init__.py); the define is absent otherwise, so the
+    default below gates the big routes off exactly like every other gate in
+    this file treats a define nobody sent.
+
+    A route behind this gate must therefore never be the only one able to
+    serve a shape: its `else` has to reach an existing kernel that fits in
+    48 KiB, which for the 16-bit GEMMs is the mma.sync ladder in
+    gemm16_kernels.mojo and for fp32 is the 64x64 TN core.
+    """
+    comptime if _PTXAS_BIG_SMEM == "1":
+        return True
+    else:
+        return False
+
+
 @always_inline
 def _dtype_arg_on[index: Int, dt: DType]() -> Bool:
     """Whether ``dt`` is the exact dtype of tensor argument ``index``."""

--- a/torch_mojo_backend/eager_kernels/variant_gates.mojo
+++ b/torch_mojo_backend/eager_kernels/variant_gates.mojo
@@ -23,21 +23,10 @@ comptime _PTXAS_BIG_SMEM = get_defined_string["PTXAS_BIG_SMEM", ""]()
 def _big_static_smem_on() -> Bool:
     """Whether this build may contain kernels using >48 KiB of *static* smem.
 
-    ptxas caps a kernel's static (non-opt-in) `.shared` at 0xc000 bytes on
-    every sm_90 part up to CUDA 12.8 and lifts the cap in CUDA 13, and it
-    fails the whole `mojo build` rather than the one over-limit kernel — so a
-    route that needs a bigger tile has to be compiled out, not merely left
-    unselected, wherever the active assembler is the older one. Python probes
-    that assembler once per process and passes `PTXAS_BIG_SMEM=1` only when
-    it accepts the larger allocation (`_ptxas_supports_big_static_smem` in
-    eager_kernels/__init__.py); the define is absent otherwise, so the
-    default below gates the big routes off exactly like every other gate in
-    this file treats a define nobody sent.
-
-    A route behind this gate must therefore never be the only one able to
-    serve a shape: its `else` has to reach an existing kernel that fits in
-    48 KiB, which for the 16-bit GEMMs is the mma.sync ladder in
-    gemm16_kernels.mojo and for fp32 is the 64x64 TN core.
+    Sent as `PTXAS_BIG_SMEM=1` only when the assembler accepts that much
+    (`_ptxas_supports_big_static_smem` in eager_kernels/__init__.py). A
+    route behind this gate must never be the only one serving a shape: its
+    fallback has to fit in 48 KiB.
     """
     comptime if _PTXAS_BIG_SMEM == "1":
         return True


### PR DESCRIPTION
ptxas caps static shared memory at 48 KiB up to CUDA 12.8 and enforces it inside `mojo build` — one over-limit kernel fails the whole `.so`, so on a 12.x-assembler machine the matmul families were not slow, they were **unimportable** (first `torch.mm` → ImportError; this is also why `main`'s matmul suites cannot run on such machines today).

The loader probes the active assembler once per process by actually building `ptxas_probe.mojo` — a minimal kernel declaring a comptime-sized static `.shared` array — with `mojo build`, the same invocation (`--emit shared-lib`, no `--target-accelerator`) real extension builds use, rather than guessing which assembler MAX will hand PTX to. `mojo build` only shells out to the binary `MODULAR_NVPTX_COMPILER_PATH` names when it auto-detects a real, physically attached accelerator (confirmed empirically: an explicit `--target-accelerator`, or none attached, both defer to PTX-only embedding and never touch that env var), which also matches the only place this probe is ever consulted in practice — building a real GEMM/BMM extension for an actual mojo device.

Two legs, same sizes as before (131,072-byte big leg, 49,152-byte control leg so a broken toolchain is not mistaken for a capped one), and `-D PTXAS_BIG_SMEM=1` is sent only when the big leg builds. The verdict is now memoized on disk under `__mojocache__`, keyed by toolchain identity plus the compiler binary's path and size/mtime fingerprint, so only the first process per (toolchain, compiler) pays the `mojo build` seconds; `functools.cache` stays as the in-process layer on top. Comptime gates keep the big-smem WGMMA/TMA routes out of 48 KiB-regime builds; the mma.sync ladders and the 64×64 fp32 TN core serve every shape there. With the define present, emitted device code is byte-identical to before. `TORCH_MOJO_BACKEND_PTXAS_BIG_SMEM=0/1` overrides, short-circuiting before either the build or the disk cache; with no `MODULAR_NVPTX_COMPILER_PATH`, MAX assembles with its bundled compiler and nothing changes.

Slice of #421; independent. The follow-up dual-mode PR restores full speed to the 12.x regime; this one makes every install importable and correct first. Validated on the SLURM H100 cluster with real ptxas 12.8 (probe answers False, full `tests/test_ptxas_gating.py` and `tests/test_eager_kernel_loader.py` pass, including the two-extension-family end-to-end correctness worker) and with the variable unset / a fake ptxas-13 stand-in (both answer True).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AbxaDeRuA7yywYEUuZV72