### PR TITLE
Implement torch.Stream / torch.Event and the accelerator stream API

### DIFF
--- a/benchmarks/test_coverage.py
+++ b/benchmarks/test_coverage.py
@@ -109,6 +109,12 @@ SKIPPED_OPS: dict[str, str] = {
         "scalar extraction / sync primitive: the cost is the sync, not a kernel"
     ),
     "aten::normal_": "host-side torch RNG + upload; no device kernel of ours",
+    "aten::record_stream": (
+        "stream-lifetime bookkeeping, not compute: records a MAX event on "
+        "the named stream so a buffer's free is fenced behind a foreign "
+        "reader (device_streams.record_use). No kernel launches, so there "
+        "is no device time to measure"
+    ),
     # -- out-variant plumbing --------------------------------------------
     "aten::addcdiv.out": _OUT,
     "aten::addcmul.out": _OUT,

--- a/docs/streams.md
+++ b/docs/streams.md
@@ -1,0 +1,59 @@
+# Streams and events on the mojo device
+
+The mojo device supports the device-generic accelerator stream API:
+
+```python
+s = torch.Stream(device=torch.accelerator.current_accelerator())
+cur = torch.accelerator.current_stream()
+s.wait_stream(cur)
+with s:
+    ...                      # torch.accelerator.current_stream() is now s
+e = s.record_event()         # a torch.Event
+cur.wait_event(e)
+e.synchronize()
+```
+
+`torch.Stream(device="mojo")`, `torch.Event(device="mojo", enable_timing=True)`,
+`torch.accelerator.current_stream()` / `set_stream()`, and the `torch.mojo`
+module equivalents (`Stream`, `Event`, `current_stream`, `default_stream`,
+`set_stream`, `stream`) all work, with `query` / `synchronize` /
+`wait_event` / `wait_stream` / `record_event` / `elapsed_time` backed by
+real MAX events on real device streams. `isinstance(s, torch.Stream)`
+holds in both directions. Not supported: interprocess events
+(`from_ipc_handle`), stream priorities (accepted, always 0 — MAX has them,
+this backend does not pass the argument through yet), and graph capture
+(`is_capturing()` is always `False`).
+
+`Stream.stream_id` is the stream's MAX `DeviceContext` pointer (torch treats
+a stream id as an opaque int); the native `CUstream`/`hipStream_t` is
+`Stream.native_handle`.
+
+## Why registration patches torch.Stream
+
+PyTorch's generic `torch.Stream`/`torch.Event` route through a C++ device
+guard that is a stub for Python-backed PrivateUse1 devices — every stream
+it mints is stream id 0 and every wait/record is a silent no-op. So
+`register_mojo_devices()` dispatches construction on mojo devices to the
+implementations in `mojo_device/streams.py` (built on
+`mojo_device/device_streams.py`, which also carries the NCCL comm stream
+for distributed training). This mirrors the existing
+`torch.accelerator.synchronize` patch and disappears if upstream ever
+forwards the guard hooks to Python device modules.
+
+## Execution semantics (read this before pipelining)
+
+Eager mojo kernels currently always **execute on the device's default
+stream**, regardless of the current stream. `with s:` tracks the current
+stream per thread and every ordering primitive acts on the real streams,
+so device-agnostic pipelining code runs with exactly the semantics it
+would have on CUDA with a single stream: correct, but without extra
+compute concurrency. (NCCL collectives are the exception — they really do
+run on their own side stream and overlap compute; see `docs/distributed.md`.)
+Redirecting kernel launches through per-stream MAX DeviceContexts is the
+known follow-up that would make `with s:` fully concurrent.
+
+Two rules carried over from CUDA apply unchanged: work you enqueue is only
+on a stream once the kernel-call queue has launched it (host reads and
+`torch.mojo.synchronize()` drain it for you), and a tensor produced on one
+stream must be ordered (event or `wait_stream`) before another stream —
+including external consumers — touches it.

--- a/tests/test_mojo_streams.py
+++ b/tests/test_mojo_streams.py
@@ -1,6 +1,144 @@
-"""Side device streams and the cross-stream free fence."""
+"""torch.Stream / torch.Event support (mojo_device/streams.py) and the
+underlying device streams / free fence (mojo_device/device_streams.py)."""
 
+import pytest
 import torch
