### PR TITLE
Fix bf16 floor_divide subnormal underflow on the mojo CPU device

### DIFF
--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -222,6 +222,34 @@ def test_fast_floor_divide_narrow_float_boundary(mojo_device, dtype):
     torch.testing.assert_close(result, torch.floor_divide(x, y))
 
 
+def test_fast_floor_divide_subnormal_quotient_underflow(mojo_device):
+    """Regression test for a CPU-only bug distinct from the boundary-rounding
+    one above: `a` sits exactly at float32's smallest NORMAL magnitude
+    (2**-126, itself exactly representable in bf16 -- not subnormal), and
+    dividing it by an O(1) `b` produces a true quotient that underflows into
+    float32's subnormal range. The CPU `elementwise` codegen this kernel's
+    CPU dispatch goes through was observed to flush that subnormal quotient
+    to zero (a bare scalar `mojo run` of the same fp32 division does NOT
+    flush -- this is specific to that compiled CPU path), giving floor(0) =
+    0 instead of the correct -1. float64's subnormal threshold (~2**-1074)
+    is nowhere near reachable from a bf16 operand, so the CPU dispatch
+    widens to float64 instead of float32 for this op (`cpu_floordiv_f64` in
+    logic_ops.mojo's `_bin_vec_op`); GPU device kernels are unaffected and
+    stay on float32. bf16-only: fp16's own normal range bottoms out at
+    2**-14, far above float32's subnormal cliff (~2**-149), so an fp16
+    operand can never reach this failure mode through the same fp32
+    upcast. Exact values from a fresh OpInfo conformance failure:
+    `conformance/test_opinfo.py::test_matches_cpu_div_floor_rounding_mojo_bfloat16`,
+    sample 5, index (3, 6, 2)."""
+    dtype = torch.bfloat16
+    x = torch.tensor([2.0**-126], dtype=dtype)
+    y = torch.tensor([-4.71875], dtype=dtype)
+    result = torch.floor_divide(x.to(mojo_device), y.to(mojo_device)).cpu()
+    ref = torch.floor_divide(x, y)
+    torch.testing.assert_close(result, ref)
+    torch.testing.assert_close(ref, torch.tensor([-1.0], dtype=dtype))
+
+
 @pytest.mark.parametrize("rounding_mode", ["floor", "trunc"])
 @pytest.mark.parametrize(
     "dtype", [torch.float32, torch.float64, torch.int32, torch.int64, torch.uint8]

--- a/torch_mojo_backend/eager_kernels/logic_ops/logic_ops.mojo
+++ b/torch_mojo_backend/eager_kernels/logic_ops/logic_ops.mojo
@@ -235,7 +235,12 @@ def _add_f32_bf16_contig(
 
 @always_inline
 def _bin_vec_op[
-    dtype: DType, out_dtype: DType, op_code: Int, is_cmp: Bool, width: Int
+    dtype: DType,
+    out_dtype: DType,
+    op_code: Int,
+    is_cmp: Bool,
+    width: Int,
+    cpu_floordiv_f64: Bool = False,
 ](a: SIMD[dtype, width], b: SIMD[dtype, width]) -> SIMD[out_dtype, width]:
     """The op itself on one SIMD group: `dtype x dtype -> out_dtype`.
 
@@ -252,6 +257,14 @@ def _bin_vec_op[
     Runtime-unreachable (dtype, op) combos are pre-gated by the launcher;
     they still instantiate, so every branch must compile -- hence the
     trailing pass-through return.
+
+    `cpu_floordiv_f64` only affects BOP_FLOORDIV's bf16/fp16 widening (see
+    there); every other op ignores it. It defaults False so the four GPU
+    device-kernel call sites (`_bin_bcast_kernel`, `_bin_flat_vec_kernel`,
+    `_bin_rowvec_kernel`) are untouched byte-for-byte -- float64 is not a
+    legal GPU op here (Apple's Metal backend has no float64 at all, see the
+    `has_apple_gpu_accelerator()` guard in `_binary_bcast`). Only the one
+    CPU `elementwise` call site in `_binary_bcast` passes True.
     """
     comptime if is_cmp:
         # `<` and friends are Scalar-only in mojo 1.0; the elementwise forms
@@ -309,11 +322,11 @@ def _bin_vec_op[
         comptime if op_code == BOP_FLOORDIV:
             # `//` = floor(a / b), matching torch.floor_divide for both
             # float and integer dtypes. bf16/fp16 need the division itself
-            # done at fp32: computed directly in their own 8/11-bit mantissa,
-            # the quotient can round onto the wrong side of an integer
-            # boundary before the floor -- e.g. a true quotient of 5.985
-            # rounds to 6.0 in bf16, giving floor_divide = 6 instead of 5.
-            # torch's floor_divide algorithm (`div_floor_floating` in
+            # done wider than their own 8/11-bit mantissa, or the quotient
+            # can round onto the wrong side of an integer boundary before
+            # the floor -- e.g. a true quotient of 5.985 rounds to 6.0 in
+            # bf16, giving floor_divide = 6 instead of 5. torch's
+            # floor_divide algorithm (`div_floor_floating` in
             # c10/util/generic_math.h) is more involved than a plain
             # divide-then-floor, but empirically (verified directly against
             # torch.floor_divide on real bf16/fp16 tensors, including this
@@ -323,10 +336,31 @@ def _bin_vec_op[
             # One body serves every kernel in this family now, so this lives
             # in one place; before the vectorization refactor the same fix had
             # to be written twice, in the scalar body and its SIMD twin.
+            #
+            # CPU-only wrinkle: `elementwise[..., simd_width=1]`'s compiled
+            # CPU lowering flushes subnormal fp32 results to zero (verified
+            # with a bare `mojo run` scalar repro, which does NOT flush --
+            # so this is specific to the CPU `elementwise` codegen, not
+            # Mojo's Float32 arithmetic in general). A bf16 numerator near
+            # DType.float32's min normal (~1.1755e-38) divided by an O(1)
+            # denominator lands the true fp32 quotient in fp32's subnormal
+            # range; flushed to zero, floor(0) = 0 instead of the correct
+            # -1. fp64's subnormal threshold is ~2.2e-308 -- nowhere near
+            # reachable from bf16/fp16 operands -- so widening the CPU path
+            # to fp64 sidesteps the flush entirely without chasing whatever
+            # sets the CPU codegen's FTZ mode. GPU device kernels are not
+            # observed to flush (measured against this same input) and stay
+            # on fp32 unconditionally: fp64 is not just slower there, it is
+            # outright unsupported on Apple's Metal backend.
             comptime if dtype == DType.float16 or dtype == DType.bfloat16:
-                return (
-                    a.cast[DType.float32]() // b.cast[DType.float32]()
-                ).cast[out_dtype]()
+                comptime if cpu_floordiv_f64:
+                    return (
+                        a.cast[DType.float64]() // b.cast[DType.float64]()
+                    ).cast[out_dtype]()
+                else:
+                    return (
+                        a.cast[DType.float32]() // b.cast[DType.float32]()
+                    ).cast[out_dtype]()
             else:
                 return (a // b).cast[out_dtype]()
         comptime if op_code == BOP_TRUNCDIV:
@@ -624,7 +658,12 @@ def _binary_bcast[
                     var a = l_ptr[i0 * ls0 + i1 * ls1 + i2 * ls2 + i3 * ls3]
                     var b = r_ptr[i0 * rs0 + i1 * rs1 + i2 * rs2 + i3 * rs3]
                     out_ptr[i] = _bin_vec_op[
-                        dtype, out_dtype, op_code, is_cmp, 1
+                        dtype,
+                        out_dtype,
+                        op_code,
+                        is_cmp,
+                        1,
+                        cpu_floordiv_f64=True,
                     ](a, b)[0]
 
                 elementwise[func, simd_width=1](Coord(total), ctx)


### PR DESCRIPTION
## Summary

`conformance/test_opinfo.py::TestOpInfoConformancePRIVATEUSE1::test_matches_cpu_div_floor_rounding_mojo_bfloat16`
was the only failing shard across the repo's open-PR CI queue (fresh log:
run 33492061069, job 99805588364). It fails only on CI's "not mojo_device"
runners, which have no accelerator — `mojo:0` there resolves to the mojo
CPU device.

1 of 250 elements was off by exactly 1.0, at a real subnormal-quotient
boundary (not the integer-rounding boundary #402/#407 already handle):

```
a = 2**-126  (bfloat16, exactly float32's smallest NORMAL magnitude)
b = -4.71875 (bfloat16)
torch CPU:  floor_divide(a, b) == -1.0
mojo:cpu:   floor_divide(a, b) ==  0.0   (wrong)
```

## Root cause

`BOP_FLOORDIV` widens bf16/fp16 operands to float32 before dividing (an
existing fix, needed so the quotient doesn't round across an integer
boundary at native 8/11-bit precision). The CPU dispatch path in
`_binary_bcast` — `elementwise[..., simd_width=1]` — was observed to flush
subnormal float32 **results** to zero. A bare `mojo run` scalar repro of
the identical float32 division does **not** flush, so this is specific to
that compiled CPU codegen path, not Mojo's `Float32` arithmetic in general.

`2**-126 / -4.71875` has a true quotient of `~-2.49e-39`, inside float32's
subnormal range (`< 2**-126`). Flushed to zero, `floor(0) = 0` instead of
the correct `-1`.

## Fix

On the CPU dispatch only, widen `BOP_FLOORDIV`'s bf16/fp16 path to
**float64** instead of float32. float64's subnormal threshold (~2.2e-308)
is nowhere near reachable from a bf16/fp16 operand, so this sidesteps the
flush entirely without chasing whatever sets the CPU codegen's FTZ mode.

A new `cpu_floordiv_f64` template parameter on `_bin_vec_op` defaults
`False`, so the four GPU device-kernel call sites
(`_bin_bcast_kernel`/`_bin_flat_vec_kernel`/`_bin_rowvec_kernel`, all
launched only off `_binary_bcast`'s non-CPU branch) are untouched
byte-for-byte — float64 is not just slower on GPU, it is outright
**unsupported on Apple's Metal backend** (see the existing
`has_apple_gpu_accelerator()` guard right above in the same function), so a
blanket fp64 widening was not an option. Only the one CPU `elementwise`
call site opts in.

Verified with `scripts/compare_kernel_asm.py` (before = pristine
`upstream/main`, after = this branch) against `sm_90a`, `gfx942`, and
`apple-m4`: **0 kernel differences** on all three — the GPU device code is
provably unaffected.

### `div_trunc` bf16 on CPU

Checked for the same boundary class per the task brief. Trunc's
tensor/tensor path computes at **native** bf16 precision (no fp32/fp64
widening at all — see the existing comment on `BOP_TRUNCDIV`, matching
torch's own `div_trunc_cpu` kernel), so it isn't exposed to this cast-path
issue the same way. It already passes in CI, and to check it wasn't luck I
ran 2000 adversarial probes targeting exactly the subnormal-quotient
region (deliberately constructed inputs near float32's normal/subnormal
boundary, both signs, both rounding modes) against this fixed tree:
**0 trunc failures**, vs. 217 for floor's remaining, out-of-scope
fully-subnormal-**input** case (a bf16 operand that is *itself* subnormal,
not merely a normal value whose *quotient* underflows — a deeper,
unreproduced-by-any-current-OpInfo-sample issue that's a separate
investigation). No `known_unsupported.py` entry needed for trunc.

## Test plan

- [x] `CUDA_VISIBLE_DEVICES="" uv run pytest "conformance/test_opinfo.py::TestOpInfoConformancePRIVATEUSE1::test_matches_cpu_div_floor_rounding_mojo_bfloat16" -v` — was failing, now PASSED (re-ran 3x for determinism, same result every time).
- [x] `CUDA_VISIBLE_DEVICES="" uv run pytest conformance/test_opinfo.py -k "div_floor_rounding or div_trunc_rounding" -q` — 8 passed, 2 skipped (unrelated `test_errors_match` nodes).
- [x] `CUDA_VISIBLE_DEVICES="" uv run pytest conformance/test_known_unsupported.py -q` — 7 passed (unchanged; no entry added).
- [x] `CUDA_VISIBLE_DEVICES="" uv run pytest tests/test_aten_functions.py -k div -q` — 17 passed, 6 xfailed (pre-existing, from #407).
- [x] `flock /tmp/gpu_lock_0.lock uv run pytest tests/test_eager_kernels.py -k "div or floor_divide" -q` (real H100) — 44 passed, GPU leg included — confirms the fix does not change GPU behavior.
- [x] `flock /tmp/gpu_lock_0.lock uv run pytest conformance/test_opinfo.py -k "div_floor_rounding or div_trunc_rounding" -q` (real H100) — 8 passed, 2 skipped, same as before the change.
- [x] `scripts/compare_kernel_asm.py --before <pristine upstream/main> --after . --accelerator {sm_90a,gfx942,apple-m4} --modules logic_ops --ops FloorDivSpec TruncDivSpec --dtypes bfloat16 float16` — 0 kernel differences, all three.
- [x] New regression test `tests/test_eager_kernels.py::test_fast_floor_divide_subnormal_quotient_underflow` — red on pristine `upstream/main` (verified by temporarily reverting just the `.mojo` change in-tree), green on this branch, on both `mojo:cpu` and `mojo:gpu`.
- [x] `uvx pre-commit run --files torch_mojo_backend/eager_kernels/logic_ops/logic_ops.mojo tests/test_eager_kernels.py` — clean.
- [x] `uv run pytest benchmarks/test_coverage.py -q` — 2 passed (no accelerator needed; reconciliation unaffected since bf16 floor_divide isn't in the benchmark's dtype sweep, and no baseline entries changed).

## Note on #407

Not touched — it's an independent PR (bf16 scalar trunc precision,
int div-by-zero, `div.out_mode` dtype pairs) and doesn't overlap this
CPU-only floor_divide subnormal fix. Checked whether it needs rebasing
onto current `main` post-#423's `_strides` → `_mojo_strides` rename;
report separately if action is needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Co2wBC1UYzM4y9PEC92Af