+
+from torch_mojo_backend import register_mojo_devices
+
+
+def test_dispatch_installed_and_cpu_delegation():
+    register_mojo_devices()
+    assert getattr(torch.Stream, "_torch_mojo_backend", False)
+    assert getattr(torch.Event, "_torch_mojo_backend", False)
+    cpu_stream = torch.Stream(device="cpu")
+    assert isinstance(cpu_stream, torch.Stream)
+    from torch_mojo_backend.mojo_device.streams import Stream as MojoStream
+
+    assert not isinstance(cpu_stream, MojoStream)
+
+
+def test_stream_construction_and_identity(mojo_gpu: str):
+    stream = torch.Stream(device=mojo_gpu)
+    assert isinstance(stream, torch.Stream)
+    from torch_mojo_backend.mojo_device.streams import Stream as MojoStream
+
+    assert isinstance(stream, MojoStream)
+    assert stream.device == torch.device("mojo", 0)
+    assert stream.device_index == 0
+    assert stream.device_type == "mojo"
+    assert stream.native_handle != 0
+    assert stream.stream_id == stream._device_stream.ctx_ptr
+    assert stream.stream_id != stream.native_handle  # a context, not a stream
+    assert stream.is_capturing() is False
+    assert stream != torch.mojo.default_stream()
+    assert stream == stream
+
+
+def test_current_stream_and_context_manager(mojo_gpu: str):
+    default = torch.mojo.default_stream()
+    assert torch.accelerator.current_stream() == default
+    assert torch.mojo.current_stream() == default
+    side = torch.Stream(device=mojo_gpu)
+    with side:
+        assert torch.accelerator.current_stream() == side
+        assert torch.mojo.current_stream() == side
+    assert torch.accelerator.current_stream() == default
+    torch.mojo.set_stream(side)
+    assert torch.mojo.current_stream() == side
+    torch.mojo.set_stream(default)
+    assert torch.mojo.current_stream() == default
+
+
+def test_documented_device_agnostic_pattern(mojo_gpu: str):
+    stream = torch.Stream(device=torch.accelerator.current_accelerator())
+    current = torch.accelerator.current_stream()
+    stream.wait_stream(current)
+    with stream:
+        assert torch.accelerator.current_stream() == stream
+    event = stream.record_event()
+    assert isinstance(event, torch.Event)
+    current.wait_event(event)
+    stream.synchronize()
+    assert stream.query()
+
+
+def test_wait_stream_orders_real_work(mojo_gpu: str):
+    x = torch.randn(2048, 2048, device=mojo_gpu)
+    y = (x * 1.5 + 0.25).tanh()
+    from torch_mojo_backend.mojo_device import deferred_compile
+
+    deferred_compile.drain()
+    side = torch.Stream(device=mojo_gpu)
+    side.wait_stream(torch.mojo.current_stream())
+    event = side.record_event()
+    event.synchronize()
+    assert event.query()
+    torch.testing.assert_close(
+        y.cpu(), (x.cpu() * 1.5 + 0.25).tanh(), atol=1e-4, rtol=1e-4
+    )
+
+
+def test_event_semantics(mojo_gpu: str):
+    unrecorded = torch.Event(device=mojo_gpu)
+    assert unrecorded.query() is True
+    unrecorded.synchronize()  # no-op by contract
+    with pytest.raises(RuntimeError):
+        unrecorded.wait(torch.mojo.default_stream())
+    with pytest.raises(NotImplementedError):
+        torch.Event(device=mojo_gpu, interprocess=True)
+
+    start = torch.Event(device=mojo_gpu, enable_timing=True)
+    end = torch.Event(device=mojo_gpu, enable_timing=True)
+    stream = torch.mojo.default_stream()
+    torch.mojo.synchronize()
+    start.record(stream)
+    x = torch.randn(1024, 1024, device=mojo_gpu)
+    (x * 2.0).cpu()  # forces the work through the queue and the device
+    end.record(stream)
+    end.synchronize()
+    assert start.query() and end.query()
+    assert start.elapsed_time(end) >= 0.0
+    assert end.device == torch.device("mojo", 0)
+
+    untimed = torch.Event(device=mojo_gpu)
+    untimed.record(stream)
+    with pytest.raises(RuntimeError):
+        untimed.elapsed_time(end)
+
+
+def test_stream_is_a_real_torch_stream_for_cpp_argument_parsing(mojo_gpu: str):
+    """THPStream_Check requires the concrete torch._C.Stream type, not duck typing."""
+    stream = torch.mojo.current_stream()
+    assert isinstance(stream, torch._C.Stream)
+    assert stream.stream_id == stream._device_stream.ctx_ptr
+
+
+def test_record_stream_accepts_mojo_streams(mojo_gpu: str):
+    tensor = torch.ones(1024, device=mojo_gpu)
+    # The device's own stream owns the free already: nothing to fence.
+    tensor.record_stream(torch.mojo.current_stream())
+    assert tensor._holder._events is None
+
+    side = torch.mojo.Stream()
+    tensor.record_stream(side)
+    assert set(tensor._holder._events) == {side.stream_id}
+
+    # Recording the same stream twice keeps one (newest) event for it.
+    tensor.record_stream(side)
+    assert set(tensor._holder._events) == {side.stream_id}
+    assert tensor.cpu().sum().item() == 1024.0
+
+
+def test_record_stream_under_no_dispatch(mojo_gpu: str):
+    """record_stream must work under no_dispatch(), as torch.distributed calls it."""
+    from torch.utils._mode_utils import no_dispatch
+
+    tensor = torch.ones(64, device=mojo_gpu)
+    side = torch.mojo.Stream()
+    with no_dispatch():
+        tensor.record_stream(side)
+    assert set(tensor._holder._events) == {side.stream_id}
 
 
 def test_side_stream_is_distinct_from_default(mojo_gpu: str):

--- a/torch_mojo_backend/mojo_device/aten_ops/streams.py
+++ b/torch_mojo_backend/mojo_device/aten_ops/streams.py
@@ -1,0 +1,34 @@
+"""Stream-lifetime ops: this backend's answer to ``record_stream``."""
+
+import torch
+
+from torch_mojo_backend.mojo_device import device_streams
+from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
+
+from .support import _unsupported
+
+
+# aten::record_stream(Tensor(a!) self, Stream s) -> ()
+def mojo_device_record_stream(self: TorchMojoTensor, s: torch._C.Stream) -> None:
+    """Order ``self``'s eventual free after work already on stream ``s``.
+
+    A thin adapter onto ``device_streams.record_use_on_stream_ctx``: the
+    ``c10::Stream``'s id *is* the mojo stream's MAX ``DeviceContext``
+    pointer.
+
+    Recording against the default stream is a no-op, and that is the common
+    case here: eager kernels always execute on the default stream even
+    inside ``with torch.mojo.stream(side)``, so a library pipelining on side
+    streams (FSDP1 does) records buffers against streams that carry none of
+    the work yet. The fence is still enqueued honestly and becomes
+    load-bearing once kernel launches follow the current stream.
+    """
+    if not isinstance(self, TorchMojoTensor):
+        raise _unsupported("aten::record_stream", (self, s))
+    device = self._device
+    if getattr(device, "api", None) == "cpu":
+        # The CPU device has one stream; there is nothing to fence.
+        return
+    device_streams.record_use_on_stream_ctx(
+        self._holder, int(s.stream_id), device_streams.default_stream_ctx_ptr(device)
+    )

--- a/torch_mojo_backend/mojo_device/device_streams.py
+++ b/torch_mojo_backend/mojo_device/device_streams.py
@@ -85,6 +85,15 @@ class Stream:
             return
         self._stream.wait_for(self.device)
 
+    def wait_stream(self, other: "Stream") -> None:
+        """Order later work here after everything `other` has right now.
+
+        Tail-at-call-time semantics — the free fence wants the different
+        thing (a point-in-time wait), and uses `record_fence_event` instead.
+        """
+        if other is not self:
+            self._stream.wait_for(other._stream)
+
     def make_default_stream_wait(self) -> None:
         """Order subsequent default-stream work after this stream's work."""
         if self.is_default:
@@ -101,8 +110,16 @@ class Stream:
         """Waitable by another stream at any later time — see module docstring."""
         return _holder_mod().fence_event_record(self.ctx_ptr)
 
-    def record_event(self) -> max.driver.DeviceEvent:
-        return self._stream.record_event()
+    def record_event(
+        self, event: max.driver.DeviceEvent | None = None
+    ) -> max.driver.DeviceEvent:
+        """Capture everything enqueued here so far. Pass an existing event
+        to re-record it (e.g. a timing event) instead of minting a new one.
+        """
+        if event is None:
+            return self._stream.record_event()
+        self._stream.record_event(event)
+        return event
 
     def query(self) -> bool:
         """True once this stream's enqueued work has completed.

--- a/torch_mojo_backend/mojo_device/mojo_device_aten_ops.py
+++ b/torch_mojo_backend/mojo_device/mojo_device_aten_ops.py
@@ -75,6 +75,7 @@ from .aten_ops.inplace import (
 )
 from .aten_ops.reductions import mojo_device_min_dim, mojo_device_min_dim_min
 from .aten_ops.rng import mojo_device_normal_
+from .aten_ops.streams import mojo_device_record_stream
 from .aten_ops.support import _eager_impl, _not_implemented, _out_variant
 from .aten_ops.transfer import mojo_device__copy_from, mojo_device__to_copy
 
@@ -355,6 +356,7 @@ _register_fast("aten::permute", "fast_aten_permute")
 _register_fast("aten::pow.Tensor_Scalar", "fast_aten_pow")
 _register_fast("aten::pow.Tensor_Tensor", "fast_aten_pow_tensor_tensor")
 _register_fast("aten::reciprocal", "fast_aten_reciprocal")
+register_aten_op("aten::record_stream")(mojo_device_record_stream)
 register_aten_op("aten::relu")(mojo_device_relu)
 register_aten_op("aten::relu_")(mojo_device_relu_)
 _register_fast("aten::remainder.Scalar", "fast_aten_remainder")

--- a/torch_mojo_backend/mojo_device/register.py
+++ b/torch_mojo_backend/mojo_device/register.py
@@ -53,6 +53,98 @@ def _install_torch_accelerator_synchronize(torch_mojo_device_module):
     torch.accelerator.synchronize = synchronize
 
 
+def _install_torch_accelerator_stream_api(torch_mojo_device_module):
+    """Route torch.accelerator.current_stream/set_stream to mojo streams.
+
+    Same reason as the synchronize patch above: the Python PrivateUse1
+    guard's stream hooks are stubs (every torch.Stream it mints is a silent
+    no-op object), so the generic accelerator entry points would otherwise
+    hand back streams that do nothing.
+    """
+    original_current_stream = torch.accelerator.current_stream
+    if getattr(original_current_stream, "_torch_mojo_backend", False):
+        return
+    mojo_device = torch.device("mojo")
+
+    @wraps(original_current_stream)
+    def current_stream(device=None):
+        if torch.accelerator.current_accelerator() != mojo_device:
+            return original_current_stream(device)
+        return torch_mojo_device_module.current_stream(device)
+
+    current_stream._torch_mojo_backend = True
+    torch.accelerator.current_stream = current_stream
+
+    original_set_stream = torch.accelerator.set_stream
+
+    @wraps(original_set_stream)
+    def set_stream(stream):
+        from torch_mojo_backend.mojo_device.streams import Stream as MojoStream
+
+        if isinstance(stream, MojoStream):
+            return torch_mojo_device_module.set_stream(stream)
+        return original_set_stream(stream)
+
+    set_stream._torch_mojo_backend = True
+    torch.accelerator.set_stream = set_stream
+
+
+def _install_torch_stream_event_dispatch():
+    """Dispatch torch.Stream/torch.Event on mojo devices to real classes.
+
+    Construction through the original classes reaches the stub C++ guard and
+    yields inert objects, so a metaclass routes mojo devices to
+    mojo_device/streams.py while delegating everything else (and the
+    explicit ``stream_id=``/``device_type=`` reconstruction overload) to the
+    originals. ``isinstance`` accepts both families in both directions.
+    """
+    if getattr(torch.Stream, "_torch_mojo_backend", False):
+        return
+    from torch_mojo_backend.mojo_device import streams as mojo_streams
+
+    original_stream = torch.Stream
+    original_event = torch.Event
+
+    def _wants_mojo(args, kwargs):
+        device = kwargs.get("device", args[0] if args else None)
+        if device is None or isinstance(device, int):
+            accelerator = torch.accelerator.current_accelerator()
+            return accelerator is not None and accelerator.type == "mojo"
+        try:
+            return torch.device(device).type == "mojo"
+        except (TypeError, RuntimeError, ValueError):
+            return False
+
+    class _StreamMeta(type):
+        def __call__(cls, *args, **kwargs):
+            if "stream_id" in kwargs or "device_type" in kwargs:
+                return original_stream(*args, **kwargs)
+            if _wants_mojo(args, kwargs):
+                return mojo_streams.Stream(*args, **kwargs)
+            return original_stream(*args, **kwargs)
+
+        def __instancecheck__(cls, instance):
+            return isinstance(instance, (original_stream, mojo_streams.Stream))
+
+    class Stream(metaclass=_StreamMeta):
+        _torch_mojo_backend = True
+
+    class _EventMeta(type):
+        def __call__(cls, *args, **kwargs):
+            if _wants_mojo(args, kwargs):
+                return mojo_streams.Event(*args, **kwargs)
+            return original_event(*args, **kwargs)
+
+        def __instancecheck__(cls, instance):
+            return isinstance(instance, (original_event, mojo_streams.Event))
+
+    class Event(metaclass=_EventMeta):
+        _torch_mojo_backend = True
+
+    torch.Stream = Stream
+    torch.Event = Event
+
+
 def _declare_mojo_tensor_as_plain_tensor():
     """Add TorchMojoTensor to torch's HANDLED_TYPES allowlists.
 
@@ -236,6 +328,8 @@ def register_mojo_devices():
         "mojo", backend_module=torch_mojo_device_module
     )
     _install_torch_accelerator_synchronize(torch_mojo_device_module)
+    _install_torch_accelerator_stream_api(torch_mojo_device_module)
+    _install_torch_stream_event_dispatch()
 
     # PyTorch deliberately uses exact-type checks before selecting foreach
     # optimizers. TorchMojoTensor is a transparent PrivateUse1 wrapper, so

--- a/torch_mojo_backend/mojo_device/streams.py
+++ b/torch_mojo_backend/mojo_device/streams.py
@@ -1,0 +1,304 @@
+"""torch.Stream / torch.Event support for the mojo device.
+
+PyTorch's generic torch.Stream/torch.Event route through a C++ device guard
+that is a stub for Python-backed PrivateUse1 devices: stream construction
+always reports stream id 0 and record/wait/query are silent no-ops.
+register_mojo_devices() dispatches mojo devices to the classes here instead
+— the same remedy the backend already applies to
+torch.accelerator.synchronize. User streams are
+mojo_device.device_streams.Stream instances; see that module's docstring
+for the completion-event vs fence-event split.
+
+Stream derives from the real torch._C.Stream so C++ argument parsing
+(THPStream_Check) accepts it wherever a schema declares a Stream — notably
+aten::record_stream. Its stream_id is the device stream's per-stream MAX
+DeviceContext pointer, an opaque int to torch and the token
+aten::record_stream uses to find the stream to fence a buffer's free
+against (mojo_device/aten_ops/streams.py). The native
+CUstream/hipStream_t stays available as Stream.native_handle.
+
+Execution semantics: eager mojo kernels always EXECUTE on the device's
+default stream today. `with stream:` only tracks the current stream per
+thread (current_stream()/event/wait act on it); it does not redirect
+kernel launches, so device-agnostic pipelining code gets CUDA-single-
+stream semantics — correct, without the extra compute concurrency.
+Redirecting launches through per-stream MAX DeviceContexts is the known
+follow-up.
+"""
+
+import itertools
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import max.driver
+import torch
+
+from torch_mojo_backend.mojo_device import device_streams
+
+_PRIVATEUSE1_DEVICE_TYPE = int(torch._C._autograd.DeviceType.PrivateUse1)
+_user_stream_ids = itertools.count()
+_current_stacks = threading.local()  # {device_index: [Stream, ...]} per thread
+# No annotation: beartype's claw checks module-level annotated globals and
+# rejects the forward reference to Stream (defined below).
+_default_streams = {}  # {device_index: Stream}
+_default_streams_lock = threading.Lock()
+
+
+def _current_device_index() -> int:
+    from torch_mojo_backend.mojo_device import torch_mojo_device_module
+
+    return torch_mojo_device_module.current_device()
+
+
+def _resolve_index(device: object) -> int:
+    if device is None:
+        return _current_device_index()
+    if isinstance(device, int):
+        return device
+    resolved = torch.device(device)
+    if resolved.type != "mojo":
+        raise ValueError(f"expected a mojo device, got {resolved}")
+    return resolved.index if resolved.index is not None else _current_device_index()
+
+
+def _max_device_of(index: int) -> object:
+    from torch_mojo_backend.mojo_device.torch_mojo_tensor import (
+        find_equivalent_max_device,
+    )
+
+    return find_equivalent_max_device(torch.device("mojo", index))
+
+
+class Event:
+    """Mirror of torch.Event for mojo devices, backed by a driver event.
+
+    Both backing events are created lazily at first ``record``, on the
+    device of the stream being recorded. ``blocking`` is accepted and
+    ignored (host waits always yield); ``interprocess`` is unsupported.
+    """
+
+    def __init__(
+        self,
+        device: object = None,
+        *,
+        enable_timing: bool = False,
+        blocking: bool = False,
+        interprocess: bool = False,
+    ) -> None:
+        if interprocess:
+            raise NotImplementedError(
+                "interprocess events are not supported on the mojo device"
+            )
+        self.enable_timing = enable_timing
+        # driver event: host-side query/synchronize/timing. fence event:
+        # what another stream can be made to wait on (device_streams.py).
+        self._event: max.driver.DeviceEvent | None = None
+        self._fence: object | None = None
+        self._device_index: int | None = (
+            None if device is None else _resolve_index(device)
+        )
+
+    @property
+    def device(self) -> torch.device | None:
+        if self._device_index is None:
+            return None
+        return torch.device("mojo", self._device_index)
+
+    def record(self, stream: "Stream | None" = None) -> None:
+        if stream is None:
+            stream = current_stream(self._device_index)
+        device_stream = stream._device_stream
+        if self._event is None:
+            self._event = max.driver.DeviceEvent(
+                device_stream.device, enable_timing=self.enable_timing
+            )
+        # Back to back on one stream: both mark the same point in it.
+        device_stream.record_event(self._event)
+        self._fence = device_stream.record_fence_event()
+        self._device_index = stream.device_index
+
+    def wait(self, stream: "Stream | None" = None) -> None:
+        if self._fence is None:
+            raise RuntimeError("Event must be recorded before it can be waited on")
+        if stream is None:
+            stream = current_stream(self._device_index)
+        stream._device_stream.wait_fence_event(self._fence)
+
+    def query(self) -> bool:
+        return True if self._event is None else self._event.is_ready()
+
+    def synchronize(self) -> None:
+        if self._event is not None:
+            self._event.synchronize()
+
+    def elapsed_time(self, end_event: "Event") -> float:
+        if not (self.enable_timing and end_event.enable_timing):
+            raise RuntimeError("both events must be created with enable_timing=True")
+        if self._event is None or end_event._event is None:
+            raise RuntimeError("both events must be recorded before elapsed_time")
+        return self._event.elapsed_time(end_event._event)
+
+    @classmethod
+    def from_ipc_handle(cls, device: object, handle: bytes) -> "Event":
+        raise NotImplementedError(
+            "interprocess events are not supported on the mojo device"
+        )
+
+    def __repr__(self) -> str:
+        return f"torch.mojo.Event(device={self.device}, recorded={self._event is not None})"
+
+
+class Stream(torch._C.Stream):
+    """Mirror of torch.Stream for mojo devices, backed by a device stream.
+
+    Derived from the real ``torch._C.Stream`` (captured here rather than via
+    ``torch.Stream``, which ``register_mojo_devices()`` later replaces with
+    a dispatching wrapper) so C++ argument parsing (``THPStream_Check``)
+    accepts it wherever a schema declares a ``Stream`` — notably
+    ``aten::record_stream``. Every ordering method below overrides the
+    base's stub PrivateUse1 device-guard no-op.
+    """
+
+    def __new__(
+        cls,
+        device: object = None,
+        priority: int = 0,
+        *,
+        _device_stream: device_streams.Stream | None = None,
+    ) -> "Stream":
+        index = _resolve_index(device)
+        if _device_stream is None:
+            _device_stream = device_streams.Stream(
+                _max_device_of(index), f"user-{next(_user_stream_ids)}"
+            )
+        self = super().__new__(
+            cls, _device_stream.ctx_ptr, index, _PRIVATEUSE1_DEVICE_TYPE
+        )
+        self._device_stream = _device_stream
+        self._index = index
+        # MAX supports stream priorities but max.driver.DeviceStream's
+        # constructor doesn't take one yet; accepted and reported as 0.
+        self.priority = 0
+        return self
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        # Everything happens in __new__ (the base type is a C type whose
+        # tp_new takes the three identity fields); accept and ignore the
+        # constructor arguments so `Stream(device, priority=...)` works.
+        pass
+
+    @property
+    def device(self) -> torch.device:
+        return torch.device("mojo", self._index)
+
+    @property
+    def device_index(self) -> int:
+        return self._index
+
+    @property
+    def device_type(self) -> str:
+        return "mojo"
+
+    @property
+    def stream_id(self) -> int:
+        return self._device_stream.ctx_ptr
+
+    @property
+    def native_handle(self) -> int:
+        return self._device_stream.handle
+
+    def query(self) -> bool:
+        return self._device_stream.query()
+
+    def synchronize(self) -> None:
+        self._device_stream.synchronize()
+
+    def wait_event(self, event: Event) -> None:
+        event.wait(self)
+
+    def wait_stream(self, other: "Stream | torch.Stream") -> None:
+        """Order this stream after everything enqueued on `other` so far."""
+        self._device_stream.wait_stream(_stream_of(other, self._index))
+
+    def record_event(self, event: Event | None = None) -> Event:
+        if event is None:
+            event = Event(device=self._index)
+        event.record(self)
+        return event
+
+    def is_capturing(self) -> bool:
+        return False  # no graph capture on the mojo device
+
+    def __enter__(self) -> "Stream":
+        stacks = getattr(_current_stacks, "stacks", None)
+        if stacks is None:
+            stacks = _current_stacks.stacks = {}
+        stacks.setdefault(self._index, []).append(self)
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        _current_stacks.stacks[self._index].pop()
+
+    def __eq__(self, other: object) -> bool:
+        return (
+            isinstance(other, Stream)
+            and other._device_stream.ctx_ptr == self._device_stream.ctx_ptr
+        )
+
+    def __hash__(self) -> int:
+        return hash(self._device_stream.ctx_ptr)
+
+    def __repr__(self) -> str:
+        return (
+            f"torch.mojo.Stream(device=mojo:{self._index}, "
+            f"native_handle=0x{self._device_stream.handle:x}"
+            f"{', default' if self._device_stream.is_default else ''})"
+        )
+
+
+def _stream_of(stream: object, index: int) -> device_streams.Stream:
+    """The device stream of ours, or of a stub torch.Stream (= the default
+    stream: the stub PrivateUse1 guard can only ever describe that one)."""
+    if isinstance(stream, Stream):
+        return stream._device_stream
+    return default_stream(index)._device_stream
+
+
+def default_stream(device: object = None) -> Stream:
+    index = _resolve_index(device)
+    with _default_streams_lock:
+        stream = _default_streams.get(index)
+        if stream is None:
+            stream = Stream(
+                device=index,
+                _device_stream=device_streams.default_stream(_max_device_of(index)),
+            )
+            _default_streams[index] = stream
+        return stream
+
+
+def current_stream(device: object = None) -> Stream:
+    index = _resolve_index(device)
+    stacks = getattr(_current_stacks, "stacks", None)
+    if stacks and stacks.get(index):
+        return stacks[index][-1]
+    return default_stream(index)
+
+
+def set_stream(stream: Stream) -> None:
+    """Make `stream` this thread's ambient current stream (no nesting)."""
+    stacks = getattr(_current_stacks, "stacks", None)
+    if stacks is None:
+        stacks = _current_stacks.stacks = {}
+    stacks[stream.device_index] = [stream]
+
+
+@contextmanager
+def stream(stream: "Stream | None") -> Iterator[None]:
+    """Context-manager helper mirroring torch.cuda.stream(s)."""
+    if stream is None:
+        yield
+        return
+    with stream:
+        yield

--- a/torch_mojo_backend/mojo_device/torch_mojo_device_module.py
+++ b/torch_mojo_backend/mojo_device/torch_mojo_device_module.py
@@ -197,3 +197,45 @@ def synchronize(device: "int | str | torch.device | None" = None) -> None:
 
 def get_amp_supported_dtype():
     return [torch.float16, torch.bfloat16]  # TODO change
+
+
+def memory_stats(device: "int | str | torch.device | None" = None) -> dict[str, int]:
+    """Whole-device memory counters, straight from the MAX driver.
+
+    Deliberately NOT torch.cuda's key names ("allocated_bytes.all.current"
+    and friends): those describe a caching allocator's per-process
+    accounting, and MAX exposes no such thing — ``Device.stats`` reports the
+    driver's device-wide free/total plus its graph pools. Inventing the CUDA
+    keys from those would mean reporting another process's allocations as
+    this one's. Callers that want the CUDA schema should read
+    ``torch.cuda.memory_stats`` on a CUDA build; callers that want a number
+    for this device get honest ones here.
+    """
+    from .torch_mojo_tensor import find_equivalent_max_device
+
+    stats = find_equivalent_max_device(_resolve_sync_device(device)).stats
+    return {name: int(value) for name, value in dict(stats).items()}
+
+
+def memory_summary(
+    device: "int | str | torch.device | None" = None, abbreviated: bool = False
+) -> str:
+    """Human-readable ``memory_stats``. FSDP prints this in OOM messages."""
+    resolved = _resolve_sync_device(device)
+    lines = [f"Mojo device memory ({resolved}), as reported by the MAX driver:"]
+    for name, value in memory_stats(device).items():
+        lines.append(f"  {name:24s} {value:>18,d}")
+    return "\n".join(lines)
+
+
+# Streams: real torch.Stream/torch.Event support, dispatched here by
+# register_mojo_devices() because the generic classes' C++ guard is a stub
+# for Python PrivateUse1 backends. See mojo_device/streams.py.
+from torch_mojo_backend.mojo_device.streams import (  # noqa: E402
+    Event as Event,
+)
+from torch_mojo_backend.mojo_device.streams import Stream as Stream
+from torch_mojo_backend.mojo_device.streams import current_stream as current_stream
+from torch_mojo_backend.mojo_device.streams import default_stream as default_stream
+from torch_mojo_backend.mojo_device.streams import set_stream as set_stream
+from torch_mojo_backend.mojo_device.streams import stream as stream


### PR DESCRIPTION
`torch.Stream(device="mojo")` and `torch.Event` now work: real MAX events and side streams behind the documented accelerator API — query/synchronize/wait_event/wait_stream/record_event, elapsed_time, current_stream/set_stream/default_stream, the stream context manager, and `torch.accelerator.current_stream/set_stream`. The C++ PrivateUse1 stream guard is a stub, so construction and isinstance dispatch to the Python implementation at registration; `Stream` derives from `torch._C.Stream` so C-level `THPStream_Check` accepts it.

### A torch.Event is two MAX events

No single event type answers everything `torch.Event` promises, so `record()` records two, back to back on the same stream (they therefore mark the same point in it):

| | backing | serves |
|---|---|---|
| completion | `max.driver.DeviceEvent` | `query()` → `is_ready()`, `synchronize()`, `elapsed_time()` (honours `enable_timing`) |
| fence | Mojo event in `tensor_holder` | `Event.wait(stream)` / `Stream.wait_event(event)` |

The second exists because one stream waiting on an event another stream recorded *earlier* is the one primitive `max.driver` does not expose — see #431 for why `DeviceStream.wait_for(stream)` (tail semantics) is not a substitute. Nothing binds a vendor library; there is no ctypes anywhere in this path.

`Stream.stream_id` is the stream's MAX `DeviceContext` pointer rather than the native `CUstream`. torch treats a stream id as an opaque int, and that pointer is the token every ordering call in this backend takes, so `aten::record_stream` can fence a buffer's free against the stream it names with no translation step. The native handle is still reachable as `Stream.native_handle` (that is what NCCL is handed). Stream priorities are accepted and reported as 0 — MAX does support them (`DeviceContext.create_stream(priority=…)`), `max.driver.DeviceStream`'s constructor does not take one yet.

### Execution semantics, stated plainly

(docs/streams.md) Eager kernels still EXECUTE on the default stream; the ordering primitives are real, so `with stream:` regions order correctly but add no compute concurrency yet (per-stream launch contexts are the known follow-up). `aten::record_stream` is a thin adapter onto the cross-stream free fence and works under `no_dispatch()` — how torch.distributed calls it. `torch.mojo` gains `memory_stats`/`memory_summary` from MAX device stats.

**Stacked on #431** — review the last commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AbxaDeRuA7yywYEUuZV72
