### PR TITLE
Replace runtime beartype checking with the ty static type checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
         run: |
           uvx pre-commit run --all-files
 
+      - name: Type check with ty
+        run: |
+          uv run ty check
+
   # The one part of benchmarks/ that CI can gate on: it reconciles the
   # suite's bookkeeping — every registered op benchmarked or skipped with a
   # reason, every recorded baseline still addressed by a test node — without

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,9 @@ TORCH_MOJO_BACKEND_VERBOSE=1 uv run pytest tests/test_compiler.py
 uv run ruff check .
 uv run ruff format .
 
+# Run the static type checker (must exit 0)
+uv run ty check
+
 # Or use pre-commit for all checks
 uvx pre-commit run --all-files
 ```
@@ -37,7 +40,9 @@ Always use uv to run commands to ensure the correct environment is activated. Ne
 
 
 ## Development Notes
-- **Code Quality**: Uses Ruff for linting/formatting with Python 3.11+ target and pyupgrade rules
+- **Code Quality**: Uses Ruff for linting/formatting with Python 3.11+ target and
+  pyupgrade rules, plus flake8-annotations (`ANN`) to require type hints; Astral's
+  `ty` (`uv run ty check`) statically checks those hints — see "Type hints" below
 - **Debugging Tools**:
   - Environment variables for profiling and verbose output
   - Graph visualization when `TORCH_MOJO_BACKEND_VERBOSE=1`
@@ -298,19 +303,39 @@ Use `: object` only when no other option is possible. Prefer precise types,
 unions, `Protocol`s (e.g. `MojoTensorLike` for payload-level helpers), or a
 `TypeVar` for pass-through functions.
 
-These hints are enforced at runtime by beartype, but only while running the
-unit tests: `tests/conftest.py` sets `TORCH_MOJO_BACKEND_BEARTYPE=1`, and
-production imports leave it off so no wrapper frames are added to hot paths.
-Set the variable explicitly to enable or disable checking in other contexts.
+These hints are enforced statically by Astral's `ty` type checker
+(`uv run ty check`), which must exit 0. Suppressing a diagnostic (per-rule
+or per-path in `[tool.ty]` in pyproject.toml) is a last resort for
+demonstrable `ty` false positives or third-party stub gaps (torch/max
+untyped surfaces), each needing a one-line reason — prefer a real, precise
+type over widening to `Any`/`object`.
+
+`ty` infers unannotated parameters and returns as `Unknown` and raises no
+diagnostic on their misuse, so a function with no hints at all is invisible
+to it. Ruff's `ANN` rules (`uv run ruff check`) are the backstop that catches
+a missing annotation in the first place; `ty` then checks that the
+annotation is correct. `tests/` and `current_bench/` are exempt from `ANN`
+(per-file-ignores in pyproject.toml): tests/ predates the rule by ~5k
+gaps, mostly pytest fixture params, and current_bench/ is ad hoc GPU
+profiling scratch, not shipped code. `ty` itself still checks whatever code
+in those two paths happens to already be annotated; only `current_bench/`
+and the untracked `deeplink/` are excluded from `ty` entirely.
+
+On a box with an active conda environment, run `ty` through `uv run`
+(`uv run ty check`), not the bare `ty` binary: `CONDA_PREFIX` makes ty's
+site-packages discovery fail outright when set to a non-standard conda
+layout. `[tool.ty.environment] python = ".venv"` in pyproject.toml pins the
+venv explicitly so this doesn't bite even outside `uv run`.
 
 ## To find the correct type hints for a function
 It may be hard to find the correct type hints for a function. What you should do in this case is:
 1) Add an obviously wrong type hint, for example datetime.timezone in an aten function.
-2) Run an existing unit test that calls this function.
-3) Beartype will throw an error and give the name of the type being actually passed to the function.
-4) Replace the type hint by the type given by beartype.
-5) Run the unit test again to check that it works.
-6) Run the whole test suite to verify that the type hint shouldn't be wider.
+2) Run `uv run ty check` (whole repo, or `uv run ty check path/to/file.py`).
+3) `ty` reports the inferred type of the value actually flowing into that
+   argument in its diagnostic.
+4) Replace the type hint with the type `ty` reported.
+5) Run `uv run ty check` again to confirm the diagnostic is gone.
+6) Run the relevant unit test(s) to check the annotation matches runtime behavior.
 
 ## Rules about the eager mode
 

--- a/benchmarks/bench_lib/baselines.py
+++ b/benchmarks/bench_lib/baselines.py
@@ -474,8 +474,8 @@ def rebuild(path: Path = BASELINES_PATH) -> None:
     raw = json.loads(block)
     if isinstance(raw, dict) and raw.get("format") in (3, 4):
         stripped = _without_legacy_aggregates(raw)
-        raw = {
-            "configs": _transposed(stripped.get("configs", {})),
-            "format": FORMAT_VERSION,
-        }
+        # Parsed JSON, shape guaranteed by the format-3/4 contract this
+        # migration handles, not something isinstance can verify past "dict".
+        configs = typing.cast("dict[str, dict]", stripped.get("configs", {}))
+        raw = {"configs": _transposed(configs), "format": FORMAT_VERSION}
     write(_parse(raw, path), path)

--- a/benchmarks/bench_lib/cases.py
+++ b/benchmarks/bench_lib/cases.py
@@ -13,6 +13,8 @@ own aten op token in baselines.html.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 import pytest
 import torch
 
@@ -54,7 +56,7 @@ def unit_interval(shape: tuple[int, ...], dtype: torch.dtype) -> torch.Tensor:
     return (torch.rand(shape, dtype=torch.float32) * 0.9 + 0.05).to(dtype)
 
 
-def op_params(ops: dict[str, object]) -> list[object]:
+def op_params(ops: Mapping[str, object]) -> list[object]:
     """One pytest.param per op, marked with bench_op so the baseline tree
     stores the case under the aten op token rather than the test name."""
     return [

--- a/benchmarks/bench_lib/check.py
+++ b/benchmarks/bench_lib/check.py
@@ -76,7 +76,10 @@ def _sync_for(device: str) -> Callable[[], None]:
     if device == "mps":
         return torch.mps.synchronize
     if device == "mojo":
-        return torch.mojo.synchronize
+        # torch.mojo is installed at runtime by register_mojo_devices()
+        # (_setup_privateuseone_for_python_backend), not a real torch stub
+        # module.
+        return torch.mojo.synchronize  # ty: ignore[unresolved-attribute]
     return lambda: None
 
 
@@ -116,6 +119,12 @@ def bench_key(node: pytest.Function) -> baselines.BenchKey:
         shape=params["shape_id"],
         layout=params.get("layout", "contig"),
     )
+
+
+# Notes staged for the terminal summary (see pytest_terminal_summary in
+# conftest.py). pytest.Config.stash is the typed, plugin-private alternative
+# to bolting an ad hoc attribute onto the Config instance.
+BENCH_NOTES_KEY: pytest.StashKey[list[str]] = pytest.StashKey()
 
 
 class Bench:
@@ -254,8 +263,6 @@ class Bench:
         baselines.merge_write(self._hw.key, {entry_key: ratio})
 
     def _note(self, message: str) -> None:
-        notes = getattr(self._request.config, "_bench_notes", None)
-        if notes is None:
-            notes = []
-            self._request.config._bench_notes = notes
+        stash = self._request.config.stash
+        notes = stash.setdefault(BENCH_NOTES_KEY, [])
         notes.append(message)

--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -25,7 +25,8 @@ from pathlib import Path
 
 import pytest
 import torch
-from bench_lib.check import Bench, bench_key, update_mode
+from _pytest.terminal import TerminalReporter
+from bench_lib.check import BENCH_NOTES_KEY, Bench, bench_key, update_mode
 from bench_lib.hw import Hardware, detect
 
 # Set to a path to make collection write every benchmark node's baseline
@@ -109,9 +110,11 @@ def bench(
 
 
 def pytest_terminal_summary(
-    terminalreporter, exitstatus: int, config: pytest.Config
+    terminalreporter: TerminalReporter,
+    exitstatus: pytest.ExitCode,
+    config: pytest.Config,
 ) -> None:
-    notes = getattr(config, "_bench_notes", [])
+    notes = config.stash.get(BENCH_NOTES_KEY, [])
     if not notes:
         return
     terminalreporter.section("benchmark baselines")

--- a/benchmarks/test_attention.py
+++ b/benchmarks/test_attention.py
@@ -10,6 +10,8 @@ single-sequence decode-prefill regime.  All cases are causal.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 import pytest
 import torch
 import torch.nn.functional as F
@@ -35,16 +37,18 @@ SKIPPED: dict[str, str] = {}
 
 def _qkv(
     shape_id: str, dtype_id: str, hw: Hardware, mojo: torch.device
-) -> tuple[list[torch.Tensor], list[torch.Tensor], float]:
+) -> tuple[
+    tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+    tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+    float,
+]:
     b, h, s, d = SHAPES[shape_id]
     dtype = DTYPES[dtype_id]
-    refs, ours = [], []
-    for _ in range(3):
-        ref, our = both(torch.randn(b, h, s, d, dtype=dtype), hw, mojo)
-        refs.append(ref)
-        ours.append(our)
+    q_ref, q_our = both(torch.randn(b, h, s, d, dtype=dtype), hw, mojo)
+    k_ref, k_our = both(torch.randn(b, h, s, d, dtype=dtype), hw, mojo)
+    v_ref, v_our = both(torch.randn(b, h, s, d, dtype=dtype), hw, mojo)
     flops = 4.0 * b * h * s * s * d / 2.0  # causal halves the score matrix
-    return refs, ours, flops
+    return (q_ref, k_ref, v_ref), (q_our, k_our, v_our), flops
 
 
 @pytest.mark.parametrize("dtype_id", ("bf16", "f16"))
@@ -127,7 +131,7 @@ def test_sdpa_flash_backward(
         torch.randn(b, h, s, d, dtype=DTYPES[dtype_id]), hw, mojo_device
     )
 
-    def forward(leg: list[torch.Tensor]) -> tuple:
+    def forward(leg: Sequence[torch.Tensor]) -> tuple:
         return torch.ops.aten._scaled_dot_product_flash_attention(
             *leg, 0.0, True, False
         )
@@ -140,7 +144,7 @@ def test_sdpa_flash_backward(
     except NotImplementedError as exc:
         pytest.skip(f"not supported on the mojo device: {exc}")
 
-    def backward(grad: torch.Tensor, leg: list[torch.Tensor], fwd: tuple) -> tuple:
+    def backward(grad: torch.Tensor, leg: Sequence[torch.Tensor], fwd: tuple) -> tuple:
         out, logsumexp, cum_q, cum_k, max_q, max_k, seed, offset, _ = fwd
         return torch.ops.aten._scaled_dot_product_flash_attention_backward(
             grad,

--- a/benchmarks/test_coverage.py
+++ b/benchmarks/test_coverage.py
@@ -31,7 +31,12 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from bench_lib import baselines
 
-from conftest import KEY_DUMP_ENV
+# conftest is resolved via the sys.path.insert above (this script also runs
+# standalone, not just under pytest's conftest auto-discovery); ty's module
+# resolver doesn't follow that runtime path manipulation. (A real fix is
+# `environment.root = ["benchmarks"]` in [tool.ty], mirroring the sys.path
+# insert -- left for a repo-wide config change rather than a local workaround.)
+from conftest import KEY_DUMP_ENV  # ty: ignore[unresolved-import]
 
 BENCH_DIR = Path(__file__).resolve().parent
 

--- a/benchmarks/test_foreach.py
+++ b/benchmarks/test_foreach.py
@@ -211,7 +211,13 @@ def test_fused_adamw(
     steps_ref = [s.to(hw.stock_device) for s in steps_cpu]
     steps_our = [s.to(mojo_device) for s in steps_cpu]
 
-    def step(params, grads, avgs, sqs, steps) -> None:
+    def step(
+        params: list[torch.Tensor],
+        grads: list[torch.Tensor],
+        avgs: list[torch.Tensor],
+        sqs: list[torch.Tensor],
+        steps: list[torch.Tensor],
+    ) -> None:
         torch.ops.aten._fused_adamw_(
             params,
             grads,

--- a/conformance/conftest.py
+++ b/conformance/conftest.py
@@ -51,4 +51,8 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 
 @pytest.fixture(scope="session")
 def mojo_available() -> bool:
-    return bool(getattr(torch, "mojo", None) and torch.mojo.is_available())
+    # torch.mojo is installed at runtime by register_mojo_devices()
+    # (_setup_privateuseone_for_python_backend), not a real torch stub module.
+    return bool(
+        getattr(torch, "mojo", None) and torch.mojo.is_available()  # ty: ignore[unresolved-attribute]
+    )

--- a/conformance/regenerate_known_unsupported.py
+++ b/conformance/regenerate_known_unsupported.py
@@ -43,7 +43,11 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from types import ModuleType
 from typing import Any
+
+import pytest
+from _pytest.runner import CallInfo
 
 _RECORD_DIR_ENV = "CONFORMANCE_UNSUPPORTED_RECORD_DIR"
 _HERE = Path(__file__).resolve().parent
@@ -107,7 +111,11 @@ def _record(event: dict[str, Any]) -> None:
         handle.flush()
 
 
-def pytest_exception_interact(node: Any, call: Any, report: Any) -> None:
+def pytest_exception_interact(
+    node: pytest.Item | pytest.Collector,
+    call: CallInfo[Any],
+    report: pytest.CollectReport | pytest.TestReport,
+) -> None:
     """Record what a failing node raised."""
     if not report.failed or call.excinfo is None:
         return
@@ -127,7 +135,7 @@ def pytest_exception_interact(node: Any, call: Any, report: Any) -> None:
     )
 
 
-def pytest_runtest_logreport(report: Any) -> None:
+def pytest_runtest_logreport(report: pytest.TestReport) -> None:
     """Record every node's outcome, so a node that ran can be told from one that
     did not: only the first is evidence about the table."""
     if report.when != "call":
@@ -153,7 +161,7 @@ def pytest_runtest_logreport(report: Any) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _import_suite() -> Any:
+def _import_suite() -> ModuleType:
     """The conformance test module, imported the way its conftest does."""
     os.environ.setdefault("PYTORCH_TESTING_DEVICE_FOR_CUSTOM", "privateuse1")
     sys.path.insert(0, str(_HERE))
@@ -177,7 +185,7 @@ def _device_token() -> str:
     return str(torch._C._get_privateuse1_backend_name())
 
 
-def _node_index(suite: Any) -> dict[str, tuple[str, str, str]]:
+def _node_index(suite: ModuleType) -> dict[str, tuple[str, str, str]]:
     """Generated node name -> (test name, operator token, dtype token).
 
     Built from the same op_db and dtypes the suite parametrizes over, so

--- a/conformance/test_opinfo.py
+++ b/conformance/test_opinfo.py
@@ -34,7 +34,6 @@ from __future__ import annotations
 import functools
 import unittest
 from collections.abc import Callable
-from typing import Any
 
 import known_unsupported
 import pytest
@@ -45,6 +44,7 @@ from torch.testing._internal.common_device_type import (
 )
 from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.common_utils import TestCase, run_tests
+from torch.testing._internal.opinfo.core import OpInfo, SampleInput
 
 # The dtypes worth exercising on an accelerator backend.  Deliberately not the
 # full OpInfo set: float64 is absent on some GPUs we target and complex is not
@@ -53,7 +53,7 @@ from torch.testing._internal.common_utils import TestCase, run_tests
 _DTYPES = (torch.float32, torch.bfloat16, torch.float16, torch.int64, torch.bool)
 
 
-def _to_cpu(value: Any) -> Any:
+def _to_cpu(value: object) -> object:
     if isinstance(value, torch.Tensor):
         return value.detach().cpu()
     if isinstance(value, list | tuple):
@@ -113,7 +113,9 @@ def _declining_rather_than_rejecting(
     return not any(issubclass(kind, NotImplementedError) for kind in demanded)
 
 
-def _tensor_specs(sample: Any) -> list[tuple[torch.Size, torch.dtype, torch.device]]:
+def _tensor_specs(
+    sample: SampleInput,
+) -> list[tuple[torch.Size, torch.dtype, torch.device]]:
     """Shape, dtype and device of every tensor in `sample`, in the order
     `SampleInput.transform` visits them.
 
@@ -122,7 +124,7 @@ def _tensor_specs(sample: Any) -> list[tuple[torch.Size, torch.dtype, torch.devi
     """
     specs: list[tuple[torch.Size, torch.dtype, torch.device]] = []
 
-    def record(value: Any) -> Any:
+    def record(value: object) -> object:
         if isinstance(value, torch.Tensor):
             specs.append((value.shape, value.dtype, value.device))
         return value
@@ -132,7 +134,7 @@ def _tensor_specs(sample: Any) -> list[tuple[torch.Size, torch.dtype, torch.devi
 
 
 def _opinfo_placements(
-    op: Any, dtype: torch.dtype
+    op: OpInfo, dtype: torch.dtype
 ) -> list[list[tuple[torch.Size, torch.dtype, torch.device]]] | None:
     """Where OpInfo itself puts each sample-input tensor when it builds this
     operator's samples for a device -- one entry per tensor, per sample.
@@ -183,10 +185,10 @@ def _opinfo_placements(
 
 
 def _to_device(
-    sample: Any,
+    sample: SampleInput,
     device: str,
     placement: list[tuple[torch.Size, torch.dtype, torch.device]] | None,
-) -> Any:
+) -> SampleInput:
     """`sample`, built on the CPU, with every tensor moved to `device` except
     the ones `placement` says OpInfo keeps on the CPU.
 
@@ -202,7 +204,7 @@ def _to_device(
         iter([p[2].type == "cpu" for p in placement]) if placement is not None else None
     )
 
-    def move(value: Any) -> Any:
+    def move(value: object) -> object:
         # transform() also visits torch.dtype values, which have no device.
         if not isinstance(value, torch.Tensor):
             return value
@@ -213,7 +215,7 @@ def _to_device(
     return sample.transform(move)
 
 
-def _cross_device_comparison_skip_reason(op: Any, dtype: torch.dtype) -> str | None:
+def _cross_device_comparison_skip_reason(op: OpInfo, dtype: torch.dtype) -> str | None:
     """None, or why `test_matches_cpu` should not compare this op's output.
 
     OpInfo already flags operators whose output is legitimately allowed to
@@ -277,7 +279,7 @@ class TestOpInfoConformance(TestCase):
     """One test per (operator, dtype), driven entirely by OpInfo metadata."""
 
     @ops(op_db, allowed_dtypes=_DTYPES)
-    def test_matches_cpu(self, device: str, dtype: torch.dtype, op: Any) -> None:
+    def test_matches_cpu(self, device: str, dtype: torch.dtype, op: OpInfo) -> None:
         """Same operator, same inputs, mojo vs CPU, at OpInfo's own tolerance.
 
         Samples are built on the CPU and moved, never built on the device.
@@ -308,7 +310,7 @@ class TestOpInfoConformance(TestCase):
         else:
             _run_declared_unsupported(reason, run)
 
-    def _compare_with_cpu(self, device: str, dtype: torch.dtype, op: Any) -> None:
+    def _compare_with_cpu(self, device: str, dtype: torch.dtype, op: OpInfo) -> None:
         """One `test_matches_cpu` case: every sample, device leg vs CPU leg."""
         placements = _opinfo_placements(op, dtype)
         checked = 0
@@ -332,7 +334,7 @@ class TestOpInfoConformance(TestCase):
         [op for op in op_db if op.error_inputs_func is not None],
         allowed_dtypes=(torch.float32,),
     )
-    def test_errors_match(self, device: str, dtype: torch.dtype, op: Any) -> None:
+    def test_errors_match(self, device: str, dtype: torch.dtype, op: OpInfo) -> None:
         """The inputs PyTorch says must raise, must raise here too.
 
         A backend that silently accepts a malformed call is a worse failure
@@ -356,7 +358,7 @@ class TestOpInfoConformance(TestCase):
         else:
             _run_declared_unsupported(reason, run)
 
-    def _check_error_inputs(self, device: str, op: Any) -> None:
+    def _check_error_inputs(self, device: str, op: OpInfo) -> None:
         """One `test_errors_match` case: every error input OpInfo declares."""
         checked = 0
         for error_input in op.error_inputs(device):

--- a/demo_scripts/densenet.py
+++ b/demo_scripts/densenet.py
@@ -3,8 +3,11 @@ import os
 import requests
 import torch
 from PIL import Image
-from torchvision import transforms
-from torchvision.models import densenet121
+
+# torchvision is a demo-only extra, not a project dependency (pip install it
+# yourself to run this script).
+from torchvision import transforms  # ty: ignore[unresolved-import]
+from torchvision.models import densenet121  # ty: ignore[unresolved-import]
 
 from torch_mojo_backend import get_accelerators, mojo_backend
 

--- a/demo_scripts/gemma3.py
+++ b/demo_scripts/gemma3.py
@@ -1,6 +1,8 @@
 import json
 import os
+from collections.abc import Iterator
 from pathlib import Path
+from typing import TypedDict, cast
 
 import torch
 import torch.nn as nn
@@ -18,8 +20,26 @@ os.environ["TORCH_MOJO_BACKEND_DEBUG_GRAPH"] = "0"
 USE_INSTRUCT_MODEL = True
 
 
+class GemmaConfig(TypedDict):
+    vocab_size: int
+    context_length: int
+    emb_dim: int
+    n_heads: int
+    n_layers: int
+    hidden_dim: int
+    head_dim: int
+    qk_norm: bool
+    n_kv_groups: int
+    rope_local_base: float
+    rope_base: float
+    sliding_window: int
+    layer_types: list[str]
+    dtype: torch.dtype
+    query_pre_attn_scalar: int
+
+
 class FeedForward(nn.Module):
-    def __init__(self, cfg):
+    def __init__(self, cfg: GemmaConfig) -> None:
         super().__init__()
         self.fc1 = nn.Linear(
             cfg["emb_dim"], cfg["hidden_dim"], dtype=cfg["dtype"], bias=False
@@ -31,7 +51,7 @@ class FeedForward(nn.Module):
             cfg["hidden_dim"], cfg["emb_dim"], dtype=cfg["dtype"], bias=False
         )
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         x_fc1 = self.fc1(x)
         x_fc2 = self.fc2(x)
         x = nn.functional.gelu(x_fc1, approximate="tanh") * x_fc2
@@ -39,14 +59,14 @@ class FeedForward(nn.Module):
 
 
 class RMSNorm(nn.Module):
-    def __init__(self, emb_dim, eps=1e-6, bias=False):
+    def __init__(self, emb_dim: int, eps: float = 1e-6, bias: bool = False) -> None:
         super().__init__()
         self.eps = eps
         # Gemma3 stores zero-centered weights and uses (1 + weight) during forward
         self.scale = nn.Parameter(torch.zeros(emb_dim))
         self.shift = nn.Parameter(torch.zeros(emb_dim)) if bias else None
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         # Match HF Gemma3: compute norm in float32, then scale by (1 + w)
         input_dtype = x.dtype
         x_f = x.float()
@@ -61,8 +81,11 @@ class RMSNorm(nn.Module):
 
 
 def compute_rope_params(
-    head_dim, theta_base=10_000, context_length=4096, dtype=torch.float32
-):
+    head_dim: int,
+    theta_base: float = 10_000,
+    context_length: int = 4096,
+    dtype: torch.dtype = torch.float32,
+) -> tuple[torch.Tensor, torch.Tensor]:
     assert head_dim % 2 == 0, "Embedding dimension must be even"
 
     # Compute the inverse frequencies
@@ -92,7 +115,7 @@ def compute_rope_params(
     return cos, sin
 
 
-def apply_rope(x, cos, sin):
+def apply_rope(x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor) -> torch.Tensor:
     # x: (batch_size, num_heads, seq_len, head_dim)
     batch_size, num_heads, seq_len, head_dim = x.shape
     assert head_dim % 2 == 0, "Head dimension must be even"
@@ -116,14 +139,14 @@ def apply_rope(x, cos, sin):
 class GroupedQueryAttention(nn.Module):
     def __init__(
         self,
-        d_in,
-        num_heads,
-        num_kv_groups,
-        head_dim=None,
-        qk_norm=False,
-        query_pre_attn_scalar=None,
-        dtype=None,
-    ):
+        d_in: int,
+        num_heads: int,
+        num_kv_groups: int,
+        head_dim: int | None = None,
+        qk_norm: bool = False,
+        query_pre_attn_scalar: float | None = None,
+        dtype: torch.dtype | None = None,
+    ) -> None:
         super().__init__()
         assert num_heads % num_kv_groups == 0, (
             "num_heads must be divisible by num_kv_groups"
@@ -161,7 +184,9 @@ class GroupedQueryAttention(nn.Module):
         else:
             self.scaling = (head_dim) ** -0.5
 
-    def forward(self, x, mask, cos, sin):
+    def forward(
+        self, x: torch.Tensor, mask: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor
+    ) -> torch.Tensor:
         b, num_tokens, _ = x.shape
 
         # Apply projections
@@ -209,7 +234,7 @@ class GroupedQueryAttention(nn.Module):
 
 
 class TransformerBlock(nn.Module):
-    def __init__(self, cfg, attn_type):
+    def __init__(self, cfg: GemmaConfig, attn_type: str) -> None:
         super().__init__()
         self.attn_type = attn_type
 
@@ -229,8 +254,15 @@ class TransformerBlock(nn.Module):
         self.post_feedforward_layernorm = RMSNorm(cfg["emb_dim"], eps=1e-6)
 
     def forward(
-        self, x, mask_global, mask_local, cos_global, sin_global, cos_local, sin_local
-    ):
+        self,
+        x: torch.Tensor,
+        mask_global: torch.Tensor,
+        mask_local: torch.Tensor,
+        cos_global: torch.Tensor,
+        sin_global: torch.Tensor,
+        cos_local: torch.Tensor,
+        sin_local: torch.Tensor,
+    ) -> torch.Tensor:
         # Shortcut connection for attention block
         shortcut = x
         x = self.input_layernorm(x)
@@ -258,7 +290,14 @@ class TransformerBlock(nn.Module):
 
 
 class Gemma3Model(nn.Module):
-    def __init__(self, cfg):
+    # register_buffer (unlike a direct `self.x = ...` assignment) doesn't give
+    # the type checker anything to infer these attributes' types from.
+    cos_local: torch.Tensor
+    sin_local: torch.Tensor
+    cos_global: torch.Tensor
+    sin_global: torch.Tensor
+
+    def __init__(self, cfg: GemmaConfig) -> None:
         super().__init__()
         assert (
             cfg["layer_types"] is not None
@@ -298,7 +337,9 @@ class Gemma3Model(nn.Module):
         self.register_buffer("cos_global", cos_global, persistent=False)
         self.register_buffer("sin_global", sin_global, persistent=False)
 
-    def _create_masks(self, seq_len, device):
+    def _create_masks(
+        self, seq_len: int, device: torch.device
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         ones = torch.ones((seq_len, seq_len), dtype=torch.bool, device=device)
 
         # mask_global (future is masked: j > i)
@@ -343,7 +384,7 @@ class Gemma3Model(nn.Module):
         mask_local = mask_global | far_past
         return mask_global, mask_local
 
-    def forward(self, input_ids):
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
         # Forward pass
         b, seq_len = input_ids.shape
         x = self.tok_emb(input_ids) * (self.cfg["emb_dim"] ** 0.5)
@@ -365,7 +406,7 @@ class Gemma3Model(nn.Module):
         return logits
 
 
-GEMMA3_CONFIG_270M = {
+GEMMA3_CONFIG_270M: GemmaConfig = {
     "vocab_size": 262_144,
     "context_length": 32_768,
     "emb_dim": 640,
@@ -418,7 +459,9 @@ total_params_normalized = total_params - model.tok_emb.weight.numel()
 print(f"\nTotal number of unique parameters: {total_params_normalized:,}")
 
 
-def model_memory_size(model, input_dtype=torch.float32):
+def model_memory_size(
+    model: nn.Module, input_dtype: torch.dtype = torch.float32
+) -> float:
     total_params = 0
     total_grads = 0
     for param in model.parameters():
@@ -460,8 +503,12 @@ else:
 model.to(device)
 
 
-def load_weights_into_gemma(model, param_config, params):
-    def assign(left, right, tensor_name="unknown"):
+def load_weights_into_gemma(
+    model: Gemma3Model, param_config: GemmaConfig, params: dict[str, torch.Tensor]
+) -> None:
+    def assign(
+        left: torch.Tensor, right: torch.Tensor, tensor_name: str = "unknown"
+    ) -> nn.Parameter:
         if left.shape != right.shape:
             raise ValueError(
                 f"Shape mismatch in tensor '{tensor_name}'. Left: {left.shape}, Right: {right.shape}"
@@ -482,8 +529,14 @@ def load_weights_into_gemma(model, param_config, params):
 
     # Iterate over transformer layers
     for l in range(param_config["n_layers"]):
+        # ModuleList.__getitem__ is typed as -> Module; narrow to the
+        # concrete type actually stored (Gemma3Model.__init__ only ever
+        # puts TransformerBlocks in `blocks`).
         block = model.blocks[l]
+        assert isinstance(block, TransformerBlock)
         att = block.att
+        assert att.q_norm is not None
+        assert att.k_norm is not None
         # Attention projections
         att.W_query.weight = assign(
             att.W_query.weight,
@@ -610,7 +663,7 @@ from tokenizers import Tokenizer
 
 
 class GemmaTokenizer:
-    def __init__(self, tokenizer_file_path: str):
+    def __init__(self, tokenizer_file_path: str) -> None:
         tok_file = Path(tokenizer_file_path)
         self._tok = Tokenizer.from_file(str(tok_file))
         # Attempt to identify EOS and padding tokens
@@ -625,7 +678,7 @@ class GemmaTokenizer:
         return self._tok.decode(ids, skip_special_tokens=False)
 
 
-def apply_chat_template(user_text):
+def apply_chat_template(user_text: str) -> str:
     return f"<start_of_turn>user\n{user_text}<end_of_turn>\n<start_of_turn>model\n"
 
 
@@ -648,10 +701,18 @@ prompt = apply_chat_template("Give me a short introduction to large language mod
 input_token_ids = tokenizer.encode(prompt)
 
 
-model = torch.compile(model, backend=mojo_backend)
+# torch.compile's stub returns a generic Callable here, but the
+# OptimizedModule it actually returns is still an nn.Module (.eval() and
+# calling it both still work).
+model = cast(nn.Module, torch.compile(model, backend=mojo_backend))
 
 
-def generate_text_basic_stream(model, token_ids, max_new_tokens, eos_token_id=None):
+def generate_text_basic_stream(
+    model: nn.Module,
+    token_ids: torch.Tensor,
+    max_new_tokens: int,
+    eos_token_id: int | None = None,
+) -> Iterator[torch.Tensor]:
     model.eval()
     with torch.no_grad():
         for _ in range(max_new_tokens):

--- a/demo_scripts/gpt2.py
+++ b/demo_scripts/gpt2.py
@@ -1,5 +1,6 @@
 import math
 import os
+from typing import Any, Protocol
 
 import torch
 import torch.nn as nn
@@ -12,8 +13,35 @@ os.environ["TORCH_MOJO_BACKEND_PROFILE"] = "1"
 os.environ["TORCH_MOJO_BACKEND_VERBOSE"] = "0"
 
 
+class GPTConfig:
+    attn_pdrop: float = 0.1
+    embd_pdrop: float = 0.1
+    resid_pdrop: float = 0.1
+
+    def __init__(
+        self,
+        vocab_size: int,
+        block_size: int,
+        n_layer: int,
+        n_head: int,
+        n_embd: int,
+        **kwargs: object,
+    ) -> None:
+        self.vocab_size = vocab_size
+        self.block_size = block_size
+        self.n_layer = n_layer
+        self.n_head = n_head
+        self.n_embd = n_embd
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
 class CausalSelfAttention(nn.Module):
-    def __init__(self, config):
+    # register_buffer (unlike a direct `self.bias = ...` assignment) doesn't
+    # give the type checker anything to infer the attribute's type from.
+    bias: torch.Tensor
+
+    def __init__(self, config: GPTConfig) -> None:
         super().__init__()
         assert config.n_embd % config.n_head == 0
 
@@ -33,7 +61,7 @@ class CausalSelfAttention(nn.Module):
             ),
         )
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         B, T, C = x.size()
 
         q, k, v = self.c_attn(x).split(self.n_embd, dim=2)
@@ -53,13 +81,13 @@ class CausalSelfAttention(nn.Module):
 
 
 class MLP(nn.Module):
-    def __init__(self, config):
+    def __init__(self, config: GPTConfig) -> None:
         super().__init__()
         self.c_fc = nn.Linear(config.n_embd, 4 * config.n_embd, bias=True)
         self.c_proj = nn.Linear(4 * config.n_embd, config.n_embd, bias=True)
         self.dropout = nn.Dropout(config.resid_pdrop)
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         x = self.c_fc(x)
         x = F.gelu(x)
         x = self.c_proj(x)
@@ -68,41 +96,34 @@ class MLP(nn.Module):
 
 
 class Block(nn.Module):
-    def __init__(self, config):
+    def __init__(self, config: GPTConfig) -> None:
         super().__init__()
         self.ln_1 = nn.LayerNorm(config.n_embd)
         self.attn = CausalSelfAttention(config)
         self.ln_2 = nn.LayerNorm(config.n_embd)
         self.mlp = MLP(config)
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         x = x + self.attn(self.ln_1(x))
         x = x + self.mlp(self.ln_2(x))
         return x
 
 
-class GPTConfig:
-    attn_pdrop = 0.1
-    embd_pdrop = 0.1
-    resid_pdrop = 0.1
-
-    def __init__(self, vocab_size, block_size, **kwargs):
-        self.vocab_size = vocab_size
-        self.block_size = block_size
-        for k, v in kwargs.items():
-            setattr(self, k, v)
-
-
 class GPT2(nn.Module):
-    def __init__(self, config):
+    def __init__(self, config: GPTConfig) -> None:
         super().__init__()
         assert config.vocab_size is not None
         assert config.block_size is not None
         self.config = config
 
+        # Local typed refs so the weight tie below (and the class-level
+        # declarations further down) don't have to go through ModuleDict's
+        # attribute access, which nn.Module.__getattr__ types as Tensor | Module
+        # (it doesn't know the dict's keys statically).
+        wte = nn.Embedding(config.vocab_size, config.n_embd)
         self.transformer = nn.ModuleDict(
             dict(
-                wte=nn.Embedding(config.vocab_size, config.n_embd),
+                wte=wte,
                 wpe=nn.Embedding(config.block_size, config.n_embd),
                 drop=nn.Dropout(config.embd_pdrop),
                 h=nn.ModuleList([Block(config) for _ in range(config.n_layer)]),
@@ -111,7 +132,7 @@ class GPT2(nn.Module):
         )
         self.lm_head = nn.Linear(config.n_embd, config.vocab_size, bias=False)
 
-        self.transformer.wte.weight = self.lm_head.weight
+        wte.weight = self.lm_head.weight
 
         self.apply(self._init_weights)
         for pn, p in self.named_parameters():
@@ -120,7 +141,7 @@ class GPT2(nn.Module):
                     p, mean=0.0, std=0.02 / math.sqrt(2 * config.n_layer)
                 )
 
-    def _init_weights(self, module):
+    def _init_weights(self, module: nn.Module) -> None:
         if isinstance(module, nn.Linear):
             torch.nn.init.normal_(module.weight, mean=0.0, std=0.02)
             if module.bias is not None:
@@ -129,7 +150,9 @@ class GPT2(nn.Module):
             torch.nn.init.normal_(module.weight, mean=0.0, std=0.02)
 
     @classmethod
-    def from_pretrained(cls, model_type, override_args=None):
+    def from_pretrained(
+        cls, model_type: str, override_args: dict[str, Any] | None = None
+    ) -> "GPT2":
         assert model_type in {"gpt2", "gpt2-medium", "gpt2-large", "gpt2-xl"}
         override_args = override_args or {}
         assert all(k == "dropout" for k in override_args)
@@ -183,9 +206,15 @@ class GPT2(nn.Module):
 
         return model
 
-    def configure_optimizers(self, weight_decay, learning_rate, betas, device_type):
-        decay = set()
-        no_decay = set()
+    def configure_optimizers(
+        self,
+        weight_decay: float,
+        learning_rate: float,
+        betas: tuple[float, float],
+        device_type: str,
+    ) -> torch.optim.Optimizer:
+        decay: set[str] = set()
+        no_decay: set[str] = set()
         whitelist_weight_modules = (torch.nn.Linear,)
         blacklist_weight_modules = (torch.nn.LayerNorm, torch.nn.Embedding)
         for mn, m in self.named_modules():
@@ -222,7 +251,9 @@ class GPT2(nn.Module):
         optimizer = torch.optim.AdamW(optim_groups, lr=learning_rate, betas=betas)
         return optimizer
 
-    def forward(self, idx, targets=None):
+    def forward(
+        self, idx: torch.Tensor, targets: torch.Tensor | None = None
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
         device = idx.device
         b, t = idx.shape
         assert t <= self.config.block_size, (
@@ -230,12 +261,17 @@ class GPT2(nn.Module):
         )
         pos = torch.arange(0, t, dtype=torch.long, device=device)
 
-        tok_emb = self.transformer.wte(idx)
-        pos_emb = self.transformer.wpe(pos)
-        x = self.transformer.drop(tok_emb + pos_emb)
-        for block in self.transformer.h:
+        # ModuleDict.__getitem__ is typed as -> Module (unlike attribute
+        # access, which nn.Module.__getattr__ types as the generic Tensor |
+        # Module since it doesn't know the dict's keys statically).
+        h_blocks = self.transformer["h"]
+        assert isinstance(h_blocks, nn.ModuleList)
+        tok_emb = self.transformer["wte"](idx)
+        pos_emb = self.transformer["wpe"](pos)
+        x = self.transformer["drop"](tok_emb + pos_emb)
+        for block in h_blocks:
             x = block(x)
-        x = self.transformer.ln_f(x)
+        x = self.transformer["ln_f"](x)
 
         if targets is not None:
             logits = self.lm_head(x)
@@ -249,7 +285,13 @@ class GPT2(nn.Module):
         return logits, loss
 
     @torch.no_grad()
-    def generate(self, idx, max_new_tokens, temperature=1.0, top_k=None):
+    def generate(
+        self,
+        idx: torch.Tensor,
+        max_new_tokens: int,
+        temperature: float = 1.0,
+        top_k: int | None = None,
+    ) -> torch.Tensor:
         for _ in range(max_new_tokens):
             idx_cond = (
                 idx
@@ -268,7 +310,12 @@ class GPT2(nn.Module):
         return idx
 
 
-def load_tokenizer():
+class Tokenizer(Protocol):
+    def encode(self, text: str) -> list[int]: ...
+    def decode(self, tokens: list[int]) -> str: ...
+
+
+def load_tokenizer() -> Tokenizer:
     try:
         import tiktoken
 
@@ -278,21 +325,21 @@ def load_tokenizer():
         print("tiktoken not found, using simple character-level tokenizer")
 
         class SimpleTokenizer:
-            def __init__(self):
+            def __init__(self) -> None:
                 self.vocab = {chr(i): i for i in range(256)}
                 self.vocab.update({"<|endoftext|>": 50256})
                 self.inv_vocab = {v: k for k, v in self.vocab.items()}
 
-            def encode(self, text):
+            def encode(self, text: str) -> list[int]:
                 return [self.vocab.get(c, 50256) for c in text]
 
-            def decode(self, tokens):
+            def decode(self, tokens: list[int]) -> str:
                 return "".join([self.inv_vocab.get(t, "<unk>") for t in tokens])
 
         return SimpleTokenizer()
 
 
-def main():
+def main() -> None:
     device = "cuda" if len(list(get_accelerators())) >= 2 else "cpu"
     print(f"Using device: {device}")
 
@@ -330,7 +377,12 @@ def main():
     )
 
     @torch.no_grad()
-    def generate_with_compiled_step(idx, max_new_tokens, temperature=1.0, top_k=None):
+    def generate_with_compiled_step(
+        idx: torch.Tensor,
+        max_new_tokens: int,
+        temperature: float = 1.0,
+        top_k: int | None = None,
+    ) -> torch.Tensor:
         for _ in range(max_new_tokens):
             idx_cond = (
                 idx
@@ -366,7 +418,7 @@ def main():
     print("\n" + "=" * 50)
     print("Testing completed successfully!")
     print("=" * 50)
-    print(torch._dynamo.utils.compile_times())
+    print(torch._dynamo.utils.compile_times("str"))
 
 
 if __name__ == "__main__":

--- a/demo_scripts/gpt2.py
+++ b/demo_scripts/gpt2.py
@@ -1,6 +1,6 @@
 import math
 import os
-from typing import Any, Protocol
+from typing import Protocol
 
 import torch
 import torch.nn as nn
@@ -151,7 +151,7 @@ class GPT2(nn.Module):
 
     @classmethod
     def from_pretrained(
-        cls, model_type: str, override_args: dict[str, Any] | None = None
+        cls, model_type: str, override_args: dict[str, float] | None = None
     ) -> "GPT2":
         assert model_type in {"gpt2", "gpt2-medium", "gpt2-large", "gpt2-xl"}
         override_args = override_args or {}
@@ -170,9 +170,8 @@ class GPT2(nn.Module):
         print("forcing vocab_size=50257, block_size=1024")
         config_args["vocab_size"] = 50257
         config_args["block_size"] = 1024
-        config_args.update(override_args)
 
-        config = GPTConfig(**config_args)
+        config = GPTConfig(**config_args, **override_args)
         model = GPT2(config)
         sd = model.state_dict()
         sd_keys = sd.keys()

--- a/demo_scripts/mnist.py
+++ b/demo_scripts/mnist.py
@@ -6,14 +6,19 @@ evaluating a neural network on the MNIST dataset.
 """
 
 import os
+from collections.abc import Sized
 from pathlib import Path
+from typing import cast
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
 from torch.utils.data import DataLoader
-from torchvision import datasets, transforms
+
+# torchvision is a demo-only extra, not a project dependency (pip install it
+# yourself to run this script).
+from torchvision import datasets, transforms  # ty: ignore[unresolved-import]
 
 from torch_mojo_backend import mojo_backend
 
@@ -24,14 +29,14 @@ os.environ["TORCH_MOJO_BACKEND_VERBOSE"] = "0"
 class SimpleNet(nn.Module):
     """Simple feedforward neural network for MNIST classification."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         # Input: 28x28 = 784 pixels
         self.fc1 = nn.Linear(784, 128)
         self.fc2 = nn.Linear(128, 64)
         self.fc3 = nn.Linear(64, 10)  # 10 classes (digits 0-9)
 
-    def forward(self, x):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         # Flatten the input
         x = x.view(-1, 784)
 
@@ -44,12 +49,23 @@ class SimpleNet(nn.Module):
         return x
 
 
-def train_epoch(model, device, train_loader, optimizer, criterion, epoch):
+def train_epoch(
+    model: nn.Module,
+    device: torch.device,
+    train_loader: DataLoader,
+    optimizer: optim.Optimizer,
+    criterion: nn.Module,
+    epoch: int,
+) -> tuple[float, float]:
     """Train for one epoch."""
     model.train()
     total_loss = 0
     correct = 0
     total = 0
+    # Dataset (as opposed to IterableDataset) always supports len(), but the
+    # DataLoader.dataset attribute is typed against the common base.
+    assert isinstance(train_loader.dataset, Sized)
+    dataset_size = len(train_loader.dataset)
 
     for batch_idx, (data, target) in enumerate(train_loader):
         data, target = data.to(device), target.to(device)
@@ -72,7 +88,7 @@ def train_epoch(model, device, train_loader, optimizer, criterion, epoch):
         # Print progress
         if batch_idx % 100 == 0:
             print(
-                f"Train Epoch: {epoch} [{batch_idx * len(data)}/{len(train_loader.dataset)} "
+                f"Train Epoch: {epoch} [{batch_idx * len(data)}/{dataset_size} "
                 f"({100.0 * batch_idx / len(train_loader):.0f}%)]\t"
                 f"Loss: {loss.item():.6f}"
             )
@@ -82,7 +98,12 @@ def train_epoch(model, device, train_loader, optimizer, criterion, epoch):
     return avg_loss, accuracy
 
 
-def evaluate(model, device, test_loader, criterion):
+def evaluate(
+    model: nn.Module,
+    device: torch.device,
+    test_loader: DataLoader,
+    criterion: nn.Module,
+) -> tuple[float, float]:
     """Evaluate the model on test data."""
     model.eval()
     test_loss = 0
@@ -103,7 +124,7 @@ def evaluate(model, device, test_loader, criterion):
     return avg_loss, accuracy
 
 
-def main():
+def main() -> None:
     # Hyperparameters
     batch_size = 64
     test_batch_size = 1000
@@ -140,8 +161,10 @@ def main():
     # Model, loss, and optimizer
     model = SimpleNet().to(device)
 
-    # Compile the model with mojo_backend
-    model = torch.compile(model, backend=mojo_backend, fullgraph=True)
+    # Compile the model with mojo_backend. torch.compile's stub returns a
+    # generic Callable, but the OptimizedModule it actually returns is still
+    # an nn.Module (.parameters()/.state_dict()/.train()/.eval() all work).
+    model = cast(nn.Module, torch.compile(model, backend=mojo_backend, fullgraph=True))
 
     criterion = nn.CrossEntropyLoss()
     optimizer = optim.SGD(model.parameters(), lr=learning_rate, momentum=momentum)

--- a/demo_scripts/no_graph_breaks.py
+++ b/demo_scripts/no_graph_breaks.py
@@ -27,8 +27,12 @@ my_torch_grayscale = make_torch_op_from_mojo(
 
 def simple_graph(img: torch.Tensor) -> torch.Tensor:
     img = img - 1
-    img = my_torch_grayscale(img)
-    img = img + 1
+    grayscale = my_torch_grayscale(img)
+    # allocate_outputs_grayscale always allocates a single Tensor, so this
+    # particular custom op never takes the tuple/list branch of
+    # make_torch_op_from_mojo's general return type.
+    assert isinstance(grayscale, torch.Tensor)
+    img = grayscale + 1
     return img
 
 

--- a/demo_scripts/vgg.py
+++ b/demo_scripts/vgg.py
@@ -4,7 +4,10 @@ from io import BytesIO
 import requests
 import torch
 from PIL import Image
-from torchvision import models, transforms
+
+# torchvision is a demo-only extra, not a project dependency (pip install it
+# yourself to run this script).
+from torchvision import models, transforms  # ty: ignore[unresolved-import]
 
 from torch_mojo_backend import register_mojo_devices
 
@@ -33,7 +36,7 @@ preprocess = transforms.Compose(
 )
 
 
-def load_image(image_path_or_url):
+def load_image(image_path_or_url: str) -> Image.Image:
     if image_path_or_url.startswith("http"):
         response = requests.get(image_path_or_url)
         image = Image.open(BytesIO(response.content))
@@ -46,14 +49,14 @@ def load_image(image_path_or_url):
     return image
 
 
-def load_imagenet_labels():
+def load_imagenet_labels() -> list[str]:
     url = "https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt"
     response = requests.get(url)
     labels = response.text.strip().split("\n")
     return labels
 
 
-def predict_image(image_path_or_url, top_k=5):
+def predict_image(image_path_or_url: str, top_k: int = 5) -> None:
     image = load_image(image_path_or_url)
 
     input_tensor = preprocess(image)
@@ -72,7 +75,7 @@ def predict_image(image_path_or_url, top_k=5):
 
     print("Top Predictions: (boxer should come first)")
     for i in range(top_k):
-        class_idx = top_class[i].item()
+        class_idx = int(top_class[i].item())
         prob = top_prob[i].item()
         label = labels[class_idx]
         print(f"{i + 1:2d}. {label:30s} ({prob:.3f})")

--- a/demo_scripts/vgg_export.py
+++ b/demo_scripts/vgg_export.py
@@ -7,7 +7,10 @@ import torch
 from max.driver import Accelerator
 from max.graph import DeviceRef
 from PIL import Image
-from torchvision import models, transforms
+
+# torchvision is a demo-only extra, not a project dependency (pip install it
+# yourself to run this script).
+from torchvision import models, transforms  # ty: ignore[unresolved-import]
 
 from torch_mojo_backend.torch_compile_backend.exporter import export_to_max_graph
 
@@ -17,7 +20,7 @@ model.eval()
 dummy_input = torch.randn(1, 3, 224, 224)
 max_model = export_to_max_graph(model, (dummy_input,), force_device=DeviceRef.GPU(0))
 
-dummy_input_max_gpu = max.driver.Tensor.from_numpy(
+dummy_input_max_gpu = max.driver.Buffer.from_numpy(
     np.random.randn(1, 3, 224, 224).astype(np.float32)
 ).to(Accelerator(0))
 print(max_model(dummy_input_max_gpu))
@@ -37,7 +40,7 @@ preprocess = transforms.Compose(
 )
 
 
-def load_image(image_path_or_url):
+def load_image(image_path_or_url: str) -> Image.Image:
     if image_path_or_url.startswith("http"):
         response = requests.get(image_path_or_url)
         image = Image.open(BytesIO(response.content))
@@ -50,19 +53,19 @@ def load_image(image_path_or_url):
     return image
 
 
-def load_imagenet_labels():
+def load_imagenet_labels() -> list[str]:
     url = "https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt"
     response = requests.get(url)
     labels = response.text.strip().split("\n")
     return labels
 
 
-def predict_image(image_path_or_url, top_k=5):
+def predict_image(image_path_or_url: str, top_k: int = 5) -> None:
     image = load_image(image_path_or_url)
 
     input_tensor = preprocess(image)
     input_batch = input_tensor.unsqueeze(0)  # Add batch dimension
-    input_batch = max.driver.Tensor.from_dlpack(input_batch).to(Accelerator(0))
+    input_batch = max.driver.Buffer.from_dlpack(input_batch).to(Accelerator(0))
     output = max_model(input_batch)
 
     output = torch.tensor(output[0].to_numpy())
@@ -75,7 +78,7 @@ def predict_image(image_path_or_url, top_k=5):
 
     print("Top Predictions: (boxer should come first)")
     for i in range(top_k):
-        class_idx = top_class[i].item()
+        class_idx = int(top_class[i].item())
         prob = top_prob[i].item()
         label = labels[class_idx]
         print(f"{i + 1:2d}. {label:30s} ({prob:.3f})")

--- a/docs/fast_eager_design.md
+++ b/docs/fast_eager_design.md
@@ -67,7 +67,8 @@ Per-op call, (64, 64) float32 on the GPU mojo_device:
 | torch native CUDA eager (reference) | ~21 |
 
 End-to-end speedup today: **~50×**; the remaining ~24 µs over the bare
-call is the PyTorch dispatcher + `TorchMojoTensor` wrapping + beartype,
+call is the PyTorch dispatcher + `TorchMojoTensor` wrapping (beartype's
+runtime checking has since been replaced by static `ty` checks),
 which can be shaved independently.
 
 ## Compile granularity: one `.so` per variant, built in the background
@@ -286,8 +287,9 @@ Three structural changes, in order of impact:
    access. Fast-path tensors that only ever feed other fast ops (the vast
    majority) never construct one (~1.7 µs + a sharding-mesh init each);
    slow-path fallbacks materialize it on demand.
-3. **Hot functions opt out of beartype** with `@typing.no_type_check`
-   (the claw hook honors it), and the device lookup is `functools.cache`d.
+3. **Hot functions carried no runtime type checking** (historically a
+   beartype opt-out; checking is static via `ty` now), and the device
+   lookup is `functools.cache`d.
 
 Resulting per-op end-to-end costs at the torch level (H100 box): view
 ~8 µs, relu ~10 µs, addmm ~20 µs, conv ~35 µs — at which point resnet-18

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
     "max==26.5",
     "tabulate",
     "torch>=2.10",
-    "beartype>=0.17.0",
 ]
 
 [project.urls]
@@ -27,13 +26,60 @@ packages = ["torch_mojo_backend"]
 
 [tool.ruff]
 target-version = "py311"
+# Untracked scratch clone of unrelated third-party repos (dicp/dipu), not
+# part of this project.
+extend-exclude = ["deeplink"]
 
 [tool.ruff.lint]
 select = [
-    "F",  # pyflakes (includes unused imports)
-    "UP", # pyupgrade
+    "F",   # pyflakes (includes unused imports)
+    "UP",  # pyupgrade
+    "ANN", # flake8-annotations: every function needs type hints (ty then checks them)
 ]
 
+[tool.ruff.lint.per-file-ignores]
+# ty infers unannotated params/returns as Unknown and never flags their misuse,
+# so ANN is what actually forces a hint to exist; tests/ predates that (~5k
+# gaps, mostly pytest fixture params) and current_bench/ is ad hoc GPU
+# profiling scratch, not shipped code -- both excluded, same as in [tool.ty].
+"tests/**" = ["ANN"]
+"current_bench/**" = ["ANN"]
+
+[tool.ty.environment]
+# Pins the venv explicitly: on boxes with an active conda env, ty's
+# site-packages discovery prefers CONDA_PREFIX over sys.prefix and fails
+# outright ("Failed to discover the site-packages directory") when that
+# conda env doesn't look like a normal Python install. `uv run ty check`
+# already sidesteps this, but pin it so a bare `ty check` also works.
+python = ".venv"
+
+[tool.ty.rules]
+# Every occurrence (verified by hand, none blanket-assumed) is one of two
+# deliberate polymorphic-override points that nominal override-checking
+# cannot express: (1) MojoExtension's abstract methods are `*args/**kwargs`
+# placeholders precisely so each concrete descriptor (MojoFileExtension,
+# aten_fast.py's per-op extensions, ...) can declare its own independent
+# call ABI -- callers always go through the concrete subclass, never a
+# MojoExtension-typed reference, so this is runtime-duck-typed dispatch, not
+# a substitutability hole; (2) TorchMojoTensor's __torch_dispatch__,
+# __torch_function__, __repr__, __reduce_ex__ and the autograd Functions'
+# backward() are torch's own documented tensor-subclass/autograd extension
+# points, where every real subclass (including torch's own FakeTensor,
+# LoggingTensor, ...) intentionally uses its own signature. `ty check`
+# exits non-zero on warnings too (no `--exit-zero-on-warning` in CI), so
+# this must be "ignore", not "warn", to keep `ty check` green.
+invalid-method-override = "ignore"
+
+[tool.ty.src]
+exclude = [
+    # Untracked scratch clone of unrelated third-party repos (dicp/dipu), not
+    # part of this project.
+    "deeplink/",
+    # Ad hoc GPU profiling/comparison scratch from past kernel-optimization
+    # engagements, not shipped code; not held to the same typing bar as
+    # benchmarks/ or demo_scripts/.
+    "current_bench/",
+]
 
 [tool.uv]
 python-preference = "only-managed"
@@ -76,4 +122,5 @@ dev = [
     "pytest-random-order>=1.2.0",
     "setuptools>=80.9.0",
     "pydantic>=2.9",
+    "ty>=0.0.77",
 ]

--- a/scripts/compare_kernel_asm.py
+++ b/scripts/compare_kernel_asm.py
@@ -349,7 +349,11 @@ def plan_module(
         )
         ops = [None] if only_ops is None else []
     if only_ops is not None:
-        kept = [op for op in ops if op in only_ops]
+        # Annotated explicitly: `op in only_ops` narrows the comprehension's
+        # inferred element type to plain `str` (a tuple[str, ...] can never
+        # contain None), which -- being invariant -- list[str] then can't
+        # reassign into the list[str | None]-declared `ops` below.
+        kept: list[str | None] = [op for op in ops if op in only_ops]
         if len(kept) != len(ops):
             notes.append(f"--ops skipped {len(ops) - len(kept)} of {len(ops)} op(s)")
         ops = kept

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,6 @@ from collections.abc import Callable
 os.environ["MODULAR_TELEMETRY_ENABLED"] = "0"
 os.environ["MAX_USE_EAGER_INTERPRETER"] = "1"
 os.environ["TORCH_MOJO_BACKEND_TESTING"] = "1"
-# Type-check the whole package under tests; production imports leave it off.
-os.environ.setdefault("TORCH_MOJO_BACKEND_BEARTYPE", "1")
 import pytest
 
 # must be called before importing torch_mojo_backend
@@ -151,7 +149,7 @@ def fake_mojo_tensor() -> Callable[..., torch.Tensor]:
             storage_offset=0,
             dtype=_torch_dtype_of(dtype),
             layout=torch.strided,
-            device="cpu",
+            device=torch.device("cpu"),
             requires_grad=False,
         )
         tensor._holder = object()

--- a/tests/test_aten_functions.py
+++ b/tests/test_aten_functions.py
@@ -6,7 +6,11 @@ import torch
 import torch.nn.functional
 from torch._dynamo import mark_dynamic
 from torch._dynamo.exc import BackendCompilerFailed
-from torch.ops import aten
+
+# torch.ops is a `_Ops` instance registered into sys.modules at runtime
+# (torch/_ops.py), not a real package on disk, so no static resolver can
+# see `torch/ops/__init__.py` or `torch/ops.py`.
+from torch.ops import aten  # ty: ignore[unresolved-import]
 
 from torch_mojo_backend import aten_functions, mojo_backend, register_mojo_devices
 from torch_mojo_backend.testing import (
@@ -51,7 +55,7 @@ def test_scaled_dot_product_flash_attention_basic(
 
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
-def test_scaled_dot_product_flash_attention_with_causal(conf: Conf, dtype: str):
+def test_scaled_dot_product_flash_attention_with_causal(conf: Conf, dtype: torch.dtype):
     """Test _scaled_dot_product_flash_attention with causal masking"""
     # Flash attention only works on CUDA
     if conf.device != "cuda:0":

--- a/tests/test_call_queue.py
+++ b/tests/test_call_queue.py
@@ -21,12 +21,14 @@ import weakref
 from collections import deque
 from collections.abc import Iterator
 from pathlib import Path
+from typing import cast
 
 import pytest
 import torch
 
-from torch_mojo_backend import eager_kernels, get_accelerators
+from torch_mojo_backend import TorchMojoTensor, eager_kernels, get_accelerators
 from torch_mojo_backend.eager_kernels import aten_fast, call_queue
+from torch_mojo_backend.eager_kernels.output_specs import _TensorOutputSpec
 from torch_mojo_backend.mojo_device import torch_mojo_device_module
 
 
@@ -78,12 +80,15 @@ class _StalledBuild:
         self._unit = unit
         self._module = unit.module
         unit.module = None
-        unit.request_async = self._request  # type: ignore[method-assign]
+        unit.request_async = self._request  # ty: ignore[invalid-assignment]
         self._job = _FakeJob(self)
 
     @classmethod
     def for_call(
-        cls, prepared: eager_kernels.PreparedExtensionCall[object, object]
+        cls,
+        prepared: eager_kernels.PreparedExtensionCall[
+            _TensorOutputSpec, TorchMojoTensor
+        ],
     ) -> "_StalledBuild":
         return cls(
             eager_kernels.MOJO_EXTENSION_LOADER.unit_canonical(
@@ -147,7 +152,7 @@ class _StalledUnits:
 
 def _prepare_add(
     lhs: object, rhs: object
-) -> eager_kernels.PreparedExtensionCall[object, object]:
+) -> eager_kernels.PreparedExtensionCall[_TensorOutputSpec, TorchMojoTensor]:
     return aten_fast._BinarySpecExtension.prepare(
         "AddSpec", lhs, rhs, aten_fast.DType.float32
     )
@@ -183,7 +188,7 @@ class _FakeUnit:
         error: BaseException | None = None,
         build_error: BaseException | None = None,
     ) -> None:
-        self.extension: object = _FakeExtension(log, error)
+        self.extension: _FakeExtension = _FakeExtension(log, error)
         self.ext: object | None = self.extension if ready else None
         self.build_error = build_error
         self.builds = 0
@@ -199,6 +204,12 @@ class _FakeUnit:
 
     def ready(self) -> None:
         self.ext = self.extension
+
+
+def _q(unit: _FakeUnit) -> call_queue._QueueUnit:
+    """`_FakeUnit` implements `_QueueUnit` structurally, but `.ext` holds a
+    `_FakeExtension` stand-in rather than a real compiled module."""
+    return cast(call_queue._QueueUnit, unit)
 
 
 class _Buffer:
@@ -224,9 +235,9 @@ def test_launch_error_ends_the_episode_at_the_next_drain(isolated_queue) -> None
     buffer = _Buffer()
     retained = weakref.ref(buffer)
 
-    call_queue.kernel_call_into(first, ("first",), ())
-    call_queue.kernel_call_into(failing, ("failing",), ())
-    call_queue.kernel_call_into(successor, ("successor",), (buffer,))
+    call_queue.kernel_call_into(_q(first), ("first",), ())
+    call_queue.kernel_call_into(_q(failing), ("failing",), ())
+    call_queue.kernel_call_into(_q(successor), ("successor",), (buffer,))
     del buffer
     assert call_queue.active()
     assert retained() is not None  # the queued item retains its operands
@@ -249,7 +260,7 @@ def test_launch_error_ends_the_episode_at_the_next_drain(isolated_queue) -> None
     call_queue.drain()  # the episode is over: a clean, silent no-op
     assert log == ["first", "failing"]
 
-    call_queue.kernel_call_into(_FakeUnit(log, ready=True), ("after",), ())
+    call_queue.kernel_call_into(_q(_FakeUnit(log, ready=True)), ("after",), ())
     assert log == ["first", "failing", "after"]
 
 
@@ -264,8 +275,8 @@ def test_build_failure_behind_a_queued_launch_surfaces_from_drain(
 
     buffer = _Buffer()
     retained = weakref.ref(buffer)
-    call_queue.kernel_call_into(doomed, ("doomed",), ())
-    call_queue.kernel_call_into(successor, ("successor",), (buffer,))
+    call_queue.kernel_call_into(_q(doomed), ("doomed",), ())
+    call_queue.kernel_call_into(_q(successor), ("successor",), (buffer,))
     del buffer
 
     with pytest.raises(ImportError, match="mojo build failed"):
@@ -287,7 +298,7 @@ def test_queued_launch_out_of_memory_is_still_reported_as_such(isolated_queue) -
     )
     unit = _FakeUnit(log, error=oom)
 
-    call_queue.kernel_call_into(unit, ("oom",), ())
+    call_queue.kernel_call_into(_q(unit), ("oom",), ())
     unit.ready()
     call_queue.pump()
 
@@ -310,14 +321,14 @@ def test_thread_switch_synchronizes_once_and_keeps_fifo(
     log: list[str] = []
 
     warm = _FakeUnit(log, ready=True)
-    call_queue.kernel_call_into(warm, ("warm",), ())  # runs inline on this thread
+    call_queue.kernel_call_into(_q(warm), ("warm",), ())  # runs inline on this thread
     assert log == ["warm"]
     assert syncs == []  # first device work of the episode: no switch yet
 
     first = _FakeUnit(log)
     second = _FakeUnit(log)
-    call_queue.kernel_call_into(first, ("first",), ())
-    call_queue.kernel_call_into(second, ("second",), ())
+    call_queue.kernel_call_into(_q(first), ("first",), ())
+    call_queue.kernel_call_into(_q(second), ("second",), ())
     first.ready()
     second.ready()
 
@@ -361,11 +372,11 @@ def test_a_drain_reached_from_inside_a_launch_does_not_reorder(isolated_queue) -
             log.append(f"{label}:exit")
 
     reentrant = _FakeUnit(log)
-    reentrant.extension = _ReentrantExtension()  # type: ignore[assignment]
+    reentrant.extension = _ReentrantExtension()  # ty: ignore[invalid-assignment]
     follower = _FakeUnit(log)
 
-    call_queue.kernel_call_into(reentrant, ("first",), (buffer,))
-    call_queue.kernel_call_into(follower, ("second",), (follower_buffer,))
+    call_queue.kernel_call_into(_q(reentrant), ("first",), (buffer,))
+    call_queue.kernel_call_into(_q(follower), ("second",), (follower_buffer,))
     del buffer, follower_buffer
     reentrant.ready()
     follower.ready()
@@ -384,7 +395,7 @@ def test_external_calls_hold_their_fifo_position(isolated_queue) -> None:
     producer = _FakeUnit(log)
     retained = weakref.ref(buffer := _Buffer())
 
-    call_queue.kernel_call_into(producer, ("producer",), ())
+    call_queue.kernel_call_into(_q(producer), ("producer",), ())
     call_queue.external_call(log.append, ("consumer",), (buffer,))
     del buffer
     assert log == []
@@ -410,11 +421,13 @@ def test_a_cold_launch_retains_the_output_it_writes_into(isolated_queue) -> None
     log: list[str] = []
     retained = weakref.ref(out := _Buffer())
 
-    call_queue.kernel_call_into(_FakeUnit(log), ("cold",), (out,))
+    call_queue.kernel_call_into(_q(_FakeUnit(log)), ("cold",), (out,))
     del out
 
     assert retained() is not None  # only the queued item holds it now
-    call_queue._QUEUE[0][0].ready()
+    queued_unit = call_queue._QUEUE[0][0]
+    assert isinstance(queued_unit, _FakeUnit)
+    queued_unit.ready()
     call_queue.drain()
     assert log == ["cold"]
     assert retained() is None  # released right after its launch
@@ -455,8 +468,10 @@ def test_failed_allocation_drains_synchronizes_and_retries_once(
     # OOM once -> drain (launches the queued item), sync, retry succeeds.
     holder = _FlakyHolder([oom])
     monkeypatch.setattr(torch_mojo_tensor, "_holder_mod", lambda: holder)
-    call_queue.kernel_call_into(_FakeUnit(log), ("pending",), ())
-    call_queue._QUEUE[0][0].ready()
+    call_queue.kernel_call_into(_q(_FakeUnit(log)), ("pending",), ())
+    queued_unit = call_queue._QUEUE[0][0]
+    assert isinstance(queued_unit, _FakeUnit)
+    queued_unit.ready()
     result = torch_mojo_tensor._alloc_with_recovery(device, 4096)
     assert result[1] == 0x1000
     assert holder.calls == 2
@@ -546,7 +561,7 @@ def test_retention_budget_bounds_cold_run_ahead(
     for index, unit in enumerate(units):
         buf = _Payload()
         retained.append(weakref.ref(buf))
-        call_queue.kernel_call_into(unit, (f"cold{index}",), (buf,))
+        call_queue.kernel_call_into(_q(unit), (f"cold{index}",), (buf,))
         del buf
         if index < 3:
             # At or under budget: still queued, still retained, not blocked.
@@ -576,8 +591,8 @@ def test_retention_budget_holds_launch_errors_for_the_next_drain(
     log: list[str] = []
     failure = RuntimeError("exact variant rejected its arguments")
     failing = _FakeUnit(log, error=failure)
-    call_queue.kernel_call_into(failing, ("failing",), (_Payload(),))
-    call_queue.kernel_call_into(_FakeUnit(log), ("successor",), (_Payload(),))
+    call_queue.kernel_call_into(_q(failing), ("failing",), (_Payload(),))
+    call_queue.kernel_call_into(_q(_FakeUnit(log)), ("successor",), (_Payload(),))
 
     assert log == ["failing"]  # the budget drain launched and failed it
     assert not call_queue.active()  # rule 5 dropped the successor
@@ -942,14 +957,16 @@ def test_queued_sdpa_backward_matches_cpu(mojo_gpu, forced_queue, monkeypatch):
     q, k, v = (torch.randn(shape, generator=generator) for _ in range(3))
     grad = torch.randn(shape, generator=generator)
 
-    def run(device: str) -> tuple[torch.Tensor, ...]:
+    def run(device: str) -> tuple[torch.Tensor | None, ...]:
         # detach().clone() first: `.to("cpu")` of a CPU tensor is the tensor
         # itself, and marking the shared original as a leaf that requires
         # grad would make the device copy a non-leaf.
-        tensors = [t.detach().clone().to(device).requires_grad_() for t in (q, k, v)]
-        out = torch.nn.functional.scaled_dot_product_attention(*tensors)
+        t_q, t_k, t_v = (
+            t.detach().clone().to(device).requires_grad_() for t in (q, k, v)
+        )
+        out = torch.nn.functional.scaled_dot_product_attention(t_q, t_k, t_v)
         out.backward(grad.to(device))
-        return (out.detach(), *(tensor.grad for tensor in tensors))
+        return (out.detach(), t_q.grad, t_k.grad, t_v.grad)
 
     expected = run("cpu")
     run(mojo_gpu)  # warm every specialization the stalled region will use

--- a/tests/test_compile_mojo_device.py
+++ b/tests/test_compile_mojo_device.py
@@ -267,6 +267,8 @@ class _MiniAttentionBlock(torch.nn.Module):
     """Attention + MLP block exercising embeddings, layernorm, views,
     transposes, masked softmax and matmuls in one compiled graph."""
 
+    mask: torch.Tensor
+
     def __init__(self, vocab=64, n_embd=32, n_head=4, block_size=16):
         super().__init__()
         self.tok = torch.nn.Embedding(vocab, n_embd)

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -1,5 +1,6 @@
 import io
 from pathlib import Path
+from typing import TypedDict
 from unittest.mock import patch
 
 import numpy as np
@@ -8,7 +9,11 @@ import torch
 import torch.nn.functional as F
 from torch._dynamo import mark_dynamic
 from torch._dynamo.exc import BackendCompilerFailed
-from torch.ops import aten
+
+# torch.ops is a `_Ops` instance registered into sys.modules at runtime
+# (torch/_ops.py), not a real package on disk, so no static resolver can
+# see `torch/ops/__init__.py` or `torch/ops.py`.
+from torch.ops import aten  # ty: ignore[unresolved-import]
 
 import torch_mojo_backend
 import torch_mojo_backend.torch_compile_backend.compiler
@@ -36,7 +41,12 @@ from .conftest import require_cuda_autograd
 # the tolerance. atol=2e-2 is ~1.3x the measured worst case and still ~50x
 # below the O(1) error an actually wrong matmul produces on N(0, 1) data.
 # CPU keeps assert_close's exact fp32 defaults.
-def matmul_tolerance(device: str) -> dict[str, float]:
+class _Tolerance(TypedDict, total=False):
+    rtol: float
+    atol: float
+
+
+def matmul_tolerance(device: str) -> _Tolerance:
     if device == "cpu":
         return {}
     return {"rtol": 1e-2, "atol": 2e-2}
@@ -761,6 +771,7 @@ def test_decomposition_overload(monkeypatch):
 
     # it's normally decomposed. We check that it's not the case since we
     # implemented it ourselves.
+    assert input_gm is not None
     assert aten.t.default in [node.target for node in input_gm.graph.nodes]
 
 
@@ -795,6 +806,7 @@ def test_decomposition_overload_packet(monkeypatch):
 
     # it's normally decomposed. We check that it's not the case since we
     # implemented it ourselves.
+    assert input_gm is not None
     assert aten.transpose.int in [node.target for node in input_gm.graph.nodes]
 
 
@@ -829,6 +841,7 @@ def test_mojo_custom_op(device: str):
     def more_complexe_graph(x: torch.Tensor):
         x = x + 8
         y = my_torch_grayscale(x)
+        assert isinstance(y, torch.Tensor)
         y = y - 16
         return y
 
@@ -860,7 +873,10 @@ def test_mojo_custom_op(device: str):
 def allocate_outputs_grayscale_multi(
     pic: torch.Tensor, noise: torch.Tensor
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    return tuple(pic.new_empty(noise.shape, dtype=torch.float32) for _ in range(2))
+    return (
+        pic.new_empty(noise.shape, dtype=torch.float32),
+        pic.new_empty(noise.shape, dtype=torch.float32),
+    )
 
 
 def grayscale_multi_eager(

--- a/tests/test_eager_kernel_loader.py
+++ b/tests/test_eager_kernel_loader.py
@@ -3,13 +3,21 @@
 import inspect
 import subprocess
 from collections import deque
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
+from typing import Protocol, cast
 
 import pytest
 
 from torch_mojo_backend import eager_kernels
+
+
+class _NativeCallModule(Protocol):
+    """A loaded Mojo extension module: `ModuleType` plus its `call` ABI."""
+
+    call: Callable[..., object]
 
 
 def test_defines_are_canonical_independent_of_mapping_order() -> None:
@@ -163,7 +171,7 @@ def test_loader_reuses_one_variant_per_distinct_define_set(
 
     def fake_load_extension(module_name: str, so_path: Path) -> ModuleType:
         module = ModuleType(f"loaded_{so_path.stem}")
-        module.call = lambda: so_path.name  # type: ignore[attr-defined]
+        cast(_NativeCallModule, module).call = lambda: so_path.name
         loaded.append(module)
         return module
 
@@ -378,7 +386,7 @@ def test_prepared_call_invokes_only_constant_call_entrypoint() -> None:
         assert isinstance(output, _TensorMetadata)
         return output
 
-    module.call = call  # type: ignore[attr-defined]
+    cast(_NativeCallModule, module).call = call
 
     class FakeLoader(eager_kernels.MojoExtensionLoader):
         def load_canonical(
@@ -447,7 +455,7 @@ def test_prepared_calls_enqueue_in_fifo_order(monkeypatch: pytest.MonkeyPatch) -
     def call(label: str) -> None:
         launches.append(label)
 
-    module.call = call  # type: ignore[attr-defined]
+    cast(_NativeCallModule, module).call = call
     unit.ext = module
     queue.drain()
 
@@ -490,5 +498,16 @@ def test_spec_descriptor_canonical_defines_match_make_defines() -> None:
         (aten_fast._MatmulSpecExtension, ("MatmulSpec", (a, b), 1)),
     ]
     for extension, args in cases:
-        expected = eager_kernels.normalize_defines(extension.make_defines(*args))
-        assert extension.make_canonical_defines(*args) == expected, extension.__name__
+        # Each row pairs one concrete MojoExtension subclass with the args
+        # tuple shaped for THAT subclass's own make_defines signature (the
+        # documented per-descriptor call ABI, see MojoExtension in
+        # eager_kernels/__init__.py) -- a heterogeneous list can't correlate
+        # `extension` with `args` per row for the type checker, only at
+        # runtime.
+        expected = eager_kernels.normalize_defines(
+            extension.make_defines(*args)  # ty: ignore[missing-argument, invalid-argument-type, too-many-positional-arguments]
+        )
+        assert (
+            extension.make_canonical_defines(*args)  # ty: ignore[missing-argument, invalid-argument-type, too-many-positional-arguments]
+            == expected
+        ), extension.__name__

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -3,17 +3,52 @@
 import functools
 import math
 import weakref
+from collections.abc import Callable
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
+from typing import Protocol, cast
 
 import pytest
 import torch
 from max.driver import CPU
 from torch.testing._internal.common_methods_invocations import op_db
 
-from torch_mojo_backend import get_accelerators, register_mojo_devices
+from torch_mojo_backend import TorchMojoTensor, get_accelerators, register_mojo_devices
 
 pytestmark = pytest.mark.xdist_group(name="group1")
+
+
+class _NativeCallModule(Protocol):
+    """A loaded Mojo extension module: `ModuleType` plus its `call` ABI."""
+
+    call: Callable[..., object]
+
+
+class _MojoBackendModule(Protocol):
+    """`torch.mojo`: registered onto the `torch` module at runtime by
+    `register_mojo_devices()` via torch's own PrivateUse1 backend-module
+    mechanism (`_setup_privateuseone_for_python_backend`), so no static stub
+    knows about it."""
+
+    def manual_seed_all(self, seed: int) -> None: ...
+    def get_rng_state(
+        self, device: torch.device | int | None = None
+    ) -> torch.Tensor: ...
+    def set_rng_state(
+        self, new_state: torch.Tensor, device: torch.device | int | None = None
+    ) -> None: ...
+
+
+def _torch_mojo() -> _MojoBackendModule:
+    return cast(_MojoBackendModule, torch.mojo)  # ty: ignore[unresolved-attribute]
+
+
+def _opaque_tensor() -> torch.Tensor:
+    """A routing-only placeholder: identity-compared, never touched by real
+    tensor ops (the routes under test are monkeypatched away first), so a
+    bare `object()` is the actual runtime value -- cast to satisfy the real
+    `Tensor`-typed signatures of the aten_fast entry points under test."""
+    return cast(torch.Tensor, object())
 
 
 @pytest.fixture(autouse=True)
@@ -41,14 +76,14 @@ def _spy_defined_native_calls(
         key = (mojo_file.name, dict(defines).get("OP", ""))
         if key not in targets:
             return module
-        native_call = module.call
+        native_call = cast(_NativeCallModule, module).call
 
         def call(*args: object, **kwargs: object) -> object:
             calls[key].append((args, kwargs))
             return native_call(*args, **kwargs)
 
         wrapped = ModuleType(f"{module.__name__}.spy")
-        wrapped.call = call
+        cast(_NativeCallModule, wrapped).call = call
         return wrapped
 
     monkeypatch.setattr(
@@ -58,7 +93,8 @@ def _spy_defined_native_calls(
 
 
 def _replace_defined_native_calls(
-    monkeypatch: pytest.MonkeyPatch, replacements: dict[tuple[str, str], object]
+    monkeypatch: pytest.MonkeyPatch,
+    replacements: dict[tuple[str, str], Callable[..., object]],
 ) -> None:
     """Replace selected constant `call` entry points without compiling them."""
     from torch_mojo_backend import eager_kernels
@@ -73,7 +109,7 @@ def _replace_defined_native_calls(
         if replacement is None:
             return original_load(mojo_file, defines)
         module = ModuleType(f"mock_{mojo_file.stem}_{key[1]}")
-        module.call = replacement  # type: ignore[attr-defined]
+        cast(_NativeCallModule, module).call = replacement
         return module
 
     monkeypatch.setattr(
@@ -441,10 +477,14 @@ def test_wrapper_subclass_preserves_native_saved_output(mojo_device):
 
     actual = host_input.to(mojo_device).requires_grad_()
     output = torch.exp(actual)
+    assert isinstance(output, TorchMojoTensor)
+    assert output.grad_fn is not None
     assert type(output.grad_fn).__name__ == "ExpBackward0"
 
-    saved = output.grad_fn._saved_result
-    assert isinstance(saved, type(output))
+    # `_saved_result` is codegen'd per-op onto ExpBackward0 and friends, not
+    # declared on the generic Node type torch's stubs expose.
+    saved = getattr(output.grad_fn, "_saved_result")
+    assert isinstance(saved, TorchMojoTensor)
     assert saved is not output
     assert saved._holder is output._holder
     assert saved._ptr == output._ptr
@@ -1305,6 +1345,8 @@ def test_fast_group_norm_without_affine(mojo_gpu):
 def test_fast_batch_norm_inference(mojo_device):
     x = torch.randn(2, 64, 14, 14)
     bn = torch.nn.BatchNorm2d(64).eval()
+    assert bn.running_mean is not None
+    assert bn.running_var is not None
     bn.running_mean.normal_()
     bn.running_var.uniform_(0.5, 2.0)
     bn_dev = torch.nn.BatchNorm2d(64).eval()
@@ -1387,7 +1429,9 @@ def test_fast_native_layer_norm_fp32_gpu_optional_affine_without_fill(
     )
 
     assert actual is not aten_fast.NOT_HANDLED
+    assert isinstance(actual, tuple)
     for got, want, tolerance in zip(actual, expected, (1e-5, 1e-5, 1e-4), strict=True):
+        assert isinstance(got, TorchMojoTensor)
         torch.testing.assert_close(got.cpu(), want, atol=tolerance, rtol=tolerance)
     torch.testing.assert_close(device_storage.cpu(), input_storage, rtol=0, atol=0)
 
@@ -1412,7 +1456,9 @@ def test_fast_native_layer_norm_gpu_prologue_runs_without_a_gpu(
     device = SimpleNamespace(label="gpu")
     next_ptr = iter(range(300, 400))
 
-    def tensor(shape, dtype=None):
+    def tensor(
+        shape: tuple[int, ...], dtype: aten_fast.DType | None = None
+    ) -> SimpleNamespace:
         shape = tuple(shape)
         return SimpleNamespace(
             _shape=shape,
@@ -1450,15 +1496,22 @@ def test_fast_native_layer_norm_gpu_prologue_runs_without_a_gpu(
         },
     )
 
-    actual = aten_fast.fast_aten_native_layer_norm(input, (7,), weight, bias, 1e-5)
+    actual = aten_fast.fast_aten_native_layer_norm(
+        cast(torch.Tensor, input),
+        (7,),
+        cast("torch.Tensor | None", weight),
+        cast("torch.Tensor | None", bias),
+        1e-5,
+    )
 
     assert actual is not aten_fast.NOT_HANDLED
+    assert isinstance(actual, tuple)
     out, mean, rstd = actual
     assert (out._shape, mean._shape, rstd._shape) == ((3, 7), (3, 1), (3, 1))
     assert len(calls) == 1
     launch = calls[0]
-    assert launch[4] == (weight._ptr if has_weight else 0)
-    assert launch[5] == (bias._ptr if has_bias else 0)
+    assert launch[4] == (weight._ptr if weight is not None else 0)
+    assert launch[5] == (bias._ptr if bias is not None else 0)
     assert launch[6:8] == (3, 7)
     assert launch[9:11] == (int(has_weight), int(has_bias))
 
@@ -1487,6 +1540,7 @@ def test_fast_native_layer_norm_fp32_gpu_noncontiguous_inputs(mojo_gpu):
     assert actual[2].is_contiguous()
     assert actual[1].shape == actual[2].shape == torch.Size([2, 1, 1])
     for got, want, tolerance in zip(actual, expected, (1e-5, 1e-5, 1e-4), strict=True):
+        assert isinstance(got, TorchMojoTensor)
         torch.testing.assert_close(got.cpu(), want, atol=tolerance, rtol=tolerance)
 
 
@@ -1996,6 +2050,8 @@ def test_fast_native_layer_norm_weight_only_autograd(mojo_gpu):
 
     assert device_input._version == input_version
     assert device_weight._version == weight_version
+    assert device_input.grad is not None
+    assert device_weight.grad is not None
     torch.testing.assert_close(
         device_input.grad.cpu(), host_input.grad, atol=2e-3, rtol=2e-3
     )
@@ -2132,9 +2188,14 @@ def test_fast_native_layer_norm_backward_empty_rows(mojo_gpu):
     weight = torch.randn(cols).to(mojo_gpu)
     bias = torch.randn(cols).to(mojo_gpu)
 
-    grad_input, grad_weight, grad_bias = aten_fast.fast_aten_native_layer_norm_backward(
+    backward_result = aten_fast.fast_aten_native_layer_norm_backward(
         grad_output, input, (cols,), mean, rstd, weight, bias, (True, True, True)
     )
+    assert isinstance(backward_result, tuple)
+    grad_input, grad_weight, grad_bias = backward_result
+    assert isinstance(grad_input, TorchMojoTensor)
+    assert isinstance(grad_weight, TorchMojoTensor)
+    assert isinstance(grad_bias, TorchMojoTensor)
 
     assert grad_input.shape == input.shape
     assert grad_input.numel() == 0
@@ -2154,15 +2215,15 @@ def test_fast_layer_norm_training_backward(mojo_gpu, affine):
     bias = torch.randn(384, generator=generator) if affine else None
 
     reference_input = input.clone().requires_grad_()
-    reference_weight = weight.clone().requires_grad_() if affine else None
-    reference_bias = bias.clone().requires_grad_() if affine else None
+    reference_weight = weight.clone().requires_grad_() if weight is not None else None
+    reference_bias = bias.clone().requires_grad_() if bias is not None else None
     torch.nn.functional.layer_norm(
         reference_input, (384,), reference_weight, reference_bias, 1e-5
     ).backward(grad_output)
 
     mojo_input = input.to(mojo_gpu).requires_grad_()
-    mojo_weight = weight.to(mojo_gpu).requires_grad_() if affine else None
-    mojo_bias = bias.to(mojo_gpu).requires_grad_() if affine else None
+    mojo_weight = weight.to(mojo_gpu).requires_grad_() if weight is not None else None
+    mojo_bias = bias.to(mojo_gpu).requires_grad_() if bias is not None else None
     backward_counter = EAGER_CALL_COUNTERS["aten::native_layer_norm_backward"]
     calls_before = backward_counter.call_count
     mojo_output = torch.nn.functional.layer_norm(
@@ -2178,6 +2239,10 @@ def test_fast_layer_norm_training_backward(mojo_gpu, affine):
         mojo_input.grad.cpu(), reference_input.grad, atol=2e-4, rtol=2e-4
     )
     if affine:
+        assert mojo_weight is not None
+        assert mojo_bias is not None
+        assert reference_weight is not None
+        assert reference_bias is not None
         assert mojo_weight.grad is not None
         assert mojo_bias.grad is not None
         torch.testing.assert_close(
@@ -2215,20 +2280,22 @@ def test_fast_layer_norm_native_saved_tensor_hooks(mojo_gpu):
     host_bias = torch.randn(7, generator=generator)
     grad_output = torch.randn(3, 7, generator=generator)
 
-    reference = [
+    # A fixed-length tuple (not a list) so ty can see *reference[1:] unpacks
+    # exactly (weight, bias) below.
+    reference = (
         host_input.clone().requires_grad_(),
         host_weight.clone().requires_grad_(),
         host_bias.clone().requires_grad_(),
-    ]
+    )
     torch.nn.functional.layer_norm(reference[0], (7,), *reference[1:]).backward(
         grad_output
     )
 
-    actual = [
+    actual = (
         host_input.to(mojo_gpu).requires_grad_(),
         host_weight.to(mojo_gpu).requires_grad_(),
         host_bias.to(mojo_gpu).requires_grad_(),
-    ]
+    )
     hook_calls = []
 
     def pack(tensor):
@@ -2268,18 +2335,20 @@ def test_fast_layer_norm_native_double_backward(mojo_gpu):
         )
         return input_grad, *second_grads
 
-    reference = [
+    # A fixed-length tuple (not a list) so ty can see *reference/*actual
+    # unpack exactly 3 positional args below.
+    reference = (
         host_input.clone().requires_grad_(),
         host_weight.clone().requires_grad_(),
         host_bias.clone().requires_grad_(),
-    ]
+    )
     expected = derivatives(*reference, first_seed, second_seed)
 
-    actual = [
+    actual = (
         host_input.to(mojo_gpu).requires_grad_(),
         host_weight.to(mojo_gpu).requires_grad_(),
         host_bias.to(mojo_gpu).requires_grad_(),
-    ]
+    )
     got = derivatives(*actual, first_seed.to(mojo_gpu), second_seed.to(mojo_gpu))
 
     assert type(got[0].grad_fn).__name__ == "NativeLayerNormBackwardBackward0"
@@ -2358,11 +2427,11 @@ def test_fast_native_layer_norm_rejects_wrong_affine_shape(mojo_gpu, monkeypatch
 def test_fast_native_dropout_forward_semantics(mojo_gpu, p, train, should_advance_rng):
     input = torch.linspace(-4.0, 4.0, 257)
     mojo_input = input.to(mojo_gpu)
-    torch.mojo.manual_seed_all((1 << 63) + 20260718)
-    before = torch.mojo.get_rng_state(mojo_input.device)
+    _torch_mojo().manual_seed_all((1 << 63) + 20260718)
+    before = _torch_mojo().get_rng_state(mojo_input.device)
 
     output, mask = torch.ops.aten.native_dropout.default(mojo_input, p, train)
-    after = torch.mojo.get_rng_state(mojo_input.device)
+    after = _torch_mojo().get_rng_state(mojo_input.device)
 
     assert output is not mojo_input
     assert output.shape == mojo_input.shape
@@ -2388,23 +2457,23 @@ def test_fast_native_dropout_forward_semantics(mojo_gpu, p, train, should_advanc
 def test_fast_native_dropout_inference_ignores_probability(mojo_gpu, p):
     input = torch.linspace(-4.0, 4.0, 17)
     mojo_input = input.to(mojo_gpu)
-    torch.mojo.manual_seed_all(20260718)
-    before = torch.mojo.get_rng_state(mojo_input.device)
+    _torch_mojo().manual_seed_all(20260718)
+    before = _torch_mojo().get_rng_state(mojo_input.device)
 
     output, mask = torch.ops.aten.native_dropout.default(mojo_input, p, False)
 
     assert output is not mojo_input
     torch.testing.assert_close(output.cpu(), input)
     assert mask.cpu().all()
-    torch.testing.assert_close(torch.mojo.get_rng_state(mojo_input.device), before)
+    torch.testing.assert_close(_torch_mojo().get_rng_state(mojo_input.device), before)
 
 
 def test_fast_native_dropout_empty_does_not_advance_rng(mojo_gpu):
     input = torch.empty(0, 7).to(mojo_gpu)
-    torch.mojo.manual_seed_all(20260718)
-    before = torch.mojo.get_rng_state(input.device)
+    _torch_mojo().manual_seed_all(20260718)
+    before = _torch_mojo().get_rng_state(input.device)
     output, mask = torch.ops.aten.native_dropout.default(input, 0.0, True)
-    after = torch.mojo.get_rng_state(input.device)
+    after = _torch_mojo().get_rng_state(input.device)
 
     assert output is not input
     assert output.shape == input.shape
@@ -2415,17 +2484,17 @@ def test_fast_native_dropout_empty_does_not_advance_rng(mojo_gpu):
 
 def test_fast_native_dropout_rng_state_replays_exactly(mojo_gpu):
     input = torch.randn(4097).to(mojo_gpu)
-    torch.mojo.manual_seed_all((1 << 63) + 0x12345)
-    initial = torch.mojo.get_rng_state(input.device)
+    _torch_mojo().manual_seed_all((1 << 63) + 0x12345)
+    initial = _torch_mojo().get_rng_state(input.device)
     first_output, first_mask = torch.ops.aten.native_dropout.default(input, 0.2, True)
-    advanced = torch.mojo.get_rng_state(input.device)
+    advanced = _torch_mojo().get_rng_state(input.device)
 
-    torch.mojo.set_rng_state(initial, input.device)
+    _torch_mojo().set_rng_state(initial, input.device)
     replay_output, replay_mask = torch.ops.aten.native_dropout.default(input, 0.2, True)
 
     torch.testing.assert_close(replay_mask.cpu(), first_mask.cpu())
     torch.testing.assert_close(replay_output.cpu(), first_output.cpu())
-    torch.testing.assert_close(torch.mojo.get_rng_state(input.device), advanced)
+    torch.testing.assert_close(_torch_mojo().get_rng_state(input.device), advanced)
 
 
 def _philox_rng_state(seed: int, counter: int) -> torch.Tensor:
@@ -2449,9 +2518,11 @@ def test_fast_native_dropout_reserves_exact_full_width_interval(mojo_gpu, monkey
     input = torch.arange(9, dtype=torch.float32).to(mojo_gpu)
     seed = (1 << 63) + 0x1234_5678
     counter = (1 << 63) + 0x9ABC_DEF0
-    torch.mojo.set_rng_state(_philox_rng_state(seed, counter), input.device)
+    _torch_mojo().set_rng_state(_philox_rng_state(seed, counter), input.device)
 
-    output, mask = aten_fast.fast_aten_native_dropout(input, 0.0, True)
+    dropout_result = aten_fast.fast_aten_native_dropout(input, 0.0, True)
+    assert isinstance(dropout_result, tuple)
+    output, mask = dropout_result
 
     assert output.shape == input.shape
     assert mask.shape == input.shape
@@ -2466,7 +2537,7 @@ def test_fast_native_dropout_reserves_exact_full_width_interval(mojo_gpu, monkey
         counter & 0xFFFF_FFFF,
         counter >> 32,
     )
-    assert _decode_philox_rng_state(torch.mojo.get_rng_state(input.device)) == (
+    assert _decode_philox_rng_state(_torch_mojo().get_rng_state(input.device)) == (
         seed,
         counter + 3,
     )
@@ -2484,16 +2555,16 @@ def test_fast_native_dropout_reservation_wrap_does_not_mutate_state(
     )
     input = torch.arange(4, dtype=torch.float32).to(mojo_gpu)
     seed = (1 << 64) - 1
-    torch.mojo.set_rng_state(_philox_rng_state(seed, (1 << 64) - 2), input.device)
+    _torch_mojo().set_rng_state(_philox_rng_state(seed, (1 << 64) - 2), input.device)
 
     aten_fast.fast_aten_native_dropout(input, 0.0, True)
-    endpoint = torch.mojo.get_rng_state(input.device)
+    endpoint = _torch_mojo().get_rng_state(input.device)
     assert _decode_philox_rng_state(endpoint) == (seed, (1 << 64) - 1)
     assert len(calls) == 1
 
     with pytest.raises(OverflowError, match="wrap uint64"):
         aten_fast.fast_aten_native_dropout(input, 0.0, True)
-    torch.testing.assert_close(torch.mojo.get_rng_state(input.device), endpoint)
+    torch.testing.assert_close(_torch_mojo().get_rng_state(input.device), endpoint)
     assert len(calls) == 1
 
 
@@ -2505,8 +2576,8 @@ def test_fast_native_dropout_invalid_probability_does_not_touch_rng_or_input(
     from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
 
     input = torch.randn(3, 8).to(mojo_gpu)[:, ::2]
-    torch.mojo.manual_seed_all(20260718)
-    before = torch.mojo.get_rng_state(input.device)
+    _torch_mojo().manual_seed_all(20260718)
+    before = _torch_mojo().get_rng_state(input.device)
 
     def fail_materialization(_self):
         raise AssertionError("invalid dropout metadata materialized the input")
@@ -2516,7 +2587,7 @@ def test_fast_native_dropout_invalid_probability_does_not_touch_rng_or_input(
     )
     with pytest.raises(RuntimeError, match="probability has to be between 0 and 1"):
         aten_fast.fast_aten_native_dropout(input, p, True)
-    torch.testing.assert_close(torch.mojo.get_rng_state(input.device), before)
+    torch.testing.assert_close(_torch_mojo().get_rng_state(input.device), before)
 
 
 def test_fast_native_dropout_backward_multiplication_semantics(mojo_gpu):
@@ -2627,6 +2698,7 @@ def test_fast_native_dropout_saved_tensor_hooks(mojo_gpu):
 
     shape = (3, 17)
     assert hook_calls == [("pack", "mojo", shape), ("unpack", "cpu", shape)]
+    assert input.grad is not None
     torch.testing.assert_close(input.grad.cpu(), grad_output * mask.cpu() * 1.25)
 
 
@@ -2647,7 +2719,7 @@ UNIFORM_DTYPES = [torch.float32, torch.bfloat16, torch.float16, torch.float64]
 @pytest.mark.parametrize(("low", "high"), [(0.0, 1.0), (-100.0, 100.0), (1.0, 2.0)])
 def test_fast_uniform_bounds_and_distribution(mojo_device, dtype, low, high):
     """Half-open [from, to) on a large sample, plus the first two moments."""
-    torch.mojo.manual_seed_all(20260814)
+    _torch_mojo().manual_seed_all(20260814)
     drawn = torch.empty(200_000, dtype=dtype, device=mojo_device).uniform_(low, high)
     host = drawn.cpu().double()
 
@@ -2668,7 +2740,7 @@ def test_fast_uniform_narrow_dtype_never_reaches_to(mojo_device, dtype):
     `from` instead, and `from` is otherwise unreachable here: only an exact
     zero word produces it, with probability 2**-24 per element.
     """
-    torch.mojo.manual_seed_all(20260814)
+    _torch_mojo().manual_seed_all(20260814)
     host = (
         torch.empty(200_000, dtype=dtype, device=mojo_device)
         .uniform_(0.0, 1.0)
@@ -2711,7 +2783,7 @@ def test_fast_uniform_reserves_one_counter_per_philox_group(
     drawn = torch.empty(numel, dtype=dtype, device=mojo_gpu)
     seed = (1 << 63) + 0x1234_5678
     counter = (1 << 63) + 0x9ABC_DEF0
-    torch.mojo.set_rng_state(_philox_rng_state(seed, counter), drawn.device)
+    _torch_mojo().set_rng_state(_philox_rng_state(seed, counter), drawn.device)
 
     drawn.uniform_(-1.0, 3.0)
 
@@ -2724,7 +2796,7 @@ def test_fast_uniform_reserves_one_counter_per_philox_group(
         counter & 0xFFFF_FFFF,
         counter >> 32,
     )
-    assert _decode_philox_rng_state(torch.mojo.get_rng_state(drawn.device)) == (
+    assert _decode_philox_rng_state(_torch_mojo().get_rng_state(drawn.device)) == (
         seed,
         counter + counters,
     )
@@ -2737,7 +2809,7 @@ def test_fast_uniform_adjacent_draws_are_independent(mojo_gpu):
     advance at all, shows up here and nowhere else: exact float32 collisions
     between two 8192-element draws are otherwise ~1 in 2**24 per element.
     """
-    torch.mojo.manual_seed_all(20260814)
+    _torch_mojo().manual_seed_all(20260814)
     first = torch.empty(8192, device=mojo_gpu).uniform_().cpu()
     second = torch.empty(8192, device=mojo_gpu).uniform_().cpu()
 
@@ -2752,40 +2824,40 @@ def test_fast_uniform_adjacent_draws_are_independent(mojo_gpu):
 
 def test_fast_uniform_non_multiple_of_four_draws_do_not_overlap(mojo_gpu):
     """A ragged draw leaves the stream exactly two counters further on."""
-    torch.mojo.manual_seed_all(20260814)
-    state = torch.mojo.get_rng_state(mojo_gpu)
+    _torch_mojo().manual_seed_all(20260814)
+    state = _torch_mojo().get_rng_state(mojo_gpu)
     seed, counter = _decode_philox_rng_state(state)
 
     first = torch.empty(7, device=mojo_gpu).uniform_().cpu()
     second = torch.empty(7, device=mojo_gpu).uniform_().cpu()
 
-    torch.mojo.set_rng_state(_philox_rng_state(seed, counter + 2), mojo_gpu)
+    _torch_mojo().set_rng_state(_philox_rng_state(seed, counter + 2), mojo_gpu)
     replayed_second = torch.empty(7, device=mojo_gpu).uniform_().cpu()
     assert torch.equal(second, replayed_second)
     assert not torch.equal(first, second)
 
 
 def test_fast_uniform_is_reproducible_under_manual_seed(mojo_device):
-    torch.mojo.manual_seed_all(4242)
+    _torch_mojo().manual_seed_all(4242)
     first = torch.empty(1023, device=mojo_device).uniform_(-2.0, 5.0).cpu()
-    torch.mojo.manual_seed_all(4242)
+    _torch_mojo().manual_seed_all(4242)
     second = torch.empty(1023, device=mojo_device).uniform_(-2.0, 5.0).cpu()
 
     assert torch.equal(first, second)
 
 
 def test_fast_uniform_rng_state_round_trips(mojo_device):
-    torch.mojo.manual_seed_all((1 << 63) + 0x54321)
-    initial = torch.mojo.get_rng_state(mojo_device)
+    _torch_mojo().manual_seed_all((1 << 63) + 0x54321)
+    initial = _torch_mojo().get_rng_state(mojo_device)
     first = torch.empty(1025, device=mojo_device).uniform_().cpu()
-    advanced = torch.mojo.get_rng_state(mojo_device)
+    advanced = _torch_mojo().get_rng_state(mojo_device)
     assert not torch.equal(initial, advanced)
 
-    torch.mojo.set_rng_state(initial, mojo_device)
+    _torch_mojo().set_rng_state(initial, mojo_device)
     replayed = torch.empty(1025, device=mojo_device).uniform_().cpu()
 
     assert torch.equal(first, replayed)
-    torch.testing.assert_close(torch.mojo.get_rng_state(mojo_device), advanced)
+    torch.testing.assert_close(_torch_mojo().get_rng_state(mojo_device), advanced)
 
 
 def test_fast_uniform_wide_and_scalar_store_paths_agree(mojo_gpu):
@@ -2795,14 +2867,15 @@ def test_fast_uniform_wide_and_scalar_store_paths_agree(mojo_gpu):
     scalar kernel runs instead. Both kernels index the stream the same way, so
     the same reservation has to produce the same values.
     """
-    torch.mojo.manual_seed_all(20260814)
-    state = torch.mojo.get_rng_state(mojo_gpu)
+    _torch_mojo().manual_seed_all(20260814)
+    state = _torch_mojo().get_rng_state(mojo_gpu)
     aligned = torch.zeros(8, device=mojo_gpu)
     aligned.uniform_(-1.0, 1.0)
 
-    torch.mojo.set_rng_state(state, mojo_gpu)
+    _torch_mojo().set_rng_state(state, mojo_gpu)
     storage = torch.zeros(9, device=mojo_gpu)
     offset_view = storage[1:]
+    assert isinstance(offset_view, TorchMojoTensor)
     assert offset_view._ptr % 16 != 0
     offset_view.uniform_(-1.0, 1.0)
 
@@ -2813,11 +2886,11 @@ def test_fast_uniform_wide_and_scalar_store_paths_agree(mojo_gpu):
 
 def test_fast_uniform_strided_destination_matches_contiguous(mojo_gpu):
     """A view's values depend on its logical index, never on its layout."""
-    torch.mojo.manual_seed_all(20260814)
-    state = torch.mojo.get_rng_state(mojo_gpu)
+    _torch_mojo().manual_seed_all(20260814)
+    state = _torch_mojo().get_rng_state(mojo_gpu)
     contiguous = torch.empty(4, 4, device=mojo_gpu).uniform_(10.0, 11.0)
 
-    torch.mojo.set_rng_state(state, mojo_gpu)
+    _torch_mojo().set_rng_state(state, mojo_gpu)
     storage = torch.zeros(4, 8, device=mojo_gpu)
     view = storage[:, ::2]
     assert not view.is_contiguous()
@@ -2830,11 +2903,11 @@ def test_fast_uniform_strided_destination_matches_contiguous(mojo_gpu):
 
 def test_fast_uniform_empty_does_not_advance_rng(mojo_gpu):
     drawn = torch.empty(0, 5, device=mojo_gpu)
-    torch.mojo.manual_seed_all(20260814)
-    before = torch.mojo.get_rng_state(drawn.device)
+    _torch_mojo().manual_seed_all(20260814)
+    before = _torch_mojo().get_rng_state(drawn.device)
 
     assert drawn.uniform_() is drawn
-    torch.testing.assert_close(torch.mojo.get_rng_state(drawn.device), before)
+    torch.testing.assert_close(_torch_mojo().get_rng_state(drawn.device), before)
 
 
 @pytest.mark.parametrize(
@@ -2849,23 +2922,23 @@ def test_fast_uniform_empty_does_not_advance_rng(mojo_gpu):
 )
 def test_fast_uniform_rejects_bad_bounds(mojo_gpu, dtype, low, high, message):
     """ATen's own checks, including on an empty tensor (ATen checks first)."""
-    torch.mojo.manual_seed_all(20260814)
-    before = torch.mojo.get_rng_state(mojo_gpu)
+    _torch_mojo().manual_seed_all(20260814)
+    before = _torch_mojo().get_rng_state(mojo_gpu)
     for numel in (10, 0):
         drawn = torch.empty(numel, dtype=dtype, device=mojo_gpu)
         with pytest.raises(RuntimeError, match=message):
             drawn.uniform_(low, high)
-    torch.testing.assert_close(torch.mojo.get_rng_state(mojo_gpu), before)
+    torch.testing.assert_close(_torch_mojo().get_rng_state(mojo_gpu), before)
 
 
 def test_fast_uniform_refuses_an_explicit_generator(mojo_gpu):
-    torch.mojo.manual_seed_all(20260814)
-    before = torch.mojo.get_rng_state(mojo_gpu)
+    _torch_mojo().manual_seed_all(20260814)
+    before = _torch_mojo().get_rng_state(mojo_gpu)
     drawn = torch.empty(4, device=mojo_gpu)
 
     with pytest.raises(NotImplementedError, match="explicit generator"):
         drawn.uniform_(0.0, 1.0, generator=torch.Generator())
-    torch.testing.assert_close(torch.mojo.get_rng_state(mojo_gpu), before)
+    torch.testing.assert_close(_torch_mojo().get_rng_state(mojo_gpu), before)
 
 
 def test_fast_uniform_declines_integer_dtypes(mojo_gpu):
@@ -2916,8 +2989,10 @@ def test_fast_lerp_scalar_out_and_inplace_alias(mojo_gpu):
     expected = torch.lerp(start, end, weight)
     device_start = start.to(mojo_gpu)
     device_end = end.to(mojo_gpu)
+    assert isinstance(device_start, TorchMojoTensor)
 
     out = torch.empty_like(device_start)
+    assert isinstance(out, TorchMojoTensor)
     out_holder, out_ptr = out._holder, out._ptr
     returned = torch.lerp(device_start, device_end, weight, out=out)
     assert returned is out
@@ -2944,6 +3019,7 @@ def test_fast_l2_norm_out_and_mul_inplace_alias(mojo_gpu):
     expected = torch.linalg.vector_norm(input)
 
     out = torch.empty((), dtype=torch.float32, device=mojo_gpu)
+    assert isinstance(out, TorchMojoTensor)
     out_holder, out_ptr = out._holder, out._ptr
     returned = torch.linalg.vector_norm(device_input, out=out)
     assert returned is out
@@ -2957,6 +3033,7 @@ def test_fast_l2_norm_out_and_mul_inplace_alias(mojo_gpu):
     )
 
     base = torch.arange(12, dtype=torch.float32).to(mojo_gpu)
+    assert isinstance(base, TorchMojoTensor)
     view = base[::2]
     observer = base.view(3, 4)
     base_holder, base_ptr = base._holder, base._ptr
@@ -3050,7 +3127,9 @@ def test_fast_foreach_add_scalar_inplace_chunk_boundary(mojo_gpu, dtype):
         for index in range(1, 65)
     ]
     host_inputs.append(torch.linspace(-3.0, 4.0, 65_537).to(dtype))
-    device_inputs = [tensor.to(mojo_gpu) for tensor in host_inputs]
+    device_inputs = cast(
+        list[TorchMojoTensor], [tensor.to(mojo_gpu) for tensor in host_inputs]
+    )
     allocation_state = [
         (tensor._holder, tensor._ptr, tensor._version) for tensor in device_inputs
     ]
@@ -3149,7 +3228,10 @@ def test_fast_foreach_add_scalar_matches_adamw_step_counters(mojo_gpu, monkeypat
     bridge_calls = native_calls[target]
     assert len(bridge_calls) == 3
     bridge_args = [args for args, _ in bridge_calls]
-    assert all(len(args[0]) == 150 for args in bridge_args)
+    for args in bridge_args:
+        first_arg = args[0]
+        assert isinstance(first_arg, list | tuple)
+        assert len(first_arg) == 150
     for step in steps:
         assert step.shape == torch.Size([])
         assert step.cpu().item() == 3.0
@@ -3162,7 +3244,9 @@ def test_fast_foreach_mul_tensor_inplace_chunk_boundary(mojo_gpu):
         torch.tensor([float(index), -float(index)]) for index in range(1, 64)
     ]
     host_inputs.append(torch.linspace(-3.0, 4.0, 65_537))
-    device_inputs = [tensor.to(mojo_gpu) for tensor in host_inputs]
+    device_inputs = cast(
+        list[TorchMojoTensor], [tensor.to(mojo_gpu) for tensor in host_inputs]
+    )
     allocation_state = [
         (tensor._holder, tensor._ptr, tensor._version) for tensor in device_inputs
     ]
@@ -3205,6 +3289,7 @@ def test_fast_foreach_mul_tensor_duplicate_is_sequential(mojo_gpu):
     """A duplicate entry is multiplied twice and bumps its version twice."""
     counter, calls_before = _eager_registration_snapshot("aten::_foreach_mul_.Tensor")
     input = torch.tensor([2.0, -3.0, 5.0]).to(mojo_gpu)
+    assert isinstance(input, TorchMojoTensor)
     holder, ptr, version = input._holder, input._ptr, input._version
     coefficient = torch.tensor(0.5, dtype=torch.float32).to(mojo_gpu)
 
@@ -3221,10 +3306,10 @@ def test_fast_foreach_mul_tensor_duplicate_is_sequential(mojo_gpu):
 
 def test_fast_foreach_mul_tensor_validates_scalar_before_writes(mojo_gpu):
     counter, calls_before = _eager_registration_snapshot("aten::_foreach_mul_.Tensor")
-    inputs = [
-        torch.tensor([1.0, 2.0]).to(mojo_gpu),
-        torch.tensor([-3.0, 4.0]).to(mojo_gpu),
-    ]
+    inputs = cast(
+        list[TorchMojoTensor],
+        [torch.tensor([1.0, 2.0]).to(mojo_gpu), torch.tensor([-3.0, 4.0]).to(mojo_gpu)],
+    )
     allocation_state = [
         (tensor._holder, tensor._ptr, tensor._version, tensor.cpu())
         for tensor in inputs
@@ -3248,6 +3333,7 @@ def test_fast_foreach_mul_tensor_preserves_strided_fallback(mojo_gpu):
     counter, calls_before = _eager_registration_snapshot("aten::_foreach_mul_.Tensor")
     base = torch.arange(12, dtype=torch.float32).to(mojo_gpu)
     input = base[::2]
+    assert isinstance(input, TorchMojoTensor)
     assert not input.is_contiguous()
     holder, ptr, version = input._holder, input._ptr, input._version
     coefficient = torch.tensor(0.25, dtype=torch.float32).to(mojo_gpu)
@@ -3283,6 +3369,7 @@ def test_fast_foreach_mul_tensor_overlapping_views_are_sequential(mojo_gpu):
 def test_fast_foreach_mul_tensor_rejects_scalar_alias_before_writes(mojo_gpu):
     counter, calls_before = _eager_registration_snapshot("aten::_foreach_mul_.Tensor")
     input = torch.tensor([2.0, 3.0, 4.0]).to(mojo_gpu)
+    assert isinstance(input, TorchMojoTensor)
     scalar_alias = input[0]
     holder, ptr, version = input._holder, input._ptr, input._version
 
@@ -3373,6 +3460,7 @@ def test_fast_clip_grad_norm_foreach_routing(mojo_gpu, foreach):
     assert mul_counter.call_count == mul_calls_before + expected_foreach_calls
     torch.testing.assert_close(actual_norm.cpu(), expected_norm)
     for actual, expected in zip(device_parameters, host_parameters, strict=True):
+        assert actual.grad is not None
         torch.testing.assert_close(actual.grad.cpu(), expected.grad)
 
 
@@ -3403,6 +3491,7 @@ def test_fast_sum_contiguous_adjacent_dims(mojo_device, shape, dims, keepdim):
     expected_input = host_storage[1:-1].reshape(shape)
     device_storage = host_storage.to(mojo_device)
     device_input = device_storage[1:-1].view(shape)
+    assert isinstance(device_input, TorchMojoTensor)
     holder, ptr = device_input._holder, device_input._ptr
 
     actual = device_input.sum(dim=dims, keepdim=keepdim)
@@ -3745,6 +3834,8 @@ def test_fast_embedding_dense_backward_repeated_padding(mojo_gpu, strided):
         assert not grad_output.is_contiguous()
         device_indices = index_storage.to(mojo_gpu)[:, ::2]
         device_grad_output = grad_storage.to(mojo_gpu)[..., ::2]
+        assert isinstance(device_indices, TorchMojoTensor)
+        assert isinstance(device_grad_output, TorchMojoTensor)
         assert not device_indices._is_contiguous
         assert not device_grad_output._is_contiguous
     else:
@@ -3781,6 +3872,8 @@ def test_fast_embedding_dense_backward_strided_temporary_lifetime(
     )
     device_indices = indices_storage.to(mojo_gpu)[:, ::2]
     device_grad_output = grad_storage.to(mojo_gpu)[..., ::2]
+    assert isinstance(device_indices, TorchMojoTensor)
+    assert isinstance(device_grad_output, TorchMojoTensor)
     assert not device_indices._is_contiguous
     assert not device_grad_output._is_contiguous
 
@@ -3812,6 +3905,8 @@ def test_fast_embedding_dense_backward_host_bridge_abi(mojo_gpu, monkeypatch):
     )
     grad_output = grad_storage[3:].view(2, 3, 5)
     indices = index_storage[2:].view(2, 3)
+    assert isinstance(grad_output, TorchMojoTensor)
+    assert isinstance(indices, TorchMojoTensor)
     calls = []
     _replace_defined_native_calls(
         monkeypatch,
@@ -3825,6 +3920,7 @@ def test_fast_embedding_dense_backward_host_bridge_abi(mojo_gpu, monkeypatch):
     output = aten_fast.fast_aten_embedding_dense_backward(
         grad_output, indices, 11, 7, False
     )
+    assert isinstance(output, TorchMojoTensor)
 
     assert len(calls) == 1
     assert calls[0] == (
@@ -3840,7 +3936,9 @@ def test_fast_embedding_dense_backward_host_bridge_abi(mojo_gpu, monkeypatch):
     )
     assert calls[0][-1] == output._device._device_context_ptr()
     assert output._device == grad_output._device
-    assert output._holder.get_nbytes() == 11 * 5 * torch.float32.itemsize
+    # _holder is the opaque Mojo TensorHolder (no Python stub); get_nbytes is
+    # its own native method.
+    assert getattr(output._holder, "get_nbytes")() == 11 * 5 * torch.float32.itemsize
 
 
 def test_fast_embedding_dense_backward_uses_each_gpu_context():
@@ -3897,6 +3995,7 @@ def test_fast_embedding_training_backward(mojo_gpu):
     )
     actual.backward(grad_output.to(mojo_gpu))
     torch.testing.assert_close(actual.cpu(), expected.detach(), rtol=0, atol=0)
+    assert device_weight.grad is not None
     torch.testing.assert_close(device_weight.grad.cpu(), weight.grad, rtol=0, atol=0)
 
 
@@ -3993,11 +4092,13 @@ def test_fast_gelu_forward_bf16_direct_runtime_layout(
     input = backing[storage_offset:].view(shape)
     device_backing = backing.to(mojo_gpu)
     device_input = device_backing[storage_offset:].view(shape)
+    assert isinstance(device_input, TorchMojoTensor)
     input_ptr = device_input._ptr
     input_version = device_input._version
     target = ("activation_forward_ops.mojo", "GeluForwardBF16")
     native_calls = _spy_defined_native_calls(monkeypatch, {target})
     actual = torch.nn.functional.gelu(device_input, approximate=approximate)
+    assert isinstance(actual, TorchMojoTensor)
     expected = torch.nn.functional.gelu(input, approximate=approximate)
 
     assert [args for args, _ in native_calls[target]] == [
@@ -4379,7 +4480,9 @@ def test_fast_gelu_backward_rejects_mixed_dtype_before_materialization(
 @pytest.mark.parametrize("value", [False, True])
 def test_fast_bool_fill_scalar(mojo_device, value):
     actual = torch.empty(3, 5, dtype=torch.bool).to(mojo_device)
+    assert isinstance(actual, TorchMojoTensor)
     returned = actual.t().fill_(value)
+    assert isinstance(returned, TorchMojoTensor)
     assert returned is not actual
     assert returned._ptr == actual._ptr
     torch.testing.assert_close(actual.cpu(), torch.full((3, 5), value))
@@ -4671,7 +4774,9 @@ def test_fast_mm_addmm(mojo_gpu):
 # operands straight to it, so a copy-free route reading the wrong strides -- or
 # a missing scratch copy -- shows up here rather than as a wrong training loss.
 # Queued and inline launches both, because a queued launch cannot fall back.
-def _strided_matmul_cases(device: torch.device) -> list[tuple[str, object, object]]:
+def _strided_matmul_cases(
+    device: torch.device,
+) -> list[tuple[str, torch.Tensor, torch.Tensor]]:
     def to(x: torch.Tensor) -> torch.Tensor:
         return x.to(device)
 
@@ -4981,6 +5086,7 @@ def test_fast_argreduce_strided_direct_gate_matches_the_kernel_regime(
     )
 
     contiguous = _t(torch.randn(8, _ARG_DIRECT_MIN_INNER).to(mojo_gpu))
+    assert contiguous is not None
     assert _arg_strided_direct_ok("ArgminSpec", contiguous, (0,))
     assert _arg_strided_direct_ok("ArgmaxSpec", contiguous, (0,))
     # trailing dims belong to the contiguous-axis kernels
@@ -4989,11 +5095,14 @@ def test_fast_argreduce_strided_direct_gate_matches_the_kernel_regime(
     assert not _arg_strided_direct_ok("SumSpec", contiguous, (0,))
     # below the coalescing floor, and non-contiguous operands, materialize
     narrow = _t(torch.randn(8, _ARG_DIRECT_MIN_INNER - 1).to(mojo_gpu))
+    assert narrow is not None
     assert not _arg_strided_direct_ok("ArgmaxSpec", narrow, (0,))
     strided = _t(torch.randn(8, 64).to(mojo_gpu)[:, ::2])
+    assert strided is not None
     assert not _arg_strided_direct_ok("ArgmaxSpec", strided, (0,))
     # a non-adjacent dim interval is not a (outer, reduce, inner) view
     cube = _t(torch.randn(4, 5, 64).to(mojo_gpu))
+    assert cube is not None
     assert not _arg_strided_direct_ok("ArgmaxSpec", cube, (0, 2))
 
 
@@ -5878,6 +5987,7 @@ def test_fast_nll_loss_rejects_unsupported_metadata_without_resizing(mojo_gpu):
     device_log_probs = log_probs.to(mojo_gpu)
     device_target = target.to(mojo_gpu)
     output = torch.empty(3, device=mojo_gpu)
+    assert isinstance(output, TorchMojoTensor)
     bad_total_weight = torch.empty((), dtype=torch.float16, device=mojo_gpu)
 
     with pytest.raises(NotImplementedError, match="nll_loss_forward.output"):
@@ -6012,6 +6122,7 @@ def test_fast_nll_loss_autograd_uses_saved_tensor_hooks(mojo_gpu):
     assert hook_calls == [("pack", "mojo", shape) for shape in expected_shapes] + [
         ("unpack", "cpu", shape) for shape in expected_shapes
     ]
+    assert actual.grad is not None
     torch.testing.assert_close(actual.grad.cpu(), reference.grad)
 
 
@@ -6127,11 +6238,16 @@ def test_fast_linear_training_backward(mojo_gpu, with_bias):
     bias = torch.randn(64, generator=generator) if with_bias else None
     grad_output = torch.randn(2, 16, 64, generator=generator)
 
-    reference_inputs = [x.clone().requires_grad_(), weight.clone().requires_grad_()]
+    # Fixed-length tuples (not lists) so ty sees *reference_inputs/*mojo_inputs
+    # unpack exactly (input, weight) below.
+    reference_inputs = (x.clone().requires_grad_(), weight.clone().requires_grad_())
     reference_bias = bias.clone().requires_grad_() if bias is not None else None
     torch.nn.functional.linear(*reference_inputs, reference_bias).backward(grad_output)
 
-    mojo_inputs = [tensor.to(mojo_gpu).requires_grad_() for tensor in (x, weight)]
+    mojo_inputs = (
+        x.to(mojo_gpu).requires_grad_(),
+        weight.to(mojo_gpu).requires_grad_(),
+    )
     mojo_bias = bias.to(mojo_gpu).requires_grad_() if bias is not None else None
     backward_counter = EAGER_CALL_COUNTERS["aten::linear_backward"]
     calls_before = backward_counter.call_count
@@ -6148,6 +6264,7 @@ def test_fast_linear_training_backward(mojo_gpu, with_bias):
             actual.grad.cpu(), expected.grad, atol=2e-4, rtol=2e-4
         )
     if mojo_bias is not None:
+        assert reference_bias is not None
         assert mojo_bias.grad is not None
         torch.testing.assert_close(
             mojo_bias.grad.cpu(), reference_bias.grad, atol=2e-4, rtol=2e-4
@@ -6509,7 +6626,12 @@ def test_bf16_matmul_family_precedes_tf32_and_tensorspec(monkeypatch):
     """Every eligible public entry point gives BF16 the first opportunity."""
     from torch_mojo_backend.eager_kernels import aten_fast
 
-    lhs, rhs, bias, weight = object(), object(), object(), object()
+    lhs, rhs, bias, weight = (
+        _opaque_tensor(),
+        _opaque_tensor(),
+        _opaque_tensor(),
+        _opaque_tensor(),
+    )
     gemm_result, linear_result, bmm_result = object(), object(), object()
     gemm_calls = []
     linear_calls = []
@@ -6594,7 +6716,7 @@ def test_addmm_skips_split_for_misaligned_shapes(monkeypatch):
     def tensor(shape):
         return SimpleNamespace(_shape=tuple(shape))
 
-    lhs, rhs, bias = tensor((357, 333)), tensor((333, 789)), object()
+    lhs, rhs, bias = tensor((357, 333)), tensor((333, 789)), _opaque_tensor()
     fused_result = object()
     fused_calls = []
 
@@ -6622,7 +6744,7 @@ def test_addmm_tries_split_for_aligned_shapes(monkeypatch):
     def tensor(shape):
         return SimpleNamespace(_shape=tuple(shape))
 
-    lhs, rhs, bias = tensor((128, 128)), tensor((128, 128)), object()
+    lhs, rhs, bias = tensor((128, 128)), tensor((128, 128)), _opaque_tensor()
     mm_result, biased_result = object(), object()
     gemm_calls = []
     add_calls = []
@@ -6720,7 +6842,12 @@ def test_tf32_matmul_family_prefers_opt_in_routes(monkeypatch):
     """Eligible public matmul calls return before the TensorSpec fallback."""
     from torch_mojo_backend.eager_kernels import aten_fast
 
-    lhs, rhs, bias, weight = object(), object(), object(), object()
+    lhs, rhs, bias, weight = (
+        _opaque_tensor(),
+        _opaque_tensor(),
+        _opaque_tensor(),
+        _opaque_tensor(),
+    )
     gemm_result, linear_result, bmm_result = object(), object(), object()
     gemm_calls = []
     linear_calls = []
@@ -6769,7 +6896,7 @@ def test_tf32_matmul_family_highest_retains_tensorspec_fallback(monkeypatch):
     from torch_mojo_backend import eager_kernels
     from torch_mojo_backend.eager_kernels import aten_fast
 
-    lhs, rhs, bias, input, weight = (object() for _ in range(5))
+    lhs, rhs, bias, input, weight = (_opaque_tensor() for _ in range(5))
     fallback = object()
     spec_calls = []
     tf32_import_calls = []
@@ -6833,7 +6960,7 @@ def test_matmul_spec_device_oom_is_not_disguised_as_unsupported(
         _mojo_file: Path, _defines: eager_kernels.CanonicalDefines
     ) -> ModuleType:
         module = ModuleType("matmul_oom_test_extension")
-        module.call = raise_allocator_oom
+        cast(_NativeCallModule, module).call = raise_allocator_oom
         return module
 
     def fake_allocate_output(
@@ -6867,7 +6994,9 @@ def test_tf32_addmm_scalars_retain_existing_not_handled_contract(monkeypatch):
     )
 
     assert (
-        aten_fast.fast_aten_addmm(object(), object(), object(), alpha=2.0)
+        aten_fast.fast_aten_addmm(
+            _opaque_tensor(), _opaque_tensor(), _opaque_tensor(), alpha=2.0
+        )
         is aten_fast.NOT_HANDLED
     )
     assert calls == []
@@ -6876,7 +7005,7 @@ def test_tf32_addmm_scalars_retain_existing_not_handled_contract(monkeypatch):
 def test_tf32_linear_flattens_contiguous_gpt_input_as_zero_copy_view(monkeypatch):
     from torch_mojo_backend.eager_kernels import aten_fast
 
-    input, weight, bias = object(), object(), object()
+    input, weight, bias = _opaque_tensor(), _opaque_tensor(), _opaque_tensor()
     holder = object()
     input_metadata = SimpleNamespace(
         _shape=(2, 3, 4, 8), _is_contiguous=True, _offset=7, _holder=holder
@@ -6918,7 +7047,7 @@ def test_tf32_linear_flattens_contiguous_gpt_input_as_zero_copy_view(monkeypatch
 def test_tf32_linear_noncontiguous_batch_retains_tensorspec_path(monkeypatch):
     from torch_mojo_backend.eager_kernels import aten_fast
 
-    input, weight = object(), object()
+    input, weight = _opaque_tensor(), _opaque_tensor()
     input_metadata = SimpleNamespace(_shape=(2, 3, 8), _is_contiguous=False)
     weight_metadata = SimpleNamespace(_shape=(11, 8))
     fallback = object()
@@ -7039,9 +7168,11 @@ def test_sdpa_forward_tf32_bmm_routing_preserves_raw_fallback(
         },
     )
 
-    out, probabilities, mask = aten_fast._sdpa_math_forward_with_dropout(
+    sdpa_result = aten_fast._sdpa_math_forward_with_dropout(
         q, k, v, False, None, dropout_p
     )
+    assert isinstance(sdpa_result, tuple)
+    out, probabilities, mask = sdpa_result
 
     assert out._shape == (2, 3, 5, 4)
     assert probabilities._shape == (2, 3, 5, 7)
@@ -7163,7 +7294,11 @@ def test_bf16_gemm_host_bridge_layouts_offsets_context_and_highest(
 
     try:
         out = aten_fast._try_gemm16_mm(
-            lhs, rhs, bias, transpose_b=transpose_b, output_shape=(2, 3, n)
+            lhs,
+            rhs,
+            cast("torch.Tensor | None", bias),
+            transpose_b=transpose_b,
+            output_shape=(2, 3, n),
         )
     finally:
         torch.set_float32_matmul_precision(old_precision)
@@ -7319,6 +7454,7 @@ def test_gemm16_float16_every_entry_point_launches_the_bridge(
         expected = torch.bmm(a.cpu().float(), b.cpu().float().transpose(1, 2))
         launched = ("gemm16_matmul_ops.mojo", "Bmm16")
 
+    assert isinstance(actual, torch.Tensor)
     assert actual.dtype == torch.float16
     assert len(calls[launched]) == 1, f"{op} did not reach the 16-bit GEMM bridge"
     torch.testing.assert_close(actual.cpu().float(), expected, atol=2e-2, rtol=2e-3)
@@ -7364,13 +7500,18 @@ def test_gemm16_float16_linear_backward_matches_fp32_reference(
     host_weight = half(out_features, in_features)
     host_grad = half(rows, out_features)
 
-    grad_input, grad_weight, grad_bias = aten_fast.fast_aten_linear_backward(
+    linear_backward_result = aten_fast.fast_aten_linear_backward(
         host_input.to(mojo_h100),
         host_grad.to(mojo_h100),
         host_weight.to(mojo_h100),
         [True, True, True],
     )
-    assert grad_input is not aten_fast.NOT_HANDLED
+    assert linear_backward_result is not aten_fast.NOT_HANDLED
+    assert isinstance(linear_backward_result, tuple)
+    grad_input, grad_weight, grad_bias = linear_backward_result
+    assert isinstance(grad_input, torch.Tensor)
+    assert isinstance(grad_weight, torch.Tensor)
+    assert isinstance(grad_bias, torch.Tensor)
     assert grad_input.dtype == torch.float16
     assert grad_weight.dtype == torch.float16
 
@@ -7484,13 +7625,18 @@ def test_bf16_gemm_rejects_invalid_metadata_before_resolve_or_allocation(
     monkeypatch.setattr(aten_fast, "_alloc", fail_late_path)
     monkeypatch.setattr(aten_fast, "_ctx_ptr", fail_late_path)
 
-    assert aten_fast._try_gemm16_mm(lhs, rhs, bias, output_shape=output_shape) is None
+    assert (
+        aten_fast._try_gemm16_mm(
+            lhs, rhs, cast("torch.Tensor | None", bias), output_shape=output_shape
+        )
+        is None
+    )
 
 
 def test_bf16_linear_flattens_contiguous_gpt_input_without_precision_query(monkeypatch):
     from torch_mojo_backend.eager_kernels import aten_fast
 
-    input, weight, bias = object(), object(), object()
+    input, weight, bias = _opaque_tensor(), _opaque_tensor(), _opaque_tensor()
     holder = object()
     input_metadata = SimpleNamespace(
         _shape=(2, 3, 4, 8), _is_contiguous=True, _offset=7, _holder=holder
@@ -7881,6 +8027,8 @@ def test_tf32_helpers_route_each_fake_device_context_and_reject_cross_device(
 
         gemm_output = aten_fast._try_tf32_gemm(lhs, rhs)
         bmm_output = aten_fast._try_tf32_bmm(batched_lhs, batched_rhs)
+        assert gemm_output is not None
+        assert bmm_output is not None
         assert gemm_output._device is device
         assert bmm_output._device is device
         assert gemm_calls[-1][-1] == 8000 + device.id
@@ -7931,6 +8079,7 @@ def test_tf32_gemm_host_bridge_layouts(
     rhs_shape = (n, k) if transpose_b else (k, n)
     rhs = dense_view(rhs_shape, rhs_transposed)
     bias = torch.randn(n).to(mojo_h100)
+    assert isinstance(bias, TorchMojoTensor)
     calls = []
 
     def record(*args):
@@ -8017,8 +8166,8 @@ def test_tf32_gemm_rejects_non_mojo_bias_before_operand_inspection(monkeypatch):
     """A supplied CPU bias cannot be silently reinterpreted as no bias."""
     from torch_mojo_backend.eager_kernels import aten_fast
 
-    lhs = object()
-    rhs = object()
+    lhs = _opaque_tensor()
+    rhs = _opaque_tensor()
     cpu_bias = torch.randn(7)
     mojo_metadata = object()
 
@@ -8096,6 +8245,7 @@ def test_tf32_gemm_host_bridge_rejects_before_allocation(
         rhs = torch.randn(5, 7).to(mojo_cpu)
     elif invalid_case == "inner_stride":
         storage = torch.empty(128).to(mojo_h100)
+        assert isinstance(storage, TorchMojoTensor)
         lhs = aten_fast._view_of(storage, (6, 5), (10, 2), 1)
     else:
         output_shape = (5, 7)
@@ -8128,6 +8278,7 @@ def test_tf32_bmm_host_bridge_strided_dense_layouts(
         batch_stride = matrix_elements + gap
         storage_elements = offset + (batches - 1) * batch_stride + matrix_elements
         storage = torch.empty(storage_elements + 4).to(mojo_h100)
+        assert isinstance(storage, TorchMojoTensor)
         strides = (batch_stride, 1, rows) if transposed else (batch_stride, cols, 1)
         return aten_fast._view_of(storage, shape, strides, offset), batch_stride
 
@@ -8209,9 +8360,11 @@ def test_tf32_bmm_host_bridge_rejects_unsupported_inputs(
     rhs = torch.randn(2, 9, 5).to(mojo_h100)
     if invalid_case == "inner_stride":
         storage = torch.empty(512).to(mojo_h100)
+        assert isinstance(storage, TorchMojoTensor)
         lhs = aten_fast._view_of(storage, (2, 7, 9), (200, 20, 2), 1)
     elif invalid_case == "overlap":
         storage = torch.empty(256).to(mojo_h100)
+        assert isinstance(storage, TorchMojoTensor)
         lhs = aten_fast._view_of(storage, (2, 7, 9), (62, 9, 1), 0)
     elif invalid_case == "batch":
         rhs = torch.randn(3, 9, 5).to(mojo_h100)
@@ -8258,7 +8411,9 @@ def _bf16_dense_matrix_pair(generator, shape, transposed, offset, mojo_h100):
     )
     strides = (1, rows) if transposed else (cols, 1)
     host = torch.as_strided(storage, shape, strides, offset)
-    device = aten_fast._view_of(storage.to(mojo_h100), shape, strides, offset)
+    device_storage = storage.to(mojo_h100)
+    assert isinstance(device_storage, TorchMojoTensor)
+    device = aten_fast._view_of(device_storage, shape, strides, offset)
     return host, device
 
 
@@ -8279,7 +8434,9 @@ def _bf16_dense_batched_pair(
     storage = torch.randn(storage_elements, generator=generator).to(dtype)
     strides = (batch_stride, 1, rows) if transposed else (batch_stride, cols, 1)
     host = torch.as_strided(storage, shape, strides, offset)
-    device = aten_fast._view_of(storage.to(mojo_h100), shape, strides, offset)
+    device_storage = storage.to(mojo_h100)
+    assert isinstance(device_storage, TorchMojoTensor)
+    device = aten_fast._view_of(device_storage, shape, strides, offset)
     return host, device
 
 
@@ -8526,9 +8683,9 @@ def test_bf16_real_gemm_extension_handles_tails_offsets_and_all_layouts(
     )
     bias_storage = torch.randn(n + 7, generator=generator).to(torch.bfloat16)
     bias = bias_storage[3 : 3 + n]
-    mojo_bias = aten_fast._view_of(
-        bias_storage.to(mojo_h100), (n,), (1,), 3, contiguous=True
-    )
+    device_bias_storage = bias_storage.to(mojo_h100)
+    assert isinstance(device_bias_storage, TorchMojoTensor)
+    mojo_bias = aten_fast._view_of(device_bias_storage, (n,), (1,), 3, contiguous=True)
 
     product = torch.mm(lhs.float(), rhs.float())
     expected = (product if operation == "mm" else product + bias.float()).to(
@@ -8698,6 +8855,7 @@ def test_bf16_real_bmm_extension_handles_all_layouts_offsets_and_padded_batches(
         actual = aten_fast._fast_aten_bmm_transpose_b(mojo_lhs, mojo_rhs)
     else:
         actual = torch.bmm(mojo_lhs, mojo_rhs)
+    assert isinstance(actual, torch.Tensor)
 
     _assert_bf16_fp32_accumulation_close(actual.cpu(), expected)
 
@@ -8889,6 +9047,7 @@ def test_bf16_real_bmm_batched_nn_v5_broadcast_a(
     a2d = torch.randn(m, k, generator=generator).to(dtype)
     lhs = a2d.unsqueeze(0).expand(batch, m, k)
     mojo_a2d = a2d.to(mojo_h100)
+    assert isinstance(mojo_a2d, TorchMojoTensor)
     mojo_lhs = aten_fast._view_of(mojo_a2d, (batch, m, k), (0, k, 1), 0)
     rhs, mojo_rhs = _bf16_dense_batched_pair(
         generator, (batch, k, n), False, 0, 2, mojo_h100, dtype
@@ -9028,7 +9187,9 @@ def _f32_transposed_dense_pair(
 
     storage = torch.randn(offset + m * k + 4, generator=generator)
     host = torch.as_strided(storage, (m, k), (1, m), offset)
-    dev = aten_fast._view_of(storage.to(device), (m, k), (1, m), offset)
+    device_storage = storage.to(device)
+    assert isinstance(device_storage, TorchMojoTensor)
+    dev = aten_fast._view_of(device_storage, (m, k), (1, m), offset)
     return host, dev
 
 
@@ -9182,7 +9343,9 @@ def _tf32_dense_matrix_pair(generator, shape, transposed, offset, mojo_h100):
     storage = torch.randn(offset + rows * cols + 4, generator=generator)
     strides = (1, rows) if transposed else (cols, 1)
     host = torch.as_strided(storage, shape, strides, offset)
-    device = aten_fast._view_of(storage.to(mojo_h100), shape, strides, offset)
+    device_storage = storage.to(mojo_h100)
+    assert isinstance(device_storage, TorchMojoTensor)
+    device = aten_fast._view_of(device_storage, shape, strides, offset)
     return host, device
 
 
@@ -9197,7 +9360,9 @@ def _tf32_dense_batched_pair(generator, shape, transposed, gap, offset, mojo_h10
     storage = torch.randn(storage_elements, generator=generator)
     strides = (batch_stride, 1, rows) if transposed else (batch_stride, cols, 1)
     host = torch.as_strided(storage, shape, strides, offset)
-    device = aten_fast._view_of(storage.to(mojo_h100), shape, strides, offset)
+    device_storage = storage.to(mojo_h100)
+    assert isinstance(device_storage, TorchMojoTensor)
+    device = aten_fast._view_of(device_storage, shape, strides, offset)
     return host, device
 
 
@@ -9226,9 +9391,9 @@ def test_tf32_real_gemm_extension_handles_tails_offsets_and_layouts(
     )
     bias_storage = torch.randn(n + 7, generator=generator)
     bias = bias_storage[3 : 3 + n]
-    mojo_bias = aten_fast._view_of(
-        bias_storage.to(mojo_h100), (n,), (1,), 3, contiguous=True
-    )
+    device_bias_storage = bias_storage.to(mojo_h100)
+    assert isinstance(device_bias_storage, TorchMojoTensor)
+    mojo_bias = aten_fast._view_of(device_bias_storage, (n,), (1,), 3, contiguous=True)
 
     def fail_spec(*_args, **_kwargs):
         raise AssertionError("eligible TF32 GEMM reached the SIMT fallback")
@@ -9284,6 +9449,7 @@ def test_tf32_real_bmm_extension_handles_layouts_offsets_and_padded_batches(
     finally:
         torch.set_float32_matmul_precision(old_precision)
 
+    assert isinstance(actual, torch.Tensor)
     torch.testing.assert_close(actual.cpu(), expected, atol=5e-2, rtol=5e-2)
 
 
@@ -9543,13 +9709,16 @@ def test_fa4_causal_gapped_qkv_forward_backward(
         actual_output = torch.nn.functional.scaled_dot_product_attention(
             *mojo_inputs, dropout_p=0.0, is_causal=True
         )
+        assert isinstance(actual_output, TorchMojoTensor)
         assert type(actual_output.grad_fn).__name__ == (
             "ScaledDotProductFlashAttentionBackward0"
         )
         assert backward_counter.call_count == calls_before
         assert actual_output.dtype == dtype
         assert not actual_output._is_contiguous
-        assert actual_output.transpose(1, 2)._is_contiguous
+        transposed_output = actual_output.transpose(1, 2)
+        assert isinstance(transposed_output, TorchMojoTensor)
+        assert transposed_output._is_contiguous
         actual_output.backward(grad_output.to(mojo_h100))
         assert backward_counter.call_count == calls_before + 1
 
@@ -9688,9 +9857,13 @@ def test_fa4_bhsd_native_forward_backward_matches_reference(
     )
     reference_output.backward(grad_output.float())
 
-    mojo_inputs = [
-        tensor.to(mojo_h100).detach().requires_grad_() for tensor in (query, key, value)
-    ]
+    mojo_inputs = cast(
+        list[TorchMojoTensor],
+        [
+            tensor.to(mojo_h100).detach().requires_grad_()
+            for tensor in (query, key, value)
+        ],
+    )
     for tensor in mojo_inputs:
         assert tensor._is_contiguous
         assert tensor._ptr % 16 == 0
@@ -9771,11 +9944,16 @@ def test_fa4_bhsd_d64_direct_partial_tail_block(mojo_h100, batch, heads, seqlen,
     )
 
     q, k, v = (tensor.to(mojo_h100) for tensor in (query, key, value))
+    assert isinstance(q, TorchMojoTensor)
+    assert isinstance(k, TorchMojoTensor)
+    assert isinstance(v, TorchMojoTensor)
     for tensor in (q, k, v):
         assert tensor._is_contiguous
         assert tensor._ptr % 16 == 0
     out = torch.empty(batch, heads, seqlen, head_dim, dtype=dtype, device=mojo_h100)
     logsumexp = torch.empty(batch, heads, seqlen, dtype=torch.float32, device=mojo_h100)
+    assert isinstance(out, TorchMojoTensor)
+    assert isinstance(logsumexp, TorchMojoTensor)
     assert out._ptr % 16 == 0
     scale = 1.0 / math.sqrt(head_dim)
 
@@ -9859,7 +10037,9 @@ def test_fa4_sdpa_odd_seqlen_forward_matches_reference(
         *reference_inputs, dropout_p=0.0, is_causal=True
     )
 
-    mojo_inputs = [tensor.to(mojo_h100) for tensor in (query, key, value)]
+    mojo_inputs = cast(
+        list[TorchMojoTensor], [tensor.to(mojo_h100) for tensor in (query, key, value)]
+    )
     for tensor in mojo_inputs:
         assert tensor._is_contiguous
         assert tensor._ptr % 16 == 0
@@ -10048,6 +10228,7 @@ def test_fa4_bhsd_gate_rejects_misaligned_offset_view(mojo_h100, monkeypatch, he
             torch.randn(numel + 1, generator=generator, dtype=torch.float32) * 0.25
         ).to(torch.bfloat16)
         view = host.to(mojo_h100)[1:].view(batch, heads, seqlen, head_dim)
+        assert isinstance(view, TorchMojoTensor)
         assert view._is_contiguous
         assert view._ptr % 16 != 0
         return view
@@ -10119,7 +10300,10 @@ def test_fast_sdpa_causal_training_backward(mojo_gpu):
         *ref_inputs, dropout_p=0.0, is_causal=True
     )
     ref_output.backward(grad_output.to(reference_device))
-    ref_grads = [tensor.grad.cpu() for tensor in ref_inputs]
+    ref_grads = []
+    for tensor in ref_inputs:
+        assert tensor.grad is not None
+        ref_grads.append(tensor.grad.cpu())
 
     mojo_inputs = [
         tensor.detach().clone().to(mojo_gpu).requires_grad_() for tensor in (q, k, v)
@@ -10253,7 +10437,10 @@ def test_fast_sdpa_partial_gradients_save_and_compute_only_dependencies(
     actual_output = torch.nn.functional.scaled_dot_product_attention(
         *actual_inputs, dropout_p=0.0, is_causal=True
     )
-    assert actual_output.grad_fn.saved_names == expected_saved
+    assert actual_output.grad_fn is not None
+    # `saved_names` is codegen'd per-op onto the concrete backward Node, not
+    # declared on the generic Node type torch's stubs expose.
+    assert getattr(actual_output.grad_fn, "saved_names") == expected_saved
     # The counts below are about the backward. The causal forward also issues a
     # batched GEMM through the same helper, so zero the counters here rather than
     # let a forward call be mistaken for a gradient's.
@@ -10277,6 +10464,7 @@ def test_fast_sdpa_partial_gradients_save_and_compute_only_dependencies(
     ):
         assert (actual.grad is not None) == (name == requires)
         if name == requires:
+            assert isinstance(actual.grad, TorchMojoTensor)
             assert actual.grad._is_contiguous
             torch.testing.assert_close(
                 actual.grad.cpu(), reference.grad, atol=3e-2, rtol=3e-2
@@ -10320,8 +10508,13 @@ def test_fused_flash_attention_partial_gradients_match_reference(mojo_gpu, requi
         for name, tensor in zip(names, host_inputs, strict=True)
     ]
     # Only meaningful if the fused path actually claims these inputs.
+    # actual_inputs is a list comprehension result; ty can't see its length
+    # is fixed at 3, so unpack it into a known-arity tuple first.
+    actual_q, actual_k, actual_v = actual_inputs
     assert (
-        aten_fast._fused_fa_inputs(*actual_inputs, None, 0.0, True, None, False)
+        aten_fast._fused_fa_inputs(
+            actual_q, actual_k, actual_v, None, 0.0, True, None, False
+        )
         is not None
     ), "fused path declined the inputs this test exists to cover"
 
@@ -10334,6 +10527,7 @@ def test_fused_flash_attention_partial_gradients_match_reference(mojo_gpu, requi
     ):
         assert (actual.grad is not None) == (name == requires)
         if name == requires:
+            assert actual.grad is not None
             assert torch.isfinite(actual.grad.cpu()).all()
             torch.testing.assert_close(
                 actual.grad.cpu(), reference.grad, atol=3e-2, rtol=3e-2
@@ -10379,14 +10573,19 @@ def test_fast_sdpa_saved_tensor_hooks_own_saved_allocations(mojo_gpu, monkeypatc
         actual_output = torch.nn.functional.scaled_dot_product_attention(
             *actual_inputs, dropout_p=0.0, is_causal=False
         )
-        assert actual_output.grad_fn.saved_names == (
+        assert actual_output.grad_fn is not None
+        # `saved_names`/`saved_payloads` are codegen'd per-op onto the
+        # concrete backward Node, not declared on the generic Node type
+        # torch's stubs expose.
+        assert getattr(actual_output.grad_fn, "saved_names") == (
             "query",
             "key",
             "value",
             "probabilities",
         )
         assert all(
-            payload.holder is None for payload in actual_output.grad_fn.saved_payloads
+            payload.holder is None
+            for payload in getattr(actual_output.grad_fn, "saved_payloads")
         )
         actual_output.backward(grad_output.to(mojo_gpu))
 
@@ -10440,8 +10639,13 @@ def test_fused_flash_attention_saved_tensor_hooks_own_saved_allocations(mojo_gpu
         return tensor
 
     actual_inputs = [tensor.to(mojo_gpu).requires_grad_() for tensor in host_inputs]
+    # actual_inputs is a list comprehension result; ty can't see its length
+    # is fixed at 3, so unpack it into a known-arity tuple first.
+    actual_q, actual_k, actual_v = actual_inputs
     assert (
-        aten_fast._fused_fa_inputs(*actual_inputs, None, 0.0, False, None, False)
+        aten_fast._fused_fa_inputs(
+            actual_q, actual_k, actual_v, None, 0.0, False, None, False
+        )
         is not None
     ), "fused path declined the inputs this test exists to cover"
 
@@ -10449,7 +10653,11 @@ def test_fused_flash_attention_saved_tensor_hooks_own_saved_allocations(mojo_gpu
         actual_output = torch.nn.functional.scaled_dot_product_attention(
             *actual_inputs, dropout_p=0.0, is_causal=False
         )
-        assert actual_output.grad_fn.saved_names == (
+        assert actual_output.grad_fn is not None
+        # `saved_names`/`saved_payloads` are codegen'd per-op onto the
+        # concrete backward Node, not declared on the generic Node type
+        # torch's stubs expose.
+        assert getattr(actual_output.grad_fn, "saved_names") == (
             "query",
             "key",
             "value",
@@ -10460,7 +10668,8 @@ def test_fused_flash_attention_saved_tensor_hooks_own_saved_allocations(mojo_gpu
         # may retain the original holder -- that is what would defeat a
         # CPU/offload hook.
         assert all(
-            payload.holder is None for payload in actual_output.grad_fn.saved_payloads
+            payload.holder is None
+            for payload in getattr(actual_output.grad_fn, "saved_payloads")
         )
         actual_output.backward(grad_output.to(mojo_gpu))
 
@@ -10514,6 +10723,9 @@ def test_sdpa_fused_backward_host_bridge_abi(mojo_gpu, monkeypatch):
     probabilities = probs_storage[1 : 1 + elements].view(shape)
     grad = grad_storage[2 : 2 + elements].view(shape)
     mask = mask_storage[3 : 3 + elements].view(shape)
+    assert isinstance(probabilities, TorchMojoTensor)
+    assert isinstance(grad, TorchMojoTensor)
+    assert isinstance(mask, TorchMojoTensor)
     calls = []
     _replace_defined_native_calls(
         monkeypatch,
@@ -10529,6 +10741,7 @@ def test_sdpa_fused_backward_host_bridge_abi(mojo_gpu, monkeypatch):
     )
 
     assert out is not aten_fast.NOT_HANDLED
+    assert isinstance(out, TorchMojoTensor)
     assert tuple(out.shape) == shape
     assert len(calls) == 1
     args = calls[0]
@@ -10546,6 +10759,9 @@ def test_sdpa_fused_backward_materializes_strided_operands(mojo_gpu, monkeypatch
     probabilities = torch.randn(shape).to(mojo_gpu).transpose(1, 2)
     grad = torch.randn(shape).to(mojo_gpu).transpose(1, 2)
     mask = torch.ones(shape, dtype=torch.bool).to(mojo_gpu).transpose(1, 2)
+    assert isinstance(probabilities, TorchMojoTensor)
+    assert isinstance(grad, TorchMojoTensor)
+    assert isinstance(mask, TorchMojoTensor)
     assert not probabilities._is_contiguous
     assert not grad._is_contiguous
     assert not mask._is_contiguous
@@ -10565,6 +10781,7 @@ def test_sdpa_fused_backward_materializes_strided_operands(mojo_gpu, monkeypatch
     )
 
     assert out is not aten_fast.NOT_HANDLED
+    assert isinstance(out, TorchMojoTensor)
     assert tuple(out.shape) == (2, 5, 3)
     assert out._is_contiguous
     assert len(calls) == 1
@@ -10618,6 +10835,7 @@ def test_sdpa_fused_backward_empty_skips_bridge(mojo_gpu, monkeypatch):
     )
 
     assert out is not aten_fast.NOT_HANDLED
+    assert isinstance(out, TorchMojoTensor)
     assert tuple(out.shape) == (2, 0)
     assert calls == []
 
@@ -10695,17 +10913,18 @@ def test_fast_sdpa_dropout_matches_captured_mask_reference(
 
     def capture_dropout(input, p, train):
         result = native_dropout(input, p, train)
+        assert isinstance(result, tuple)
         captured_masks.append(result[1])
         return result
 
     monkeypatch.setattr(aten_fast, "fast_aten_native_dropout", capture_dropout)
-    torch.mojo.manual_seed_all((1 << 63) + 20260718)
+    _torch_mojo().manual_seed_all((1 << 63) + 20260718)
     actual_output = torch.nn.functional.scaled_dot_product_attention(
         *mojo_inputs, dropout_p=0.2, is_causal=is_causal
     )
     assert len(captured_masks) == 1
     keep = captured_masks[0].cpu().reshape(batch, heads, length, length)
-    state_after_forward = torch.mojo.get_rng_state(mojo_inputs[0].device)
+    state_after_forward = _torch_mojo().get_rng_state(mojo_inputs[0].device)
 
     reference_inputs = [tensor.clone().requires_grad_() for tensor in host_inputs]
     query, key, value = reference_inputs
@@ -10720,7 +10939,7 @@ def test_fast_sdpa_dropout_matches_captured_mask_reference(
     actual_output.backward(grad_output.to(mojo_gpu))
 
     torch.testing.assert_close(
-        torch.mojo.get_rng_state(mojo_inputs[0].device), state_after_forward
+        _torch_mojo().get_rng_state(mojo_inputs[0].device), state_after_forward
     )
     torch.testing.assert_close(
         actual_output.cpu(), reference_output.detach(), atol=2e-2, rtol=2e-2
@@ -10742,14 +10961,14 @@ def test_fast_sdpa_dropout_reserves_exact_probability_interval(mojo_gpu, dropout
     value = torch.randn(batch, heads, key_length, head_dim).to(mojo_gpu)
     seed = (1 << 63) + 0x1234
     counter = (1 << 63) + 0x5678
-    torch.mojo.set_rng_state(_philox_rng_state(seed, counter), query.device)
+    _torch_mojo().set_rng_state(_philox_rng_state(seed, counter), query.device)
 
     output = torch.nn.functional.scaled_dot_product_attention(
         query, key, value, dropout_p=dropout_p, is_causal=True
     )
     probability_elements = batch * heads * query_length * key_length
     expected_increment = (probability_elements + 3) // 4 if 0.0 < dropout_p < 1.0 else 0
-    assert _decode_philox_rng_state(torch.mojo.get_rng_state(query.device)) == (
+    assert _decode_philox_rng_state(_torch_mojo().get_rng_state(query.device)) == (
         seed,
         counter + expected_increment,
     )
@@ -10880,6 +11099,7 @@ def test_fast_log_softmax_uses_saved_tensor_hooks(mojo_gpu):
         )
 
     assert hook_calls == [("pack", "mojo"), ("unpack", "cpu")]
+    assert actual.grad is not None
     torch.testing.assert_close(actual.grad.cpu(), reference.grad, atol=2e-5, rtol=2e-5)
 
 

--- a/tests/test_eager_optimizer_ops.py
+++ b/tests/test_eager_optimizer_ops.py
@@ -3,6 +3,7 @@
 import pytest
 import torch
 
+from torch_mojo_backend import TorchMojoTensor
 from torch_mojo_backend.testing import CallChecker
 
 pytestmark = pytest.mark.xdist_group(name="group1")
@@ -350,6 +351,7 @@ def test_sub_out_supports_optimizer_step_rollback(
 ):
     _watch_eager_op(call_checker, "aten::sub.out")
     step = torch.tensor(4.0, device=mojo_gpu)
+    assert isinstance(step, TorchMojoTensor)
     found_inf = torch.tensor(1.0, device=mojo_gpu)
     holder, ptr = step._holder, step._ptr
 
@@ -445,10 +447,12 @@ def test_fused_adamw_optimizer_found_inf_rolls_back_step(
     mojo_optimizer = torch.optim.AdamW([mojo_parameter], lr=0.01, fused=True)
     cpu_parameter.grad = gradient.clone()
     mojo_parameter.grad = gradient.to(mojo_gpu)
-    cpu_optimizer.grad_scale = torch.tensor(2.0)
-    cpu_optimizer.found_inf = torch.tensor(1.0)
-    mojo_optimizer.grad_scale = torch.tensor(2.0, device=mojo_gpu)
-    mojo_optimizer.found_inf = torch.tensor(1.0, device=mojo_gpu)
+    # grad_scale/found_inf are an internal GradScaler contract the fused
+    # optimizers read via getattr; torch's own AdamW stub doesn't declare them.
+    setattr(cpu_optimizer, "grad_scale", torch.tensor(2.0))
+    setattr(cpu_optimizer, "found_inf", torch.tensor(1.0))
+    setattr(mojo_optimizer, "grad_scale", torch.tensor(2.0, device=mojo_gpu))
+    setattr(mojo_optimizer, "found_inf", torch.tensor(1.0, device=mojo_gpu))
 
     cpu_optimizer.step()
     mojo_optimizer.step()
@@ -458,8 +462,8 @@ def test_fused_adamw_optimizer_found_inf_rolls_back_step(
     assert mojo_state["step"].dtype == torch.float32
     assert mojo_state["step"].item() == 0
 
-    cpu_optimizer.found_inf.fill_(0.0)
-    mojo_optimizer.found_inf.fill_(0.0)
+    getattr(cpu_optimizer, "found_inf").fill_(0.0)
+    getattr(mojo_optimizer, "found_inf").fill_(0.0)
     cpu_optimizer.step()
     mojo_optimizer.step()
     torch.testing.assert_close(
@@ -585,7 +589,10 @@ def test_batched_foreach_misaligned_views_match_cpu(
     _watch_eager_op(call_checker, op_name)
     cpu_lists = _misaligned_foreach_lists("cpu", stagger=stagger)
     mojo_lists = _misaligned_foreach_lists(mojo_gpu, stagger=stagger)
-    assert any(tensor._ptr % 16 for tensor in mojo_lists[0])
+    assert any(
+        isinstance(tensor, TorchMojoTensor) and tensor._ptr % 16
+        for tensor in mojo_lists[0]
+    )
     apply(*cpu_lists)
     apply(*mojo_lists)
     for expected, actual in zip(cpu_lists[0], mojo_lists[0], strict=True):
@@ -671,6 +678,8 @@ def test_batched_foreach_sqrt_matches_cpu(mojo_gpu: str, call_checker: CallCheck
         # eager kernels call `ieee_sqrt` from op_utils instead.
         torch.testing.assert_close(actual_out.cpu(), expected_out, rtol=0, atol=0)
     for original, actual_out in zip(mojo_inputs, actual, strict=True):
+        assert isinstance(original, TorchMojoTensor)
+        assert isinstance(actual_out, TorchMojoTensor)
         if original.numel() > 0:
             assert actual_out._ptr != original._ptr
 
@@ -684,7 +693,10 @@ def test_batched_foreach_sqrt_misaligned_input_matches_cpu(mojo_gpu: str):
     """
     cpu_inputs = _misaligned_foreach_lists("cpu")[2]
     mojo_inputs = _misaligned_foreach_lists(mojo_gpu)[2]
-    assert any(tensor._ptr % 16 for tensor in mojo_inputs)
+    assert any(
+        isinstance(tensor, TorchMojoTensor) and tensor._ptr % 16
+        for tensor in mojo_inputs
+    )
     expected = [tensor.double().sqrt().to(tensor.dtype) for tensor in cpu_inputs]
     for expected_out, actual_out in zip(
         expected, torch._foreach_sqrt(mojo_inputs), strict=True
@@ -742,6 +754,7 @@ def test_lerp_scalar_out_supports_strided_self_alias(
 
     device_base = base.to(mojo_gpu)
     device_self = device_base[:, 1::2]
+    assert isinstance(device_self, TorchMojoTensor)
     device_end = end.to(mojo_gpu)
     assert not device_self._is_contiguous
     assert not device_self.is_contiguous()
@@ -830,12 +843,14 @@ def test_optimizer_out_ops_resize_public_shape_metadata(
     _watch_eager_op(call_checker, op_name)
     out = torch.empty(0, dtype=torch.float32, device=mojo_gpu)
     marker = object()
-    out.user_marker = marker
+    # Arbitrary user attribute, unrelated to the tensor's own payload; setattr
+    # keeps this honest instead of pretending Tensor declares `user_marker`.
+    setattr(out, "user_marker", marker)
     version = out._version
     returned = invoke(out)
 
     assert returned is out
-    assert out.user_marker is marker
+    assert getattr(out, "user_marker") is marker
     assert out._version == version + 1
     assert tuple(out._shape) == tuple(expected.shape)
     torch.testing.assert_close(out.cpu(), expected)
@@ -858,6 +873,7 @@ def test_linalg_vector_norm_out_strided_and_empty(
         base = torch.linspace(-3.0, 4.0, 35).reshape(5, 7)
         input = base.t()
         device_input = base.to(mojo_gpu).t()
+        assert isinstance(device_input, TorchMojoTensor)
         dim = [1]
         keepdim = True
         assert not device_input._is_contiguous
@@ -869,6 +885,7 @@ def test_linalg_vector_norm_out_strided_and_empty(
 
     expected = torch.linalg.vector_norm(input, 2, dim, keepdim)
     out = torch.empty_like(expected, device=mojo_gpu)
+    assert isinstance(out, TorchMojoTensor)
     holder, ptr = out._holder, out._ptr
     returned = torch.ops.aten.linalg_vector_norm.out(
         device_input, 2, dim, keepdim, dtype=None, out=out
@@ -887,6 +904,7 @@ def test_mul_tensor_inplace_preserves_strided_alias(
 
     base = torch.arange(12, dtype=torch.float32).to(mojo_gpu)
     view = base[::2]
+    assert isinstance(view, TorchMojoTensor)
     observer = base.view(3, 4)
     coefficient = torch.tensor(0.25, dtype=torch.float32).to(mojo_gpu)
     expected = torch.arange(12, dtype=torch.float32)
@@ -910,7 +928,9 @@ def test_mul_out_resize_preserves_existing_storage_alias(
     _watch_eager_op(call_checker, "aten::mul.out")
 
     base = torch.arange(8, dtype=torch.float32).to(mojo_gpu)
+    assert isinstance(base, TorchMojoTensor)
     out = base[storage_offset:storage_offset]
+    assert isinstance(out, TorchMojoTensor)
     lhs = torch.tensor([2.0, 3.0], device=mojo_gpu)
     rhs = torch.tensor([5.0, 7.0], device=mojo_gpu)
     holder = base._holder

--- a/tests/test_fa4_host_wiring.py
+++ b/tests/test_fa4_host_wiring.py
@@ -3,12 +3,14 @@
 import math
 from pathlib import Path
 from types import SimpleNamespace
+from typing import cast
 
 import pytest
 import torch
 
 from torch_mojo_backend.eager_kernels import aten_fast
 from torch_mojo_backend.mojo_device import mojo_device_autograd as autograd
+from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
 
 
 def _device(*, arch: str = "sm_90a") -> SimpleNamespace:
@@ -42,6 +44,15 @@ def _tensor(
         _is_contiguous=contiguous,
         _holder=object(),
     )
+
+
+def _mt(tensor: SimpleNamespace | None) -> TorchMojoTensor:
+    """`_tensor()` fakes carry every payload attribute the Tensor-/
+    TorchMojoTensor-typed signatures under test read; SimpleNamespace isn't
+    nominally either, so cast at the call boundary. Also covers the rare
+    literal-``None`` call: `_fa4_bhsd_layout`/`_fa4_strided_bthd_layout`
+    check ``tensor is None`` at runtime despite their non-Optional hint."""
+    return cast(TorchMojoTensor, tensor)
 
 
 def test_fa4_rejects_ineligible_regimes_before_loading_or_device_work(
@@ -80,7 +91,9 @@ def test_fa4_rejects_ineligible_regimes_before_loading_or_device_work(
         }
         kwargs.update(overrides)
         assert (
-            aten_fast.fast_fa4_16bit_d64_causal_forward(query, key, value, **kwargs)
+            aten_fast.fast_fa4_16bit_d64_causal_forward(
+                _mt(query), _mt(key), _mt(value), **kwargs
+            )
             is aten_fast.NOT_HANDLED
         )
 
@@ -91,10 +104,13 @@ def test_fa4_forward_bridge_uses_dynamic_bthd_allocations(
     import torch_mojo_backend.eager_flash_attention as package
 
     device = _device()
-    public = [
+    # A fixed 3-tuple (not a list/tuple(generator)) so *public below unpacks
+    # to a fixed arity instead of tuple[SimpleNamespace, ...].
+    q_pub, k_pub, v_pub = (
         _tensor(name, shape=(3, 12, 256, 64), device=device, ptr=ptr)
         for name, ptr in zip(("q", "k", "v"), (10, 20, 30), strict=True)
-    ]
+    )
+    public = (q_pub, k_pub, v_pub)
     native = {
         tensor.name: _tensor(
             f"{tensor.name}_native",
@@ -142,8 +158,9 @@ def test_fa4_forward_bridge_uses_dynamic_bthd_allocations(
     )
 
     result = aten_fast.fast_fa4_16bit_d64_causal_forward(
-        *public, is_causal=True, scale=0.125
+        _mt(q_pub), _mt(k_pub), _mt(v_pub), is_causal=True, scale=0.125
     )
+    assert isinstance(result, tuple)
     output, logsumexp, q_native, k_native, v_native = result
 
     assert output._shape == (3, 12, 256, 64)
@@ -180,7 +197,9 @@ def test_fa4_forward_bridge_selects_f16_kernel_symbol_and_allocation(
     import torch_mojo_backend.eager_flash_attention as package
 
     device = _device()
-    public = [
+    # A fixed 3-tuple (not a list/tuple(generator)) so *public below unpacks
+    # to a fixed arity instead of tuple[SimpleNamespace, ...].
+    q_pub, k_pub, v_pub = (
         _tensor(
             name,
             shape=(3, 12, 256, 64),
@@ -189,7 +208,8 @@ def test_fa4_forward_bridge_selects_f16_kernel_symbol_and_allocation(
             dtype=aten_fast.DType.float16,
         )
         for name, ptr in zip(("q", "k", "v"), (10, 20, 30), strict=True)
-    ]
+    )
+    public = (q_pub, k_pub, v_pub)
     native = {
         tensor.name: _tensor(
             f"{tensor.name}_native",
@@ -242,8 +262,9 @@ def test_fa4_forward_bridge_selects_f16_kernel_symbol_and_allocation(
     )
 
     result = aten_fast.fast_fa4_16bit_d64_causal_forward(
-        *public, is_causal=True, scale=0.125
+        _mt(q_pub), _mt(k_pub), _mt(v_pub), is_causal=True, scale=0.125
     )
+    assert isinstance(result, tuple)
     output, logsumexp, q_native, k_native, v_native = result
 
     assert output._shape == (3, 12, 256, 64)
@@ -278,7 +299,9 @@ def test_fa4_rejects_mixed_bf16_f16_inputs(monkeypatch: pytest.MonkeyPatch) -> N
     k = _tensor("k", dtype=aten_fast.DType.float16, device=device)
     v = _tensor("v", dtype=aten_fast.DType.bfloat16, device=device)
     assert (
-        aten_fast._fa4_16bit_d64_causal_inputs(q, k, v, None, 0.0, True, None, False)
+        aten_fast._fa4_16bit_d64_causal_inputs(
+            _mt(q), _mt(k), _mt(v), None, 0.0, True, None, False
+        )
         is None
     )
 
@@ -290,7 +313,7 @@ def test_fa4_strided_layout_contract_is_strict() -> None:
     eligible = _tensor(
         "q_native", shape=shape, ptr=0x1000, strides=strides, contiguous=False
     )
-    assert aten_fast._fa4_strided_bthd_layout(eligible)
+    assert aten_fast._fa4_strided_bthd_layout(_mt(eligible))
     # f16 is the same 2-byte width as bf16, so the same layout is eligible.
     eligible_f16 = _tensor(
         "q_native_f16",
@@ -300,7 +323,7 @@ def test_fa4_strided_layout_contract_is_strict() -> None:
         contiguous=False,
         dtype=aten_fast.DType.float16,
     )
-    assert aten_fast._fa4_strided_bthd_layout(eligible_f16)
+    assert aten_fast._fa4_strided_bthd_layout(_mt(eligible_f16))
 
     invalid = []
     for updates in (
@@ -318,7 +341,9 @@ def test_fa4_strided_layout_contract_is_strict() -> None:
         for name, value in updates.items():
             setattr(candidate, name, value)
         invalid.append(candidate)
-    assert not any(aten_fast._fa4_strided_bthd_layout(tensor) for tensor in invalid)
+    assert not any(
+        aten_fast._fa4_strided_bthd_layout(_mt(tensor)) for tensor in invalid
+    )
 
 
 def test_fa4_canonical_fused_qkv_uses_zero_copy_strided_forward_bridge(
@@ -332,7 +357,7 @@ def test_fa4_canonical_fused_qkv_uses_zero_copy_strided_forward_bridge(
     batch_stride = seqlen * token_stride
     public_strides = (batch_stride, head_dim, token_stride, 1)
     pointers = (0x1000, 0x1600, 0x1C00)
-    public = tuple(
+    q_pub, k_pub, v_pub = (
         _tensor(
             name,
             shape=(batch, heads, seqlen, head_dim),
@@ -391,11 +416,11 @@ def test_fa4_canonical_fused_qkv_uses_zero_copy_strided_forward_bridge(
         ),
     )
 
-    output, logsumexp, q_native, k_native, v_native = (
-        aten_fast.fast_fa4_16bit_d64_causal_forward(
-            *public, is_causal=True, scale=0.125
-        )
+    result = aten_fast.fast_fa4_16bit_d64_causal_forward(
+        _mt(q_pub), _mt(k_pub), _mt(v_pub), is_causal=True, scale=0.125
     )
+    assert isinstance(result, tuple)
+    output, logsumexp, q_native, k_native, v_native = result
 
     physical_strides = (batch_stride, token_stride, head_dim, 1)
     assert output._shape == (batch, heads, seqlen, head_dim)
@@ -439,7 +464,7 @@ def test_fa4_offset_view_public_layout_copies_and_uses_contiguous_fallback(
     device = _device()
     # +2 bytes (one bf16/f16 element) off a 16-byte-aligned address: still
     # fully contiguous, but ptr % 16 != 0.
-    public = tuple(
+    q_pub, k_pub, v_pub = (
         _tensor(name, shape=(2, 12, 256, 64), device=device, ptr=ptr)
         for name, ptr in zip("qkv", (0x1002, 0x2002, 0x3002), strict=True)
     )
@@ -500,7 +525,7 @@ def test_fa4_offset_view_public_layout_copies_and_uses_contiguous_fallback(
     )
 
     result = aten_fast.fast_fa4_16bit_d64_causal_forward(
-        *public, is_causal=True, scale=0.125
+        _mt(q_pub), _mt(k_pub), _mt(v_pub), is_causal=True, scale=0.125
     )
 
     assert result is not aten_fast.NOT_HANDLED
@@ -519,10 +544,13 @@ def test_fa4_forward_bridge_uses_bhsd_native_path_for_aligned_contiguous_public_
     import torch_mojo_backend.eager_flash_attention as package
 
     device = _device()
-    public = tuple(
+    # A fixed 3-tuple (not tuple(generator)) so *public below unpacks to a
+    # fixed arity instead of tuple[SimpleNamespace, ...].
+    q_pub, k_pub, v_pub = (
         _tensor(name, shape=(3, 12, 256, 64), device=device, ptr=ptr)
         for name, ptr in zip("qkv", (0x1000, 0x2000, 0x3000), strict=True)
     )
+    public = (q_pub, k_pub, v_pub)
     allocations = []
     bridge_calls = []
 
@@ -561,8 +589,9 @@ def test_fa4_forward_bridge_uses_bhsd_native_path_for_aligned_contiguous_public_
     )
 
     result = aten_fast.fast_fa4_16bit_d64_causal_forward(
-        *public, is_causal=True, scale=0.125
+        _mt(q_pub), _mt(k_pub), _mt(v_pub), is_causal=True, scale=0.125
     )
+    assert isinstance(result, tuple)
     output, logsumexp, q_native, k_native, v_native = result
 
     assert output is allocations[0]
@@ -587,22 +616,22 @@ def test_fa4_forward_bridge_uses_bhsd_native_path_for_aligned_contiguous_public_
 
 def test_fa4_bhsd_layout_requires_contiguity_and_16_byte_alignment() -> None:
     base = _tensor("q", shape=(3, 12, 256, 64), ptr=0x1000)
-    assert aten_fast._fa4_bhsd_layout(base)
+    assert aten_fast._fa4_bhsd_layout(_mt(base))
 
     misaligned = SimpleNamespace(**vars(base))
     misaligned._ptr = base._ptr + 2
-    assert not aten_fast._fa4_bhsd_layout(misaligned)
+    assert not aten_fast._fa4_bhsd_layout(_mt(misaligned))
 
     non_contiguous = SimpleNamespace(**vars(base))
     non_contiguous._is_contiguous = False
-    assert not aten_fast._fa4_bhsd_layout(non_contiguous)
+    assert not aten_fast._fa4_bhsd_layout(_mt(non_contiguous))
 
     wrong_dtype = SimpleNamespace(**vars(base))
     wrong_dtype._dtype = aten_fast.DType.float32
     wrong_dtype._itemsize = 4
-    assert not aten_fast._fa4_bhsd_layout(wrong_dtype)
+    assert not aten_fast._fa4_bhsd_layout(_mt(wrong_dtype))
 
-    assert not aten_fast._fa4_bhsd_layout(None)
+    assert not aten_fast._fa4_bhsd_layout(_mt(None))
 
 
 def test_direct_flash_aten_returns_real_lse_and_cuda_shaped_auxiliaries(
@@ -639,8 +668,9 @@ def test_direct_flash_aten_returns_real_lse_and_cuda_shaped_auxiliaries(
     monkeypatch.setattr(aten_fast, "_alloc", alloc)
 
     result = aten_fast.fast_aten__scaled_dot_product_flash_attention(
-        query, key, value, dropout_p=0.0, is_causal=True
+        _mt(query), _mt(key), _mt(value), dropout_p=0.0, is_causal=True
     )
+    assert isinstance(result, tuple)
 
     assert result[:6] == (output, logsumexp, None, None, 256, 256)
     assert result[6]._dtype == aten_fast.DType.uint64
@@ -653,7 +683,12 @@ def test_direct_flash_aten_returns_real_lse_and_cuda_shaped_auxiliaries(
     ]
     assert (
         aten_fast.fast_aten__scaled_dot_product_flash_attention(
-            query, key, value, dropout_p=0.0, is_causal=True, return_debug_mask=True
+            _mt(query),
+            _mt(key),
+            _mt(value),
+            dropout_p=0.0,
+            is_causal=True,
+            return_debug_mask=True,
         )
         is aten_fast.NOT_HANDLED
     )
@@ -714,20 +749,23 @@ def test_direct_flash_backward_materializes_strided_logsumexp(
     )
 
     result = aten_fast.fast_aten__scaled_dot_product_flash_attention_backward(
-        grad,
-        query,
-        key,
-        value,
-        output,
-        lse,
+        _mt(grad),
+        _mt(query),
+        _mt(key),
+        _mt(value),
+        _mt(output),
+        _mt(lse),
         None,
         None,
         128,
         128,
         0.0,
         True,
-        None,
-        None,
+        # Dropout is 0.0, so philox_seed/philox_offset are read but never
+        # dereferenced -- production accepts this despite the non-Optional
+        # hint (aten_fast.py:8414, `_ = philox_seed, philox_offset`).
+        cast(torch.Tensor, None),
+        cast(torch.Tensor, None),
         scale=0.125,
     )
 
@@ -808,20 +846,26 @@ def test_fa4_saved_variable_recompute_rederives_natives_independently(
     )
 
     result = aten_fast.fast_aten__scaled_dot_product_flash_attention_backward(
-        grad,
-        query,
-        key,
-        value,
-        None,  # out: unpacked as a bare tensor, triggers the recompute path
-        None,  # logsumexp: ditto
+        _mt(grad),
+        _mt(query),
+        _mt(key),
+        _mt(value),
+        # out/logsumexp: unpacked as a bare tensor, triggers the recompute
+        # path -- `_t(None) is None` once _t is monkeypatched to identity
+        # above, despite the non-Optional hint.
+        cast(torch.Tensor, None),
+        cast(torch.Tensor, None),
         None,
         None,
         128,
         128,
         0.0,
         True,
-        None,
-        None,
+        # Dropout is 0.0, so philox_seed/philox_offset are read but never
+        # dereferenced -- production accepts this despite the non-Optional
+        # hint (aten_fast.py:8414, `_ = philox_seed, philox_offset`).
+        cast(torch.Tensor, None),
+        cast(torch.Tensor, None),
         scale=0.125,
     )
 
@@ -901,8 +945,15 @@ def test_fa4_combined_backward_bridge_allocates_exact_scratch(
     )
 
     gradients = aten_fast.fast_fa4_16bit_d64_causal_backward(
-        q_native, k_native, v_native, output, logsumexp, grad_output, 0.125
+        _mt(q_native),
+        _mt(k_native),
+        _mt(v_native),
+        _mt(output),
+        _mt(logsumexp),
+        _mt(grad_output),
+        0.125,
     )
+    assert isinstance(gradients, tuple)
 
     assert [gradient._shape for gradient in gradients] == [(2, 4, 384, 64)] * 3
     assert [(item._shape, item._dtype) for item in allocations] == [
@@ -1029,8 +1080,15 @@ def test_fa4_canonical_fused_qkv_uses_strided_backward_bridge(
     )
 
     gradients = aten_fast.fast_fa4_16bit_d64_causal_backward(
-        q_native, k_native, v_native, output, logsumexp, grad_output, 0.125
+        _mt(q_native),
+        _mt(k_native),
+        _mt(v_native),
+        _mt(output),
+        _mt(logsumexp),
+        _mt(grad_output),
+        0.125,
     )
+    assert isinstance(gradients, tuple)
 
     assert [gradient._shape for gradient in gradients] == [public_shape] * 3
     assert strided_calls == [
@@ -1070,7 +1128,12 @@ def test_fa4_eligible_backward_routes_to_native_flash_with_public_inputs(
     physical BTHD copies are made inside the kernel bridge and are not what
     gets saved) and neither custom Function may be entered.
     """
-    public = tuple(_tensor(name, ptr=index) for index, name in enumerate("qkv", 1))
+    # A literal 3-tuple (not tuple(generator)) so *public below unpacks to a
+    # fixed arity instead of tuple[T, ...].
+    q_pub, k_pub, v_pub = (
+        _tensor(name, ptr=index) for index, name in enumerate("qkv", 1)
+    )
+    public = (q_pub, k_pub, v_pub)
     for tensor in public:
         tensor.requires_grad = True
     output = _tensor("output", ptr=200)
@@ -1097,7 +1160,7 @@ def test_fa4_eligible_backward_routes_to_native_flash_with_public_inputs(
     monkeypatch.setattr(autograd._FusedFlashAttentionAutograd, "apply", forbidden)
 
     actual = autograd._scaled_dot_product_attention_autograd(
-        *public, None, 0.0, True, scale=0.125
+        _mt(q_pub), _mt(k_pub), _mt(v_pub), None, 0.0, True, scale=0.125
     )
 
     assert actual is output

--- a/tests/test_model_state_conversion.py
+++ b/tests/test_model_state_conversion.py
@@ -5,7 +5,7 @@ import io
 import pytest
 import torch
 
-from torch_mojo_backend import register_mojo_devices
+from torch_mojo_backend import TorchMojoTensor, register_mojo_devices
 
 
 @pytest.fixture(autouse=True)
@@ -27,8 +27,12 @@ def test_module_to_mojo_preserves_tied_parameters(mojo_device):
     module.to(mojo_device)
 
     assert module.embedding.weight is module.projection.weight
-    assert module.embedding.weight._holder is module.projection.weight._holder
-    assert module.embedding.weight._ptr == module.projection.weight._ptr
+    embedding_weight = module.embedding.weight
+    projection_weight = module.projection.weight
+    assert isinstance(embedding_weight, TorchMojoTensor)
+    assert isinstance(projection_weight, TorchMojoTensor)
+    assert embedding_weight._holder is projection_weight._holder
+    assert embedding_weight._ptr == projection_weight._ptr
     assert len(list(module.parameters())) == 1
 
 

--- a/tests/test_mojo_autocast.py
+++ b/tests/test_mojo_autocast.py
@@ -25,8 +25,9 @@ def mojo_h100():
 
 
 def test_mojo_autocast_fallback_and_required_policies_are_registered() -> None:
+    # Exists at runtime; missing from torch's own DispatchKey stub.
     assert torch._C._dispatch_has_backend_fallback(
-        torch._C.DispatchKey.AutocastPrivateUse1
+        getattr(torch._C.DispatchKey, "AutocastPrivateUse1")
     )
     for name in (
         "addmm",

--- a/tests/test_mojo_device.py
+++ b/tests/test_mojo_device.py
@@ -6,11 +6,14 @@ import time
 import weakref
 from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
+from typing import cast
 
+import max.driver
 import pytest
 import torch
 
 from torch_mojo_backend import TorchMojoTensor, mojo_backend, register_mojo_devices
+from torch_mojo_backend.mojo_device import torch_mojo_device_module
 from torch_mojo_backend.mojo_device import torch_mojo_tensor as mojo_tensor_module
 from torch_mojo_backend.mojo_device.torch_mojo_device_module import (
     _reserve_philox_state,
@@ -38,14 +41,14 @@ def test_mojo_is_the_default_torch_accelerator():
 
 def test_torch_accelerator_synchronize_uses_mojo_device_module(monkeypatch):
     calls = []
-    original_synchronize = torch.mojo.synchronize
-    original_device = torch.mojo.current_device()
+    original_synchronize = torch_mojo_device_module.synchronize
+    original_device = torch_mojo_device_module.current_device()
 
     def recording_synchronize(device=None):
         calls.append(device)
         return original_synchronize(device)
 
-    monkeypatch.setattr(torch.mojo, "synchronize", recording_synchronize)
+    monkeypatch.setattr(torch_mojo_device_module, "synchronize", recording_synchronize)
 
     try:
         torch.accelerator.synchronize()
@@ -53,10 +56,10 @@ def test_torch_accelerator_synchronize_uses_mojo_device_module(monkeypatch):
         torch.accelerator.synchronize(0)
 
         if torch.accelerator.device_count() > 1:
-            torch.mojo.set_device(1)
+            torch_mojo_device_module.set_device(1)
             torch.accelerator.synchronize()
     finally:
-        torch.mojo.set_device(original_device)
+        torch_mojo_device_module.set_device(original_device)
 
     assert calls[:3] == [original_device, original_device, 0]
     if torch.accelerator.device_count() > 1:
@@ -145,20 +148,22 @@ def test_indexless_mojo_device_uses_and_restores_current_device():
     if len(accelerators) < 2:
         pytest.skip("requires two Mojo devices, including the MAX CPU device")
 
-    original_index = torch.mojo.current_device()
+    original_index = torch_mojo_device_module.current_device()
     alternate_index = (original_index + 1) % len(accelerators)
     try:
-        torch.mojo.set_device(alternate_index)
+        torch_mojo_device_module.set_device(alternate_index)
 
         assert (
             find_equivalent_max_device(torch.device("mojo"))
             == accelerators[alternate_index]
         )
-        assert torch.empty(1, device="mojo")._device == accelerators[alternate_index]
+        empty_tensor = torch.empty(1, device="mojo")
+        assert isinstance(empty_tensor, TorchMojoTensor)
+        assert empty_tensor._device == accelerators[alternate_index]
     finally:
-        torch.mojo.set_device(original_index)
+        torch_mojo_device_module.set_device(original_index)
 
-    assert torch.mojo.current_device() == original_index
+    assert torch_mojo_device_module.current_device() == original_index
     assert (
         find_equivalent_max_device(torch.device("mojo")) == accelerators[original_index]
     )
@@ -210,6 +215,7 @@ def test_non_blocking_cpu_source_lifetime(mojo_device):
     source = torch.arange(1 << 20, dtype=torch.int32)
     expected = source.clone()
     uploaded = source.to(mojo_device, non_blocking=True)
+    assert isinstance(uploaded, TorchMojoTensor)
     if uploaded._device.label == "gpu":
         assert uploaded._device in _PENDING_H2D
 
@@ -227,10 +233,12 @@ def test_non_blocking_cpu_source_lifetime(mojo_device):
 def test_synchronized_transfers_reap_completed_cpu_sources(mojo_device):
     """Later blocking H2D/D2H operations release completed async sources."""
     first = torch.arange(4096).to(mojo_device, non_blocking=True)
+    assert isinstance(first, TorchMojoTensor)
     torch.zeros(4096).to(mojo_device)
     assert first._device not in _PENDING_H2D
 
     second = torch.arange(4096).to(mojo_device, non_blocking=True)
+    assert isinstance(second, TorchMojoTensor)
     torch.testing.assert_close(second.cpu(), torch.arange(4096))
     assert second._device not in _PENDING_H2D
 
@@ -243,14 +251,14 @@ def test_non_blocking_h2d_does_not_drain_prior_gpu_work(mojo_device):
 
     a = torch.randn(4096, 4096).to(mojo_device)
     b = torch.randn(4096, 4096).to(mojo_device)
-    torch.mojo.synchronize(mojo_device)
+    torch_mojo_device_module.synchronize(mojo_device)
 
     # Establish a conservative duration for the work placed ahead of H2D.
     _ = a @ b
-    torch.mojo.synchronize(mojo_device)
+    torch_mojo_device_module.synchronize(mojo_device)
     started = time.perf_counter()
     _ = a @ b
-    torch.mojo.synchronize(mojo_device)
+    torch_mojo_device_module.synchronize(mojo_device)
     matmul_seconds = time.perf_counter() - started
 
     delayed = a @ b
@@ -259,7 +267,7 @@ def test_non_blocking_h2d_does_not_drain_prior_gpu_work(mojo_device):
     upload_return_seconds = time.perf_counter() - started
 
     assert upload_return_seconds < matmul_seconds * 0.5
-    torch.mojo.synchronize(mojo_device)
+    torch_mojo_device_module.synchronize(mojo_device)
     torch.testing.assert_close(uploaded.cpu(), torch.arange(4096))
     assert delayed.shape == (4096, 4096)
 
@@ -274,7 +282,7 @@ def test_non_blocking_h2d_does_not_drain_prior_gpu_work(mojo_device):
     large_upload_return_seconds = time.perf_counter() - started
 
     assert large_upload_return_seconds < matmul_seconds * 0.5
-    torch.mojo.synchronize(mojo_device)
+    torch_mojo_device_module.synchronize(mojo_device)
     torch.testing.assert_close(large_uploaded.cpu(), source)
     assert delayed.shape == (4096, 4096)
 
@@ -282,8 +290,9 @@ def test_non_blocking_h2d_does_not_drain_prior_gpu_work(mojo_device):
     # CPU source must stay alive while both operations wait behind prior work.
     destination_storage = torch.empty((elements, 2), device=mojo_device)
     destination = destination_storage[:, 1]
+    assert isinstance(destination, TorchMojoTensor)
     destination.copy_(torch.zeros(elements), non_blocking=True)
-    torch.mojo.synchronize(mojo_device)
+    torch_mojo_device_module.synchronize(mojo_device)
 
     expected = source.clone()
     # The staged strided path has a few milliseconds of legitimate host-side
@@ -293,7 +302,7 @@ def test_non_blocking_h2d_does_not_drain_prior_gpu_work(mojo_device):
     started = time.perf_counter()
     for _ in range(queue_repeats):
         _ = a @ b
-    torch.mojo.synchronize(mojo_device)
+    torch_mojo_device_module.synchronize(mojo_device)
     queued_matmul_seconds = time.perf_counter() - started
 
     delayed = [a @ b for _ in range(queue_repeats)]
@@ -307,7 +316,7 @@ def test_non_blocking_h2d_does_not_drain_prior_gpu_work(mojo_device):
     for _ in range(8):
         torch.empty_like(expected).fill_(-1)
 
-    torch.mojo.synchronize(mojo_device)
+    torch_mojo_device_module.synchronize(mojo_device)
     assert destination._device not in _PENDING_H2D
     torch.testing.assert_close(destination.cpu(), expected)
     assert all(result.shape == (4096, 4096) for result in delayed)
@@ -329,13 +338,13 @@ def test_non_blocking_mojo_to_cpu_does_not_drain_prior_gpu_work(mojo_device):
 
     # Warm the pinned-host allocation and DLPack adoption paths before timing.
     _ = source.to("cpu", non_blocking=True)
-    torch.mojo.synchronize(mojo_device)
+    torch_mojo_device_module.synchronize(mojo_device)
 
     queue_repeats = 8
     started = time.perf_counter()
     for _ in range(queue_repeats):
         _ = a @ b
-    torch.mojo.synchronize(mojo_device)
+    torch_mojo_device_module.synchronize(mojo_device)
     queued_matmul_seconds = time.perf_counter() - started
 
     delayed = [a @ b for _ in range(queue_repeats)]
@@ -346,7 +355,7 @@ def test_non_blocking_mojo_to_cpu_does_not_drain_prior_gpu_work(mojo_device):
     assert download_return_seconds < queued_matmul_seconds * 0.5
     assert max_device in pending_d2h
 
-    torch.mojo.synchronize(mojo_device)
+    torch_mojo_device_module.synchronize(mojo_device)
     assert max_device not in pending_d2h
     torch.testing.assert_close(downloaded, expected)
     assert all(result.shape == (4096, 4096) for result in delayed)
@@ -366,7 +375,7 @@ def test_non_blocking_strided_d2h_survives_source_destruction(mojo_device):
     assert isinstance(retained, tuple) and len(retained) == 2
 
     del source, storage
-    torch.mojo.synchronize(mojo_device)
+    torch_mojo_device_module.synchronize(mojo_device)
     torch.testing.assert_close(downloaded, expected)
     assert max_device not in mojo_tensor_module._PENDING_D2H
 
@@ -382,7 +391,7 @@ def test_non_blocking_d2h_survives_destination_destruction(mojo_device):
     a = torch.randn(4096, 4096).to(mojo_device)
     b = torch.randn(4096, 4096).to(mojo_device)
     source = torch.arange(1 << 20, dtype=torch.float32).to(mojo_device)
-    torch.mojo.synchronize(mojo_device)
+    torch_mojo_device_module.synchronize(mojo_device)
 
     delayed = [a @ b for _ in range(8)]
     exports_before = len(dlpack._live_exports)
@@ -398,7 +407,7 @@ def test_non_blocking_d2h_survives_destination_destruction(mojo_device):
     assert len(dlpack._live_exports) == exports_before
     assert max_device in mojo_tensor_module._PENDING_D2H
 
-    torch.mojo.synchronize(mojo_device)
+    torch_mojo_device_module.synchronize(mojo_device)
     assert max_device not in mojo_tensor_module._PENDING_D2H
     assert all(result.shape == (4096, 4096) for result in delayed)
 
@@ -447,7 +456,10 @@ def test_transfer_query_failure_retains_new_dma_owner(direction):
         def __init__(self):
             self.default_stream = FakeStream()
 
-    device = FakeDevice()
+    fake_device = FakeDevice()
+    # _PENDING_H2D/_PENDING_D2H are keyed structurally (only default_stream is
+    # read); cast the host-contract stand-in to the declared key type.
+    device = cast(max.driver.Device, fake_device)
     old_owner = object()
     new_owner = object()
     if direction == "h2d":
@@ -471,7 +483,7 @@ def test_transfer_query_failure_retains_new_dma_owner(direction):
             record()
         assert list(pending[device]) == [
             (pending[device][0][0], old_owner),
-            (device.default_stream.current, new_owner),
+            (fake_device.default_stream.current, new_owner),
         ]
     finally:
         with lock:
@@ -496,7 +508,7 @@ def test_transfer_record_and_sync_failure_retains_owner(direction):
         def __init__(self):
             self.default_stream = FailingStream()
 
-    device = FakeDevice()
+    device = cast(max.driver.Device, FakeDevice())
     owner = Owner()
     owner_ref = weakref.ref(owner)
     try:
@@ -538,11 +550,11 @@ def test_same_device_d2d_does_not_drain_prior_gpu_work(mojo_device):
     contiguous_destination.copy_(contiguous_source)
     strided_destination.copy_(strided_source)
     _ = a @ b
-    torch.mojo.synchronize(mojo_device)
+    torch_mojo_device_module.synchronize(mojo_device)
 
     started = time.perf_counter()
     _ = a @ b
-    torch.mojo.synchronize(mojo_device)
+    torch_mojo_device_module.synchronize(mojo_device)
     matmul_seconds = time.perf_counter() - started
 
     for layout, destination, source in (
@@ -555,7 +567,7 @@ def test_same_device_d2d_does_not_drain_prior_gpu_work(mojo_device):
         copy_return_seconds = time.perf_counter() - started
 
         assert copy_return_seconds < matmul_seconds * 0.5, layout
-        torch.mojo.synchronize(mojo_device)
+        torch_mojo_device_module.synchronize(mojo_device)
         torch.testing.assert_close(destination.cpu(), expected)
         assert delayed.shape == (4096, 4096)
 
@@ -564,57 +576,67 @@ def test_mojo_rng_state_exact_replay_and_high_bit_seed(mojo_device):
     """Public RNG snapshots exactly replay per-device Philox reservations."""
     device = torch.device(mojo_device)
     seed = (1 << 63) + 0x12345
-    torch.mojo.manual_seed_all(seed)
+    torch_mojo_device_module.manual_seed_all(seed)
 
-    initial = torch.mojo.get_rng_state(device)
+    initial = torch_mojo_device_module.get_rng_state(device)
     assert initial.dtype == torch.uint8
     assert initial.shape == (16,)
 
     assert _reserve_philox_state(device, 17) == (seed, 0)
-    advanced = torch.mojo.get_rng_state(device)
+    advanced = torch_mojo_device_module.get_rng_state(device)
     assert not torch.equal(advanced, initial)
 
-    torch.mojo.set_rng_state(initial, device)
+    torch_mojo_device_module.set_rng_state(initial, device)
     assert _reserve_philox_state(device, 17) == (seed, 0)
-    torch.testing.assert_close(torch.mojo.get_rng_state(device), advanced)
+    torch.testing.assert_close(torch_mojo_device_module.get_rng_state(device), advanced)
 
 
 def test_mojo_rng_state_is_per_device():
     """Consuming one Mojo device's counter does not advance another device."""
-    if torch.mojo.device_count() < 2:
+    if torch_mojo_device_module.device_count() < 2:
         pytest.skip("requires two Mojo devices, including the MAX CPU device")
 
     first = torch.device("mojo:0")
     second = torch.device("mojo:1")
-    torch.mojo.manual_seed_all(20260718)
-    second_before = torch.mojo.get_rng_state(second)
+    torch_mojo_device_module.manual_seed_all(20260718)
+    second_before = torch_mojo_device_module.get_rng_state(second)
 
     assert _reserve_philox_state(first, 257) == (20260718, 0)
-    torch.testing.assert_close(torch.mojo.get_rng_state(second), second_before)
+    torch.testing.assert_close(
+        torch_mojo_device_module.get_rng_state(second), second_before
+    )
     assert _reserve_philox_state(second, 1) == (20260718, 0)
 
 
 def test_mojo_rng_state_rejects_malformed_state(mojo_device):
     device = torch.device(mojo_device)
     with pytest.raises(ValueError, match="16-element uint8"):
-        torch.mojo.set_rng_state(torch.zeros(16, dtype=torch.int64), device)
+        torch_mojo_device_module.set_rng_state(
+            torch.zeros(16, dtype=torch.int64), device
+        )
     with pytest.raises(ValueError, match="16-element uint8"):
-        torch.mojo.set_rng_state(torch.zeros(15, dtype=torch.uint8), device)
+        torch_mojo_device_module.set_rng_state(
+            torch.zeros(15, dtype=torch.uint8), device
+        )
 
 
 def test_mojo_rng_seed_bounds_do_not_mutate_state(mojo_device):
     device = torch.device(mojo_device)
-    torch.mojo.manual_seed_all(20260718)
-    before = torch.mojo.get_rng_state(device)
+    torch_mojo_device_module.manual_seed_all(20260718)
+    before = torch_mojo_device_module.get_rng_state(device)
 
     for invalid_seed in (1 << 64, -(1 << 63) - 1):
         with pytest.raises(ValueError, match="Overflow"):
-            torch.mojo.manual_seed_all(invalid_seed)
-        torch.testing.assert_close(torch.mojo.get_rng_state(device), before)
+            torch_mojo_device_module.manual_seed_all(invalid_seed)
+        torch.testing.assert_close(
+            torch_mojo_device_module.get_rng_state(device), before
+        )
 
         with pytest.raises(ValueError, match="Overflow"):
             torch.manual_seed(invalid_seed)
-        torch.testing.assert_close(torch.mojo.get_rng_state(device), before)
+        torch.testing.assert_close(
+            torch_mojo_device_module.get_rng_state(device), before
+        )
         # A CUDA-enabled PyTorch queues manual_seed_all() until its first CUDA
         # initialization.  The custom-device validation above then raises, so
         # replace that deferred invalid callback before another test initializes
@@ -625,17 +647,17 @@ def test_mojo_rng_seed_bounds_do_not_mutate_state(mojo_device):
 
 def test_mojo_rng_state_accepts_reshaped_byte_tensor(mojo_device):
     device = torch.device(mojo_device)
-    torch.mojo.manual_seed_all((1 << 63) + 20260718)
-    initial = torch.mojo.get_rng_state(device)
+    torch_mojo_device_module.manual_seed_all((1 << 63) + 20260718)
+    initial = torch_mojo_device_module.get_rng_state(device)
     _reserve_philox_state(device, 37)
 
-    torch.mojo.set_rng_state(initial.reshape(4, 4), device)
+    torch_mojo_device_module.set_rng_state(initial.reshape(4, 4), device)
     assert _reserve_philox_state(device, 37) == ((1 << 63) + 20260718, 0)
 
 
 def test_mojo_rng_reservations_are_atomic_and_reject_wrap(mojo_device):
     device = torch.device(mojo_device)
-    torch.mojo.manual_seed_all(20260718)
+    torch_mojo_device_module.manual_seed_all(20260718)
 
     reservations = 512
     with ThreadPoolExecutor(max_workers=16) as pool:
@@ -647,25 +669,31 @@ def test_mojo_rng_reservations_are_atomic_and_reject_wrap(mojo_device):
     seed = (1 << 63) + 7
     counter = (1 << 64) - 1
     encoded = seed.to_bytes(8, "little") + counter.to_bytes(8, "little")
-    torch.mojo.set_rng_state(torch.tensor(list(encoded), dtype=torch.uint8), device)
-    before = torch.mojo.get_rng_state(device)
+    torch_mojo_device_module.set_rng_state(
+        torch.tensor(list(encoded), dtype=torch.uint8), device
+    )
+    before = torch_mojo_device_module.get_rng_state(device)
 
     with pytest.raises(OverflowError, match="would wrap"):
         _reserve_philox_state(device, 1)
-    torch.testing.assert_close(torch.mojo.get_rng_state(device), before)
+    torch.testing.assert_close(torch_mojo_device_module.get_rng_state(device), before)
 
 
 def test_torch_fork_rng_restores_mojo_counter(mojo_device):
     device = torch.device(mojo_device)
-    index = torch.mojo.current_device() if device.index is None else device.index
-    torch.mojo.manual_seed_all(91)
-    before = torch.mojo.get_rng_state(device)
+    index = (
+        torch_mojo_device_module.current_device()
+        if device.index is None
+        else device.index
+    )
+    torch_mojo_device_module.manual_seed_all(91)
+    before = torch_mojo_device_module.get_rng_state(device)
 
     with torch.random.fork_rng(devices=[index], device_type="mojo"):
         assert _reserve_philox_state(device, 33) == (91, 0)
-        assert not torch.equal(torch.mojo.get_rng_state(device), before)
+        assert not torch.equal(torch_mojo_device_module.get_rng_state(device), before)
 
-    torch.testing.assert_close(torch.mojo.get_rng_state(device), before)
+    torch.testing.assert_close(torch_mojo_device_module.get_rng_state(device), before)
 
 
 def test_dtype_preservation(mojo_device):
@@ -716,8 +744,12 @@ def test_module_to_mojo_preserves_tied_parameters(mojo_device):
     module.to(mojo_device)
 
     assert module.embedding.weight is module.projection.weight
-    assert module.embedding.weight._holder is module.projection.weight._holder
-    assert module.embedding.weight._ptr == module.projection.weight._ptr
+    embedding_weight = module.embedding.weight
+    projection_weight = module.projection.weight
+    assert isinstance(embedding_weight, TorchMojoTensor)
+    assert isinstance(projection_weight, TorchMojoTensor)
+    assert embedding_weight._holder is projection_weight._holder
+    assert embedding_weight._ptr == projection_weight._ptr
     assert len(list(module.parameters())) == 1
 
 
@@ -766,7 +798,7 @@ def test_mojo_adamw_step_matches_cpu(mojo_gpu_available, foreach):
         cpu_optimizer.step()
         mojo_optimizer.step()
 
-    torch.mojo.synchronize(mojo_gpu)
+    torch_mojo_device_module.synchronize(mojo_gpu)
     torch.testing.assert_close(mojo_parameter.cpu(), cpu_parameter)
     cpu_state = cpu_optimizer.state[cpu_parameter]
     mojo_state = mojo_optimizer.state[mojo_parameter]
@@ -810,7 +842,7 @@ def test_mojo_checkpoint_resumes_through_portable_cpu_state(mojo_gpu_available):
     for parameter in resumed_model.parameters():
         parameter.grad = torch.ones_like(parameter)
     resumed_optimizer.step()
-    torch.mojo.synchronize(mojo_gpu)
+    torch_mojo_device_module.synchronize(mojo_gpu)
     assert all(
         torch.isfinite(parameter.cpu()).all()
         for parameter in resumed_model.parameters()
@@ -845,10 +877,12 @@ def test_mojo_clip_grad_norm_matches_cpu(mojo_gpu_available, foreach):
         cpu_parameters, 1.25, foreach=foreach
     )
     actual_norm = torch.nn.utils.clip_grad_norm_(mojo_parameters, 1.25, foreach=foreach)
-    torch.mojo.synchronize(mojo_gpu)
+    torch_mojo_device_module.synchronize(mojo_gpu)
 
     torch.testing.assert_close(actual_norm.cpu(), expected_norm)
     for actual, expected in zip(mojo_parameters, cpu_parameters, strict=True):
+        # Both grads were assigned above.
+        assert actual.grad is not None
         torch.testing.assert_close(actual.grad.cpu(), expected.grad)
 
 
@@ -1135,6 +1169,7 @@ def test_copy_into_mojo_from_another_backend(mojo_gpu):
 def test_from_cpu_rejects_a_device_source(mojo_gpu):
     """The guard behind both call sites: a message, never a fault."""
     on_device = torch.zeros(4, device=mojo_gpu)
+    assert isinstance(on_device, TorchMojoTensor)
     with pytest.raises(RuntimeError, match="requires a CPU source"):
         TorchMojoTensor._from_cpu(on_device, on_device._device)
 
@@ -1154,16 +1189,16 @@ def test_same_gpu_transfer_skips_the_host(mojo_gpu):
 
     big = torch.randn(1 << 26, device="cuda")  # 256 MB
     big.to(mojo_gpu)
-    torch.mojo.synchronize()
+    torch_mojo_device_module.synchronize()
 
     start = time.perf_counter()
     moved = big.to(mojo_gpu)
-    torch.mojo.synchronize()
+    torch_mojo_device_module.synchronize()
     on_device = time.perf_counter() - start
 
     start = time.perf_counter()
     bounced = big.cpu().to(mojo_gpu)
-    torch.mojo.synchronize()
+    torch_mojo_device_module.synchronize()
     through_host = time.perf_counter() - start
 
     assert torch.equal(moved.cpu(), bounced.cpu())
@@ -1183,7 +1218,8 @@ def test_pointer_ordinal_identifies_the_owning_gpu(mojo_gpu):
     from torch_mojo_backend.mojo_device import cuda_peer
 
     on_mojo = torch.zeros(8, device=mojo_gpu)
-    torch.mojo.synchronize()
+    assert isinstance(on_mojo, TorchMojoTensor)
+    torch_mojo_device_module.synchronize()
     assert cuda_peer.device_ordinal(on_mojo._ptr) is not None
     assert cuda_peer.device_ordinal(0) is None
     assert cuda_peer.device_ordinal(torch.zeros(8).data_ptr()) is None
@@ -1210,10 +1246,15 @@ def test_library_attributes_do_not_clobber_the_payload(mojo_gpu_available):
     if not mojo_gpu_available:
         pytest.skip("requires a MAX GPU")
     tensor = torch.arange(8, dtype=torch.float32, device="mojo:0")
+    assert isinstance(tensor, TorchMojoTensor)
     strides = tensor._mojo_strides
-    tensor._strides = ((1,), (1,))
-    tensor._shapes = (torch.Size([4]), torch.Size([4]))
-    tensor._numels = (4, 4)
+    # Simulates FSDP1 writing its own bookkeeping onto the wrapper instance;
+    # these names are deliberately not part of TorchMojoTensor's declared
+    # payload, so setattr (not a plain attribute assignment) is the honest
+    # way to write them.
+    setattr(tensor, "_strides", ((1,), (1,)))
+    setattr(tensor, "_shapes", (torch.Size([4]), torch.Size([4])))
+    setattr(tensor, "_numels", (4, 4))
     assert tensor._mojo_strides == strides
     first, second = torch.split(tensor, [4, 4])
     assert second.cpu().tolist() == [4.0, 5.0, 6.0, 7.0]

--- a/tests/test_mojo_device_runtime.py
+++ b/tests/test_mojo_device_runtime.py
@@ -3,11 +3,14 @@
 import gc
 import weakref
 from concurrent.futures import ThreadPoolExecutor
+from typing import cast
 
+import max.driver
 import pytest
 import torch
 
-from torch_mojo_backend import register_mojo_devices
+from torch_mojo_backend import TorchMojoTensor, register_mojo_devices
+from torch_mojo_backend.mojo_device import torch_mojo_device_module
 from torch_mojo_backend.mojo_device import torch_mojo_tensor as mojo_tensor_module
 from torch_mojo_backend.mojo_device.torch_mojo_device_module import (
     _reserve_philox_state,
@@ -34,20 +37,20 @@ def test_mojo_is_the_default_torch_accelerator():
 
 def test_torch_accelerator_synchronize_uses_mojo_device_module(monkeypatch):
     calls = []
-    original_synchronize = torch.mojo.synchronize
-    original_device = torch.mojo.current_device()
+    original_synchronize = torch_mojo_device_module.synchronize
+    original_device = torch_mojo_device_module.current_device()
 
     def recording_synchronize(device=None):
         calls.append(device)
         return original_synchronize(device)
 
-    monkeypatch.setattr(torch.mojo, "synchronize", recording_synchronize)
+    monkeypatch.setattr(torch_mojo_device_module, "synchronize", recording_synchronize)
     try:
         torch.accelerator.synchronize()
         torch.accelerator.synchronize("mojo")
         torch.accelerator.synchronize(0)
     finally:
-        torch.mojo.set_device(original_device)
+        torch_mojo_device_module.set_device(original_device)
 
     assert calls == [original_device, original_device, 0]
     with pytest.raises(ValueError, match="doesn't match the current accelerator mojo"):
@@ -58,17 +61,19 @@ def test_indexless_mojo_device_uses_current_device():
     accelerators = get_ordered_accelerators()
     if len(accelerators) < 2:
         pytest.skip("requires two Mojo devices, including the MAX CPU device")
-    original_index = torch.mojo.current_device()
+    original_index = torch_mojo_device_module.current_device()
     alternate_index = (original_index + 1) % len(accelerators)
     try:
-        torch.mojo.set_device(alternate_index)
+        torch_mojo_device_module.set_device(alternate_index)
         assert (
             find_equivalent_max_device(torch.device("mojo"))
             == accelerators[alternate_index]
         )
-        assert torch.empty(1, device="mojo")._device == accelerators[alternate_index]
+        empty_tensor = torch.empty(1, device="mojo")
+        assert isinstance(empty_tensor, TorchMojoTensor)
+        assert empty_tensor._device == accelerators[alternate_index]
     finally:
-        torch.mojo.set_device(original_index)
+        torch_mojo_device_module.set_device(original_index)
 
 
 def test_non_blocking_cpu_to_mojo_transfers(mojo_device):
@@ -86,6 +91,7 @@ def test_non_blocking_cpu_source_lifetime(mojo_device):
     source = torch.arange(1 << 20, dtype=torch.int32)
     expected = source.clone()
     uploaded = source.to(mojo_device, non_blocking=True)
+    assert isinstance(uploaded, TorchMojoTensor)
     del source
     for _ in range(8):
         torch.empty_like(expected).fill_(-1)
@@ -98,6 +104,7 @@ def test_non_blocking_cpu_source_lifetime(mojo_device):
 def test_non_blocking_mojo_to_cpu_transfer(mojo_device):
     expected = torch.arange(1 << 16, dtype=torch.float32)
     source = expected.to(mojo_device)
+    assert isinstance(source, TorchMojoTensor)
     downloaded = source.to("cpu", non_blocking=True)
 
     torch.accelerator.synchronize(mojo_device)
@@ -126,7 +133,9 @@ def test_transfer_query_failure_retains_new_dma_owner(direction):
         def __init__(self):
             self.default_stream = FakeStream()
 
-    device = FakeDevice()
+    # _PENDING_H2D/_PENDING_D2H are keyed structurally (only default_stream is
+    # read); cast the host-contract stand-in to the declared key type.
+    device = cast(max.driver.Device, FakeDevice())
     old_owner = object()
     new_owner = object()
     if direction == "h2d":
@@ -170,7 +179,7 @@ def test_transfer_record_and_sync_failure_retains_owner(direction):
         def __init__(self):
             self.default_stream = FailingStream()
 
-    device = FakeDevice()
+    device = cast(max.driver.Device, FakeDevice())
     owner = Owner()
     owner_ref = weakref.ref(owner)
     try:
@@ -190,40 +199,46 @@ def test_transfer_record_and_sync_failure_retains_owner(direction):
 def test_mojo_rng_state_exact_replay_and_high_bit_seed(mojo_device):
     device = torch.device(mojo_device)
     seed = (1 << 63) + 0x12345
-    torch.mojo.manual_seed_all(seed)
-    initial = torch.mojo.get_rng_state(device)
+    torch_mojo_device_module.manual_seed_all(seed)
+    initial = torch_mojo_device_module.get_rng_state(device)
     assert initial.dtype == torch.uint8
     assert initial.shape == (16,)
 
     assert _reserve_philox_state(device, 17) == (seed, 0)
-    advanced = torch.mojo.get_rng_state(device)
-    torch.mojo.set_rng_state(initial, device)
+    advanced = torch_mojo_device_module.get_rng_state(device)
+    torch_mojo_device_module.set_rng_state(initial, device)
     assert _reserve_philox_state(device, 17) == (seed, 0)
-    torch.testing.assert_close(torch.mojo.get_rng_state(device), advanced)
+    torch.testing.assert_close(torch_mojo_device_module.get_rng_state(device), advanced)
 
 
 def test_mojo_rng_state_is_per_device():
-    if torch.mojo.device_count() < 2:
+    if torch_mojo_device_module.device_count() < 2:
         pytest.skip("requires two Mojo devices")
     first = torch.device("mojo:0")
     second = torch.device("mojo:1")
-    torch.mojo.manual_seed_all(20260718)
-    second_before = torch.mojo.get_rng_state(second)
+    torch_mojo_device_module.manual_seed_all(20260718)
+    second_before = torch_mojo_device_module.get_rng_state(second)
     assert _reserve_philox_state(first, 257) == (20260718, 0)
-    torch.testing.assert_close(torch.mojo.get_rng_state(second), second_before)
+    torch.testing.assert_close(
+        torch_mojo_device_module.get_rng_state(second), second_before
+    )
 
 
 def test_mojo_rng_state_rejects_malformed_state(mojo_device):
     device = torch.device(mojo_device)
     with pytest.raises(ValueError, match="16-element uint8"):
-        torch.mojo.set_rng_state(torch.zeros(16, dtype=torch.int64), device)
+        torch_mojo_device_module.set_rng_state(
+            torch.zeros(16, dtype=torch.int64), device
+        )
     with pytest.raises(ValueError, match="16-element uint8"):
-        torch.mojo.set_rng_state(torch.zeros(15, dtype=torch.uint8), device)
+        torch_mojo_device_module.set_rng_state(
+            torch.zeros(15, dtype=torch.uint8), device
+        )
 
 
 def test_mojo_rng_reservations_are_atomic_and_reject_wrap(mojo_device):
     device = torch.device(mojo_device)
-    torch.mojo.manual_seed_all(20260718)
+    torch_mojo_device_module.manual_seed_all(20260718)
     reservations = 256
     with ThreadPoolExecutor(max_workers=16) as pool:
         bases = list(
@@ -234,18 +249,24 @@ def test_mojo_rng_reservations_are_atomic_and_reject_wrap(mojo_device):
     seed = (1 << 63) + 7
     counter = (1 << 64) - 1
     encoded = seed.to_bytes(8, "little") + counter.to_bytes(8, "little")
-    torch.mojo.set_rng_state(torch.tensor(list(encoded), dtype=torch.uint8), device)
-    before = torch.mojo.get_rng_state(device)
+    torch_mojo_device_module.set_rng_state(
+        torch.tensor(list(encoded), dtype=torch.uint8), device
+    )
+    before = torch_mojo_device_module.get_rng_state(device)
     with pytest.raises(OverflowError, match="would wrap"):
         _reserve_philox_state(device, 1)
-    torch.testing.assert_close(torch.mojo.get_rng_state(device), before)
+    torch.testing.assert_close(torch_mojo_device_module.get_rng_state(device), before)
 
 
 def test_torch_fork_rng_restores_mojo_counter(mojo_device):
     device = torch.device(mojo_device)
-    index = torch.mojo.current_device() if device.index is None else device.index
-    torch.mojo.manual_seed_all(91)
-    before = torch.mojo.get_rng_state(device)
+    index = (
+        torch_mojo_device_module.current_device()
+        if device.index is None
+        else device.index
+    )
+    torch_mojo_device_module.manual_seed_all(91)
+    before = torch_mojo_device_module.get_rng_state(device)
     with torch.random.fork_rng(devices=[index], device_type="mojo"):
         assert _reserve_philox_state(device, 33) == (91, 0)
-    torch.testing.assert_close(torch.mojo.get_rng_state(device), before)
+    torch.testing.assert_close(torch_mojo_device_module.get_rng_state(device), before)

--- a/tests/test_mojo_streams.py
+++ b/tests/test_mojo_streams.py
@@ -5,24 +5,35 @@ import pytest
 import torch
 
 from torch_mojo_backend import register_mojo_devices
+from torch_mojo_backend.mojo_device import torch_mojo_device_module as torch_mojo
+from torch_mojo_backend.mojo_device.streams import Stream as MojoStream
+from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
+
+
+def _mt(tensor: torch.Tensor) -> TorchMojoTensor:
+    assert isinstance(tensor, TorchMojoTensor)
+    return tensor
+
+
+def _fenced_streams(tensor: torch.Tensor) -> set[int] | None:
+    events = _mt(tensor)._holder._events
+    return None if events is None else set(events)
 
 
 def test_dispatch_installed_and_cpu_delegation():
     register_mojo_devices()
+    # `torch.mojo` is registered onto `torch` at runtime; no stub knows it.
+    assert torch.mojo is torch_mojo  # ty: ignore[unresolved-attribute]
     assert getattr(torch.Stream, "_torch_mojo_backend", False)
     assert getattr(torch.Event, "_torch_mojo_backend", False)
     cpu_stream = torch.Stream(device="cpu")
     assert isinstance(cpu_stream, torch.Stream)
-    from torch_mojo_backend.mojo_device.streams import Stream as MojoStream
-
     assert not isinstance(cpu_stream, MojoStream)
 
 
 def test_stream_construction_and_identity(mojo_gpu: str):
     stream = torch.Stream(device=mojo_gpu)
     assert isinstance(stream, torch.Stream)
-    from torch_mojo_backend.mojo_device.streams import Stream as MojoStream
-
     assert isinstance(stream, MojoStream)
     assert stream.device == torch.device("mojo", 0)
     assert stream.device_index == 0
@@ -31,23 +42,24 @@ def test_stream_construction_and_identity(mojo_gpu: str):
     assert stream.stream_id == stream._device_stream.ctx_ptr
     assert stream.stream_id != stream.native_handle  # a context, not a stream
     assert stream.is_capturing() is False
-    assert stream != torch.mojo.default_stream()
+    assert stream != torch_mojo.default_stream()
     assert stream == stream
 
 
 def test_current_stream_and_context_manager(mojo_gpu: str):
-    default = torch.mojo.default_stream()
+    default = torch_mojo.default_stream()
     assert torch.accelerator.current_stream() == default
-    assert torch.mojo.current_stream() == default
+    assert torch_mojo.current_stream() == default
     side = torch.Stream(device=mojo_gpu)
+    assert isinstance(side, MojoStream)
     with side:
         assert torch.accelerator.current_stream() == side
-        assert torch.mojo.current_stream() == side
+        assert torch_mojo.current_stream() == side
     assert torch.accelerator.current_stream() == default
-    torch.mojo.set_stream(side)
-    assert torch.mojo.current_stream() == side
-    torch.mojo.set_stream(default)
-    assert torch.mojo.current_stream() == default
+    torch_mojo.set_stream(side)
+    assert torch_mojo.current_stream() == side
+    torch_mojo.set_stream(default)
+    assert torch_mojo.current_stream() == default
 
 
 def test_documented_device_agnostic_pattern(mojo_gpu: str):
@@ -70,7 +82,7 @@ def test_wait_stream_orders_real_work(mojo_gpu: str):
 
     deferred_compile.drain()
     side = torch.Stream(device=mojo_gpu)
-    side.wait_stream(torch.mojo.current_stream())
+    side.wait_stream(torch_mojo.current_stream())
     event = side.record_event()
     event.synchronize()
     assert event.query()
@@ -84,14 +96,14 @@ def test_event_semantics(mojo_gpu: str):
     assert unrecorded.query() is True
     unrecorded.synchronize()  # no-op by contract
     with pytest.raises(RuntimeError):
-        unrecorded.wait(torch.mojo.default_stream())
+        unrecorded.wait(torch_mojo.default_stream())
     with pytest.raises(NotImplementedError):
         torch.Event(device=mojo_gpu, interprocess=True)
 
     start = torch.Event(device=mojo_gpu, enable_timing=True)
     end = torch.Event(device=mojo_gpu, enable_timing=True)
-    stream = torch.mojo.default_stream()
-    torch.mojo.synchronize()
+    stream = torch_mojo.default_stream()
+    torch_mojo.synchronize()
     start.record(stream)
     x = torch.randn(1024, 1024, device=mojo_gpu)
     (x * 2.0).cpu()  # forces the work through the queue and the device
@@ -109,7 +121,7 @@ def test_event_semantics(mojo_gpu: str):
 
 def test_stream_is_a_real_torch_stream_for_cpp_argument_parsing(mojo_gpu: str):
     """THPStream_Check requires the concrete torch._C.Stream type, not duck typing."""
-    stream = torch.mojo.current_stream()
+    stream = torch_mojo.current_stream()
     assert isinstance(stream, torch._C.Stream)
     assert stream.stream_id == stream._device_stream.ctx_ptr
 
@@ -117,16 +129,16 @@ def test_stream_is_a_real_torch_stream_for_cpp_argument_parsing(mojo_gpu: str):
 def test_record_stream_accepts_mojo_streams(mojo_gpu: str):
     tensor = torch.ones(1024, device=mojo_gpu)
     # The device's own stream owns the free already: nothing to fence.
-    tensor.record_stream(torch.mojo.current_stream())
-    assert tensor._holder._events is None
+    tensor.record_stream(torch_mojo.current_stream())
+    assert _fenced_streams(tensor) is None
 
-    side = torch.mojo.Stream()
+    side = torch_mojo.Stream()
     tensor.record_stream(side)
-    assert set(tensor._holder._events) == {side.stream_id}
+    assert _fenced_streams(tensor) == {side.stream_id}
 
     # Recording the same stream twice keeps one (newest) event for it.
     tensor.record_stream(side)
-    assert set(tensor._holder._events) == {side.stream_id}
+    assert _fenced_streams(tensor) == {side.stream_id}
     assert tensor.cpu().sum().item() == 1024.0
 
 
@@ -135,10 +147,10 @@ def test_record_stream_under_no_dispatch(mojo_gpu: str):
     from torch.utils._mode_utils import no_dispatch
 
     tensor = torch.ones(64, device=mojo_gpu)
-    side = torch.mojo.Stream()
+    side = torch_mojo.Stream()
     with no_dispatch():
         tensor.record_stream(side)
-    assert set(tensor._holder._events) == {side.stream_id}
+    assert _fenced_streams(tensor) == {side.stream_id}
 
 
 def test_side_stream_is_distinct_from_default(mojo_gpu: str):
@@ -166,10 +178,10 @@ def test_side_stream_is_distinct_from_default(mojo_gpu: str):
 
 def test_record_use_fences_free_against_side_stream_reader(mojo_gpu: str):
     """record_use fences a free so a side-stream reader can't race pool reuse."""
-    from torch_mojo_backend import eager_kernels
     from torch_mojo_backend.mojo_device import deferred_compile
     from torch_mojo_backend.mojo_device.device_streams import get_stream, record_use
     from torch_mojo_backend.mojo_device.torch_mojo_tensor import (
+        _holder_mod,
         find_equivalent_max_device,
     )
 
@@ -184,18 +196,18 @@ def test_record_use_fences_free_against_side_stream_reader(mojo_gpu: str):
         sink = torch.empty((copies * n,), device=mojo_gpu)
         deferred_compile.drain()
         stream.wait_default_stream()
-        source_ptr = source._ptr
+        source_ptr = _mt(source)._ptr
         for k in range(copies):
-            eager_kernels.tensor_holder.copy_d2d(
-                stream.ctx_ptr, sink._ptr + k * n * 4, source_ptr, n * 4
+            _holder_mod().copy_d2d(
+                stream.ctx_ptr, _mt(sink)._ptr + k * n * 4, source_ptr, n * 4
             )
-        record_use(source._holder, stream)
+        record_use(_mt(source)._holder, stream)
         del source  # free is now fenced behind the stream's copies
         overwriter = torch.full((n,), 2.0, device=mojo_gpu)
         deferred_compile.drain()
-        reused_any = reused_any or overwriter._ptr == source_ptr
+        reused_any = reused_any or _mt(overwriter)._ptr == source_ptr
         stream.synchronize()
-        torch.mojo.synchronize()
+        torch_mojo.synchronize()
         assert int((sink.cpu() != 1.0).sum().item()) == 0
         del overwriter, sink
     assert reused_any, "allocator never reused the freed block; test inconclusive"

--- a/tests/test_out_variant_resize.py
+++ b/tests/test_out_variant_resize.py
@@ -3,6 +3,7 @@
 import pytest
 import torch
 
+from torch_mojo_backend import TorchMojoTensor
 from torch_mojo_backend.testing import CallChecker
 
 pytestmark = pytest.mark.xdist_group(name="group1")
@@ -20,7 +21,9 @@ def test_mul_out_resize_preserves_existing_storage_alias(
 ):
     _watch_eager_op(call_checker, "aten::mul.out")
     base = torch.arange(8, dtype=torch.float32).to(mojo_gpu)
+    assert isinstance(base, TorchMojoTensor)
     out = base[storage_offset:storage_offset]
+    assert isinstance(out, TorchMojoTensor)
     lhs = torch.tensor([2.0, 3.0], device=mojo_gpu)
     rhs = torch.tensor([5.0, 7.0], device=mojo_gpu)
     holder = base._holder
@@ -45,6 +48,7 @@ def test_resized_out_invalidates_cached_tensor_spec(
     from torch_mojo_backend.eager_kernels.aten_fast import _spec_of
 
     out = torch.empty((), dtype=torch.float32, device=mojo_gpu)
+    assert isinstance(out, TorchMojoTensor)
     _spec_of(out)
     assert "_spec" in out.__dict__
 

--- a/tests/test_sdpa_host_wiring.py
+++ b/tests/test_sdpa_host_wiring.py
@@ -1,9 +1,11 @@
 from types import SimpleNamespace
+from typing import cast
 
 import pytest
 
 from torch_mojo_backend import eager_kernels
 from torch_mojo_backend.mojo_device import mojo_device_autograd as autograd
+from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
 
 
 class _Token:
@@ -15,6 +17,20 @@ class _Token:
 
     def __repr__(self) -> str:
         return self.name
+
+
+def _gt(token: "_Token") -> TorchMojoTensor:
+    """`backward()` reads `TorchMojoTensor` methods/fields no `_Token` has,
+    but every call in this file replaces `_fast()` wholesale with a fake
+    whose ops only ever pass `_Token`s around; cast at the call boundary."""
+    return cast(TorchMojoTensor, token)
+
+
+def _ctx(namespace: SimpleNamespace) -> autograd._MojoAutogradCtx:
+    """The namespaces below set every field `backward()` actually reads
+    (`getattr(ctx, "is_causal", False)` tolerates the rest); cast at the
+    call boundary since SimpleNamespace isn't nominally the Protocol."""
+    return cast(autograd._MojoAutogradCtx, namespace)
 
 
 def _patch_saved_and_views(
@@ -136,10 +152,10 @@ def test_sdpa_query_gradient_prefers_fused_dropout_softmax_backward(
     monkeypatch.setattr(autograd, "_fast", lambda: fake_fast)
 
     result = autograd._ScaledDotProductAttentionAutograd.backward(
-        ctx, _Token("grad_output")
+        _ctx(ctx), _gt(_Token("grad_output"))
     )
 
-    assert result[0].name.startswith("view(dquery(dscores-fused")
+    assert cast(_Token, result[0]).name.startswith("view(dquery(dscores-fused")
     assert result[1:] == (None, None, None, None, None, None, None)
     assert len(fused_calls) == 1
     probabilities, grad, mask, dropout_scale, score_scale, causal, q_len = fused_calls[
@@ -205,7 +221,7 @@ def test_sdpa_fused_not_handled_preserves_decomposition_order(
     monkeypatch.setattr(autograd, "_fast", lambda: fake_fast)
 
     result = autograd._ScaledDotProductAttentionAutograd.backward(
-        ctx, _Token("grad_output")
+        _ctx(ctx), _gt(_Token("grad_output"))
     )
 
     names = [operation[0] for operation in operations]
@@ -223,7 +239,7 @@ def test_sdpa_fused_not_handled_preserves_decomposition_order(
     assert multiplies[1][1] == "centered"
     assert multiplies[1][2].startswith("view(probabilities")
     assert multiplies[2][2] == ctx.scale
-    assert result[0].name.startswith("view(dquery")
+    assert cast(_Token, result[0]).name.startswith("view(dquery")
 
 
 @pytest.mark.parametrize("has_dropout", [False, True])
@@ -276,11 +292,11 @@ def test_sdpa_value_only_gradient_skips_fused_score_gradient(
     monkeypatch.setattr(autograd, "_fast", lambda: fake_fast)
 
     result = autograd._ScaledDotProductAttentionAutograd.backward(
-        ctx, _Token("grad_output")
+        _ctx(ctx), _gt(_Token("grad_output"))
     )
 
     assert result[:2] == (None, None)
-    assert result[2].name.startswith("view(view(transpose")
+    assert cast(_Token, result[2]).name.startswith("view(view(transpose")
     assert [call[0] for call in calls] == (
         ["dropout", "transpose", "bmm", "transpose"]
         if has_dropout

--- a/tests/test_tensor_spec_oom.py
+++ b/tests/test_tensor_spec_oom.py
@@ -58,7 +58,7 @@ def test_tensor_spec_fallbacks_propagate_device_oom(
         _mojo_file: Path, _defines: eager_kernels.CanonicalDefines
     ) -> ModuleType:
         module = ModuleType("oom_test_extension")
-        module.call = raise_allocator_oom
+        setattr(module, "call", raise_allocator_oom)
         return module
 
     def fake_allocate_output(
@@ -123,7 +123,7 @@ def test_tensor_spec_unsupported_metadata_still_uses_fallback(
         _mojo_file: Path, _defines: eager_kernels.CanonicalDefines
     ) -> ModuleType:
         module = ModuleType("unsupported_test_extension")
-        module.call = raise_unsupported
+        setattr(module, "call", raise_unsupported)
         return module
 
     def fake_allocate_output(

--- a/torch_mojo_backend/__init__.py
+++ b/torch_mojo_backend/__init__.py
@@ -1,13 +1,3 @@
-import os
-
-# Off by default: beartype's wrapper frames cost real per-call CPU time in
-# eager hot paths. The test suite opts in via tests/conftest.py.
-if os.environ.get("TORCH_MOJO_BACKEND_BEARTYPE", "0") == "1":
-    from beartype.claw import beartype_this_package
-
-    beartype_this_package()
-
-
 from torch_mojo_backend.custom_torch_ops_in_mojo.torch_custom_ops import (
     make_torch_op_from_mojo,
 )

--- a/torch_mojo_backend/aten_functions.py
+++ b/torch_mojo_backend/aten_functions.py
@@ -302,6 +302,17 @@ def type_promotion(
     return x, y
 
 
+def _scale_operand(
+    other: MaxTensor | int | float, alpha: Scalar
+) -> MaxTensor | int | float:
+    """`other * alpha` for add/sub's `alpha`; `other` is a Python number for
+    the Scalar overloads."""
+    if isinstance(other, TensorValue | MaxEagerTensor):
+        return aten_mul(other, alpha)
+    assert not isinstance(alpha, Dim)  # a number times a Dim was never supported
+    return other * alpha
+
+
 _SEARCHSORTED_DTYPES = (
     DType.float32,
     DType.bfloat16,
@@ -1170,11 +1181,11 @@ def aten_add(
     promoted_input, promoted_other = type_promotion(input, other)
     # input is always a genuine Tensor per both ATen overloads, and
     # type_promotion only ever replaces a Dim operand or casts a tensor's
-    # dtype -- never turns a MaxTensor into a plain Scalar.
+    # dtype -- never turns a MaxTensor into a plain Scalar. `other` may stay
+    # a Python number (the Scalar overload).
     assert isinstance(promoted_input, TensorValue | MaxEagerTensor)
-    assert isinstance(promoted_other, TensorValue | MaxEagerTensor)
     if alpha != 1:
-        promoted_other = aten_mul(promoted_other, alpha)
+        promoted_other = _scale_operand(promoted_other, alpha)
     return promoted_input + promoted_other
 
 
@@ -3488,10 +3499,11 @@ def aten_select_scatter(
 
     # Handle negative index
     dim_size = input.shape[dim]
-    assert isinstance(dim_size, StaticDim), (
-        f"select_scatter requires a static size for dim {dim}, got {dim_size!r}"
-    )
     if index < 0:
+        assert isinstance(dim_size, StaticDim), (
+            f"a negative select_scatter index needs a static size for dim {dim}, "
+            f"got {dim_size!r}"
+        )
         index = index + dim_size.dim
 
     # Step 1: Create a range tensor for the dimension to build the mask
@@ -3503,7 +3515,7 @@ def aten_select_scatter(
 
     # Step 3: Reshape mask to have correct broadcasting shape
     # All dimensions except 'dim' should be 1
-    mask_shape = [StaticDim(1)] * len(input.shape)
+    mask_shape = [Dim(1)] * len(input.shape)
     mask_shape[dim] = dim_size
     mask = F.reshape(mask_1d, mask_shape)
 
@@ -3627,16 +3639,16 @@ def aten_squeeze(input: MaxTensor, dim: int | list[int]) -> MaxTensor:
 # sub.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor
 @map_to(aten.sub)
 def aten_sub(
-    input: MaxTensor, other: MaxTensor | Scalar, alpha: Scalar = 1
+    input: MaxTensor | int | float, other: MaxTensor | Scalar, alpha: Scalar = 1
 ) -> MaxTensor:
     promoted_input, other = type_promotion(input, other)
-    # input is always a genuine Tensor per both ATen overloads; type_promotion
-    # only ever replaces a Dim operand or casts a tensor's dtype.
-    assert isinstance(promoted_input, TensorValue | MaxEagerTensor)
     if alpha != 1:
-        assert isinstance(other, TensorValue | MaxEagerTensor)
-        other = aten_mul(other, alpha)
-    return promoted_input - other
+        other = _scale_operand(other, alpha)
+    result = promoted_input - other
+    # At least one operand is a tensor (rsub decomposes to a number minus
+    # a tensor, hence the widened `input`).
+    assert isinstance(result, TensorValue | MaxEagerTensor)
+    return result
 
 
 # sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor

--- a/torch_mojo_backend/aten_functions.py
+++ b/torch_mojo_backend/aten_functions.py
@@ -11,7 +11,7 @@ import itertools
 import math
 import operator
 from collections.abc import Callable, Sequence
-from typing import Any, Literal, TypeVar, cast
+from typing import Literal, TypeVar, cast
 
 import max.driver as max_driver
 import max.graph.ops as max_ops
@@ -41,11 +41,9 @@ from torch_mojo_backend.flags import verbose_enabled
 from torch_mojo_backend.mojo_device.torch_mojo_tensor import get_ordered_accelerators
 from torch_mojo_backend.types import CountedCallable, MaxTensor, Scalar, SymIntType
 
-# F.functional's own stub returns Callable[..., Any] (a distributed-dispatch
-# wrapper around the graph op), incompatible with flash_attention_gpu's own
-# precise imported signature -- rebind under a new name instead of narrowing
-# the import.
-_flash_attention_gpu: Callable[..., Any] = F.functional(flash_attention_gpu)
+# F.functional's stub returns Callable[..., Any], incompatible with the
+# imported flash_attention_gpu's precise signature: rebind under a new name.
+_flash_attention_gpu: Callable[..., MaxTensor] = F.functional(flash_attention_gpu)
 
 # MAX made the `functional` reduction helpers (mean/sum/argmax/argmin and the
 # reduction forms of max/min) eager-only: they assert their input is an eager

--- a/torch_mojo_backend/aten_functions.py
+++ b/torch_mojo_backend/aten_functions.py
@@ -10,8 +10,8 @@ import functools
 import itertools
 import math
 import operator
-import os
-from typing import Literal
+from collections.abc import Callable, Sequence
+from typing import Any, Literal, TypeVar, cast
 
 import max.driver as max_driver
 import max.graph.ops as max_ops
@@ -20,23 +20,32 @@ import torch
 from max.dtype import DType
 from max.experimental import functional as F
 from max.experimental.random import gaussian as max_gaussian
+from max.experimental.tensor import Tensor as MaxEagerTensor
 from max.experimental.torch import max_dtype_to_torch
 from max.experimental.torch.torch import max_device_ref, torch_dtype_to_max
-from max.graph import Dim, StaticDim
+from max.graph import Dim, StaticDim, TensorValue
 from max.graph.type import DeviceRef
 from max.nn.attention import MHAMaskVariant
 from max.nn.kernels import flash_attention_gpu
 from torch._decomp import core_aten_decompositions
 from torch._ops import OpOverload, OpOverloadPacket
-from torch.ops import aten
+
+# torch.ops is a `_Ops` instance registered into sys.modules at runtime
+# (torch/_ops.py), not a real package on disk, so no static resolver can
+# see `torch/ops/__init__.py` or `torch/ops.py`.
+from torch.ops import aten  # ty: ignore[unresolved-import]
 
 import torch_mojo_backend.is_running_tests
 from torch_mojo_backend import custom_mojo_ops
 from torch_mojo_backend.flags import verbose_enabled
 from torch_mojo_backend.mojo_device.torch_mojo_tensor import get_ordered_accelerators
-from torch_mojo_backend.types import MaxTensor, Scalar, SymIntType
+from torch_mojo_backend.types import CountedCallable, MaxTensor, Scalar, SymIntType
 
-flash_attention_gpu = F.functional(flash_attention_gpu)
+# F.functional's own stub returns Callable[..., Any] (a distributed-dispatch
+# wrapper around the graph op), incompatible with flash_attention_gpu's own
+# precise imported signature -- rebind under a new name instead of narrowing
+# the import.
+_flash_attention_gpu: Callable[..., Any] = F.functional(flash_attention_gpu)
 
 # MAX made the `functional` reduction helpers (mean/sum/argmax/argmin and the
 # reduction forms of max/min) eager-only: they assert their input is an eager
@@ -52,6 +61,29 @@ _reduce_argmin = F.functional(max_ops.argmin)
 # F.transfer_to is eager-only (reads Tensor.real); re-wrap the graph op so it
 # also works on graph TensorValues in the torch.compile backend.
 _transfer_to = F.functional(max_ops.transfer_to)
+# F.where asserts its result is an eager Tensor; F.broadcast_to/split/sigmoid/
+# gelu are typed `Tensor`-only even though their `_impl`s already forward to
+# the dual-path graph op. Re-wrap all five the same way, both to restore
+# graph-mode support and to get a stable, precise-enough Callable[..., Any]
+# signature instead of each thin wrapper's narrower stub.
+_broadcast_to = F.functional(max_ops.broadcast_to)
+_where = F.functional(max_ops.where)
+_split = F.functional(max_ops.split)
+_sigmoid = F.functional(max_ops.sigmoid)
+_gelu = F.functional(max_ops.gelu)
+
+
+def _scalar_constant(
+    value: Scalar, *, dtype: DType, device: DeviceRef | max_driver.Device
+) -> MaxTensor:
+    """A 0-d constant from a fill/scatter-style Scalar value.
+
+    `Scalar` also covers a symbolic Dim for ops that legitimately take one
+    (e.g. shape-manipulation); a fill/scatter value is never one, and
+    F.constant only accepts a real number.
+    """
+    assert not isinstance(value, Dim)
+    return F.constant(value, dtype=dtype, device=device)
 
 
 def find_broadcast_shape(shape_a: list[Dim], shape_b: list[Dim]) -> list[Dim]:
@@ -113,8 +145,11 @@ def _only_first_output_used() -> bool:
 # Ops that need to be decomposed.
 DECOMPOSITION_TABLE = core_aten_decompositions()
 original_decomposition_table_size = len(DECOMPOSITION_TABLE)
-# Initialize the mapping dictionary
-MAPPING_TORCH_ATEN_TO_MOJO = {}
+# Initialize the mapping dictionary. Keys are heterogeneous on purpose: an
+# OpOverload/OpOverloadPacket, one of IDENTICAL_FUNCTIONS' builtins/operators,
+# or a plain custom-op name string (torch_custom_ops.make_torch_op_from_mojo)
+# — used only as opaque identity keys, never introspected.
+MAPPING_TORCH_ATEN_TO_MOJO: dict[object, Callable[..., object]] = {}
 
 
 IDENTICAL_FUNCTIONS = [
@@ -154,27 +189,34 @@ for func in IDENTICAL_FUNCTIONS:
 
 number_of_decompositions_removed = 0
 
+_F = TypeVar("_F", bound=Callable[..., object])
 
-def map_to(func):
-    def decorator(func_to_map):
-        if os.environ.get("TORCH_MOJO_BACKEND_BEARTYPE", "0") == "1":
-            from beartype import beartype
 
-            func_to_map = beartype(func_to_map)
+def map_to(func: OpOverload | OpOverloadPacket) -> Callable[[_F], _F]:
+    """Pass-through: the decorated name keeps its own signature statically
+    (so callers elsewhere in this file see e.g. `aten_mean`'s real
+    `(...) -> MaxTensor`, not a generic `Callable[..., object]`), while the
+    runtime object may be a call-counted wrapper under tests.
+    """
 
+    def decorator(func_to_map: _F) -> _F:
         # We count the number of calls here because otherwise it's hard to
         # get it with mock since the functions are all gathered at import time
         # into dicts.
         if torch_mojo_backend.is_running_tests.IS_RUNNING_TESTS:
 
-            @functools.wraps(func_to_map)
-            def wrapped_func(*args, **kwargs):
-                wrapped_func.call_count += 1
+            def wrapped_func(*args: object, **kwargs: object) -> object:
+                result.call_count += 1
                 return func_to_map(*args, **kwargs)
 
-            wrapped_func.call_count = 0
+            # functools.wraps's stub types its result as a plain callable
+            # with no room for the extra `call_count` attribute; update_wrapper
+            # does the same __name__/__doc__/__wrapped__ copy without that.
+            functools.update_wrapper(wrapped_func, func_to_map)
+            result = cast(CountedCallable, wrapped_func)
+            result.call_count = 0
 
-            MAPPING_TORCH_ATEN_TO_MOJO[func] = wrapped_func
+            MAPPING_TORCH_ATEN_TO_MOJO[func] = result
         else:
             MAPPING_TORCH_ATEN_TO_MOJO[func] = func_to_map
         if isinstance(func, OpOverload):
@@ -192,7 +234,7 @@ def map_to(func):
                 f"Expected OpOverload or OpOverloadPacket, got {type(func)}"
             )
         if torch_mojo_backend.is_running_tests.IS_RUNNING_TESTS:
-            return wrapped_func
+            return cast(_F, result)
         else:
             return func_to_map
 
@@ -202,19 +244,21 @@ def map_to(func):
 # Add direct mappings with decorators
 
 
-def get_float_dtype(x, y):
+def get_float_dtype(x: MaxTensor, y: MaxTensor) -> DType | None:
     for t in (x, y):
         if t.dtype.is_float():
             return t.dtype
+    return None
 
 
-def get_int_dtype(x, y):
+def get_int_dtype(x: MaxTensor, y: MaxTensor) -> DType | None:
     for t in (x, y):
         if t.dtype.is_integral():
             return t.dtype
+    return None
 
 
-def _materialize_dim(dim: Dim, like=None):
+def _materialize_dim(dim: Dim, like: MaxTensor | None = None) -> MaxTensor:
     """A symbolic Dim as a scalar tensor, usable in tensor arithmetic.
 
     torch treats SymInt operands like python scalars: the result keeps the
@@ -230,18 +274,26 @@ def _materialize_dim(dim: Dim, like=None):
     return t
 
 
-def type_promotion(x, y):
+def type_promotion(
+    x: MaxTensor | Scalar, y: MaxTensor | Scalar
+) -> tuple[MaxTensor | int | float, MaxTensor | int | float]:
     if isinstance(x, Dim) and isinstance(y, Dim):
         x = _materialize_dim(x)
         y = _materialize_dim(y, x)
     elif isinstance(x, Dim):
+        # A companion plain python scalar (no dtype/device to borrow) isn't
+        # a case this branch has ever handled; the isinstance/int/float
+        # check below only runs after materialization.
+        assert isinstance(y, TensorValue | MaxEagerTensor)
         x = _materialize_dim(x, y)
     elif isinstance(y, Dim):
+        assert isinstance(x, TensorValue | MaxEagerTensor)
         y = _materialize_dim(y, x)
     if isinstance(x, int | float) or isinstance(y, int | float):
         # case not handled yet
         return x, y
 
+    assert not isinstance(x, Dim) and not isinstance(y, Dim)
     float_dtype = get_float_dtype(x, y)
     int_dtype = get_int_dtype(x, y)
     if float_dtype is not None and int_dtype is not None:
@@ -269,6 +321,9 @@ def _searchsorted_tensor_dtype(left: DType, right: DType) -> DType:
 
 def _searchsorted_scalar_dtype(boundary_dtype: DType, value: Scalar) -> DType:
     """Wrapped-number promotion used by ATen's Scalar overloads."""
+    assert not isinstance(value, Dim), (
+        f"searchsorted's Scalar overload expects a number, got a Dim: {value!r}"
+    )
     promoted = torch.result_type(
         torch.empty((), dtype=max_dtype_to_torch(boundary_dtype)), value
     )
@@ -374,7 +429,7 @@ def _searchsorted_impl(
     boundary_size = sorted_sequence.shape[-1]
     if isinstance(boundary_size, StaticDim) and int(boundary_size) == 0:
         zero = F.constant(0, dtype=output_dtype, device=values.device)
-        return F.broadcast_to(zero, values.shape)
+        return _broadcast_to(zero, values.shape)
 
     values = F.unsqueeze(values, axis=-1)
     if len(sorted_sequence.shape) != 1:
@@ -405,20 +460,23 @@ def _searchsorted_impl(
     # peak memory versus an int64 mask, then cast only the reduced result.
     counts = _reduce_sum(F.cast(count_mask, dtype=DType.int32), axis=-1)
     if common_dtype.is_float():
-        counts = F.where(
+        counts = _where(
             F.equal(counts, numeric_boundary_count), total_boundary_count, counts
         )
     return F.squeeze(F.cast(counts, dtype=output_dtype), axis=-1)
 
 
 @map_to(aten.floordiv)
-def aten_floordiv(x, y):
+def aten_floordiv(x: MaxTensor, y: int | float | MaxTensor) -> MaxTensor:
     return operator.floordiv(x, y)
 
 
 # _local_scalar_dense(Tensor self) -> Scalar
 @map_to(aten._local_scalar_dense)
 def aten__local_scalar_dense(tensor: MaxTensor) -> Scalar:
+    # Extracting a concrete Python scalar is inherently an eager-only read;
+    # a graph-mode TensorValue has no runtime value to read at trace time.
+    assert isinstance(tensor, MaxEagerTensor)
     if tensor.num_elements() != 1:
         raise ValueError(
             f"_local_scalar_dense requires a tensor with a single element, got {tensor.num_elements()} elements"
@@ -439,7 +497,7 @@ def aten_all(
         dim = [dim]
     if dim is None:
         # Return True if any element is True (reduce all dimensions)
-        dim = tuple(range(len(input.shape)))
+        dim = list(range(len(input.shape)))
 
     # Handle negative dimensions
     dim = [x if x >= 0 else len(input.shape) + x for x in dim]
@@ -613,7 +671,7 @@ def aten__scaled_dot_product_attention_math(
     *,
     scale: float | None = None,
     enable_gqa: bool = False,
-):
+) -> tuple[MaxTensor, MaxTensor]:
     if dropout_mask is not None:
         raise NotImplementedError(
             "dropout_mask is not supported in aten._scaled_dot_product_attention_math yet"
@@ -630,7 +688,7 @@ def aten__scaled_dot_product_attention_math(
             def _repeat_kv(x: MaxTensor) -> MaxTensor:
                 b, h, s, d = x.shape
                 x = F.reshape(x, (b, h, 1, s, d))
-                x = F.broadcast_to(x, (b, h, group, s, d))
+                x = _broadcast_to(x, (b, h, group, s, d))
                 return F.reshape(x, (b, int(h) * group, s, d))
 
             key = _repeat_kv(key)
@@ -676,7 +734,7 @@ def aten__scaled_dot_product_efficient_attention(
     is_causal: bool = False,
     *,
     scale: float | None = None,
-):
+) -> tuple[MaxTensor, MaxTensor, None, None]:
     # The overload cuda picks for fp32 sdpa. Only `output` is consumed at
     # inference (the philox seed/offset outputs exist for dropout replay in
     # training).
@@ -706,7 +764,17 @@ def aten__scaled_dot_product_flash_attention(
     is_causal: bool = False,
     return_debug_mask: bool = False,
     scale: float | None = None,
-):
+) -> tuple[
+    MaxTensor,
+    MaxTensor,
+    MaxTensor,
+    MaxTensor,
+    Dim,
+    Dim,
+    MaxTensor,
+    MaxTensor,
+    MaxTensor,
+]:
     # We return only the first element for now because we don't support training yet.
     # PyTorch provides tensors in shape [batch, num_heads, seq_len, head_dim]
     # MAX expects tensors in shape [batch, seq_len, num_heads, head_dim]
@@ -759,7 +827,7 @@ def aten__scaled_dot_product_flash_attention(
             attn_out = F.cast(attn_out, dtype=DType.bfloat16)
     else:
         # Call flash attention on GPU.
-        attn_out = flash_attention_gpu(q, k, v, mask_variant=mask_variant, scale=scale)
+        attn_out = _flash_attention_gpu(q, k, v, mask_variant=mask_variant, scale=scale)
 
     # Transpose back to PyTorch format [batch, num_heads, seq_len, head_dim]
     result = F.permute(attn_out, [0, 2, 1, 3])
@@ -778,7 +846,7 @@ def aten__scaled_dot_product_flash_attention(
     seq_len_k_int = int(seq_len_k if isinstance(seq_len_k, Dim) else seq_len_k)
     head_dim_int = int(head_dim if isinstance(head_dim, Dim) else head_dim)
 
-    logsumexp = F.broadcast_to(
+    logsumexp = _broadcast_to(
         F.constant(0, dtype=DType.float32, device=result.device),
         [batch_size_int, num_heads_int, seq_len_int],
     )
@@ -786,10 +854,10 @@ def aten__scaled_dot_product_flash_attention(
     # cum_seq_q and cum_seq_k are cumulative sequence length vectors for packed
     # layouts; for dense attention the real backend returns None, but this backend
     # currently returns symbolic zero placeholders.
-    cum_seq_q = F.broadcast_to(
+    cum_seq_q = _broadcast_to(
         F.constant(0, dtype=DType.int32, device=result.device), [batch_size_int]
     )
-    cum_seq_k = F.broadcast_to(
+    cum_seq_k = _broadcast_to(
         F.constant(0, dtype=DType.int32, device=result.device), [batch_size_int]
     )
 
@@ -798,10 +866,10 @@ def aten__scaled_dot_product_flash_attention(
     max_k = seq_len_k
 
     # RNG state placeholders: seed + offset tensors used by flash attention kernels.
-    rng_state = F.broadcast_to(
+    rng_state = _broadcast_to(
         F.constant(0, dtype=DType.int64, device=result.device), [2]
     )
-    unused = F.broadcast_to(F.constant(0, dtype=DType.int64, device=result.device), [])
+    unused = _broadcast_to(F.constant(0, dtype=DType.int64, device=result.device), [])
 
     # debug_attn_mask is a compressed debug representation when requested; otherwise
     # it is returned as an empty tensor.
@@ -813,12 +881,12 @@ def aten__scaled_dot_product_flash_attention(
             max_seqlen_k = 2 * block_size
         else:
             max_seqlen_k = math.ceil(seq_len_k_int / block_size)
-        debug_attn_mask = F.broadcast_to(
+        debug_attn_mask = _broadcast_to(
             F.constant(0, dtype=result.dtype, device=result.device),
             [batch_size_int, num_heads_int, seq_len_int, max_seqlen_k],
         )
     else:
-        debug_attn_mask = F.broadcast_to(
+        debug_attn_mask = _broadcast_to(
             F.constant(0, dtype=result.dtype, device=result.device), []
         )
 
@@ -839,7 +907,7 @@ def aten__scaled_dot_product_flash_attention(
 
 # _softmax(Tensor self, int dim, bool half_to_float) -> Tensor
 @map_to(aten._softmax)
-def aten__softmax(self: MaxTensor, dim: int, half_to_float: bool):
+def aten__softmax(self: MaxTensor, dim: int, half_to_float: bool) -> MaxTensor:
     if half_to_float:
         dtype = torch.float32
     else:
@@ -848,7 +916,9 @@ def aten__softmax(self: MaxTensor, dim: int, half_to_float: bool):
 
 
 @map_to(aten.softmax)
-def aten_softmax(input, dim=-1, dtype=None):
+def aten_softmax(
+    input: MaxTensor, dim: int = -1, dtype: torch.dtype | None = None
+) -> MaxTensor:
     if dtype is not None:
         max_dtype = torch_dtype_to_max(dtype)
         input = F.cast(input, dtype=max_dtype)
@@ -1004,7 +1074,7 @@ def aten__to_copy(
     pin_memory: bool | None = None,
     non_blocking: bool = False,
     memory_format: torch.memory_format | None = None,
-):
+) -> MaxTensor:
     result = tensor
     if device is not None:
         result = _transfer_to(result, torch_device_to_max_device(device))
@@ -1015,7 +1085,7 @@ def aten__to_copy(
 
 # abs(Tensor self) -> Tensor
 @map_to(aten.abs)
-def aten_abs(x: MaxTensor):
+def aten_abs(x: MaxTensor) -> MaxTensor:
     return F.abs(x)
 
 
@@ -1033,7 +1103,7 @@ def aten_acos(x: MaxTensor) -> MaxTensor:
     Returns:
         Arccosine of the input in radians [0, π]
     """
-    # Create constants as tensors for use in F.where()
+    # Create constants as tensors for use in _where()
     zero = F.constant(0.0, dtype=x.dtype, device=x.device)
     one = F.constant(1.0, dtype=x.dtype, device=x.device)
     neg_one = F.constant(-1.0, dtype=x.dtype, device=x.device)
@@ -1050,15 +1120,15 @@ def aten_acos(x: MaxTensor) -> MaxTensor:
     # Large domain: x_squared = (1 - |x|) / 2, d = sqrt(x_squared)
     x_squared_small = x_clamped * x_clamped
     x_squared_large = (1.0 - x_abs) * 0.5
-    x_squared = F.where(small_domain, x_squared_small, x_squared_large)
+    x_squared = _where(small_domain, x_squared_small, x_squared_large)
 
     d_small = x_abs
     d_large = F.sqrt(x_squared_large)
-    d = F.where(small_domain, d_small, d_large)
+    d = _where(small_domain, d_small, d_large)
 
     # Handle special case |x| = 1 (d should be 0)
     is_one = x_abs >= 1.0
-    d = F.where(is_one, zero, d)
+    d = _where(is_one, zero, d)
 
     # Polynomial evaluation using Horner's method
     # Coefficients from Mojo stdlib (Remez approximation)
@@ -1072,7 +1142,7 @@ def aten_acos(x: MaxTensor) -> MaxTensor:
     # Small domain: π/2 - (d + poly) with sign preservation
     # copysign(d, x) is implemented as d * sign(x)
     is_negative = x_clamped < 0.0
-    sign_x = F.where(is_negative, neg_one, one)
+    sign_x = _where(is_negative, neg_one, one)
     d_signed = d * sign_x
     poly_signed = poly * sign_x
     result_small = (math.pi * 0.5) - (d_signed + poly_signed)
@@ -1081,10 +1151,10 @@ def aten_acos(x: MaxTensor) -> MaxTensor:
     result_large = 2.0 * (d + poly)
 
     # For large domain with negative x: π - result
-    result_large = F.where(is_negative, math.pi - result_large, result_large)
+    result_large = _where(is_negative, math.pi - result_large, result_large)
 
     # Select based on domain
-    result = F.where(small_domain, result_small, result_large)
+    result = _where(small_domain, result_small, result_large)
 
     return result
 
@@ -1096,11 +1166,18 @@ def aten_acos(x: MaxTensor) -> MaxTensor:
 # add.Scalar(Tensor self, Scalar other, Scalar alpha=1) -> Tensor
 # add.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor
 @map_to(aten.add)
-def aten_add(input: MaxTensor, other: MaxTensor | Scalar, alpha: Scalar = 1):
-    input, other = type_promotion(input, other)
+def aten_add(
+    input: MaxTensor, other: MaxTensor | Scalar, alpha: Scalar = 1
+) -> MaxTensor:
+    promoted_input, promoted_other = type_promotion(input, other)
+    # input is always a genuine Tensor per both ATen overloads, and
+    # type_promotion only ever replaces a Dim operand or casts a tensor's
+    # dtype -- never turns a MaxTensor into a plain Scalar.
+    assert isinstance(promoted_input, TensorValue | MaxEagerTensor)
+    assert isinstance(promoted_other, TensorValue | MaxEagerTensor)
     if alpha != 1:
-        other = aten_mul(other, alpha)
-    return input + other
+        promoted_other = aten_mul(promoted_other, alpha)
+    return promoted_input + promoted_other
 
 
 # addcdiv(Tensor self, Tensor tensor1, Tensor tensor2, *, Scalar value=1) -> Tensor
@@ -1222,9 +1299,9 @@ def aten_any(
 
     if dim is None:
         # Return True if any element is True (reduce all dimensions)
-        dim = tuple(range(len(input.shape)))
+        dim = list(range(len(input.shape)))
     elif isinstance(dim, int):
-        dim = (dim,)
+        dim = [dim]
 
     # Handle negative dimensions
     dim = [x if x >= 0 else len(input.shape) + x for x in dim]
@@ -1266,11 +1343,11 @@ def aten_arange(
         raise ValueError("We don't support float end values for torch.arange")
     if dtype is None:
         dtype = torch.int64
-    dtype = torch_dtype_to_max(dtype)
+    max_dtype = torch_dtype_to_max(dtype)
 
     if device is None:
         device = torch.get_default_device()
-    device = torch_device_to_max_device(device)
+    max_device = torch_device_to_max_device(device)
 
     if end is None:
         # Single argument form: torch.arange(end)
@@ -1281,6 +1358,9 @@ def aten_arange(
     # The length is ceil((end - start) / step) as per PyTorch docs
     out_dim = end - start
     if step != 1:
+        # Dim only supports floor division; a non-default step forces a
+        # concrete (non-symbolic) start/end/step anyway to compute this.
+        assert isinstance(out_dim, int) and isinstance(step, int)
         out_dim = int(math.ceil(out_dim / step))
 
     # Use F.range to create the sequence
@@ -1289,12 +1369,12 @@ def aten_arange(
         Dim(end),
         Dim(step),
         out_dim=Dim(out_dim),
-        device=device,
-        dtype=dtype,
+        device=max_device,
+        dtype=max_dtype,
     )
     # TODO: Remove this when the bug is addressed in MAX, range doesn't produce the correct dtype
     # https://github.com/modular/modular/issues/5178
-    return F.cast(result, dtype=dtype)
+    return F.cast(result, dtype=max_dtype)
 
 
 # argmax(Tensor self, int? dim=None, bool keepdim=False) -> Tensor
@@ -1450,7 +1530,7 @@ def aten_avg_pool2d(
     ceil_mode: bool = False,
     count_include_pad: bool = True,
     divisor_override: int | None = None,
-):
+) -> MaxTensor:
     """
     Applies a 2D average pooling over an input signal composed of several input planes.
 
@@ -1470,25 +1550,18 @@ def aten_avg_pool2d(
     if stride is None:
         stride = kernel_size
 
-    # Ensure kernel_size, stride, and padding are tuples
-    if isinstance(kernel_size, int):
-        kernel_size = (kernel_size, kernel_size)
-    elif isinstance(kernel_size, list):
-        kernel_size = tuple(kernel_size)
-
-    if isinstance(stride, int):
-        stride = (stride, stride)
-    elif isinstance(stride, list):
-        stride = tuple(stride)
-
-    if isinstance(padding, int):
-        padding = (padding, padding)
-    elif isinstance(padding, list):
-        padding = tuple(padding)
+    # Ensure kernel_size, stride, and padding are tuples (F.avg_pool2d's shape)
+    kernel_size_hw = (
+        (kernel_size, kernel_size)
+        if isinstance(kernel_size, int)
+        else tuple(kernel_size)
+    )
+    stride_hw = (stride, stride) if isinstance(stride, int) else tuple(stride)
+    padding_hw = (padding, padding) if isinstance(padding, int) else tuple(padding)
 
     # Convert padding from PyTorch format (pad_h, pad_w) to MAX format (pad_h_before, pad_h_after, pad_w_before, pad_w_after)
-    if len(padding) == 2:
-        padding = (padding[0], padding[0], padding[1], padding[1])
+    if len(padding_hw) == 2:
+        padding_hw = (padding_hw[0], padding_hw[0], padding_hw[1], padding_hw[1])
 
     # Convert input from NCHW (PyTorch default) to NHWC (MAX requirement)
     input_nhwc = input.permute([0, 2, 3, 1])
@@ -1496,9 +1569,9 @@ def aten_avg_pool2d(
     # Apply average pooling using MAX
     result = F.avg_pool2d(
         input_nhwc,
-        kernel_size=kernel_size,
-        stride=stride,
-        padding=padding,
+        kernel_size=kernel_size_hw,
+        stride=stride_hw,
+        padding=padding_hw,
         ceil_mode=ceil_mode,
         count_boundary=count_include_pad,
     )
@@ -1523,8 +1596,8 @@ def aten_bitwise_and(input: MaxTensor, other: MaxTensor) -> MaxTensor:
     # For the moment we only support tensors of the same dimension
 
     final_shape = find_broadcast_shape(input.shape, other.shape)
-    input = F.broadcast_to(input, final_shape)
-    other = F.broadcast_to(other, final_shape)
+    input = _broadcast_to(input, final_shape)
+    other = _broadcast_to(other, final_shape)
 
     return custom_mojo_ops.bitwise_and(input, other)
 
@@ -1547,8 +1620,8 @@ def aten_bitwise_or(input: MaxTensor, other: MaxTensor) -> MaxTensor:
     # For the moment we only support tensors of the same dimension
 
     final_shape = find_broadcast_shape(input.shape, other.shape)
-    input = F.broadcast_to(input, final_shape)
-    other = F.broadcast_to(other, final_shape)
+    input = _broadcast_to(input, final_shape)
+    other = _broadcast_to(other, final_shape)
 
     return custom_mojo_ops.bitwise_or(input, other)
 
@@ -1565,8 +1638,8 @@ def aten_bitwise_xor(input: MaxTensor, other: MaxTensor) -> MaxTensor:
     # For the moment we only support tensors of the same dimension
 
     final_shape = find_broadcast_shape(input.shape, other.shape)
-    input = F.broadcast_to(input, final_shape)
-    other = F.broadcast_to(other, final_shape)
+    input = _broadcast_to(input, final_shape)
+    other = _broadcast_to(other, final_shape)
 
     return custom_mojo_ops.bitwise_xor(input, other)
 
@@ -1684,7 +1757,16 @@ def aten_clone(
 def aten_constant_pad_nd(
     input: MaxTensor, pad: list[int | Dim], value: Scalar = 0
 ) -> MaxTensor:
-    if any(isinstance(p, int) and p < 0 for p in pad):
+    # max_ops.pad wants concrete ints; a symbolic (non-static) pad amount
+    # can't be resolved at graph-build time.
+    pad_ints: list[int] = []
+    for p in pad:
+        if isinstance(p, int):
+            pad_ints.append(p)
+        else:
+            assert isinstance(p, StaticDim), f"expected a static pad amount, got {p!r}"
+            pad_ints.append(p.dim)
+    if any(p < 0 for p in pad_ints):
         raise NotImplementedError(
             "constant_pad_nd with negative padding (cropping) is not supported yet"
         )
@@ -1693,10 +1775,10 @@ def aten_constant_pad_nd(
     # dims in forward order: [before_dim0, after_dim0, before_dim1, ...].
     rank = len(input.shape)
     paddings = [0] * (2 * rank)
-    for i in range(len(pad) // 2):
+    for i in range(len(pad_ints) // 2):
         dim = rank - 1 - i
-        paddings[2 * dim] = pad[2 * i]
-        paddings[2 * dim + 1] = pad[2 * i + 1]
+        paddings[2 * dim] = pad_ints[2 * i]
+        paddings[2 * dim + 1] = pad_ints[2 * i + 1]
     return max_ops.pad(input, paddings, mode="constant", value=value)
 
 
@@ -1709,25 +1791,37 @@ def _add_bias_transposed(
     return result
 
 
-def _normalize_2d_params(stride, padding, dilation, output_padding):
-    if isinstance(stride, int):
-        stride = (stride, stride)
+def _normalize_2d_params(
+    stride: int | Sequence[SymIntType],
+    padding: int | Sequence[SymIntType],
+    dilation: int | Sequence[SymIntType],
+    output_padding: int | Sequence[SymIntType],
+) -> tuple[
+    tuple[SymIntType, SymIntType],
+    tuple[SymIntType, SymIntType, SymIntType, SymIntType],
+    tuple[SymIntType, SymIntType],
+    tuple[SymIntType, SymIntType],
+]:
+    stride = (stride, stride) if isinstance(stride, int) else (stride[0], stride[1])
     if isinstance(padding, int):
         padding = (padding, padding, padding, padding)
     elif isinstance(padding, tuple | list) and len(padding) == 2:
         padding = (padding[0], padding[0], padding[1], padding[1])
     elif isinstance(padding, tuple | list) and len(padding) == 4:
-        padding = tuple(padding)
+        padding = (padding[0], padding[1], padding[2], padding[3])
     elif isinstance(padding, str):
         raise ValueError("Padding must be an int or a tuple of ints.")
     else:
         raise ValueError(f"Unsupported padding length: {len(padding)}")
-    if isinstance(dilation, int):
-        dilation = (dilation, dilation)
+    dilation = (
+        (dilation, dilation)
+        if isinstance(dilation, int)
+        else (dilation[0], dilation[1])
+    )
     if isinstance(output_padding, int):
         output_padding = (output_padding, output_padding)
     elif isinstance(output_padding, tuple | list) and len(output_padding) == 2:
-        output_padding = tuple(output_padding)
+        output_padding = (output_padding[0], output_padding[1])
     else:
         output_padding = (0, 0)
     return stride, padding, dilation, output_padding
@@ -1765,8 +1859,8 @@ def aten_convolution(
             raise ValueError(
                 f"Weight dim 0 ({weight_in}) must be divisible by groups ({groups})."
             )
-        input_groups = F.split(input, [in_channels // groups] * groups, axis=1)
-        weight_groups = F.split(weight, [weight_in // groups] * groups, axis=0)
+        input_groups = _split(input, [in_channels // groups] * groups, axis=1)
+        weight_groups = _split(weight, [weight_in // groups] * groups, axis=0)
         partial_results = [
             aten_convolution(
                 input_group,
@@ -1838,7 +1932,7 @@ def aten_convolution(
         return _add_bias_transposed(transposed, result_ncl, bias, [1])
 
     elif input_rank == 4:
-        stride, padding, dilation, output_padding = _normalize_2d_params(
+        stride_2d, padding_2d, dilation_2d, output_padding_2d = _normalize_2d_params(
             stride, padding, dilation, output_padding
         )
         input_nhwc = input.permute([0, 2, 3, 1])
@@ -1849,10 +1943,10 @@ def aten_convolution(
                 input_nhwc,
                 weight_rscf,
                 bias=None,
-                stride=stride,
-                padding=padding,
-                dilation=dilation,
-                output_paddings=output_padding,
+                stride=stride_2d,
+                padding=padding_2d,
+                dilation=dilation_2d,
+                output_paddings=output_padding_2d,
                 input_layout=max_type.ConvInputLayout.NHWC,
                 filter_layout=max_type.FilterLayout.RSCF,
             )
@@ -1861,9 +1955,9 @@ def aten_convolution(
                 input_nhwc,
                 weight_rscf,
                 bias=bias,
-                stride=stride,
-                padding=padding,
-                dilation=dilation,
+                stride=stride_2d,
+                padding=padding_2d,
+                dilation=dilation_2d,
                 groups=groups,
                 input_layout=max_type.ConvInputLayout.NHWC,
                 filter_layout=max_type.FilterLayout.RSCF,
@@ -1963,7 +2057,7 @@ def aten_embedding(
     padding_idx: SymIntType = -1,
     scale_grad_by_freq: bool = False,
     sparse: bool = False,
-):
+) -> MaxTensor:
     # For some reason with aten, input and weight are inverted.
     return torch_embedding_equivalent(
         weight,
@@ -1976,13 +2070,13 @@ def aten_embedding(
 
 
 def torch_embedding_equivalent(
-    input,
-    weight,
-    padding_idx=None,
-    max_norm=None,
-    scale_grad_by_freq=False,
-    sparse=False,
-):
+    input: MaxTensor,
+    weight: MaxTensor,
+    padding_idx: SymIntType | None = None,
+    max_norm: float | None = None,
+    scale_grad_by_freq: bool = False,
+    sparse: bool = False,
+) -> MaxTensor:
     if max_norm is not None:
         raise NotImplementedError(
             "max_norm is not supported yet in this embedding implementation"
@@ -2127,7 +2221,7 @@ def aten_expand(
         else:
             target_shape.append(dim_size)
 
-    return F.broadcast_to(tensor, target_shape)
+    return _broadcast_to(tensor, target_shape)
 
 
 # expm1(Tensor self) -> Tensor
@@ -2144,10 +2238,10 @@ def aten_fill_scalar(input: MaxTensor, value: Scalar) -> MaxTensor:
     target_shape = input.shape
 
     # Create a scalar constant with the fill value
-    scalar = F.constant(value, dtype=target_dtype, device=target_device)
+    scalar = _scalar_constant(value, dtype=target_dtype, device=target_device)
 
     # Broadcast the scalar to the target shape
-    return F.broadcast_to(scalar, target_shape)
+    return _broadcast_to(scalar, target_shape)
 
 
 # fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)
@@ -2183,18 +2277,18 @@ def aten_full(
     layout: torch.layout | None = None,
     device: torch.device | None = None,
     pin_memory: bool | None = None,
-):
+) -> MaxTensor:
     if dtype is None:
         dtype = torch.float32
-    dtype = torch_dtype_to_max(dtype)
+    target_dtype = torch_dtype_to_max(dtype)
 
     if device is None:
         device = torch.get_default_device()
-    device = torch_device_to_max_device(device)
+    target_device = torch_device_to_max_device(device)
 
     # Create a scalar constant with the fill value
-    scalar = F.constant(fill_value, dtype=dtype, device=device)
-    return F.broadcast_to(scalar, size)
+    scalar = _scalar_constant(fill_value, dtype=target_dtype, device=target_device)
+    return _broadcast_to(scalar, size)
 
 
 # full_like(Tensor self, Scalar fill_value, *, ScalarType? dtype=None, Layout? layout=None, Device? device=None, bool? pin_memory=None, MemoryFormat? memory_format=None) -> Tensor
@@ -2225,8 +2319,8 @@ def aten_full_like(
     target_shape = input.shape
 
     # Create a scalar constant with the fill value
-    scalar = F.constant(fill_value, dtype=target_dtype, device=target_device)
-    return F.broadcast_to(scalar, target_shape)
+    scalar = _scalar_constant(fill_value, dtype=target_dtype, device=target_device)
+    return _broadcast_to(scalar, target_shape)
 
 
 # gather(Tensor self, int dim, Tensor index, *, bool sparse_grad=False) -> Tensor
@@ -2244,7 +2338,7 @@ def aten_ge(input: MaxTensor, other: MaxTensor | Scalar) -> MaxTensor:
 def aten_gelu(
     input: MaxTensor, approximate: Literal["tanh", "none"] = "none"
 ) -> MaxTensor:
-    return F.gelu(input, approximate=approximate)
+    return _gelu(input, approximate=approximate)
 
 
 # gelu_backward(Tensor grad_output, Tensor self, *, str approximate='none') -> Tensor
@@ -2288,7 +2382,7 @@ def aten_gelu_backward(
 # gt.Scalar(Tensor self, Scalar other) -> Tensor
 # gt.Tensor(Tensor self, Tensor other) -> Tensor
 @map_to(aten.gt)
-def aten_gt(x: MaxTensor, y: Scalar | MaxTensor) -> MaxTensor:
+def aten_gt(x: MaxTensor, y: int | float | MaxTensor) -> MaxTensor:
     return operator.gt(x, y)
 
 
@@ -2318,7 +2412,10 @@ def aten_index(input: MaxTensor, indices: list[MaxTensor | None]) -> MaxTensor:
             i += 1
         end = i
 
-        block_tensors = indices[start:end]
+        # The while-loop above only advances past non-None entries, so this
+        # slice never actually holds a None -- narrow it explicitly.
+        block_tensors = [t for t in indices[start:end] if t is not None]
+        assert len(block_tensors) == end - start
 
         if end - start == 1:
             # Single-axis indexing — use gather
@@ -2329,14 +2426,14 @@ def aten_index(input: MaxTensor, indices: list[MaxTensor | None]) -> MaxTensor:
             # First broadcast indices to same shape
             final_shape = broadcast_shape([t.shape for t in block_tensors])
 
-            b_indices = [F.broadcast_to(t, final_shape) for t in block_tensors]
+            b_indices = [_broadcast_to(t, final_shape) for t in block_tensors]
 
             # Stack into shape [..., num_axes]
             stacked = F.stack(b_indices, axis=-1)
 
             # We still have to broadcast them so that they match the starting dimensions
             for j in range(start - 1, -1, -1):
-                stacked = F.broadcast_to(
+                stacked = _broadcast_to(
                     stacked[None, ...], [input.shape[j]] + list(stacked.shape)
                 )
 
@@ -2346,14 +2443,17 @@ def aten_index(input: MaxTensor, indices: list[MaxTensor | None]) -> MaxTensor:
     return result
 
 
-def broadcast_shape(shapes):
+def broadcast_shape(
+    shapes: Sequence[MaxTensor | Sequence[int | Dim]],
+) -> list[int | Dim]:
     # Normalize: extract raw tuples/lists of dims
-    norm_shapes = []
+    norm_shapes: list[list[int | Dim]] = []
     for s in shapes:
-        if hasattr(s, "shape"):
-            s = s.shape
+        dims: Sequence[int | Dim] = (
+            s.shape if isinstance(s, TensorValue | MaxEagerTensor) else s
+        )
         # convert Shape-like to list if needed
-        norm_shapes.append(list(s))
+        norm_shapes.append(list(dims))
 
     if not norm_shapes:
         return []
@@ -2366,7 +2466,7 @@ def broadcast_shape(shapes):
         padded.append(pad + list(s))
 
     # Helper: recognize "dimension == 1"
-    def is_one(d):
+    def is_one(d: int | Dim) -> bool:
         # Covers ints == 1 and Dim-like objects that compare equal to 1
         return d == 1
 
@@ -2520,7 +2620,7 @@ def aten_linear_backward(
 
     def zeros(shape: list[Dim] | tuple[Dim, ...]) -> MaxTensor:
         zero = F.constant(0, dtype=grad_output.dtype, device=grad_output.device)
-        return F.broadcast_to(zero, shape)
+        return _broadcast_to(zero, shape)
 
     grad_input = None
     if mask[0]:
@@ -2681,32 +2781,36 @@ def aten_max(
 # max_pool2d_with_indices(Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, int[2] dilation=1, bool ceil_mode=False) -> (Tensor, Tensor)
 @map_to(aten.max_pool2d_with_indices)
 def aten_max_pool2d_with_indices(
-    input, kernel_size, stride=None, padding=0, dilation=1, ceil_mode=False
+    input: MaxTensor,
+    kernel_size: list[int] | int,
+    stride: list[int] | int | None = None,
+    padding: list[int] | int = 0,
+    dilation: list[int] | int = 1,
+    ceil_mode: bool = False,
 ) -> tuple[MaxTensor, MaxTensor]:
     # the first output is the values, the second output is the indices
     # most of the time people just want the values so we'll implement that
     # for now.
-    if not stride:
-        stride = kernel_size
+    stride = stride or kernel_size
 
-    if isinstance(kernel_size, int):
-        kernel_size = (kernel_size, kernel_size)
-    if isinstance(stride, int):
-        stride = (stride, stride)
-    if isinstance(padding, int):
-        padding = (padding, padding)
-    if isinstance(dilation, int):
-        dilation = (dilation, dilation)
+    kernel_size_hw = (
+        (kernel_size, kernel_size)
+        if isinstance(kernel_size, int)
+        else tuple(kernel_size)
+    )
+    stride_hw = (stride, stride) if isinstance(stride, int) else tuple(stride)
+    padding_hw = (padding, padding) if isinstance(padding, int) else tuple(padding)
+    dilation_hw = (dilation, dilation) if isinstance(dilation, int) else tuple(dilation)
 
     # Convert input from NCHW (PyTorch default) to NHWC (MAX requirement)
     input_nhwc = input.permute([0, 2, 3, 1])
 
     result = F.max_pool2d(
         input_nhwc,
-        kernel_size=kernel_size,
-        stride=tuple(stride),
-        padding=tuple(padding),
-        dilation=tuple(dilation),
+        kernel_size=kernel_size_hw,
+        stride=stride_hw,
+        padding=padding_hw,
+        dilation=dilation_hw,
         ceil_mode=ceil_mode,
     )
 
@@ -2736,7 +2840,7 @@ def aten_maximum(x: MaxTensor, y: MaxTensor) -> MaxTensor:
 @map_to(aten.mean)
 def aten_mean(
     input: MaxTensor,
-    dim=None,
+    dim: Sequence[int] | int | None = None,
     keepdim: bool = False,
     *,
     dtype: torch.dtype | None = None,
@@ -2748,9 +2852,9 @@ def aten_mean(
     result = input
 
     if dim is None:
-        dim = tuple(range(len(input.shape)))
+        dim = list(range(len(input.shape)))
     elif isinstance(dim, int):
-        dim = (dim,)
+        dim = [dim]
 
     dim = [x if x >= 0 else len(input.shape) + x for x in dim]
 
@@ -2774,7 +2878,7 @@ def aten_mean(
 @map_to(aten.mean.out)
 def aten_mean_out(
     input: MaxTensor,
-    dim,
+    dim: Sequence[int] | int | None,
     keepdim: bool = False,
     *,
     dtype: torch.dtype | None = None,
@@ -2818,11 +2922,17 @@ def aten_mm(x: MaxTensor, y: MaxTensor) -> MaxTensor:
 # mul.Tensor(Tensor self, Tensor other) -> Tensor
 @map_to(aten.mul)
 def aten_mul(input: MaxTensor, other: MaxTensor | Scalar) -> MaxTensor:
-    input, other = type_promotion(input, other)
-    if input.dtype == DType.bool and getattr(other, "dtype", None) == DType.bool:
+    promoted_input, other = type_promotion(input, other)
+    # input is always a genuine Tensor per both ATen overloads; type_promotion
+    # only ever replaces a Dim operand or casts a tensor's dtype.
+    assert isinstance(promoted_input, TensorValue | MaxEagerTensor)
+    if (
+        promoted_input.dtype == DType.bool
+        and getattr(other, "dtype", None) == DType.bool
+    ):
         # MAX's mul doesn't lower for bool; torch defines it as logical AND.
-        return F.logical_and(input, other)
-    return input * other
+        return F.logical_and(promoted_input, other)
+    return promoted_input * other
 
 
 # native_batch_norm(Tensor input, Tensor? weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float momentum, float eps) -> (Tensor, Tensor, Tensor)
@@ -2954,7 +3064,13 @@ def aten_native_group_norm(
     )
 
 
-def torch_group_norm_equivalent(input, num_groups, weight=None, bias=None, eps=1e-5):
+def torch_group_norm_equivalent(
+    input: MaxTensor,
+    num_groups: int,
+    weight: MaxTensor | None = None,
+    bias: MaxTensor | None = None,
+    eps: float = 1e-5,
+) -> MaxTensor:
     # input shape: [N, C, H, W]
     N, C, H, W = input.shape
 
@@ -3025,7 +3141,10 @@ def aten_native_layer_norm(
         and weight is not None
         and bias is not None
         and _only_first_output_used()
+        and isinstance(input, TensorValue)
     ):
+        # max_ops.layer_norm is graph-only (TensorValue); the eager
+        # interpreter path falls through to the generic reduction below.
         return max_ops.layer_norm(input, weight, bias, eps), None, None
 
     # Layer norm normalizes over the last len(normalized_shape) dimensions
@@ -3054,12 +3173,18 @@ def aten_native_layer_norm(
 # normal_(Tensor(a!) self, float mean=0, float std=1, *, Generator? generator=None) -> Tensor(a!)
 @map_to(aten.normal_)
 def aten_normal_(
-    self: MaxTensor, mean: float = 0.0, std: float = 1.0, generator=None
+    self: MaxTensor,
+    mean: float = 0.0,
+    std: float = 1.0,
+    generator: torch.Generator | None = None,
 ) -> MaxTensor:
     if generator is not None:
         raise NotImplementedError(
             "aten::normal_ does not support the generator argument"
         )
+    # max_gaussian samples eagerly onto a concrete device; it has no
+    # graph-mode (DeviceRef) counterpart here.
+    assert isinstance(self.device, max_driver.Device)
     return max_gaussian(
         self.shape, mean=mean, std=std, dtype=self.dtype, device=self.device
     )
@@ -3190,9 +3315,9 @@ def aten_rsqrt(x: MaxTensor) -> MaxTensor:
 @map_to(aten.scalar_tensor)
 def aten_scalar_tensor(
     value: float | int,
-    dtype: torch.dtype = None,
-    layout: torch.layout = None,
-    device: torch.device = None,
+    dtype: torch.dtype | None = None,
+    layout: torch.layout | None = None,
+    device: torch.device | None = None,
 ) -> MaxTensor:
     if dtype is None:
         dtype = torch.float32
@@ -3221,7 +3346,7 @@ def aten_scaled_dot_product_attention(
     if attn_mask is not None and attn_mask.dtype == DType.bool:
         neg_inf = F.constant(float("-inf"), dtype=query.dtype, device=query.device)
         zero = F.constant(0.0, dtype=query.dtype, device=query.device)
-        attn_mask = F.where(attn_mask, zero, neg_inf)
+        attn_mask = _where(attn_mask, zero, neg_inf)
 
     query_device = query.device
     is_gpu = (
@@ -3298,8 +3423,8 @@ def aten_scatter_value(
     """
     # Broadcast the scalar value to match the index shape
     # We need to create a tensor filled with the value in the same shape as index
-    updates = F.broadcast_to(
-        F.constant(value, dtype=input.dtype, device=input.device), index.shape
+    updates = _broadcast_to(
+        _scalar_constant(value, dtype=input.dtype, device=input.device), index.shape
     )
     return F.scatter(input, updates, index, axis=dim)
 
@@ -3337,7 +3462,7 @@ def aten_select(input: MaxTensor, dim: int, index: SymIntType) -> MaxTensor:
     Equivalent to torch.select - selects a slice of the tensor along the given dimension at the given index.
     """
     nb_dims = len(input.shape)
-    slices = [slice(None)] * nb_dims
+    slices: list[slice | SymIntType] = [slice(None)] * nb_dims
     slices[dim] = index
     return input[slices]
 
@@ -3365,6 +3490,9 @@ def aten_select_scatter(
 
     # Handle negative index
     dim_size = input.shape[dim]
+    assert isinstance(dim_size, StaticDim), (
+        f"select_scatter requires a static size for dim {dim}, got {dim_size!r}"
+    )
     if index < 0:
         index = index + dim_size.dim
 
@@ -3382,22 +3510,22 @@ def aten_select_scatter(
     mask = F.reshape(mask_1d, mask_shape)
 
     # Step 4: Broadcast mask to input's shape
-    mask_expanded = F.broadcast_to(mask, input.shape)
+    mask_expanded = _broadcast_to(mask, input.shape)
 
     # Step 5: Unsqueeze src to add back the dimension
     src_unsqueezed = F.unsqueeze(src, dim)
 
     # Step 6: Broadcast src to match input's shape
-    src_expanded = F.broadcast_to(src_unsqueezed, input.shape)
+    src_expanded = _broadcast_to(src_unsqueezed, input.shape)
 
     # Step 7: Use where to select: where mask is True, use src, else use input
-    return F.where(mask_expanded, src_expanded, input)
+    return _where(mask_expanded, src_expanded, input)
 
 
 # sigmoid(Tensor self) -> Tensor
 @map_to(aten.sigmoid)
 def aten_sigmoid(input: MaxTensor) -> MaxTensor:
-    return F.sigmoid(input)
+    return _sigmoid(input)
 
 
 # sign(Tensor self) -> Tensor
@@ -3413,7 +3541,7 @@ def aten_sign(x: MaxTensor) -> MaxTensor:
 # silu(Tensor self) -> Tensor
 @map_to(aten.silu)
 def aten_silu(input: MaxTensor) -> MaxTensor:
-    return input * F.sigmoid(input)
+    return input * _sigmoid(input)
 
 
 # sin(Tensor self) -> Tensor
@@ -3501,12 +3629,16 @@ def aten_squeeze(input: MaxTensor, dim: int | list[int]) -> MaxTensor:
 # sub.Tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor
 @map_to(aten.sub)
 def aten_sub(
-    input: MaxTensor | int | float, other: MaxTensor | Scalar, alpha: Scalar = 1
+    input: MaxTensor, other: MaxTensor | Scalar, alpha: Scalar = 1
 ) -> MaxTensor:
-    input, other = type_promotion(input, other)
+    promoted_input, other = type_promotion(input, other)
+    # input is always a genuine Tensor per both ATen overloads; type_promotion
+    # only ever replaces a Dim operand or casts a tensor's dtype.
+    assert isinstance(promoted_input, TensorValue | MaxEagerTensor)
     if alpha != 1:
+        assert isinstance(other, TensorValue | MaxEagerTensor)
         other = aten_mul(other, alpha)
-    return input - other
+    return promoted_input - other
 
 
 # sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor
@@ -3529,9 +3661,9 @@ def aten_sum(
     result = input
 
     if not dim:
-        dim = tuple(range(len(input.shape)))
+        dim = list(range(len(input.shape)))
     elif isinstance(dim, int):
-        dim = (dim,)
+        dim = [dim]
 
     dim = [x if x >= 0 else len(input.shape) + x for x in dim]
 
@@ -3619,7 +3751,9 @@ def aten_var(
 
 # view(Tensor(a) self, SymInt[] size) -> Tensor(a)
 @map_to(aten.view)
-def aten_view(tensor: MaxTensor, *shape) -> MaxTensor:
+def aten_view(
+    tensor: MaxTensor, *shape: SymIntType | Sequence[SymIntType]
+) -> MaxTensor:
     if len(shape) == 1 and isinstance(shape[0], tuple | list):
         target_shape = list(shape[0])
     else:
@@ -3631,14 +3765,16 @@ def aten_view(tensor: MaxTensor, *shape) -> MaxTensor:
 # Same as view but skips the safety check on strides. Used internally by PyTorch
 # in decompositions (e.g. matmul 3D×2D) where the view is known to be valid.
 @map_to(aten._unsafe_view)
-def aten__unsafe_view(tensor: MaxTensor, *shape) -> MaxTensor:
+def aten__unsafe_view(
+    tensor: MaxTensor, *shape: SymIntType | Sequence[SymIntType]
+) -> MaxTensor:
     return aten_view(tensor, *shape)
 
 
 # where.self(Tensor condition, Tensor self, Tensor other) -> Tensor
 @map_to(aten.where)
 def aten_where(input: MaxTensor, condition: MaxTensor, other: MaxTensor) -> MaxTensor:
-    return F.where(input, condition, other)
+    return _where(input, condition, other)
 
 
 # stack(Tensor[] tensors, int dim=0) -> Tensor
@@ -3784,7 +3920,7 @@ def aten_split(
             new_split_size.append(shape % split_size)
     else:
         new_split_size = split_size
-    return F.split(input, new_split_size, dim)
+    return _split(input, new_split_size, dim)
 
 
 @map_to(aten.unbind)
@@ -3801,7 +3937,7 @@ def aten_unbind(input: MaxTensor, dim: int = 0) -> list[MaxTensor]:
 
     # Use split with size 1 to get individual slices, then squeeze
     split_sizes = [1] * size
-    split_tensors = F.split(input, split_sizes, dim)
+    split_tensors = _split(input, split_sizes, dim)
 
     # Squeeze each tensor to remove the dimension we split along
     result = []
@@ -3825,7 +3961,7 @@ def aten_t(input: MaxTensor) -> MaxTensor:
     return torch_transpose_equivalent(input, 0, 1)
 
 
-def torch_transpose_equivalent(tensor, dim0, dim1):
+def torch_transpose_equivalent(tensor: MaxTensor, dim0: int, dim1: int) -> MaxTensor:
     # Get the current tensor dimensions
     ndim = len(tensor.shape)
 
@@ -3859,9 +3995,7 @@ def torch_transpose_equivalent(tensor, dim0, dim1):
 # _foreach_add.Scalar(Tensor[] self, Scalar scalar) -> Tensor[]
 @map_to(aten._foreach_add.Scalar)
 def aten__foreach_add_scalar(
-    self: list[MaxTensor],
-    other: Scalar | list[MaxTensor] | list[Scalar] | MaxTensor,
-    alpha: Scalar = 1,
+    self: list[MaxTensor], other: Scalar, alpha: Scalar = 1
 ) -> list[MaxTensor]:
     return [aten_add(x, other, alpha=alpha) for x in self]
 
@@ -3869,7 +4003,7 @@ def aten__foreach_add_scalar(
 # _foreach_add.ScalarList(Tensor[] self, Scalar[] scalars) -> Tensor[]
 @map_to(aten._foreach_add.ScalarList)
 def aten__foreach_add_scalar_list(
-    self: list[MaxTensor], other: Scalar | list[MaxTensor] | list[Scalar] | MaxTensor
+    self: list[MaxTensor], other: list[Scalar]
 ) -> list[MaxTensor]:
     if len(self) != len(other):
         raise ValueError(
@@ -3901,9 +4035,7 @@ def aten__foreach_add_list(
 # _foreach_sub.Scalar(Tensor[] self, Scalar scalar) -> Tensor[]
 @map_to(aten._foreach_sub.Scalar)
 def aten__foreach_sub_scalar(
-    self: list[MaxTensor],
-    other: Scalar | list[MaxTensor] | list[Scalar] | MaxTensor,
-    alpha: Scalar = 1,
+    self: list[MaxTensor], other: Scalar, alpha: Scalar = 1
 ) -> list[MaxTensor]:
     return [aten_sub(x, other, alpha=alpha) for x in self]
 
@@ -3911,7 +4043,7 @@ def aten__foreach_sub_scalar(
 # _foreach_sub.ScalarList(Tensor[] self, Scalar[] scalars) -> Tensor[]
 @map_to(aten._foreach_sub.ScalarList)
 def aten__foreach_sub_scalar_list(
-    self: list[MaxTensor], other: Scalar | list[MaxTensor] | list[Scalar] | MaxTensor
+    self: list[MaxTensor], other: list[Scalar]
 ) -> list[MaxTensor]:
     if len(self) != len(other):
         raise ValueError(
@@ -3934,16 +4066,14 @@ def aten__foreach_sub_list(
 
 # _foreach_mul.Scalar(Tensor[] self, Scalar scalar) -> Tensor[]
 @map_to(aten._foreach_mul.Scalar)
-def aten__foreach_mul_scalar(
-    self: list[MaxTensor], other: Scalar | list[MaxTensor] | list[Scalar] | MaxTensor
-) -> list[MaxTensor]:
+def aten__foreach_mul_scalar(self: list[MaxTensor], other: Scalar) -> list[MaxTensor]:
     return [aten_mul(x, other) for x in self]
 
 
 # _foreach_mul.ScalarList(Tensor[] self, Scalar[] scalars) -> Tensor[]
 @map_to(aten._foreach_mul.ScalarList)
 def aten__foreach_mul_scalar_list(
-    self: list[MaxTensor], other: Scalar | list[MaxTensor] | list[Scalar] | MaxTensor
+    self: list[MaxTensor], other: list[Scalar]
 ) -> list[MaxTensor]:
     if len(self) != len(other):
         raise ValueError(
@@ -4168,7 +4298,7 @@ def aten__foreach_addcmul_scalarlist(
 def aten_masked_fill(
     input: MaxTensor, mask: MaxTensor, value: Scalar | MaxTensor
 ) -> MaxTensor:
-    return F.where(mask, value, input)
+    return _where(mask, value, input)
 
 
 # transpose.int(Tensor(a) self, int dim0, int dim1) -> Tensor(a)

--- a/torch_mojo_backend/custom_mojo_ops.py
+++ b/torch_mojo_backend/custom_mojo_ops.py
@@ -1,11 +1,16 @@
 from max.experimental import functional as F
-from max.graph import TensorType
+from max.graph import Dim, TensorType
 
-import torch_mojo_backend
+from torch_mojo_backend.torch_compile_backend import compiler
 from torch_mojo_backend.types import MaxTensor, Scalar
 
 
 def _scalar_to_tensor(input: MaxTensor, other: Scalar) -> MaxTensor:
+    # `Scalar` also covers a symbolic Dim for ops that legitimately take one;
+    # the bitwise ops that call this never do (ATen's Scalar there is a
+    # genuine number), and F.constant only accepts a real number.
+    if isinstance(other, Dim):
+        raise TypeError(f"bitwise scalar ops expect a number, got a Dim: {other!r}")
     return F.broadcast_to(
         F.constant(other, dtype=input.dtype, device=input.device), input.shape
     )
@@ -22,7 +27,7 @@ def gpt2_decode_attention(
         out_types=[
             TensorType(dtype=query.dtype, shape=query.shape, device=query.device)
         ],
-        custom_extensions=torch_mojo_backend.torch_compile_backend.compiler.paths_to_mojo_kernels,
+        custom_extensions=compiler.paths_to_mojo_kernels,
     )[0]
 
 
@@ -38,7 +43,7 @@ def bitwise_and(input: MaxTensor, other: MaxTensor) -> MaxTensor:
         out_types=[
             TensorType(dtype=input.dtype, shape=input.shape, device=input.device)
         ],
-        custom_extensions=torch_mojo_backend.torch_compile_backend.compiler.paths_to_mojo_kernels,
+        custom_extensions=compiler.paths_to_mojo_kernels,
     )[0]
 
 
@@ -61,7 +66,7 @@ def bitwise_not(input: MaxTensor) -> MaxTensor:
         out_types=[
             TensorType(dtype=input.dtype, shape=input.shape, device=input.device)
         ],
-        custom_extensions=torch_mojo_backend.torch_compile_backend.compiler.paths_to_mojo_kernels,
+        custom_extensions=compiler.paths_to_mojo_kernels,
     )[0]
 
 
@@ -77,7 +82,7 @@ def bitwise_or(input: MaxTensor, other: MaxTensor) -> MaxTensor:
         out_types=[
             TensorType(dtype=input.dtype, shape=input.shape, device=input.device)
         ],
-        custom_extensions=torch_mojo_backend.torch_compile_backend.compiler.paths_to_mojo_kernels,
+        custom_extensions=compiler.paths_to_mojo_kernels,
     )[0]
 
 
@@ -100,7 +105,7 @@ def bitwise_xor(input: MaxTensor, other: MaxTensor) -> MaxTensor:
         out_types=[
             TensorType(dtype=input.dtype, shape=input.shape, device=input.device)
         ],
-        custom_extensions=torch_mojo_backend.torch_compile_backend.compiler.paths_to_mojo_kernels,
+        custom_extensions=compiler.paths_to_mojo_kernels,
     )[0]
 
 
@@ -125,5 +130,5 @@ def gelu_backward(
         out_types=[
             TensorType(dtype=input.dtype, shape=input.shape, device=input.device)
         ],
-        custom_extensions=torch_mojo_backend.torch_compile_backend.compiler.paths_to_mojo_kernels,
+        custom_extensions=compiler.paths_to_mojo_kernels,
     )[0]

--- a/torch_mojo_backend/custom_torch_ops_in_mojo/torch_custom_ops.py
+++ b/torch_mojo_backend/custom_torch_ops_in_mojo/torch_custom_ops.py
@@ -1,22 +1,37 @@
+import inspect
 from collections.abc import Callable
 from pathlib import Path
+from typing import Protocol, cast
 
 import max.graph.ops as max_ops
 import torch
+from max.dtype import DType
 from max.experimental.torch import CustomOpLibrary
-from max.graph import TensorType
+from max.graph import TensorType, TensorValue
 
 import torch_mojo_backend
 import torch_mojo_backend.torch_compile_backend.compiler
 
 
+class _SignedTorchOp(Protocol):
+    """A callable carrying the `__signature__` `torch.library.custom_op`
+    introspects; `functools`-style wrapping can't express the extra
+    attribute, so the callable this wraps is cast to this structural type."""
+
+    __signature__: inspect.Signature
+
+    def __call__(self, *args: torch.Tensor, **kwargs: torch.Tensor) -> None: ...
+
+
 def make_torch_op_from_mojo(
     path_to_kernels: Path, mojo_custom_op_str: str, allocate_outputs_fn: Callable
-):
+) -> Callable[..., torch.Tensor | tuple[torch.Tensor, ...] | list[torch.Tensor]]:
     ops = CustomOpLibrary(path_to_kernels)
     mojo_custom_op = ops.__getattr__(mojo_custom_op_str)
 
-    def compiler_fn(*args, **kwargs):
+    def compiler_fn(
+        *args: TensorValue, **kwargs: bool | int | str | DType
+    ) -> tuple[object, ...]:
         # We split args into outputs and inputs
         # We assume outputs are first
         out_args = args[: mojo_custom_op.num_outputs]
@@ -38,10 +53,13 @@ def make_torch_op_from_mojo(
 
     torch_mojo_backend.torch_compile_backend.compiler._global_max_objects = None
 
-    def mojo_custom_op_with_signature(*args, **kwargs):
-        return mojo_custom_op(*args, **kwargs)
+    def mojo_custom_op_with_signature(
+        *args: torch.Tensor, **kwargs: torch.Tensor
+    ) -> None:
+        mojo_custom_op(*args, **kwargs)
 
-    mojo_custom_op_with_signature.__signature__ = mojo_custom_op.torch_signature
+    signed_op = cast(_SignedTorchOp, mojo_custom_op_with_signature)
+    signed_op.__signature__ = mojo_custom_op.torch_signature
 
     torch_mojo_backend.torch_compile_backend.compiler.paths_to_mojo_kernels.append(
         path_to_kernels
@@ -57,10 +75,13 @@ def make_torch_op_from_mojo(
 
     torch_custom_op = torch.library.custom_op(
         f"{path_to_kernels.name}::{mojo_custom_op_str}", mutates_args=mutates_args
-    )(mojo_custom_op_with_signature)
+    )(signed_op)
 
-    def fn(*args, **kwargs):
+    def fn(
+        *args: object, **kwargs: object
+    ) -> torch.Tensor | tuple[torch.Tensor, ...] | list[torch.Tensor]:
         output_tensors = allocate_outputs_fn(*args, **kwargs)
+        single_output: bool
         if isinstance(output_tensors, torch.Tensor):
             output_tensors = (output_tensors,)
             single_output = True

--- a/torch_mojo_backend/eager_flash_attention/__init__.py
+++ b/torch_mojo_backend/eager_flash_attention/__init__.py
@@ -8,12 +8,13 @@ import fcntl
 import hashlib
 import importlib
 from pathlib import Path
+from types import ModuleType
 
 import mojo.importer  # noqa: F401 - installs the .mojo import hook
 
 _PACKAGE_DIR = Path(__file__).parent
 _CACHE_DIR = _PACKAGE_DIR / "__mojocache__"
-_MODULE = None
+_MODULE: ModuleType | None = None
 
 
 def _sources_hash() -> str:
@@ -24,7 +25,7 @@ def _sources_hash() -> str:
     return hasher.hexdigest()[:16]
 
 
-def load_fa4_ops():
+def load_fa4_ops() -> ModuleType:
     """Compile once on first eligible use, then return the bridge module."""
     global _MODULE
     if _MODULE is not None:

--- a/torch_mojo_backend/eager_kernels/__init__.py
+++ b/torch_mojo_backend/eager_kernels/__init__.py
@@ -50,11 +50,11 @@ import sys
 import threading
 import time
 from abc import ABC, abstractmethod
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
-from typing import ClassVar, Generic, TypeVar
+from typing import IO, ClassVar, Generic, TypeVar, cast
 
 from max import driver
 from max.dtype import DType
@@ -461,7 +461,7 @@ def _announce_build() -> None:
     )
 
 
-def _flock_or_none(lock: object) -> bool:
+def _flock_or_none(lock: IO[str]) -> bool:
     """Take the build lock; False when this filesystem cannot lock at all.
 
     The lock only DEDUPES concurrent identical builds — correctness never
@@ -547,6 +547,8 @@ def _load_extension(module_name: str, so_path: Path) -> ModuleType:
     spec = importlib.util.spec_from_file_location(
         module_name, str(so_path), loader=loader
     )
+    # An explicit loader= makes spec_from_file_location always succeed.
+    assert spec is not None
     module = importlib.util.module_from_spec(spec)
     loader.exec_module(module)
     return module
@@ -829,7 +831,11 @@ class MojoExtension(ABC, Generic[_OutputSpecs, _ExtensionResult]):
         spec. Descriptors with several outputs override this with the same
         allocation their ``call_extension`` performs.
         """
-        return _allocate_single_output(output_specs)  # type: ignore[return-value]
+        # _ExtensionResult is this descriptor's declared result type, which
+        # the base class can't itself prove _allocate_single_output's object
+        # return satisfies -- only single-output descriptors use this default,
+        # and for those _ExtensionResult is concretely torch.Tensor.
+        return cast(_ExtensionResult, _allocate_single_output(output_specs))
 
     @classmethod
     def prepare(
@@ -843,19 +849,24 @@ class MojoExtension(ABC, Generic[_OutputSpecs, _ExtensionResult]):
         return PreparedExtensionCall(cls, defines, output_specs, args)
 
 
-def _allocate_single_output(spec: object) -> object:
+def _bootstrap_allocate_single_output(spec: object) -> object:
     """``output_specs._allocate_output_spec``, resolved on first use.
 
     ``output_specs`` imports this package, so it cannot be imported at module
-    scope here; rebinding the global on the first allocation leaves the
-    steady state at one plain lookup (the same trick as ``output_specs``'s
-    own ``_alloc``).
+    scope here; rebinding the `_allocate_single_output` global on the first
+    allocation leaves the steady state at one plain lookup (the same trick
+    as ``output_specs``'s own ``_alloc``). `_allocate_single_output` is a
+    plain variable (not `def`-bound) so this rebind type-checks against its
+    declared `Callable[[object], object]` type.
     """
     global _allocate_single_output
     from torch_mojo_backend.eager_kernels.output_specs import _allocate_output_spec
 
-    _allocate_single_output = _allocate_output_spec
-    return _allocate_output_spec(spec)
+    _allocate_single_output = cast("Callable[[object], object]", _allocate_output_spec)
+    return _allocate_single_output(spec)
+
+
+_allocate_single_output: Callable[[object], object] = _bootstrap_allocate_single_output
 
 
 class MojoFileExtension(MojoExtension[object, object]):

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -23,9 +23,9 @@ backend keeps using `aten_functions` directly.
 import math
 import struct
 import warnings
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import ClassVar, Protocol, runtime_checkable
+from typing import ClassVar, Final, Protocol, cast, runtime_checkable
 
 import torch
 from max.driver import Device
@@ -96,7 +96,9 @@ from torch_mojo_backend.eager_kernels.tf32_matmul_ops import (
 _VariantFlag = bool | int | str
 
 
-def _device_call(fn: object, *args: object, keepalive: tuple[object, ...]) -> object:
+def _device_call(
+    fn: Callable[..., object], *args: object, keepalive: tuple[object, ...]
+) -> object:
     """Launch an ungated device call (tensor_holder / fa4): when the call
     queue is active it must hold its FIFO position behind queued producers
     of its inputs; otherwise call directly. `keepalive` names the tensors
@@ -153,10 +155,51 @@ from torch_mojo_backend.mojo_device.torch_mojo_tensor import (
     _resize_payload,
     _row_major_strides,
 )
+from torch_mojo_backend.types import CountedCallable
+
+
+@runtime_checkable
+class _TensorHolderModule(Protocol):
+    """The subset of the JIT-compiled `tensor_holder` Mojo extension this
+    file calls directly. The module itself has no stubs (its source is
+    Mojo, not Python); every member here is a raw PythonObject-in,
+    PythonObject-out native call, so `object` is the honest signature."""
+
+    def make_spec(self, *args: object) -> object: ...
+    def copy_d2d(self, *args: object) -> object: ...
+    def StridedFill(self, *args: object) -> object: ...
+    def read_scalar(self, *args: object) -> object: ...
+
+
+@runtime_checkable
+class _HolderObject(Protocol):
+    """TorchMojoTensor._holder's real type: the Mojo `TensorHolder` a
+    tensor_holder.alloc() call returns. Declared `object` on TorchMojoTensor
+    (no Python stub for a Mojo class); get_nbytes is its one member used
+    outside torch_mojo_tensor.py."""
+
+    def get_nbytes(self) -> int: ...
+
+
+def _tensor_holder() -> _TensorHolderModule:
+    """`eager_kernels.tensor_holder`, typed.
+
+    `eager_kernels.__getattr__` resolves and caches it lazily so importing
+    this module never triggers a Mojo kernel compile; that resolution
+    happens on this call, same as the bare attribute access it replaces.
+    """
+    return cast(_TensorHolderModule, eager_kernels.tensor_holder)
+
+
+class _NotHandled:
+    """Sentinel: this fast path declines the input; caller falls through."""
+
+    __slots__ = ()
+
 
 # Returned when the inputs don't qualify; the registration then raises
 # NotImplementedError naming the op (there is no fallback anymore).
-NOT_HANDLED = object()
+NOT_HANDLED: Final[_NotHandled] = _NotHandled()
 
 # The host/autograd route is landed before Fable's separately validated kernel
 # port.  Do not ask mojo.importer to compile the thin bridge until every source
@@ -361,12 +404,12 @@ _FOREACH_WIDENING_DTYPES = _FLOAT_DTYPES
 AtenScalar = int | float | bool | complex
 
 
-def _t(x) -> TorchMojoTensor | None:
+def _t(x: object) -> TorchMojoTensor | None:
     """x as a TorchMojoTensor (any layout), or None."""
     return x if isinstance(x, TorchMojoTensor) else None
 
 
-def _tc(x) -> TorchMojoTensor | None:
+def _tc(x: object) -> TorchMojoTensor | None:
     """x as a *contiguous* TorchMojoTensor (materializing views), or None."""
     if isinstance(x, TorchMojoTensor):
         return x if x._is_contiguous else x._materialize_contiguous()
@@ -512,7 +555,9 @@ def _reduce_keepdim_shape(
     return _view_of(result, shape, _row_major_strides(shape), result._offset)
 
 
-def fast_aten__foreach_norm(self, ord=2, dtype=None):
+def fast_aten__foreach_norm(
+    self: Sequence[torch.Tensor], ord: AtenScalar = 2, dtype: torch.dtype | None = None
+) -> list[TorchMojoTensor] | _NotHandled:
     """Fast homogeneous FP32 L2 norms with one independent scalar output.
 
     The Mojo bridge batches runtime descriptors and uses an ordinary eager
@@ -529,9 +574,10 @@ def fast_aten__foreach_norm(self, ord=2, dtype=None):
     ):
         return NOT_HANDLED
 
-    tensors = [_t(tensor) for tensor in self]
-    if any(tensor is None for tensor in tensors):
+    unwrapped_tensors = [_t(tensor) for tensor in self]
+    if any(tensor is None for tensor in unwrapped_tensors):
         return NOT_HANDLED
+    tensors = cast(list[TorchMojoTensor], unwrapped_tensors)
     device = tensors[0]._device
     if device.api == "cpu" or any(
         tensor._device != device
@@ -565,7 +611,9 @@ def fast_aten__foreach_norm(self, ord=2, dtype=None):
     return outputs
 
 
-def foreach_norm_sequential_fallback(self, ord=2, dtype=None):
+def foreach_norm_sequential_fallback(
+    self: Sequence[torch.Tensor], ord: AtenScalar = 2, dtype: torch.dtype | None = None
+) -> list[TorchMojoTensor] | _NotHandled:
     """Device-index-correct L2 fallback using existing scalar eager ops.
 
     ATen's generic foreach decomposition synthesizes functional norm outputs
@@ -580,20 +628,23 @@ def foreach_norm_sequential_fallback(self, ord=2, dtype=None):
         or dtype not in (None, torch.float32)
     ):
         return NOT_HANDLED
-    tensors = [_t(tensor) for tensor in self]
-    if any(tensor is None or tensor._dtype != DType.float32 for tensor in tensors):
+    unwrapped = [_t(tensor) for tensor in self]
+    if any(tensor is None or tensor._dtype != DType.float32 for tensor in unwrapped):
         return NOT_HANDLED
+    tensors = cast(list[TorchMojoTensor], unwrapped)
 
-    outputs = []
+    outputs: list[TorchMojoTensor] = []
     for tensor in tensors:
         output = fast_aten_linalg_vector_norm(tensor, ord, None, False, dtype=None)
-        if output is NOT_HANDLED:
+        # isinstance, not `is`: ty doesn't narrow identity checks against a
+        # custom singleton instance the way it does for `is None`.
+        if isinstance(output, _NotHandled):
             return NOT_HANDLED
         outputs.append(output)
     return outputs
 
 
-def _foreach_tensors_overlap(tensors) -> bool:
+def _foreach_tensors_overlap(tensors: Sequence[TorchMojoTensor]) -> bool:
     """Whether contiguous mutable tensor byte intervals overlap."""
     intervals = sorted(
         (tensor._ptr, tensor._ptr + tensor._numel * tensor._itemsize)
@@ -606,7 +657,7 @@ def _foreach_tensors_overlap(tensors) -> bool:
     )
 
 
-def _is_non_overlapping_and_dense(shape, strides) -> bool:
+def _is_non_overlapping_and_dense(shape: Sequence[int], strides: Sequence[int]) -> bool:
     """Match TensorImpl's sorted-stride dense-layout classification."""
     required_stride = 1
     dimensions = sorted(
@@ -619,7 +670,9 @@ def _is_non_overlapping_and_dense(shape, strides) -> bool:
     return True
 
 
-def _foreach_scalar_overlap_kind(tensor, scalar) -> str:
+def _foreach_scalar_overlap_kind(
+    tensor: TorchMojoTensor, scalar: TorchMojoTensor
+) -> str:
     """Classify scalar overlap as none, full, or forbidden partial overlap.
 
     PyTorch reports overlap as ``TooHard`` for non-dense layouts, so those
@@ -792,16 +845,19 @@ def _foreach_launch(
     )
 
 
-def fast_aten__foreach_mul__tensor(self, other):
+def fast_aten__foreach_mul__tensor(
+    self: Sequence[torch.Tensor], other: torch.Tensor
+) -> None | _NotHandled:
     """Batched in-place multiply of a whole list by one 0-d device tensor."""
     if len(self) == 0:
         raise RuntimeError("Tensor list must have at least one tensor.")
     scalar = _t(other)
     if scalar is None or scalar._shape != () or not scalar._is_contiguous:
         return NOT_HANDLED
-    tensors = [_t(tensor) for tensor in self]
-    if any(tensor is None for tensor in tensors):
+    unwrapped_tensors = [_t(tensor) for tensor in self]
+    if any(tensor is None for tensor in unwrapped_tensors):
         return NOT_HANDLED
+    tensors = cast(list[TorchMojoTensor], unwrapped_tensors)
     overlap_kinds = [_foreach_scalar_overlap_kind(tensor, scalar) for tensor in tensors]
     if "partial" in overlap_kinds:
         raise RuntimeError(
@@ -830,7 +886,7 @@ def _foreach_scalar_inplace(
     self: Sequence[torch.Tensor],
     values: Sequence[float],
     dtypes: tuple[DType, ...] = (DType.float32,),
-) -> object:
+) -> None | _NotHandled:
     """Shared launch path of the in-place foreach mul/add/div fast ops."""
     unwrapped = _foreach_lists(self, dtypes=dtypes)
     if unwrapped is None:
@@ -844,7 +900,7 @@ def _foreach_scalar_inplace(
 
 def fast_aten__foreach_mul__scalar(
     self: Sequence[torch.Tensor], scalar: AtenScalar
-) -> object:
+) -> None | _NotHandled:
     """Batched homogeneous in-place multiply by one host scalar."""
     value = _foreach_scalar_value(scalar)
     if value is None:
@@ -856,7 +912,7 @@ def fast_aten__foreach_mul__scalar(
 
 def fast_aten__foreach_add__scalar(
     self: Sequence[torch.Tensor], scalar: AtenScalar
-) -> object:
+) -> None | _NotHandled:
     """Batched homogeneous in-place add of one host scalar.
 
     Without this ATen runs the CompositeExplicitAutograd fallback, a
@@ -874,7 +930,7 @@ def fast_aten__foreach_add__scalar(
 
 def fast_aten__foreach_div__scalarlist(
     self: Sequence[torch.Tensor], scalars: Sequence[AtenScalar]
-) -> object:
+) -> None | _NotHandled:
     """Batched homogeneous FP32 in-place divide by one scalar per tensor.
 
     FP32 only, unlike mul/add: the per-tensor `div_.Scalar` this replaces
@@ -890,7 +946,7 @@ def fast_aten__foreach_div__scalarlist(
 
 def fast_aten__foreach_lerp__scalar(
     self: Sequence[torch.Tensor], tensors1: Sequence[torch.Tensor], weight: AtenScalar
-) -> object:
+) -> None | _NotHandled:
     """Batched homogeneous FP32 in-place scalar lerp toward `tensors1`.
 
     Mirrors `fast_aten_lerp`: the weight is narrowed to float32 first and
@@ -928,7 +984,7 @@ def _foreach_addc_inplace(
     tensor1: Sequence[torch.Tensor],
     tensor2: Sequence[torch.Tensor],
     values: Sequence[float],
-) -> object:
+) -> None | _NotHandled:
     """Shared launch path of the in-place foreach addcmul/addcdiv fast ops."""
     unwrapped = _foreach_lists(self, tensor1, tensor2)
     if unwrapped is None:
@@ -945,7 +1001,7 @@ def fast_aten__foreach_addcmul__scalar(
     tensor1: Sequence[torch.Tensor],
     tensor2: Sequence[torch.Tensor],
     value: AtenScalar = 1,
-) -> object:
+) -> None | _NotHandled:
     """Batched homogeneous FP32 in-place self += value * (t1 * t2)."""
     scalar = _foreach_scalar_value(value)
     if scalar is None:
@@ -960,7 +1016,7 @@ def fast_aten__foreach_addcdiv__scalarlist(
     tensor1: Sequence[torch.Tensor],
     tensor2: Sequence[torch.Tensor],
     scalars: Sequence[AtenScalar],
-) -> object:
+) -> None | _NotHandled:
     """Batched homogeneous FP32 in-place self += s[i] * (t1 / t2)."""
     values = _foreach_scalar_values(scalars, len(self))
     if values is None:
@@ -968,7 +1024,9 @@ def fast_aten__foreach_addcdiv__scalarlist(
     return _foreach_addc_inplace(_FOREACH_ADDCDIV, self, tensor1, tensor2, values)
 
 
-def fast_aten__foreach_sqrt(self: Sequence[torch.Tensor]) -> object:
+def fast_aten__foreach_sqrt(
+    self: Sequence[torch.Tensor],
+) -> list[TorchMojoTensor] | _NotHandled:
     """Batched homogeneous FP32 out-of-place elementwise square roots."""
     unwrapped = _foreach_lists(self)
     if unwrapped is None:
@@ -979,7 +1037,9 @@ def fast_aten__foreach_sqrt(self: Sequence[torch.Tensor]) -> object:
     return outputs
 
 
-def _fused_adamw_scalar_tensor(value, name, device):
+def _fused_adamw_scalar_tensor(
+    value: torch.Tensor | None, name: str, device: Device
+) -> int:
     """Validate an optional read-only scalar and return its device pointer."""
     if value is None:
         return 0
@@ -999,23 +1059,23 @@ def _fused_adamw_scalar_tensor(value, name, device):
 
 
 def fast_aten__fused_adamw(
-    parameters,
-    grads,
-    exp_avgs,
-    exp_avg_sqs,
-    max_exp_avg_sqs,
-    state_steps,
+    parameters: Sequence[torch.Tensor],
+    grads: Sequence[torch.Tensor],
+    exp_avgs: Sequence[torch.Tensor],
+    exp_avg_sqs: Sequence[torch.Tensor],
+    max_exp_avg_sqs: Sequence[torch.Tensor],
+    state_steps: Sequence[torch.Tensor],
     *,
-    lr,
-    beta1,
-    beta2,
-    weight_decay,
-    eps,
-    amsgrad,
-    maximize,
-    grad_scale=None,
-    found_inf=None,
-):
+    lr: torch.Tensor | float | int,
+    beta1: float,
+    beta2: float,
+    weight_decay: float,
+    eps: float,
+    amsgrad: bool,
+    maximize: bool,
+    grad_scale: torch.Tensor | None = None,
+    found_inf: torch.Tensor | None = None,
+) -> None | _NotHandled:
     """Runtime-dynamic, allocation-free fused FP32 AdamW TensorList route.
 
     Validation deliberately completes for every tensor before the first
@@ -1103,17 +1163,19 @@ def fast_aten__fused_adamw(
 
     grad_scale_ptr = _fused_adamw_scalar_tensor(grad_scale, "grad_scale", device)
     found_inf_ptr = _fused_adamw_scalar_tensor(found_inf, "found_inf", device)
+    # The validation loop above already confirmed every entry (including
+    # max_exp_avg_sqs when amsgrad) is a TorchMojoTensor.
     metadata = tuple(
         value
         for index in range(tensor_count)
         for value in (
-            parameters[index]._ptr,
-            grads[index]._ptr,
-            exp_avgs[index]._ptr,
-            exp_avg_sqs[index]._ptr,
-            max_exp_avg_sqs[index]._ptr if amsgrad else 0,
-            state_steps[index]._ptr,
-            parameters[index]._numel,
+            cast(TorchMojoTensor, parameters[index])._ptr,
+            cast(TorchMojoTensor, grads[index])._ptr,
+            cast(TorchMojoTensor, exp_avgs[index])._ptr,
+            cast(TorchMojoTensor, exp_avg_sqs[index])._ptr,
+            cast(TorchMojoTensor, max_exp_avg_sqs[index])._ptr if amsgrad else 0,
+            cast(TorchMojoTensor, state_steps[index])._ptr,
+            cast(TorchMojoTensor, parameters[index])._numel,
         )
     )
     if len(metadata) != tensor_count * _FUSED_ADAMW_RECORD_FIELDS:
@@ -1174,11 +1236,26 @@ def fast_aten__fused_adamw(
 # ---------------------------------------------------------------------------
 
 
-def _spec_of(t):
-    """t's cached Mojo TensorSpec, built on first use."""
+# MojoTensorLike._device is `object` (mutable Protocol members are checked
+# invariantly, so even TorchMojoTensor's own concrete `Device` doesn't
+# satisfy the Protocol for that one member) -- every real call site here
+# passes either a TorchMojoTensor or a MojoTensorLike-typed operand.
+_SpecTensor = TorchMojoTensor | MojoTensorLike
+
+
+def _spec_of(mojo_tensor: _SpecTensor) -> object:
+    """t's cached Mojo TensorSpec, built on first use.
+
+    Every extension_args/make_defines call site here types its operand as
+    the structural MojoTensorLike (payload-only, testable with stand-ins),
+    but the cache itself is a TorchMojoTensor-specific implementation detail
+    (`__dict__`-backed, not part of the Protocol) -- real callers are always
+    the concrete class.
+    """
+    t = cast(TorchMojoTensor, mojo_tensor)
     spec = t.__dict__.get("_spec")
     if spec is None:
-        spec = eager_kernels.tensor_holder.make_spec(
+        spec = _tensor_holder().make_spec(
             t._ptr,
             len(t._shape),
             _pad8(t._shape, 1),
@@ -1190,8 +1267,16 @@ def _spec_of(t):
             1 if t._is_contiguous else 0,
             _ctx_ptr(t._device),
         )
-        t._spec = spec
+        # Same __dict__-backed cache _move_payload_attributes pops on rebind;
+        # _spec isn't a declared TorchMojoTensor attribute.
+        t.__dict__["_spec"] = spec
     return spec
+
+
+def _device_of(mojo_tensor: _SpecTensor) -> Device:
+    """MojoTensorLike._device is `object` for host-contract test doubles;
+    real operands are always a TorchMojoTensor with a concrete Device."""
+    return cast(Device, mojo_tensor._device)
 
 
 class _FillSpecExtension(
@@ -1256,7 +1341,7 @@ class _CastSpecExtension(
     def expected_output_specs(
         cls, tensor: MojoTensorLike, dtype: DType
     ) -> _TensorOutputSpec:
-        return _TensorOutputSpec(tuple(tensor._shape), dtype, tensor._device)
+        return _TensorOutputSpec(tuple(tensor._shape), dtype, _device_of(tensor))
 
     @classmethod
     def extension_args(
@@ -1295,7 +1380,9 @@ class _CumsumSpecExtension(
     def expected_output_specs(
         cls, tensor: MojoTensorLike, dim: int
     ) -> _TensorOutputSpec:
-        return _TensorOutputSpec(tuple(tensor._shape), tensor._dtype, tensor._device)
+        return _TensorOutputSpec(
+            tuple(tensor._shape), tensor._dtype, _device_of(tensor)
+        )
 
     @classmethod
     def extension_args(
@@ -1338,7 +1425,7 @@ class _BinarySpecExtension(
             # Equal shapes dominate (residual adds, grad accumulation) and
             # torch.broadcast_shapes costs ~7 µs per call.
             lhs_shape = tuple(torch.broadcast_shapes(lhs_shape, rhs_shape))
-        return _TensorOutputSpec(lhs_shape, out_dtype, lhs._device)
+        return _TensorOutputSpec(lhs_shape, out_dtype, _device_of(lhs))
 
     @classmethod
     def extension_args(
@@ -1377,7 +1464,7 @@ class _UnarySpecExtension(
     def expected_output_specs(
         cls, op: str, tensor: MojoTensorLike, out_dtype: DType
     ) -> _TensorOutputSpec:
-        return _TensorOutputSpec(tuple(tensor._shape), out_dtype, tensor._device)
+        return _TensorOutputSpec(tuple(tensor._shape), out_dtype, _device_of(tensor))
 
     @classmethod
     def extension_args(
@@ -1483,6 +1570,7 @@ def _try_spec_binary_into(
     if a is not None and b is not None and a._device != b._device:
         return None
     anchor_t = a if a is not None else b
+    assert anchor_t is not None
     device = anchor_t._device
     dtype = anchor_t._dtype
 
@@ -1492,6 +1580,8 @@ def _try_spec_binary_into(
                 return None
             a = _tc(a)
             b = _tc(b)
+            # a/b were already TorchMojoTensor; _tc only materializes.
+            assert a is not None and b is not None
         promotion = _binary_promotion(a._dtype, b._dtype)
         if promotion is None:
             return None
@@ -1516,6 +1606,7 @@ def _try_spec_binary_into(
         else:
             a = fill
 
+    assert a is not None and b is not None
     kdtype = DType.uint8 if dtype == DType.bool else dtype
     if kdtype not in _SPEC_INTO_DTYPES:
         return None
@@ -1548,7 +1639,9 @@ def _try_spec_binary_into(
     )
 
 
-def _try_spec_binary(spec_fn_name, lhs, rhs, out_dtype=None):
+def _try_spec_binary(
+    spec_fn_name: str, lhs: object, rhs: object, out_dtype: DType | None = None
+) -> TorchMojoTensor | None:
     """Broadcast binary through a logic_ops spec op, or None.
 
     Python keeps what Python must do — scalar embedding, torch's promotion
@@ -1576,6 +1669,8 @@ def _try_spec_binary(spec_fn_name, lhs, rhs, out_dtype=None):
         if len(a._shape) > 4 or len(b._shape) > 4:
             a = _tc(a)
             b = _tc(b)
+            # a/b were already TorchMojoTensor; _tc only materializes.
+            assert a is not None and b is not None
         promotion = _binary_promotion(a._dtype, b._dtype)
         if promotion is None:
             return None
@@ -1643,7 +1738,7 @@ def _try_spec_binary(spec_fn_name, lhs, rhs, out_dtype=None):
     return result
 
 
-def _try_spec_add_f32_bf16(lhs, rhs):
+def _try_spec_add_f32_bf16(lhs: object, rhs: object) -> TorchMojoTensor | None:
     """One-launch contiguous FP32 + BF16 -> FP32 add, or None.
 
     The general binary promotion path materializes its lower-precision input.
@@ -1724,18 +1819,6 @@ _SPEC_REDUCE_INTO = {
 }
 
 
-def _reduced_shape(shape: tuple, rdims: object, keepdim: bool) -> tuple:
-    rd = set(rdims)
-    out = []
-    for i, s in enumerate(shape):
-        if i in rd:
-            if keepdim:
-                out.append(1)
-        else:
-            out.append(s)
-    return tuple(out)
-
-
 class _ReductionSpecExtension(
     eager_kernels.MojoExtension[_TensorOutputSpec, TorchMojoTensor]
 ):
@@ -1780,7 +1863,7 @@ class _ReductionSpecExtension(
         out_dtype: DType,
     ) -> _TensorOutputSpec:
         shape = _reduced_shape(tuple(tensor._shape), rdims, keepdim)
-        return _TensorOutputSpec(shape, out_dtype, tensor._device)
+        return _TensorOutputSpec(shape, out_dtype, _device_of(tensor))
 
     @classmethod
     def extension_args(
@@ -1843,18 +1926,18 @@ class _MinDimSpecExtension(
     ) -> tuple[_TensorOutputSpec, _TensorOutputSpec]:
         shape = _reduced_shape(tuple(tensor._shape), (dim,), keepdim)
         return (
-            _TensorOutputSpec(shape, tensor._dtype, tensor._device),
-            _TensorOutputSpec(shape, DType.int64, tensor._device),
+            _TensorOutputSpec(shape, tensor._dtype, _device_of(tensor)),
+            _TensorOutputSpec(shape, DType.int64, _device_of(tensor)),
         )
 
     @classmethod
     def allocate_outputs(
         cls, output_specs: tuple[_TensorOutputSpec, _TensorOutputSpec]
     ) -> tuple[TorchMojoTensor, TorchMojoTensor]:
-        return (
-            _allocate_output_spec(output_specs[0]),
-            _allocate_output_spec(output_specs[1]),
-        )
+        out0 = _allocate_output_spec(output_specs[0])
+        out1 = _allocate_output_spec(output_specs[1])
+        assert isinstance(out0, TorchMojoTensor) and isinstance(out1, TorchMojoTensor)
+        return (out0, out1)
 
     @classmethod
     def extension_args(
@@ -1921,7 +2004,12 @@ def _try_spec_cumsum(a: TorchMojoTensor, dim: int) -> TorchMojoTensor | None:
         return None
 
 
-def _try_spec_unary(spec_fn_name, x, out_dtype=None, module_name="elementwise_ops"):
+def _try_spec_unary(
+    spec_fn_name: str,
+    x: object,
+    out_dtype: DType | None = None,
+    module_name: str = "elementwise_ops",
+) -> TorchMojoTensor | None:
     """Contiguous unary through a spec op, or None.
 
     `out_dtype` overrides the wrapper dtype for the bool-output ops
@@ -1962,8 +2050,14 @@ def _try_spec_unary(spec_fn_name, x, out_dtype=None, module_name="elementwise_op
 
 
 def _try_spec_reduce(
-    spec_fn_name, a, rdims, keepdim, *extra, out_dtype=None, module_name="reduction_ops"
-):
+    spec_fn_name: str,
+    a: TorchMojoTensor,
+    rdims: Sequence[int],
+    keepdim: bool,
+    *extra: object,
+    out_dtype: DType | None = None,
+    module_name: str = "reduction_ops",
+) -> TorchMojoTensor | None:
     """Trailing-dims reduction through a spec op, or None. `a` is already a
     TorchMojoTensor (dtype promotion happened upstream); the spec op raises
     on non-trailing dims / strided input and the classic path takes over."""
@@ -2120,7 +2214,9 @@ class _MatmulSpecExtension(
         shape = _spec_matmul_out_shape(op, list(tensors), transpose_b)
         if shape is None:
             raise ValueError("matmul metadata is not eligible for the spec path")
-        return _TensorOutputSpec(tuple(shape), tensors[0]._dtype, tensors[0]._device)
+        return _TensorOutputSpec(
+            tuple(shape), tensors[0]._dtype, _device_of(tensors[0])
+        )
 
     @classmethod
     def extension_args(
@@ -2134,8 +2230,8 @@ class _MatmulSpecExtension(
 
 
 def _submit_spec_matmul(
-    spec_fn_name: str, ts: tuple[MojoTensorLike, ...], transpose_b: int
-) -> torch.Tensor | None:
+    spec_fn_name: str, ts: tuple[_SpecTensor, ...], transpose_b: int
+) -> TorchMojoTensor | None:
     """One matmul spec launch over already-typed operands, or None.
 
     Declines (ineligible metadata, a Mojo-side refusal) come back as None; a
@@ -2152,7 +2248,9 @@ def _submit_spec_matmul(
         return None
 
 
-def _try_spec_matmul(spec_fn_name, tensors, transpose_b):
+def _try_spec_matmul(
+    spec_fn_name: str, tensors: tuple[torch.Tensor, ...], transpose_b: int
+) -> TorchMojoTensor | None:
     """Matmul-family spec op over already-typed operands, or None.
 
     Strided operands are passed through: `_matmul_spec_operands_launch` reads
@@ -2165,10 +2263,14 @@ def _try_spec_matmul(spec_fn_name, tensors, transpose_b):
     ts = tuple(_t(x) for x in tensors)
     if any(t is None for t in ts):
         return None
-    return _submit_spec_matmul(spec_fn_name, ts, transpose_b)
+    return _submit_spec_matmul(
+        spec_fn_name, cast(tuple[TorchMojoTensor, ...], ts), transpose_b
+    )
 
 
-def _try_spec_scalar(spec_fn_name, x, scalar):
+def _try_spec_scalar(
+    spec_fn_name: str, x: object, scalar: object
+) -> TorchMojoTensor | None:
     """Contiguous tensor-with-float-scalar through a spec op, or None."""
     if not isinstance(scalar, int | float) or isinstance(scalar, bool):
         return None
@@ -2193,7 +2295,7 @@ def _try_spec_scalar(spec_fn_name, x, scalar):
     return out
 
 
-def _try_spec_scalar_inplace(spec_fn_name: str, x, scalar) -> bool:
+def _try_spec_scalar_inplace(spec_fn_name: str, x: object, scalar: object) -> bool:
     """`x op= scalar` in place through a spec op. True when it ran.
 
     The functional spec plus `_copy_into` costs an allocation and a
@@ -2221,7 +2323,9 @@ def _try_spec_scalar_inplace(spec_fn_name: str, x, scalar) -> bool:
     return True
 
 
-def _try_spec_int_scalar(spec_fn_name, x, scalar):
+def _try_spec_int_scalar(
+    spec_fn_name: str, x: object, scalar: object
+) -> TorchMojoTensor | None:
     """Contiguous tensor-with-int-scalar through a spec op, or None."""
     if not isinstance(scalar, int) or isinstance(scalar, bool):
         return None
@@ -2246,8 +2350,8 @@ def _try_spec_int_scalar(spec_fn_name, x, scalar):
     return out
 
 
-def _on_gpu(t: MojoTensorLike) -> bool:
-    return t._device.label == "gpu"
+def _on_gpu(t: _SpecTensor) -> bool:
+    return _device_of(t).label == "gpu"
 
 
 def _alert_not_deterministic(caller: str) -> None:
@@ -2279,7 +2383,7 @@ def _copy_into(dst: TorchMojoTensor, src: TorchMojoTensor) -> None:
         return
     if dst._is_contiguous and src._is_contiguous:
         _device_call(
-            eager_kernels.tensor_holder.copy_d2d,
+            _tensor_holder().copy_d2d,
             _ctx_ptr(dst._device),
             dst._ptr,
             src._ptr,
@@ -2290,13 +2394,13 @@ def _copy_into(dst: TorchMojoTensor, src: TorchMojoTensor) -> None:
         _copy_strided_into(dst, src)
 
 
-def _valid_nll_out(tensor, dtype, device) -> bool:
+def _valid_nll_out(tensor: object, dtype: DType, device: Device) -> bool:
     """Whether an NLL out= tensor may be written or resized in place."""
     out = _t(tensor)
     return out is not None and out._dtype == dtype and out._device == device
 
 
-def _prepare_nll_out(out: TorchMojoTensor, shape):
+def _prepare_nll_out(out: TorchMojoTensor, shape: Sequence[int]) -> TorchMojoTensor:
     """Return a contiguous NLL kernel destination for ``out``.
 
     Validation is deliberately separate: callers validate every input and
@@ -2328,7 +2432,11 @@ def _prepare_nll_out(out: TorchMojoTensor, shape):
 # ---------------------------------------------------------------------------
 
 
-def _bcast_meta(*tensors):
+# (out_shape, dims4, [strides4 per tensor])
+_BcastMeta = tuple[list[int], list[int], list[list[int]]]
+
+
+def _bcast_meta(*tensors: TorchMojoTensor) -> _BcastMeta | None:
     """Broadcast metadata (rank <= 4) from the tensors' real strides.
 
     Returns (out_shape, dims4, [strides4 per tensor]) or None when the
@@ -2362,7 +2470,9 @@ def _bcast_meta(*tensors):
     return out, dims, all_strides
 
 
-def _scalar_tensor_0d(value, dtype, device) -> TorchMojoTensor:
+def _scalar_tensor_0d(
+    value: int | float, dtype: DType, device: Device
+) -> TorchMojoTensor:
     """A 0-d tensor holding `value`, for stride-0 broadcast operands."""
     return _submit_prepared_into(
         _FillSpecExtension.prepare((), float(value), dtype, device)
@@ -2380,7 +2490,9 @@ def _cast_tensor(x: TorchMojoTensor, dtype: DType) -> TorchMojoTensor:
     return _submit_prepared_into(_CastSpecExtension.prepare(t, dtype))
 
 
-def _promoted_pair(a: TorchMojoTensor, b: TorchMojoTensor):
+def _promoted_pair(
+    a: TorchMojoTensor, b: TorchMojoTensor
+) -> tuple[TorchMojoTensor, TorchMojoTensor] | None:
     """Same-dtype tensor pair following torch's promotion, or None.
 
     Only the promotions the generation loops hit: bool combined with any
@@ -2401,7 +2513,7 @@ def _promoted_pair(a: TorchMojoTensor, b: TorchMojoTensor):
     return None
 
 
-def _scalar_embed(value, dtype: DType) -> float | None:
+def _scalar_embed(value: object, dtype: DType) -> float | None:
     """`value` validated for lossless embedding into `dtype`, as a float,
     or None."""
     if not isinstance(value, int | float):
@@ -2421,7 +2533,9 @@ def _scalar_embed(value, dtype: DType) -> float | None:
     return float(value)
 
 
-def _resolve_scalar(value, dtype: DType, device) -> TorchMojoTensor | None:
+def _resolve_scalar(
+    value: object, dtype: DType, device: Device
+) -> TorchMojoTensor | None:
     """A 0-d stride-0 tensor holding a Python scalar in `dtype`, or None
     when the value doesn't embed losslessly."""
     v = _scalar_embed(value, dtype)
@@ -2494,7 +2608,9 @@ def _launch_masked_fill_scalar(
 # ---------------------------------------------------------------------------
 
 
-def _scaled_operand(other, alpha):
+def _scaled_operand(
+    other: object, alpha: int | float
+) -> TorchMojoTensor | float | None:
     """other * alpha as a tensor, for add/sub with alpha != 1, or None."""
     b = _t(other)
     if b is None:
@@ -2507,7 +2623,9 @@ def _scaled_operand(other, alpha):
     return scaled
 
 
-def fast_aten_add(input, other, alpha=1):
+def fast_aten_add(
+    input: torch.Tensor, other: object, alpha: int | float = 1
+) -> TorchMojoTensor | _NotHandled:
     if alpha != 1:
         other = _scaled_operand(other, alpha)
         if other is None:
@@ -2527,7 +2645,9 @@ def fast_aten_add(input, other, alpha=1):
 _fast_aten_add_default = fast_aten_add
 
 
-def fast_aten_add_apple(input, other, alpha=1):
+def fast_aten_add_apple(
+    input: torch.Tensor, other: object, alpha: int | float = 1
+) -> TorchMojoTensor | _NotHandled:
     """Metal specialization for equal-shape contiguous tensor addition."""
     a = _t(input)
     b = _t(other)
@@ -2565,7 +2685,9 @@ def fast_aten_add_apple(input, other, alpha=1):
     return _fast_aten_add_default(input, other, alpha)
 
 
-def fast_aten_add_(input, other, alpha=1):
+def fast_aten_add_(
+    input: torch.Tensor, other: object, alpha: int | float = 1
+) -> torch.Tensor | None:
     """In-place add into input. Returns None when unavailable."""
     dst = _t(input)
     if dst is None:
@@ -2614,7 +2736,7 @@ def fast_aten_add_(input, other, alpha=1):
     # General path: functional result, then a (strided-safe) copy back.
     result = fast_aten_add(input, other, alpha)
     if (
-        result is NOT_HANDLED
+        not isinstance(result, TorchMojoTensor)
         or result._shape != dst._shape
         or result._dtype != dst._dtype
     ):
@@ -2623,7 +2745,9 @@ def fast_aten_add_(input, other, alpha=1):
     return input
 
 
-def fast_aten_sub(input, other, alpha=1):
+def fast_aten_sub(
+    input: torch.Tensor, other: object, alpha: int | float = 1
+) -> TorchMojoTensor | _NotHandled:
     if alpha != 1:
         other = _scaled_operand(other, alpha)
         if other is None:
@@ -2641,7 +2765,7 @@ def fast_aten_sub(input, other, alpha=1):
     return NOT_HANDLED
 
 
-def fast_aten_mul(input, other):
+def fast_aten_mul(input: torch.Tensor, other: object) -> TorchMojoTensor | _NotHandled:
     result = _try_spec_scalar("MulScalarSpec", input, other)
     if result is None:
         result = _try_spec_int_scalar("MulScalarIntSpec", input, other)
@@ -2652,7 +2776,7 @@ def fast_aten_mul(input, other):
     return NOT_HANDLED
 
 
-def fast_aten_mul_(input, other):
+def fast_aten_mul_(input: torch.Tensor, other: object) -> torch.Tensor | None:
     """In-place multiply used by the foreach gradient-clipping slow path."""
     dst = _t(input)
     if dst is None:
@@ -2661,7 +2785,7 @@ def fast_aten_mul_(input, other):
         return input
     result = fast_aten_mul(input, other)
     if (
-        result is NOT_HANDLED
+        not isinstance(result, TorchMojoTensor)
         or result._shape != dst._shape
         or result._dtype != dst._dtype
         or result._device != dst._device
@@ -2681,7 +2805,9 @@ def fast_aten_mul_(input, other):
 _DIV_ROUNDING_MODE_SPECS = {"floor": "FloorDivSpec", "trunc": "TruncDivSpec"}
 
 
-def fast_aten_div(input, other, *, rounding_mode=None):
+def fast_aten_div(
+    input: torch.Tensor, other: object, *, rounding_mode: str | None = None
+) -> TorchMojoTensor | _NotHandled:
     if rounding_mode is not None:
         spec_name = _DIV_ROUNDING_MODE_SPECS.get(rounding_mode)
         if spec_name is None:
@@ -2714,7 +2840,9 @@ def fast_aten_div(input, other, *, rounding_mode=None):
     return NOT_HANDLED
 
 
-def fast_aten_lerp(self, end, weight):
+def fast_aten_lerp(
+    self: torch.Tensor, end: torch.Tensor, weight: AtenScalar
+) -> TorchMojoTensor | _NotHandled:
     """FP32 scalar lerp composed from the existing asynchronous fast ops.
 
     Match ATen's numerically stable branch from ``native/Lerp.h``.  Keeping
@@ -2758,7 +2886,9 @@ def fast_aten_lerp(self, end, weight):
     return fast_aten_sub(finish, difference, alpha=one_minus_weight)
 
 
-def fast_aten_fill_scalar(input, value):
+def fast_aten_fill_scalar(
+    input: torch.Tensor, value: object
+) -> TorchMojoTensor | _NotHandled:
     """Functional fill: new tensor, same shape/dtype, all elements = value."""
     # ``bool`` is a Python ``int`` subclass and ATen accepts it for every
     # scalar-fill dtype (most importantly for mutating saved bool masks).
@@ -2771,7 +2901,7 @@ def fast_aten_fill_scalar(input, value):
     return result if result is not None else NOT_HANDLED
 
 
-def fast_aten_fill__scalar(input, value):
+def fast_aten_fill__scalar(input: torch.Tensor, value: object) -> torch.Tensor | None:
     """In-place fill of input (any strides). Returns None when unavailable."""
     if not isinstance(value, int | float):
         return None
@@ -2782,7 +2912,7 @@ def fast_aten_fill__scalar(input, value):
         return None
     if a._numel > 0:
         _device_call(
-            eager_kernels.tensor_holder.StridedFill,
+            _tensor_holder().StridedFill,
             a._ptr,
             float(value),
             _pad8(a._shape, 1),
@@ -2794,29 +2924,29 @@ def fast_aten_fill__scalar(input, value):
     return input
 
 
-def fast_aten_maximum(x, y):
+def fast_aten_maximum(x: torch.Tensor, y: object) -> TorchMojoTensor | _NotHandled:
     result = _try_spec_binary("MaximumSpec", x, y)
     return result if result is not None else NOT_HANDLED
 
 
-def fast_aten_minimum(x, y):
+def fast_aten_minimum(x: torch.Tensor, y: object) -> TorchMojoTensor | _NotHandled:
     result = _try_spec_binary("MinimumSpec", x, y)
     return result if result is not None else NOT_HANDLED
 
 
-def fast_aten_relu(tensor):
+def fast_aten_relu(tensor: torch.Tensor) -> TorchMojoTensor | _NotHandled:
     return _unary_spec_op("ReluSpec", tensor)
 
 
-def fast_aten_exp(input):
+def fast_aten_exp(input: torch.Tensor) -> TorchMojoTensor | _NotHandled:
     return _unary_spec_op("ExpSpec", input)
 
 
-def fast_aten_tanh(x):
+def fast_aten_tanh(x: torch.Tensor) -> TorchMojoTensor | _NotHandled:
     return _unary_spec_op("TanhSpec", x)
 
 
-def fast_aten_pow(x, y):
+def fast_aten_pow(x: torch.Tensor, y: object) -> TorchMojoTensor | _NotHandled:
     result = _try_spec_scalar("PowScalarSpec", x, y)
     return result if result is not None else NOT_HANDLED
 
@@ -2831,7 +2961,7 @@ def fast_aten_pow(x, y):
 # ---------------------------------------------------------------------------
 
 
-def _unary_spec_op(spec, x):
+def _unary_spec_op(spec: str, x: object) -> TorchMojoTensor | _NotHandled:
     """Float-only unary with no classic fallback: the spec entry provably
     covers the classic gate (_FLOAT_DTYPES, strided via Mojo-side
     temporaries), so the classic chain was deleted (design doc §2.4)."""
@@ -2839,19 +2969,19 @@ def _unary_spec_op(spec, x):
     return result if result is not None else NOT_HANDLED
 
 
-def fast_aten_abs(x):
+def fast_aten_abs(x: torch.Tensor) -> TorchMojoTensor | _NotHandled:
     return _unary_spec_op("AbsSpec", x)
 
 
-def fast_aten_neg(x):
+def fast_aten_neg(x: torch.Tensor) -> TorchMojoTensor | _NotHandled:
     return _unary_spec_op("NegSpec", x)
 
 
-def fast_aten_sign(x):
+def fast_aten_sign(x: torch.Tensor) -> TorchMojoTensor | _NotHandled:
     return _unary_spec_op("SignSpec", x)
 
 
-def _int_unary_identity(x):
+def _int_unary_identity(x: torch.Tensor) -> TorchMojoTensor | None:
     """ceil/floor on integer tensors is the identity in torch; return a copy."""
     a = _t(x)
     if a is not None and a._dtype in _BITWISE_DTYPES and a._dtype != DType.bool:
@@ -2859,85 +2989,87 @@ def _int_unary_identity(x):
     return None
 
 
-def fast_aten_ceil(x):
+def fast_aten_ceil(x: torch.Tensor) -> TorchMojoTensor | _NotHandled:
     result = _int_unary_identity(x)
     if result is not None:
         return result
     return _unary_spec_op("CeilSpec", x)
 
 
-def fast_aten_floor(x):
+def fast_aten_floor(x: torch.Tensor) -> TorchMojoTensor | _NotHandled:
     result = _int_unary_identity(x)
     if result is not None:
         return result
     return _unary_spec_op("FloorSpec", x)
 
 
-def fast_aten_acos(x):
+def fast_aten_acos(x: torch.Tensor) -> TorchMojoTensor | _NotHandled:
     return _unary_spec_op("AcosSpec", x)
 
 
-def fast_aten_asinh(x):
+def fast_aten_asinh(x: torch.Tensor) -> TorchMojoTensor | _NotHandled:
     return _unary_spec_op("AsinhSpec", x)
 
 
-def fast_aten_atanh(x):
+def fast_aten_atanh(x: torch.Tensor) -> TorchMojoTensor | _NotHandled:
     return _unary_spec_op("AtanhSpec", x)
 
 
-def fast_aten_cos(x):
+def fast_aten_cos(x: torch.Tensor) -> TorchMojoTensor | _NotHandled:
     return _unary_spec_op("CosSpec", x)
 
 
-def fast_aten_cosh(x):
+def fast_aten_cosh(x: torch.Tensor) -> TorchMojoTensor | _NotHandled:
     return _unary_spec_op("CoshSpec", x)
 
 
-def fast_aten_erf(x):
+def fast_aten_erf(x: torch.Tensor) -> TorchMojoTensor | _NotHandled:
     return _unary_spec_op("ErfSpec", x)
 
 
-def fast_aten_log(x):
+def fast_aten_log(x: torch.Tensor) -> TorchMojoTensor | _NotHandled:
     return _unary_spec_op("LogSpec", x)
 
 
-def fast_aten_log1p(x):
+def fast_aten_log1p(x: torch.Tensor) -> TorchMojoTensor | _NotHandled:
     return _unary_spec_op("Log1pSpec", x)
 
 
-def fast_aten_reciprocal(x):
+def fast_aten_reciprocal(x: torch.Tensor) -> TorchMojoTensor | _NotHandled:
     return _unary_spec_op("ReciprocalSpec", x)
 
 
-def fast_aten_rsqrt(x):
+def fast_aten_rsqrt(x: torch.Tensor) -> TorchMojoTensor | _NotHandled:
     return _unary_spec_op("RsqrtSpec", x)
 
 
-def fast_aten_sigmoid(x):
+def fast_aten_sigmoid(x: torch.Tensor) -> TorchMojoTensor | _NotHandled:
     return _unary_spec_op("SigmoidSpec", x)
 
 
-def fast_aten_silu(x):
+def fast_aten_silu(x: torch.Tensor) -> TorchMojoTensor | _NotHandled:
     return _unary_spec_op("SiluSpec", x)
 
 
-def fast_aten_sin(x):
+def fast_aten_sin(x: torch.Tensor) -> TorchMojoTensor | _NotHandled:
     return _unary_spec_op("SinSpec", x)
 
 
-def fast_aten_sinh(x):
+def fast_aten_sinh(x: torch.Tensor) -> TorchMojoTensor | _NotHandled:
     return _unary_spec_op("SinhSpec", x)
 
 
-def fast_aten_sqrt(x):
+def fast_aten_sqrt(x: torch.Tensor) -> TorchMojoTensor | _NotHandled:
     return _unary_spec_op("SqrtSpec", x)
 
 
-def fast_aten_tan(x):
+def fast_aten_tan(x: torch.Tensor) -> TorchMojoTensor | _NotHandled:
     return _unary_spec_op("TanSpec", x)
 
 
-def fast_aten_gelu(input, approximate="none"):
+def fast_aten_gelu(
+    input: torch.Tensor, approximate: str = "none"
+) -> TorchMojoTensor | _NotHandled:
     if approximate == "none":
         spec = "GeluNoneSpec"
     elif approximate == "tanh":
@@ -2968,7 +3100,9 @@ def fast_aten_gelu(input, approximate="none"):
     return _unary_spec_op(spec, input)
 
 
-def fast_aten_gelu_backward(grad_output, self, *, approximate="none"):
+def fast_aten_gelu_backward(
+    grad_output: torch.Tensor, self: torch.Tensor, *, approximate: str = "none"
+) -> TorchMojoTensor | _NotHandled:
     """Float32/BFloat16 GPU GELU backward through Fable-owned Mojo kernels."""
     grad = _t(grad_output)
     input = _t(self)
@@ -2987,6 +3121,8 @@ def fast_aten_gelu_backward(grad_output, self, *, approximate="none"):
 
     grad = _tc(grad)
     input = _tc(input)
+    # grad/input were already TorchMojoTensor; _tc only materializes.
+    assert grad is not None and input is not None
     out = _alloc(input._shape, dtype, input._device)
     if out._numel > 0:
         op = "GeluBackwardBF16" if dtype == DType.bfloat16 else "GeluBackwardF32"
@@ -3009,12 +3145,12 @@ def fast_aten_gelu_backward(grad_output, self, *, approximate="none"):
     return out
 
 
-def fast_aten_isnan(x):
+def fast_aten_isnan(x: torch.Tensor) -> TorchMojoTensor | _NotHandled:
     result = _try_spec_unary("IsNanSpec", x, DType.bool)
     return result if result is not None else NOT_HANDLED
 
 
-def fast_aten_logical_not(x):
+def fast_aten_logical_not(x: torch.Tensor) -> TorchMojoTensor | _NotHandled:
     result = _try_spec_unary("LogicalNotSpec", x, DType.bool)
     return result if result is not None else NOT_HANDLED
 
@@ -3026,52 +3162,58 @@ def fast_aten_logical_not(x):
 # ---------------------------------------------------------------------------
 
 
-def fast_aten_eq(input, other):
+def fast_aten_eq(input: torch.Tensor, other: object) -> TorchMojoTensor | _NotHandled:
     result = _try_spec_binary("EqSpec", input, other, DType.bool)
     return result if result is not None else NOT_HANDLED
 
 
-def fast_aten_ne(input, other):
+def fast_aten_ne(input: torch.Tensor, other: object) -> TorchMojoTensor | _NotHandled:
     result = _try_spec_binary("NeSpec", input, other, DType.bool)
     return result if result is not None else NOT_HANDLED
 
 
-def fast_aten_lt(input, other):
+def fast_aten_lt(input: torch.Tensor, other: object) -> TorchMojoTensor | _NotHandled:
     result = _try_spec_binary("LtSpec", input, other, DType.bool)
     return result if result is not None else NOT_HANDLED
 
 
-def fast_aten_le(input, other):
+def fast_aten_le(input: torch.Tensor, other: object) -> TorchMojoTensor | _NotHandled:
     result = _try_spec_binary("LeSpec", input, other, DType.bool)
     return result if result is not None else NOT_HANDLED
 
 
-def fast_aten_gt(input, other):
+def fast_aten_gt(input: torch.Tensor, other: object) -> TorchMojoTensor | _NotHandled:
     result = _try_spec_binary("GtSpec", input, other, DType.bool)
     return result if result is not None else NOT_HANDLED
 
 
-def fast_aten_ge(input, other):
+def fast_aten_ge(input: torch.Tensor, other: object) -> TorchMojoTensor | _NotHandled:
     result = _try_spec_binary("GeSpec", input, other, DType.bool)
     return result if result is not None else NOT_HANDLED
 
 
-def fast_aten_bitwise_and(input, other):
+def fast_aten_bitwise_and(
+    input: torch.Tensor, other: object
+) -> TorchMojoTensor | _NotHandled:
     result = _try_spec_binary("BitwiseAndSpec", input, other)
     return result if result is not None else NOT_HANDLED
 
 
-def fast_aten_bitwise_or(input, other):
+def fast_aten_bitwise_or(
+    input: torch.Tensor, other: object
+) -> TorchMojoTensor | _NotHandled:
     result = _try_spec_binary("BitwiseOrSpec", input, other)
     return result if result is not None else NOT_HANDLED
 
 
-def fast_aten_bitwise_xor(input, other):
+def fast_aten_bitwise_xor(
+    input: torch.Tensor, other: object
+) -> TorchMojoTensor | _NotHandled:
     result = _try_spec_binary("BitwiseXorSpec", input, other)
     return result if result is not None else NOT_HANDLED
 
 
-def fast_aten_bitwise_not(input):
+def fast_aten_bitwise_not(input: torch.Tensor) -> TorchMojoTensor | _NotHandled:
     a = _tc(input)
     if a is None or a._dtype not in _BITWISE_DTYPES:
         return NOT_HANDLED
@@ -3092,7 +3234,13 @@ def fast_aten_bitwise_not(input):
     return out
 
 
-def fast_aten_isin(elements, test_elements, *, assume_unique=False, invert=False):
+def fast_aten_isin(
+    elements: torch.Tensor,
+    test_elements: torch.Tensor,
+    *,
+    assume_unique: bool = False,
+    invert: bool = False,
+) -> TorchMojoTensor | _NotHandled:
     del assume_unique
     el = _tc(elements)
     te = _tc(test_elements)
@@ -3106,7 +3254,8 @@ def fast_aten_isin(elements, test_elements, *, assume_unique=False, invert=False
         return NOT_HANDLED
     if el._numel > 0 and te._numel == 0:
         # x in {} is always False (True under invert).
-        return fast_filled(el._shape, 1.0 if invert else 0.0, DType.bool, el._device)
+        filled = fast_filled(el._shape, 1.0 if invert else 0.0, DType.bool, el._device)
+        return filled if filled is not None else NOT_HANDLED
     out = _alloc(el._shape, DType.bool, el._device)
     if el._numel > 0:
         _call_mojo(
@@ -3183,9 +3332,13 @@ def _searchsorted_sorter_in_range(
     maximum = fast_aten_max(sorter)
     if minimum is NOT_HANDLED or maximum is NOT_HANDLED:
         return None
+    if not isinstance(minimum, TorchMojoTensor) or not isinstance(
+        maximum, TorchMojoTensor
+    ):
+        return None
     min_value = fast_aten__local_scalar_dense(minimum)
     max_value = fast_aten__local_scalar_dense(maximum)
-    if min_value is NOT_HANDLED or max_value is NOT_HANDLED:
+    if not isinstance(min_value, int | float) or not isinstance(max_value, int | float):
         return None
     return int(min_value) >= 0 and int(max_value) < boundary_size
 
@@ -3304,6 +3457,9 @@ def _fast_searchsorted(
         )
 
     if scalar_value:
+        # A complex scalar cannot be embedded (float() on it raises); decline.
+        if not isinstance(values, int | float):
+            return NOT_HANDLED
         common_dtype = _searchsorted_scalar_dtype(boundaries._dtype, values)
         if common_dtype is None:
             return NOT_HANDLED
@@ -3322,6 +3478,7 @@ def _fast_searchsorted(
 
     boundaries = _tc(boundaries)
     input_tensor = _tc(input_tensor)
+    assert boundaries is not None and input_tensor is not None
     sorter_tensor = _tc(sorter_tensor) if sorter_tensor is not None else None
     out_dtype = DType.int32 if out_int32 else DType.int64
     out = _alloc(input_tensor._shape, out_dtype, input_tensor._device)
@@ -3410,19 +3567,25 @@ def fast_aten_searchsorted(
 # ---------------------------------------------------------------------------
 
 
-def fast_aten_remainder(input, other):
+def fast_aten_remainder(
+    input: torch.Tensor, other: object
+) -> TorchMojoTensor | _NotHandled:
     # Divisor-signed remainder (Python/torch `%`), float and int dtypes.
     result = _try_spec_binary("RemainderSpec", input, other)
     return result if result is not None else NOT_HANDLED
 
 
-def fast_aten_floor_divide(input, other):
+def fast_aten_floor_divide(
+    input: torch.Tensor, other: object
+) -> TorchMojoTensor | _NotHandled:
     # floor(input / other), float and int dtypes.
     result = _try_spec_binary("FloorDivSpec", input, other)
     return result if result is not None else NOT_HANDLED
 
 
-def fast_aten_pow_tensor_tensor(input, exponent):
+def fast_aten_pow_tensor_tensor(
+    input: torch.Tensor, exponent: object
+) -> TorchMojoTensor | _NotHandled:
     # Float-only (the kernel raises on ints, which would leave the output
     # unwritten); gate here so unsupported dtypes fall through cleanly.
     a = _t(input)
@@ -3432,7 +3595,9 @@ def fast_aten_pow_tensor_tensor(input, exponent):
     return result if result is not None else NOT_HANDLED
 
 
-def _try_logical(spec_fn_name, input, other):
+def _try_logical(
+    spec_fn_name: str, input: object, other: object
+) -> TorchMojoTensor | None:
     """Mixed-dtype logical_and / logical_xor: reduce each operand to bool
     (the nonzero test) spec-to-spec via CastSpec, then the bool spec path
     (uint8 dispatch). Same-dtype pairs already went through the spec
@@ -3454,33 +3619,40 @@ def _try_logical(spec_fn_name, input, other):
         return None
 
 
-def fast_aten_logical_and(input, other):
+def fast_aten_logical_and(
+    input: torch.Tensor, other: object
+) -> TorchMojoTensor | _NotHandled:
     result = _try_spec_binary("LogicalAndSpec", input, other, DType.bool)
     if result is None:
         result = _try_logical("LogicalAndSpec", input, other)
     return result if result is not None else NOT_HANDLED
 
 
-def fast_aten_logical_xor(input, other):
+def fast_aten_logical_xor(
+    input: torch.Tensor, other: object
+) -> TorchMojoTensor | _NotHandled:
     result = _try_spec_binary("LogicalXorSpec", input, other, DType.bool)
     if result is None:
         result = _try_logical("LogicalXorSpec", input, other)
     return result if result is not None else NOT_HANDLED
 
 
-def fast_aten_clamp(input, min=None, max=None):
+def fast_aten_clamp(
+    input: torch.Tensor, min: object = None, max: object = None
+) -> TorchMojoTensor | _NotHandled:
     a = _tc(input)
     if a is None or a._dtype not in _BCAST_DTYPES:
         return NOT_HANDLED
     if min is None and max is None:
         return NOT_HANDLED
-    for bound in (min, max):
-        if bound is not None and not isinstance(bound, int | float):
-            return NOT_HANDLED
+    if min is not None and not isinstance(min, int | float):
+        return NOT_HANDLED
+    if max is not None and not isinstance(max, int | float):
+        return NOT_HANDLED
     has_min = min is not None
     has_max = max is not None
-    lo = float(min) if has_min else 0.0
-    hi = float(max) if has_max else 0.0
+    lo = float(min) if min is not None else 0.0
+    hi = float(max) if max is not None else 0.0
     out = _alloc(a._shape, a._dtype, a._device)
     if out._numel > 0:
         _call_mojo(
@@ -3505,7 +3677,14 @@ def fast_aten_clamp(input, min=None, max=None):
     return out
 
 
-def _try_addc(kernel_name, self, tensor1, tensor2, value, allow_int):
+def _try_addc(
+    kernel_name: str,
+    self: torch.Tensor,
+    tensor1: torch.Tensor,
+    tensor2: torch.Tensor,
+    value: object,
+    allow_int: bool,
+) -> TorchMojoTensor | _NotHandled:
     a = _t(self)
     b = _t(tensor1)
     c = _t(tensor2)
@@ -3557,11 +3736,15 @@ def _try_addc(kernel_name, self, tensor1, tensor2, value, allow_int):
     return out
 
 
-def fast_aten_addcmul(self, tensor1, tensor2, value=1):
+def fast_aten_addcmul(
+    self: torch.Tensor, tensor1: torch.Tensor, tensor2: torch.Tensor, value: object = 1
+) -> TorchMojoTensor | _NotHandled:
     return _try_addc("AddcmulBcast", self, tensor1, tensor2, value, True)
 
 
-def fast_aten_addcdiv(self, tensor1, tensor2, value=1):
+def fast_aten_addcdiv(
+    self: torch.Tensor, tensor1: torch.Tensor, tensor2: torch.Tensor, value: object = 1
+) -> TorchMojoTensor | _NotHandled:
     return _try_addc("AddcdivBcast", self, tensor1, tensor2, value, False)
 
 
@@ -3571,7 +3754,7 @@ def fast_aten_addr(
     vec2: object,
     beta: int | float = 1,
     alpha: int | float = 1,
-) -> object:
+) -> TorchMojoTensor | _NotHandled:
     """beta*self + alpha*outer(vec1, vec2), fused into one kernel launch
     that reproduces CPU's own addr_kernel op order and per-op rounding
     exactly (see the comment above `_addr_bcast` in logic_ops.mojo for why
@@ -3631,7 +3814,9 @@ def fast_aten_addr(
     return out
 
 
-def _binary_operands(input, other):
+def _binary_operands(
+    input: object, other: object
+) -> tuple[TorchMojoTensor, TorchMojoTensor] | None:
     """Resolve (lhs, rhs) TorchMojoTensors with equal dtypes for the ternary
     broadcast kernels (where / masked_fill). Either operand may be a Python
     scalar (which becomes a 0-d stride-0 tensor of the tensor operand's
@@ -3651,7 +3836,9 @@ def _binary_operands(input, other):
     return None
 
 
-def fast_aten_where(condition, input, other):
+def fast_aten_where(
+    condition: torch.Tensor, input: object, other: object
+) -> TorchMojoTensor | _NotHandled:
     cond = _t(condition)
     if cond is None or cond._dtype != DType.bool:
         return NOT_HANDLED
@@ -3670,7 +3857,9 @@ def fast_aten_where(condition, input, other):
     return out
 
 
-def _masked_fill_scalar_operands(input, mask, value):
+def _masked_fill_scalar_operands(
+    input: torch.Tensor, mask: torch.Tensor, value: object
+) -> tuple[TorchMojoTensor, TorchMojoTensor, float, _BcastMeta] | None:
     """Resolve (in_t, mask_t, value: float, meta) for masked_fill's
     immediate-scalar fast path, or None.
 
@@ -3698,7 +3887,9 @@ def _masked_fill_scalar_operands(input, mask, value):
     return a, m, fval, meta
 
 
-def _masked_fill_operands(input, mask, value):
+def _masked_fill_operands(
+    input: torch.Tensor, mask: torch.Tensor, value: object
+) -> tuple[TorchMojoTensor, TorchMojoTensor, TorchMojoTensor, _BcastMeta] | None:
     """Resolve (in_t, mask_t, value_t, meta) for masked_fill, or None.
 
     `value` may be a Python scalar or a 0-dimensional tensor of input's
@@ -3741,7 +3932,9 @@ def _masked_fill_operands(input, mask, value):
     return a, m, val, meta
 
 
-def fast_aten_masked_fill(input, mask, value):
+def fast_aten_masked_fill(
+    input: torch.Tensor, mask: torch.Tensor, value: object
+) -> TorchMojoTensor | _NotHandled:
     scalar_resolved = _masked_fill_scalar_operands(input, mask, value)
     if scalar_resolved is not None:
         a, m, fval, meta = scalar_resolved
@@ -3759,7 +3952,9 @@ def fast_aten_masked_fill(input, mask, value):
     return out
 
 
-def fast_aten_masked_fill_(input, mask, value):
+def fast_aten_masked_fill_(
+    input: torch.Tensor, mask: torch.Tensor, value: object
+) -> torch.Tensor | None:
     """In-place masked fill into input. Returns None when unavailable."""
     scalar_resolved = _masked_fill_scalar_operands(input, mask, value)
     if scalar_resolved is not None:
@@ -3771,7 +3966,7 @@ def fast_aten_masked_fill_(input, mask, value):
                 _launch_masked_fill_scalar(a, m, a, fval, meta, a._dtype)
             else:
                 result = fast_aten_masked_fill(input, mask, value)
-                if result is NOT_HANDLED:
+                if not isinstance(result, TorchMojoTensor):
                     return None
                 _copy_into(a, result)
         return input
@@ -3786,7 +3981,7 @@ def fast_aten_masked_fill_(input, mask, value):
             _launch_where_bcast(a, (m, val, a), meta, a._dtype)
         else:
             result = fast_aten_masked_fill(input, mask, value)
-            if result is NOT_HANDLED:
+            if not isinstance(result, TorchMojoTensor):
                 return None
             _copy_into(a, result)
     return input
@@ -3798,7 +3993,7 @@ def fast_aten_masked_fill_(input, mask, value):
 # ---------------------------------------------------------------------------
 
 
-def _resolve_sizes(shape, numel: int) -> list[int] | None:
+def _resolve_sizes(shape: Sequence[int], numel: int) -> list[int] | None:
     # Single pass; view is the hottest op in transformer forwards.
     prod = 1
     neg = -1
@@ -3820,7 +4015,9 @@ def _resolve_sizes(shape, numel: int) -> list[int] | None:
     return sizes
 
 
-def _compute_view_strides(old_shape, old_strides, new_shape):
+def _compute_view_strides(
+    old_shape: Sequence[int], old_strides: Sequence[int], new_shape: Sequence[int]
+) -> tuple[int, ...] | None:
     """Port of ATen's computeStride: strides for viewing `old` as
     `new_shape` without a copy, or None when impossible."""
     if len(old_shape) == 0:
@@ -3859,11 +4056,14 @@ def _compute_view_strides(old_shape, old_strides, new_shape):
     return tuple(new_strides)
 
 
-def _fast_view(tensor, shape):
+def _fast_view(
+    tensor: torch.Tensor, shape: Sequence[object]
+) -> TorchMojoTensor | _NotHandled:
     if len(shape) == 1 and isinstance(shape[0], list | tuple):
         shape = shape[0]
     if not all(isinstance(s, int) for s in shape):
         return NOT_HANDLED
+    shape = cast(Sequence[int], shape)
     t = _t(tensor)
     if t is None:
         return NOT_HANDLED
@@ -3881,15 +4081,21 @@ def _fast_view(tensor, shape):
     return _view_of(t, sizes, new_strides, t._offset)
 
 
-def fast_aten_view(tensor, *shape):
+def fast_aten_view(
+    tensor: torch.Tensor, *shape: object
+) -> TorchMojoTensor | _NotHandled:
     return _fast_view(tensor, shape)
 
 
-def fast_aten__unsafe_view(tensor, *shape):
+def fast_aten__unsafe_view(
+    tensor: torch.Tensor, *shape: object
+) -> TorchMojoTensor | _NotHandled:
     return _fast_view(tensor, shape)
 
 
-def fast_aten_unsqueeze(tensor, dim):
+def fast_aten_unsqueeze(
+    tensor: torch.Tensor, dim: int
+) -> TorchMojoTensor | _NotHandled:
     t = _t(tensor)
     if t is None:
         return NOT_HANDLED
@@ -3904,7 +4110,9 @@ def fast_aten_unsqueeze(tensor, dim):
     return _view_of(t, new_shape, new_strides, t._offset)
 
 
-def fast_aten_squeeze_dim(tensor, dim):
+def fast_aten_squeeze_dim(
+    tensor: torch.Tensor, dim: int
+) -> TorchMojoTensor | _NotHandled:
     t = _t(tensor)
     if t is None:
         return NOT_HANDLED
@@ -3919,7 +4127,7 @@ def fast_aten_squeeze_dim(tensor, dim):
     return _view_of(t, new_shape, new_strides, t._offset)
 
 
-def fast_aten_alias(tensor):
+def fast_aten_alias(tensor: torch.Tensor) -> TorchMojoTensor | _NotHandled:
     t = _t(tensor)
     if t is None:
         return NOT_HANDLED
@@ -3942,22 +4150,25 @@ def fast_aten_alias(tensor):
 fast_aten_detach = fast_aten_alias
 
 
-def fast_aten_permute(input, dims):
+def fast_aten_permute(
+    input: torch.Tensor, dims: object
+) -> TorchMojoTensor | _NotHandled:
     t = _t(input)
     if t is None or not isinstance(dims, list | tuple):
         return NOT_HANDLED
     rank = len(t._shape)
     if len(dims) != rank:
         return NOT_HANDLED
-    perm = [d % rank if -rank <= d < rank else None for d in dims]
-    if None in perm or len(set(perm)) != rank:
+    unchecked_perm = [d % rank if -rank <= d < rank else None for d in dims]
+    if None in unchecked_perm or len(set(unchecked_perm)) != rank:
         return NOT_HANDLED
+    perm = cast(list[int], unchecked_perm)
     new_shape = tuple(t._shape[p] for p in perm)
     new_strides = tuple(t._mojo_strides[p] for p in perm)
     return _view_of(t, new_shape, new_strides, t._offset)
 
 
-def fast_aten_t(input):
+def fast_aten_t(input: torch.Tensor) -> TorchMojoTensor | _NotHandled:
     t = _t(input)
     if t is None or len(t._shape) > 2:
         return NOT_HANDLED
@@ -3966,7 +4177,9 @@ def fast_aten_t(input):
     return fast_aten_transpose(input, 0, 1)
 
 
-def fast_aten_transpose(input, dim0, dim1):
+def fast_aten_transpose(
+    input: torch.Tensor, dim0: object, dim1: object
+) -> TorchMojoTensor | _NotHandled:
     t = _t(input)
     if t is None or not isinstance(dim0, int) or not isinstance(dim1, int):
         return NOT_HANDLED
@@ -3984,7 +4197,9 @@ def fast_aten_transpose(input, dim0, dim1):
     return _view_of(t, shape, strides, t._offset)
 
 
-def fast_aten_expand(tensor, sizes, *, implicit=False):
+def fast_aten_expand(
+    tensor: torch.Tensor, sizes: object, *, implicit: bool = False
+) -> TorchMojoTensor | _NotHandled:
     t = _t(tensor)
     if t is None or not isinstance(sizes, list | tuple):
         return NOT_HANDLED
@@ -4015,7 +4230,12 @@ def fast_aten_expand(tensor, sizes, *, implicit=False):
     return _view_of(t, new_shape, new_strides, t._offset)
 
 
-def fast_aten_as_strided(tensor, size, stride, storage_offset=None):
+def fast_aten_as_strided(
+    tensor: torch.Tensor,
+    size: Sequence[int],
+    stride: Sequence[int],
+    storage_offset: int | None = None,
+) -> TorchMojoTensor | _NotHandled:
     """Zero-copy relayout over the tensor's storage (the holder allocation).
 
     ``storage_offset`` is absolute in elements from the storage start, which
@@ -4039,12 +4259,18 @@ def fast_aten_as_strided(tensor, size, stride, storage_offset=None):
     # one view op whose arguments are unconstrained by the input's own shape.
     if all(size):
         last = offset + sum((n - 1) * st for n, st in zip(size, stride))
-        if (last + 1) * t._itemsize > t._holder.get_nbytes():
+        if (last + 1) * t._itemsize > cast(_HolderObject, t._holder).get_nbytes():
             return NOT_HANDLED
     return _view_of(t, size, stride, offset)
 
 
-def fast_aten_slice(input, dim=0, start=None, end=None, step=1):
+def fast_aten_slice(
+    input: torch.Tensor,
+    dim: object = 0,
+    start: object = None,
+    end: object = None,
+    step: object = 1,
+) -> TorchMojoTensor | _NotHandled:
     t = _t(input)
     if t is None or not isinstance(dim, int) or not isinstance(step, int) or step < 1:
         return NOT_HANDLED
@@ -4075,7 +4301,9 @@ def fast_aten_slice(input, dim=0, start=None, end=None, step=1):
     return _view_of(t, new_shape, new_strides, new_offset)
 
 
-def fast_aten_select(input, dim, index):
+def fast_aten_select(
+    input: torch.Tensor, dim: object, index: object
+) -> TorchMojoTensor | _NotHandled:
     t = _t(input)
     if t is None or not isinstance(dim, int) or not isinstance(index, int):
         return NOT_HANDLED
@@ -4094,7 +4322,9 @@ def fast_aten_select(input, dim, index):
     return _view_of(t, new_shape, new_strides, new_offset)
 
 
-def fast_aten_split(input, split_size, dim=0):
+def fast_aten_split(
+    input: torch.Tensor, split_size: int | Sequence[int], dim: object = 0
+) -> list[TorchMojoTensor] | _NotHandled:
     t = _t(input)
     if t is None or not isinstance(dim, int):
         return NOT_HANDLED
@@ -4123,16 +4353,22 @@ def fast_aten_split(input, split_size, dim=0):
     for length in lengths:
         results.append(fast_aten_slice(t, dim, offset, offset + length))
         offset += length
-    if any(r is NOT_HANDLED for r in results):
+    # isinstance, not `is`: ty doesn't narrow identity checks against a custom
+    # singleton, and a generator's per-element check can't narrow the list.
+    if any(isinstance(r, _NotHandled) for r in results):
         return NOT_HANDLED
-    return results
+    return cast(list[TorchMojoTensor], results)
 
 
-def fast_aten_split_with_sizes(input, split_sizes, dim=0):
+def fast_aten_split_with_sizes(
+    input: torch.Tensor, split_sizes: Sequence[int], dim: int = 0
+) -> list[TorchMojoTensor] | _NotHandled:
     return fast_aten_split(input, list(split_sizes), dim)
 
 
-def fast_aten_unbind(input, dim=0):
+def fast_aten_unbind(
+    input: torch.Tensor, dim: object = 0
+) -> list[TorchMojoTensor] | _NotHandled:
     t = _t(input)
     if t is None or not isinstance(dim, int):
         return NOT_HANDLED
@@ -4141,12 +4377,14 @@ def fast_aten_unbind(input, dim=0):
         return NOT_HANDLED
     dim %= rank
     results = [fast_aten_select(t, dim, i) for i in range(t._shape[dim])]
-    if any(r is NOT_HANDLED for r in results):
+    if any(isinstance(r, _NotHandled) for r in results):
         return NOT_HANDLED
-    return results
+    return cast(list[TorchMojoTensor], results)
 
 
-def fast_aten_clone(input, *, memory_format=None):
+def fast_aten_clone(
+    input: torch.Tensor, *, memory_format: object = None
+) -> TorchMojoTensor | _NotHandled:
     t = _t(input)
     if t is None:
         return NOT_HANDLED
@@ -4173,7 +4411,7 @@ def fast_aten_clone(input, *, memory_format=None):
 _VECTOR_BYTES = 16
 
 
-def _is_legacy_empty(t) -> bool:
+def _is_legacy_empty(t: torch.Tensor) -> bool:
     x = _t(t)
     return x is not None and len(x._shape) == 1 and x._numel == 0
 
@@ -4205,21 +4443,23 @@ def _cat_vector_width(
     return width
 
 
-def fast_aten_cat(tensors, dim=0):
+def fast_aten_cat(
+    tensors: Sequence[torch.Tensor], dim: object = 0
+) -> TorchMojoTensor | _NotHandled:
     # PyTorch's cat skips legacy "empty" (1-D, size-0) tensors, e.g.
     # uninitialized KV-caches.
     real = [x for x in tensors if not _is_legacy_empty(x)]
     if not real or not isinstance(dim, int):
         return NOT_HANDLED
-    ins = [_t(x) for x in real]
-    first = ins[0]
+    unwrapped_ins = [_t(x) for x in real]
+    first = unwrapped_ins[0]
     if first is None or first._dtype not in _COPYABLE_DTYPES:
         return NOT_HANDLED
     rank = len(first._shape)
     if rank == 0 or not -rank <= dim < rank or rank > _MAX_RANK:
         return NOT_HANDLED
     dim %= rank
-    for b in ins:
+    for b in unwrapped_ins:
         if (
             b is None
             or b._dtype != first._dtype
@@ -4228,6 +4468,7 @@ def fast_aten_cat(tensors, dim=0):
             or any(i != dim and b._shape[i] != first._shape[i] for i in range(rank))
         ):
             return NOT_HANDLED
+    ins = cast(list[TorchMojoTensor], unwrapped_ins)
     out_shape = list(first._shape)
     out_shape[dim] = sum(b._shape[dim] for b in ins)
     inner = math.prod(out_shape[dim + 1 :])
@@ -4352,7 +4593,7 @@ def _try_stack_scalars(
     return out
 
 
-def fast_aten_stack(tensors, dim=0):
+def fast_aten_stack(tensors: object, dim: object = 0) -> TorchMojoTensor | _NotHandled:
     # stack = unsqueeze each input at `dim`, then concatenate along `dim`.
     # Both helpers normalize `dim` against the SAME (rank + 1) base, so a raw
     # (possibly negative) `dim` stays consistent between them.
@@ -4363,10 +4604,10 @@ def fast_aten_stack(tensors, dim=0):
     scalar_stack = _try_stack_scalars(tensors, dim)
     if scalar_stack is not None:
         return scalar_stack
-    unsqueezed = []
+    unsqueezed: list[torch.Tensor] = []
     for x in tensors:
         u = fast_aten_unsqueeze(x, dim)
-        if u is NOT_HANDLED:
+        if not isinstance(u, TorchMojoTensor):
             return NOT_HANDLED
         unsqueezed.append(u)
     return fast_aten_cat(unsqueezed, dim)
@@ -4412,7 +4653,9 @@ def _repeat_tile_plan(
     return rows, cols, r1, ncopies
 
 
-def fast_aten_repeat(input, repeats):
+def fast_aten_repeat(
+    input: torch.Tensor, repeats: object
+) -> TorchMojoTensor | _NotHandled:
     t = _tc(input)
     if t is None or t._dtype not in _COPYABLE_DTYPES:
         return NOT_HANDLED
@@ -4475,7 +4718,9 @@ def fast_aten_repeat(input, repeats):
     return out
 
 
-def _fast_triangular(input, diagonal, upper):
+def _fast_triangular(
+    input: torch.Tensor, diagonal: object, upper: int
+) -> TorchMojoTensor | _NotHandled:
     if not isinstance(diagonal, int):
         return NOT_HANDLED
     t = _tc(input)
@@ -4510,15 +4755,21 @@ def _fast_triangular(input, diagonal, upper):
     return out
 
 
-def fast_aten_tril(input, diagonal=0):
+def fast_aten_tril(
+    input: torch.Tensor, diagonal: object = 0
+) -> TorchMojoTensor | _NotHandled:
     return _fast_triangular(input, diagonal, 0)
 
 
-def fast_aten_triu(input, diagonal=0):
+def fast_aten_triu(
+    input: torch.Tensor, diagonal: object = 0
+) -> TorchMojoTensor | _NotHandled:
     return _fast_triangular(input, diagonal, 1)
 
 
-def fast_aten_index(input, indices):
+def fast_aten_index(
+    input: torch.Tensor, indices: object
+) -> TorchMojoTensor | _NotHandled:
     t = _t(input)
     if t is None or not isinstance(indices, list | tuple):
         return NOT_HANDLED
@@ -4536,6 +4787,7 @@ def fast_aten_index(input, indices):
         if src is None or src._dtype not in _COPYABLE_DTYPES or len(src._shape) < 1:
             return NOT_HANDLED
         idx_c = _tc(idx)
+        assert idx_c is not None
         row_len = 1
         for s in src._shape[1:]:
             row_len *= s
@@ -4565,16 +4817,27 @@ def fast_aten_index(input, indices):
     if idx._dtype == DType.bool:
         # Boolean mask: data-dependent output shape -> host bounce (syncs).
         cpu_self = t._to_cpu_tensor()
-        cpu_indices = tuple(
-            slice(None) if x is None else _t(x)._to_cpu_tensor() for x in indices
-        )
-        result = cpu_self[cpu_indices]
+        cpu_index_entries = []
+        for x in indices:
+            if x is None:
+                cpu_index_entries.append(slice(None))
+                continue
+            x_mojo = _t(x)
+            assert x_mojo is not None
+            cpu_index_entries.append(x_mojo._to_cpu_tensor())
+        result = cpu_self[tuple(cpu_index_entries)]
         return TorchMojoTensor._from_cpu(result, t._device)
 
     return NOT_HANDLED
 
 
-def _fast_scatter(input, dim, index, src, value):
+def _fast_scatter(
+    input: torch.Tensor,
+    dim: object,
+    index: torch.Tensor,
+    src: torch.Tensor | None,
+    value: object,
+) -> TorchMojoTensor | _NotHandled:
     a = _t(input)
     idx = _t(index)
     if a is None or idx is None or not isinstance(dim, int):
@@ -4594,6 +4857,7 @@ def _fast_scatter(input, dim, index, src, value):
 
     out = a._materialize_contiguous()  # clone(self)
     idx_c = _tc(idx)
+    assert idx_c is not None
 
     is_value = 0
     value_f = 0.0
@@ -4658,15 +4922,21 @@ def _fast_scatter(input, dim, index, src, value):
     return out
 
 
-def fast_aten_scatter_src(input, dim, index, src):
+def fast_aten_scatter_src(
+    input: torch.Tensor, dim: object, index: torch.Tensor, src: torch.Tensor
+) -> TorchMojoTensor | _NotHandled:
     return _fast_scatter(input, dim, index, src, None)
 
 
-def fast_aten_scatter_value(input, dim, index, value):
+def fast_aten_scatter_value(
+    input: torch.Tensor, dim: object, index: torch.Tensor, value: object
+) -> TorchMojoTensor | _NotHandled:
     return _fast_scatter(input, dim, index, None, value)
 
 
-def fast_aten_select_scatter(input, src, dim, index):
+def fast_aten_select_scatter(
+    input: torch.Tensor, src: torch.Tensor, dim: object, index: object
+) -> TorchMojoTensor | _NotHandled:
     a = _t(input)
     s = _t(src)
     if a is None or s is None or not isinstance(dim, int) or not isinstance(index, int):
@@ -4674,22 +4944,22 @@ def fast_aten_select_scatter(input, src, dim, index):
     if s._device != a._device:
         return NOT_HANDLED
     out = fast_aten_clone(a)
-    if out is NOT_HANDLED:
+    if not isinstance(out, TorchMojoTensor):
         return NOT_HANDLED
     view = fast_aten_select(out, dim, index)
-    if view is NOT_HANDLED:
+    if not isinstance(view, TorchMojoTensor):
         return NOT_HANDLED
     if s._dtype != out._dtype:
         s = _cast_tensor(s, out._dtype)
     if tuple(s._shape) != tuple(view._shape):
         s = fast_aten_expand(s, view._shape)
-        if s is NOT_HANDLED:
+        if not isinstance(s, TorchMojoTensor):
             return NOT_HANDLED
     _copy_into(view, s)
     return out
 
 
-def fast_aten_nonzero(input):
+def fast_aten_nonzero(input: torch.Tensor) -> TorchMojoTensor | _NotHandled:
     t = _t(input)
     if t is None:
         return NOT_HANDLED
@@ -4728,8 +4998,8 @@ def _bn_geometry(
 
 
 def _bn_inference_saved_stats(
-    running_mean: object, running_var: object, eps: object
-) -> tuple[object, object] | None:
+    running_mean: object, running_var: object, eps: float
+) -> tuple[TorchMojoTensor, TorchMojoTensor] | None:
     """`(save_mean, save_invstd)` for an inference batch norm, or None.
 
     These are NOT empty in PyTorch.  `batch_norm_cuda_out` resizes `save_mean`
@@ -4744,8 +5014,13 @@ def _bn_inference_saved_stats(
     if mean_t is None or var_t is None:
         return None
     save_mean = fast_aten_clone(mean_t)
-    save_invstd = fast_aten_rsqrt(fast_aten_add(var_t, float(eps)))
-    if save_mean is NOT_HANDLED or save_invstd is NOT_HANDLED:
+    shifted_var = fast_aten_add(var_t, float(eps))
+    if not isinstance(shifted_var, TorchMojoTensor):
+        return None
+    save_invstd = fast_aten_rsqrt(shifted_var)
+    # isinstance, not `is`: ty doesn't narrow identity checks against a
+    # custom singleton instance the way it does for `is None`.
+    if isinstance(save_mean, _NotHandled) or isinstance(save_invstd, _NotHandled):
         return None
     return save_mean, save_invstd
 
@@ -4756,8 +5031,8 @@ def _fast_batch_norm_inference_gpu(
     bias: object,
     running_mean: object,
     running_var: object,
-    eps: object,
-) -> object:
+    eps: float,
+) -> tuple[TorchMojoTensor, TorchMojoTensor, TorchMojoTensor] | _NotHandled:
     """Vectorized GPU inference batch norm, or NOT_HANDLED.
 
     Torch feeds float32 running statistics to a half/bfloat16 input (that is
@@ -4772,10 +5047,22 @@ def _fast_batch_norm_inference_gpu(
         _t(bias),
     )
     geom = _bn_geometry(a, (mean_t, var_t, gamma_t, beta_t))
-    if geom is None or mean_t._dtype != var_t._dtype or gamma_t._dtype != beta_t._dtype:
+    if geom is None:
+        return NOT_HANDLED
+    # _bn_geometry returned a geometry, so every parameter is a mojo tensor.
+    assert (
+        mean_t is not None
+        and var_t is not None
+        and gamma_t is not None
+        and beta_t is not None
+    )
+    if mean_t._dtype != var_t._dtype or gamma_t._dtype != beta_t._dtype:
         return NOT_HANDLED
     channels, inner, planes = geom
-    a = _tc(a)
+    contiguous_a = _tc(a)
+    # a was already TorchMojoTensor; _tc only materializes.
+    assert contiguous_a is not None
+    a = contiguous_a
     out = _alloc(a._shape, a._dtype, a._device)
     # The kernel emits the saved statistics itself: see _bn_inference_saved_stats
     # for why they must not be empty, and the kernel docstring for why doing it
@@ -4817,9 +5104,9 @@ def _fast_batch_norm_training(
     bias: object,
     running_mean: object,
     running_var: object,
-    momentum: object,
-    eps: object,
-) -> object:
+    momentum: float,
+    eps: float,
+) -> tuple[TorchMojoTensor, TorchMojoTensor, TorchMojoTensor] | _NotHandled:
     """`aten::native_batch_norm` with `training=True` on the GPU.
 
     The per-channel statistics reduce `{0, 2, 3}` of an NCHW tensor — an axis
@@ -4847,7 +5134,7 @@ def _fast_batch_norm_training(
     geom = _bn_geometry(a, present)
     if geom is None:
         return NOT_HANDLED
-    if has_running and mean_t._dtype != var_t._dtype:
+    if mean_t is not None and var_t is not None and mean_t._dtype != var_t._dtype:
         return NOT_HANDLED
     if gamma_t is not None and beta_t is not None and gamma_t._dtype != beta_t._dtype:
         return NOT_HANDLED
@@ -4859,9 +5146,10 @@ def _fast_batch_norm_training(
         return NOT_HANDLED
     # The saved statistics are float32 whatever the input dtype is (ATen's
     # `at::acc_type`), and the second one is the inverse standard deviation.
-    stat_dtype = mean_t._dtype if has_running else DType.float32
+    stat_dtype = mean_t._dtype if mean_t is not None else DType.float32
     param_dtype = gamma_t._dtype if gamma_t is not None else a._dtype
     a = _tc(a)
+    assert a is not None
     out = _alloc(a._shape, a._dtype, a._device)
     save_mean = _alloc((channels,), DType.float32, a._device)
     save_invstd = _alloc((channels,), DType.float32, a._device)
@@ -4875,8 +5163,8 @@ def _fast_batch_norm_training(
             a._ptr,
             gamma_t._ptr if gamma_t is not None else 0,
             beta_t._ptr if beta_t is not None else 0,
-            mean_t._ptr if has_running else 0,
-            var_t._ptr if has_running else 0,
+            mean_t._ptr if mean_t is not None else 0,
+            var_t._ptr if var_t is not None else 0,
             (
                 float(eps),
                 float(momentum),
@@ -4901,29 +5189,40 @@ def _fast_batch_norm_training(
     return out, save_mean, save_invstd
 
 
-def _fast_batch_norm_inference(input, weight, bias, running_mean, running_var, eps):
+def _fast_batch_norm_inference(
+    input: torch.Tensor,
+    weight: object,
+    bias: object,
+    running_mean: object,
+    running_var: object,
+    eps: float,
+) -> tuple[TorchMojoTensor, TorchMojoTensor, TorchMojoTensor] | _NotHandled:
     a = _t(input)
     if a is not None and _on_gpu(a) and a._dtype in _FLOAT_DTYPES:
         result = _fast_batch_norm_inference_gpu(
             a, weight, bias, running_mean, running_var, eps
         )
-        if result is not NOT_HANDLED:
+        # isinstance, not `is`: ty doesn't narrow identity checks against a
+        # custom singleton instance the way it does for `is None`.
+        if not isinstance(result, _NotHandled):
             return result
-    stats = [_t(x) for x in (running_mean, running_var, weight, bias)]
+    unwrapped_stats = [_t(x) for x in (running_mean, running_var, weight, bias)]
     if (
         a is not None
-        and all(stat is not None for stat in stats)
+        and all(stat is not None for stat in unwrapped_stats)
         and a._dtype in _FLOAT_DTYPES
         and len(a._shape) >= 2
         and a._numel > 0
         and a._is_contiguous
         and all(
-            stat._device == a._device
+            stat is not None
+            and stat._device == a._device
             and stat._dtype == a._dtype
             and stat._is_contiguous
-            for stat in stats
+            for stat in unwrapped_stats
         )
     ):
+        stats = cast(list[TorchMojoTensor], unwrapped_stats)
         out = _alloc(a._shape, a._dtype, a._device)
         _call_mojo(
             _NNExtension,
@@ -4949,10 +5248,10 @@ def _fast_batch_norm_inference(input, weight, bias, running_mean, running_var, e
         return NOT_HANDLED
     if a._numel == 0:
         return NOT_HANDLED
-    params = [_tc(x) for x in (running_mean, running_var, weight, bias)]
-    if any(p is None or p._dtype != a._dtype for p in params):
+    unwrapped_params = [_tc(x) for x in (running_mean, running_var, weight, bias)]
+    if any(p is None or p._dtype != a._dtype for p in unwrapped_params):
         return NOT_HANDLED
-    mean_t, var_t, gamma_t, beta_t = params
+    mean_t, var_t, gamma_t, beta_t = cast(list[TorchMojoTensor], unwrapped_params)
     channels = a._shape[1]
     inner = math.prod(a._shape[2:])
     out = _alloc(a._shape, a._dtype, a._device)
@@ -4987,8 +5286,15 @@ def _fast_batch_norm_inference(input, weight, bias, running_mean, running_var, e
 
 
 def fast_aten_native_batch_norm(
-    input, weight, bias, running_mean, running_var, training, momentum, eps
-):
+    input: torch.Tensor,
+    weight: object,
+    bias: object,
+    running_mean: object,
+    running_var: object,
+    training: bool,
+    momentum: float,
+    eps: float,
+) -> tuple[TorchMojoTensor, TorchMojoTensor, TorchMojoTensor] | _NotHandled:
     if not training:
         return _fast_batch_norm_inference(
             input, weight, bias, running_mean, running_var, eps
@@ -4999,14 +5305,22 @@ def fast_aten_native_batch_norm(
 
 
 def fast_aten__native_batch_norm_legit_no_training(
-    input, weight, bias, running_mean, running_var, momentum, eps
-):
+    input: torch.Tensor,
+    weight: object,
+    bias: object,
+    running_mean: object,
+    running_var: object,
+    momentum: float,
+    eps: float,
+) -> tuple[TorchMojoTensor, TorchMojoTensor, TorchMojoTensor] | _NotHandled:
     return _fast_batch_norm_inference(
         input, weight, bias, running_mean, running_var, eps
     )
 
 
-def fast_aten_native_dropout(input, p, train):
+def fast_aten_native_dropout(
+    input: torch.Tensor, p: object, train: bool | None
+) -> tuple[TorchMojoTensor, TorchMojoTensor] | _NotHandled:
     """Contiguous float32 GPU native dropout with host-owned RNG state.
 
     The Fable-owned Mojo kernel is stateless: this host path atomically
@@ -5029,7 +5343,9 @@ def fast_aten_native_dropout(input, p, train):
     if train is False:
         output = fast_aten_clone(a)
         mask = fast_filled(a._shape, True, DType.bool, a._device)
-        if output is NOT_HANDLED or mask is None:
+        # isinstance, not `is`: ty doesn't narrow identity checks against a
+        # custom singleton instance the way it does for `is None`.
+        if isinstance(output, _NotHandled) or mask is None:
             return NOT_HANDLED
         return output, mask
 
@@ -5059,6 +5375,7 @@ def fast_aten_native_dropout(input, p, train):
     # Validate and allocate before changing generator state.  No operation
     # after the reservation reads the host or synchronizes the device queue.
     a = _tc(a)
+    assert a is not None
     output = _alloc(a._shape, DType.float32, a._device)
     mask = _alloc(a._shape, DType.bool, a._device)
     seed, base_offset = _reserve_philox_state(a._torch_device, (a._numel + 3) // 4)
@@ -5085,7 +5402,9 @@ def fast_aten_native_dropout(input, p, train):
     return output, mask
 
 
-def fast_aten_native_dropout_backward(grad_output, mask, scale):
+def fast_aten_native_dropout_backward(
+    grad_output: torch.Tensor, mask: torch.Tensor, scale: object
+) -> TorchMojoTensor | _NotHandled:
     """Float32 GPU native-dropout backward through the saved bool mask."""
     grad = _t(grad_output)
     keep = _t(mask)
@@ -5103,6 +5422,7 @@ def fast_aten_native_dropout_backward(grad_output, mask, scale):
 
     grad = _tc(grad)
     keep = _tc(keep)
+    assert grad is not None and keep is not None
     grad_input = _alloc(grad._shape, DType.float32, grad._device)
     if grad._numel > 0:
         _call_mojo(
@@ -5152,7 +5472,7 @@ def fast_aten_uniform_(
     from_: float = 0.0,
     to: float = 1.0,
     generator: torch.Generator | None = None,
-) -> object:
+) -> TorchMojoTensor | _NotHandled:
     """In-place `uniform_` generated ON THE DEVICE, from the device's own
     Philox stream.
 
@@ -5259,8 +5579,8 @@ def fast_aten_uniform_(
 
 
 def _layer_norm_stats_to_input_dtype(
-    mean: MojoTensorLike, rstd: MojoTensorLike, input_dtype: DType
-) -> tuple[MojoTensorLike, MojoTensorLike]:
+    mean: _SpecTensor, rstd: _SpecTensor, input_dtype: DType
+) -> tuple[_SpecTensor, _SpecTensor]:
     """`(mean, rstd)` as ATen returns them: same dtype as the input.
 
     ATen's CPU `layer_norm` accumulates in `opmath_type` (float for a
@@ -5275,10 +5595,19 @@ def _layer_norm_stats_to_input_dtype(
     """
     if input_dtype == DType.float32:
         return mean, rstd
-    return _cast_tensor(mean, input_dtype), _cast_tensor(rstd, input_dtype)
+    return (
+        _cast_tensor(cast(TorchMojoTensor, mean), input_dtype),
+        _cast_tensor(cast(TorchMojoTensor, rstd), input_dtype),
+    )
 
 
-def fast_aten_native_layer_norm(input, normalized_shape, weight, bias, eps):
+def fast_aten_native_layer_norm(
+    input: torch.Tensor,
+    normalized_shape: Sequence[int],
+    weight: torch.Tensor | None,
+    bias: torch.Tensor | None,
+    eps: float,
+) -> tuple[TorchMojoTensor, _SpecTensor, _SpecTensor] | _NotHandled:
     a = _t(input)
     normalized_shape = tuple(normalized_shape)
     k = len(normalized_shape)
@@ -5321,10 +5650,13 @@ def fast_aten_native_layer_norm(input, normalized_shape, weight, bias, eps):
     # cross-device or wrong-shape call cannot enqueue partial work.
     eps_value = float(eps)
     a = _tc(a)
+    assert a is not None
     if weight is not None:
         gamma = _tc(gamma)
+        assert gamma is not None
     if bias is not None:
         beta = _tc(beta)
+        assert beta is not None
     # Not spec-converted: the classic prologue here is already thin, and
     # building three (holder, spec, shape, ptr) result groups measurably
     # costs more than the removed Python work (+4us/call measured A/B on
@@ -5354,8 +5686,8 @@ def fast_aten_native_layer_norm(input, normalized_shape, weight, bias, eps):
                 mean._ptr,
                 rstd._ptr,
                 a._ptr,
-                gamma._ptr if weight is not None else 0,
-                beta._ptr if bias is not None else 0,
+                gamma._ptr if gamma is not None else 0,
+                beta._ptr if beta is not None else 0,
                 rows,
                 cols,
                 eps_value,
@@ -5382,6 +5714,7 @@ def fast_aten_native_layer_norm(input, normalized_shape, weight, bias, eps):
         gamma = fast_filled((cols,), 1.0, a._dtype, a._device)
     if bias is None:
         beta = fast_filled((cols,), 0.0, a._dtype, a._device)
+    assert gamma is not None and beta is not None
     _call_mojo(
         _NNExtension,
         "LayerNorm",
@@ -5405,7 +5738,17 @@ def fast_aten_native_layer_norm(input, normalized_shape, weight, bias, eps):
 
 
 def fast_aten_native_layer_norm_backward(
-    grad_out, input, normalized_shape, mean, rstd, weight, bias, output_mask
+    grad_out: torch.Tensor,
+    input: torch.Tensor,
+    normalized_shape: Sequence[int],
+    mean: torch.Tensor,
+    rstd: torch.Tensor,
+    weight: torch.Tensor | None,
+    bias: torch.Tensor | None,
+    output_mask: Sequence[bool],
+) -> (
+    tuple[TorchMojoTensor | None, TorchMojoTensor | None, TorchMojoTensor | None]
+    | _NotHandled
 ):
     """Direct eager LayerNorm backward for the pure-Mojo f32 GPU kernels.
 
@@ -5496,6 +5839,12 @@ def fast_aten_native_layer_norm_backward(
     a = _tc(a)
     saved_mean = _tc(saved_mean)
     saved_rstd = _tc(saved_rstd)
+    assert (
+        grad is not None
+        and a is not None
+        and saved_mean is not None
+        and saved_rstd is not None
+    )
     # The affine-parameter reductions do not consume weight.  Materialize it
     # only for the grad-input kernel, which needs gamma in the dx formula.
     gamma = _tc(gamma) if gamma is not None and mask[0] else None
@@ -5555,7 +5904,10 @@ def fast_aten_native_layer_norm_backward(
 # ---------------------------------------------------------------------------
 
 
-def _torch_dtype_to_max(dtype):
+def _torch_dtype_to_max(dtype: object) -> DType | None:
+    # `object`: the autograd doubles-based tests probe this with non-dtypes.
+    if not isinstance(dtype, torch.dtype):
+        return None
     from max.experimental.torch.torch import torch_dtype_to_max
 
     try:
@@ -5564,7 +5916,7 @@ def _torch_dtype_to_max(dtype):
         return None
 
 
-def _norm_reduce_dims(dim, rank, empty_is_all):
+def _norm_reduce_dims(dim: object, rank: int, empty_is_all: bool) -> list[int] | None:
     """Sorted unique normalized reduce dims, or None if the spec is invalid.
 
     `dim=None` always reduces every dim. An empty dim list reduces every dim
@@ -5596,7 +5948,9 @@ def _norm_reduce_dims(dim, rank, empty_is_all):
     return sorted(out)
 
 
-def _reduced_shape(shape, reduce_dims, keepdim):
+def _reduced_shape(
+    shape: Sequence[int], reduce_dims: Sequence[int], keepdim: bool
+) -> tuple[int, ...]:
     """The reduction output shape (keepdim already applied)."""
     rset = set(reduce_dims)
     if keepdim:
@@ -5604,7 +5958,13 @@ def _reduced_shape(shape, reduce_dims, keepdim):
     return tuple(s for i, s in enumerate(shape) if i not in rset)
 
 
-def fast_aten_mean(input, dim=None, keepdim=False, *, dtype=None):
+def fast_aten_mean(
+    input: torch.Tensor,
+    dim: object = None,
+    keepdim: bool = False,
+    *,
+    dtype: torch.dtype | None = None,
+) -> TorchMojoTensor | _NotHandled:
     a = _t(input)
     if a is None:
         return NOT_HANDLED
@@ -5626,7 +5986,13 @@ def fast_aten_mean(input, dim=None, keepdim=False, *, dtype=None):
     return result if result is not None else NOT_HANDLED
 
 
-def fast_aten_sum(input, dim=None, keepdim=False, *, dtype=None):
+def fast_aten_sum(
+    input: torch.Tensor,
+    dim: object = None,
+    keepdim: bool = False,
+    *,
+    dtype: torch.dtype | None = None,
+) -> TorchMojoTensor | _NotHandled:
     a = _t(input)
     if a is None:
         return NOT_HANDLED
@@ -5661,7 +6027,14 @@ def fast_aten_sum(input, dim=None, keepdim=False, *, dtype=None):
     return NOT_HANDLED
 
 
-def fast_aten_linalg_vector_norm(self, ord=2, dim=None, keepdim=False, *, dtype=None):
+def fast_aten_linalg_vector_norm(
+    self: torch.Tensor,
+    ord: object = 2,
+    dim: object = None,
+    keepdim: object = False,
+    *,
+    dtype: torch.dtype | None = None,
+) -> TorchMojoTensor | _NotHandled:
     """L2 norm in ONE pass: sum of squares with the root folded into the
     accumulator's finalize (reduction_ops' NormSpec / NormL2Op).
 
@@ -5700,7 +6073,9 @@ def fast_aten_linalg_vector_norm(self, ord=2, dim=None, keepdim=False, *, dtype=
     return result if result is not None else NOT_HANDLED
 
 
-def _amax_amin(input, dim, keepdim, spec_name):
+def _amax_amin(
+    input: torch.Tensor, dim: object, keepdim: bool, spec_name: str
+) -> TorchMojoTensor | _NotHandled:
     a = _t(input)
     if a is None or a._dtype not in _ROW_REDUCE_DTYPES:
         return NOT_HANDLED
@@ -5712,15 +6087,19 @@ def _amax_amin(input, dim, keepdim, spec_name):
     return result if result is not None else NOT_HANDLED
 
 
-def fast_aten_amax(input, dim=(), keepdim=False):
+def fast_aten_amax(
+    input: torch.Tensor, dim: object = (), keepdim: bool = False
+) -> TorchMojoTensor | _NotHandled:
     return _amax_amin(input, dim, keepdim, "AmaxSpec")
 
 
-def fast_aten_amin(input, dim=(), keepdim=False):
+def fast_aten_amin(
+    input: torch.Tensor, dim: object = (), keepdim: bool = False
+) -> TorchMojoTensor | _NotHandled:
     return _amax_amin(input, dim, keepdim, "AminSpec")
 
 
-def fast_aten_min(input):
+def fast_aten_min(input: torch.Tensor) -> TorchMojoTensor | _NotHandled:
     # Values-only full reduction: aten::min(Tensor) -> Tensor.
     t = _t(input)
     if t is None:
@@ -5729,7 +6108,9 @@ def fast_aten_min(input):
     return result if result is not None else NOT_HANDLED
 
 
-def fast_aten_min_dim(input, dim, keepdim=False):
+def fast_aten_min_dim(
+    input: torch.Tensor, dim: object, keepdim: object = False
+) -> tuple[TorchMojoTensor, TorchMojoTensor] | _NotHandled:
     """aten::min.dim -> (values, indices) along `dim` (first-min-wins)."""
     a = _t(input)
     if a is None or a._dtype not in _ROW_REDUCE_DTYPES or not isinstance(dim, int):
@@ -5742,7 +6123,9 @@ def fast_aten_min_dim(input, dim, keepdim=False):
     return result if result is not None else NOT_HANDLED
 
 
-def _argreduce(input, dim, keepdim, is_min):
+def _argreduce(
+    input: torch.Tensor, dim: object, keepdim: bool, is_min: bool
+) -> TorchMojoTensor | _NotHandled:
     a = _t(input)
     if a is None or a._numel == 0 or a._dtype not in _ROW_REDUCE_DTYPES:
         return NOT_HANDLED
@@ -5761,15 +6144,21 @@ def _argreduce(input, dim, keepdim, is_min):
     return NOT_HANDLED
 
 
-def fast_aten_argmax(input, dim=None, keepdim=False):
+def fast_aten_argmax(
+    input: torch.Tensor, dim: object = None, keepdim: bool = False
+) -> TorchMojoTensor | _NotHandled:
     return _argreduce(input, dim, keepdim, is_min=False)
 
 
-def fast_aten_argmin(input, dim=None, keepdim=False):
+def fast_aten_argmin(
+    input: torch.Tensor, dim: object = None, keepdim: bool = False
+) -> TorchMojoTensor | _NotHandled:
     return _argreduce(input, dim, keepdim, is_min=True)
 
 
-def fast_aten_max(input, *args, **kwargs):
+def fast_aten_max(
+    input: torch.Tensor, *args: object, **kwargs: object
+) -> TorchMojoTensor | _NotHandled:
     # Only the values-only overload max(Tensor) -> Tensor.
     if args or kwargs:
         return NOT_HANDLED
@@ -5782,7 +6171,13 @@ def fast_aten_max(input, *args, **kwargs):
     return result if result is not None else NOT_HANDLED
 
 
-def fast_aten_var(input, dim=None, *, correction=1, keepdim=False):
+def fast_aten_var(
+    input: torch.Tensor,
+    dim: object = None,
+    *,
+    correction: object = 1,
+    keepdim: bool = False,
+) -> TorchMojoTensor | _NotHandled:
     a = _t(input)
     if a is None or a._dtype not in _FLOAT_DTYPES:
         return NOT_HANDLED
@@ -5798,7 +6193,9 @@ def fast_aten_var(input, dim=None, *, correction=1, keepdim=False):
     return result if result is not None else NOT_HANDLED
 
 
-def _any_all(input, dim, keepdim, is_all):
+def _any_all(
+    input: torch.Tensor, dim: object, keepdim: bool, is_all: bool
+) -> TorchMojoTensor | _NotHandled:
     a = _t(input)
     if a is None or a._dtype not in _ANYALL_DTYPES:
         return NOT_HANDLED
@@ -5806,6 +6203,7 @@ def _any_all(input, dim, keepdim, is_all):
     # Fast full-reduce bool path (the existing single-block AllBool/AnyBool).
     if dim is None and not keepdim and a._dtype == DType.bool:
         c = _tc(a)
+        assert c is not None
         if 0 < c._numel < (1 << 22):
             out = _alloc((), DType.bool, a._device)
             _call_mojo(
@@ -5826,15 +6224,21 @@ def _any_all(input, dim, keepdim, is_all):
     return result if result is not None else NOT_HANDLED
 
 
-def fast_aten_all(input, dim=None, keepdim=False):
+def fast_aten_all(
+    input: torch.Tensor, dim: object = None, keepdim: bool = False
+) -> TorchMojoTensor | _NotHandled:
     return _any_all(input, dim, keepdim, is_all=True)
 
 
-def fast_aten_any(input, dim=None, keepdim=False):
+def fast_aten_any(
+    input: torch.Tensor, dim: object = None, keepdim: bool = False
+) -> TorchMojoTensor | _NotHandled:
     return _any_all(input, dim, keepdim, is_all=False)
 
 
-def fast_aten__log_softmax(input, dim, half_to_float=False):
+def fast_aten__log_softmax(
+    input: torch.Tensor, dim: object, half_to_float: bool = False
+) -> TorchMojoTensor | _NotHandled:
     t = _t(input)
     if (
         t is None
@@ -5853,7 +6257,8 @@ def fast_aten__log_softmax(input, dim, half_to_float=False):
     if rank == 0:
         if dim not in (-1, 0):
             return NOT_HANDLED
-        return fast_filled((), 0.0, t._dtype, t._device)
+        filled = fast_filled((), 0.0, t._dtype, t._device)
+        return filled if filled is not None else NOT_HANDLED
     if not -rank <= dim < rank:
         return NOT_HANDLED
     dim %= rank
@@ -5862,8 +6267,10 @@ def fast_aten__log_softmax(input, dim, half_to_float=False):
         # transposes are zero-copy, the inner one materializes once.
         # (t is already fp32 here if half_to_float was set, so pass False.)
         swapped = fast_aten_transpose(t, dim, rank - 1)
+        if not isinstance(swapped, TorchMojoTensor):
+            return NOT_HANDLED
         result = fast_aten__log_softmax(swapped, rank - 1, False)
-        if result is NOT_HANDLED:
+        if not isinstance(result, TorchMojoTensor):
             return NOT_HANDLED
         return fast_aten_transpose(result, dim, rank - 1)
     result = _try_spec_unary("LogSoftmaxSpec", t, module_name="reduction_ops")
@@ -5872,7 +6279,7 @@ def fast_aten__log_softmax(input, dim, half_to_float=False):
 
 def fast_aten__log_softmax_backward_data(
     grad_output: object, output: object, dim: int, input_dtype: object
-) -> object:
+) -> TorchMojoTensor | _NotHandled:
     # `object` params: besides real (TorchMojoTensor, torch.dtype) calls, the
     # composed path's lifetime contract is regression-tested with duck-typed
     # doubles (tests/test_autograd_memory_lifetime.py).
@@ -5974,10 +6381,13 @@ def fast_aten__log_softmax_backward_data(
             grad._shape[dim],
             math.prod(grad._shape[dim + 1 :]),
         )
-        work_grad = fast_aten_view(work_grad, flat_shape)
-        work_output = fast_aten_view(work_output, flat_shape)
-        if work_grad is NOT_HANDLED or work_output is NOT_HANDLED:
+        viewed_grad = fast_aten_view(work_grad, flat_shape)
+        viewed_output = fast_aten_view(work_output, flat_shape)
+        if not isinstance(viewed_grad, TorchMojoTensor) or not isinstance(
+            viewed_output, TorchMojoTensor
+        ):
             return NOT_HANDLED
+        work_grad, work_output = viewed_grad, viewed_output
         work_dim = 1
         restore_shape = grad._shape
 
@@ -5992,15 +6402,16 @@ def fast_aten__log_softmax_backward_data(
             summed = _cast_tensor(summed, DType.float32)
 
     if summed is None:
-        summed = fast_aten_sum(work_grad, dim=[work_dim], keepdim=True)
-        if summed is NOT_HANDLED:
+        summed_result = fast_aten_sum(work_grad, dim=[work_dim], keepdim=True)
+        if not isinstance(summed_result, TorchMojoTensor):
             return NOT_HANDLED
+        summed = summed_result
     probabilities = fast_aten_exp(work_output)
-    if probabilities is NOT_HANDLED:
+    if not isinstance(probabilities, TorchMojoTensor):
         return NOT_HANDLED
 
     grad_input = fast_aten_addcmul(work_grad, probabilities, summed, value=-1.0)
-    if grad_input is NOT_HANDLED:
+    if not isinstance(grad_input, TorchMojoTensor):
         return NOT_HANDLED
 
     # The launches above have captured their inputs on this device stream.
@@ -6008,15 +6419,22 @@ def fast_aten__log_softmax_backward_data(
     # allocator can recycle them without introducing a host synchronization.
     del probabilities, summed
     if restore_shape is not None:
-        grad_input = fast_aten_view(grad_input, restore_shape)
-        if grad_input is NOT_HANDLED:
+        restored = fast_aten_view(grad_input, restore_shape)
+        if not isinstance(restored, TorchMojoTensor):
             return NOT_HANDLED
+        grad_input = restored
     if grad_input._dtype != target_dtype:
         grad_input = _cast_tensor(grad_input, target_dtype)
     return grad_input
 
 
-def _nll_loss_inputs(self, target, weight, reduction, ignore_index):
+def _nll_loss_inputs(
+    self: torch.Tensor,
+    target: torch.Tensor,
+    weight: object,
+    reduction: object,
+    ignore_index: object,
+) -> tuple[TorchMojoTensor, TorchMojoTensor, int, int] | None:
     """Validate the f32/i64 two-dimensional NLL kernel contract.
 
     This stays enqueue-only, so it cannot inspect target values on the host.
@@ -6054,12 +6472,21 @@ def _nll_loss_inputs(self, target, weight, reduction, ignore_index):
 
 
 def fast_aten_nll_loss_forward_output(
-    self, target, weight, reduction, ignore_index, *, output, total_weight
-):
+    self: torch.Tensor,
+    target: torch.Tensor,
+    weight: object,
+    reduction: object,
+    ignore_index: object,
+    *,
+    output: TorchMojoTensor,
+    total_weight: TorchMojoTensor,
+) -> tuple[TorchMojoTensor, TorchMojoTensor] | _NotHandled:
     """Direct out= NLL forward for the pure-Mojo f32 GPU kernel."""
     inputs = _nll_loss_inputs(self, target, weight, reduction, ignore_index)
     if inputs is None:
         return NOT_HANDLED
+    # _nll_loss_inputs validated both as ints.
+    assert isinstance(reduction, int) and isinstance(ignore_index, int)
     log_probs, labels, rows, classes = inputs
     if (
         output is total_weight
@@ -6081,6 +6508,7 @@ def fast_aten_nll_loss_forward_output(
             fast_aten_fill__scalar(write_output, math.nan if reduction == 1 else 0.0)
     else:
         labels_c = _tc(labels)
+        assert labels_c is not None
         _call_mojo(
             _LossExtension,
             "NllLossForwardF32",
@@ -6109,20 +6537,22 @@ def fast_aten_nll_loss_forward_output(
 
 
 def fast_aten_nll_loss_backward_grad_input(
-    grad_output,
-    self,
-    target,
-    weight,
-    reduction,
-    ignore_index,
-    total_weight,
+    grad_output: torch.Tensor,
+    self: torch.Tensor,
+    target: torch.Tensor,
+    weight: object,
+    reduction: object,
+    ignore_index: object,
+    total_weight: torch.Tensor,
     *,
-    grad_input,
-):
+    grad_input: TorchMojoTensor,
+) -> TorchMojoTensor | _NotHandled:
     """Direct out= NLL backward for the pure-Mojo f32 GPU kernel."""
     inputs = _nll_loss_inputs(self, target, weight, reduction, ignore_index)
     if inputs is None:
         return NOT_HANDLED
+    # _nll_loss_inputs validated both as ints.
+    assert isinstance(reduction, int) and isinstance(ignore_index, int)
     log_probs, labels, rows, classes = inputs
     grad = _t(grad_output)
     weight_sum = _t(total_weight)
@@ -6148,8 +6578,10 @@ def fast_aten_nll_loss_backward_grad_input(
     write_grad_input = _prepare_nll_out(grad_input, log_probs._shape)
     if rows != 0:
         labels_c = _tc(labels)
+        assert labels_c is not None
         grad_c = _tc(grad)
         weight_sum_c = _tc(weight_sum)
+        assert grad_c is not None and weight_sum_c is not None
         _call_mojo(
             _LossExtension,
             "NllLossBackwardF32",
@@ -6191,7 +6623,9 @@ _CUMSUM_DTYPES = (
 _CUMSUM_DTYPES_LEGACY = (DType.float32, DType.int32, DType.int64)
 
 
-def fast_aten_cumsum(input, dim, *, dtype=None):
+def fast_aten_cumsum(
+    input: torch.Tensor, dim: object, *, dtype: torch.dtype | None = None
+) -> TorchMojoTensor | _NotHandled:
     a = _t(input)
     if a is None or a._numel == 0:
         return NOT_HANDLED
@@ -6253,7 +6687,7 @@ def fast_aten_cumsum(input, dim, *, dtype=None):
 # ---------------------------------------------------------------------------
 
 
-def _pair(x) -> tuple[int, int] | None:
+def _pair(x: object) -> tuple[int, int] | None:
     if isinstance(x, int):
         return (x, x)
     if (
@@ -6268,8 +6702,13 @@ def _pair(x) -> tuple[int, int] | None:
 
 
 def fast_aten_max_pool2d_with_indices(
-    input, kernel_size, stride=None, padding=0, dilation=1, ceil_mode=False
-):
+    input: torch.Tensor,
+    kernel_size: object,
+    stride: object = None,
+    padding: object = 0,
+    dilation: object = 1,
+    ceil_mode: bool = False,
+) -> tuple[TorchMojoTensor, TorchMojoTensor] | _NotHandled:
     a = _tc(input)
     kernel = _pair(kernel_size)
     strides = _pair(stride) if stride not in (None, []) else kernel
@@ -6281,7 +6720,10 @@ def fast_aten_max_pool2d_with_indices(
         and a._dtype in _FLOAT_DTYPES
         and len(a._shape) == 4
         and not ceil_mode
-        and None not in (kernel, strides, pads, dils)
+        and kernel is not None
+        and strides is not None
+        and pads is not None
+        and dils is not None
     ):
         n, c, in_h, in_w = a._shape
         kh, kw = kernel
@@ -6319,14 +6761,14 @@ def fast_aten_max_pool2d_with_indices(
 
 
 def fast_aten_avg_pool2d(
-    input,
-    kernel_size,
-    stride=None,
-    padding=0,
-    ceil_mode=False,
-    count_include_pad=True,
-    divisor_override=None,
-):
+    input: torch.Tensor,
+    kernel_size: object,
+    stride: object = None,
+    padding: object = 0,
+    ceil_mode: bool = False,
+    count_include_pad: bool = True,
+    divisor_override: object = None,
+) -> TorchMojoTensor | _NotHandled:
     a = _tc(input)
     kernel = _pair(kernel_size)
     strides = _pair(stride) if stride not in (None, []) else kernel
@@ -6337,7 +6779,9 @@ def fast_aten_avg_pool2d(
         and a._dtype in _FLOAT_DTYPES
         and len(a._shape) == 4
         and not ceil_mode
-        and None not in (kernel, strides, pads)
+        and kernel is not None
+        and strides is not None
+        and pads is not None
         and (
             divisor_override is None
             or (isinstance(divisor_override, int) and divisor_override != 0)
@@ -6388,7 +6832,9 @@ def fast_aten_avg_pool2d(
     return NOT_HANDLED
 
 
-def fast_aten__adaptive_avg_pool2d(input, output_size):
+def fast_aten__adaptive_avg_pool2d(
+    input: torch.Tensor, output_size: object
+) -> TorchMojoTensor | _NotHandled:
     a = _tc(input)
     osize = _pair(output_size)
     if (
@@ -6420,7 +6866,16 @@ def fast_aten__adaptive_avg_pool2d(input, output_size):
     return NOT_HANDLED
 
 
-def fast_aten_native_group_norm(input, weight, bias, N, C, HxW, group, eps):
+def fast_aten_native_group_norm(
+    input: torch.Tensor,
+    weight: torch.Tensor | None,
+    bias: torch.Tensor | None,
+    N: int,
+    C: object,
+    HxW: int,
+    group: object,
+    eps: float,
+) -> tuple[TorchMojoTensor, TorchMojoTensor, TorchMojoTensor] | _NotHandled:
     a = _tc(input)
     if (
         a is not None
@@ -6490,6 +6945,7 @@ def fast_aten_native_group_norm(input, weight, bias, N, C, HxW, group, eps):
             gamma = fast_filled((C,), 1.0, a._dtype, a._device)
         if beta is None:
             beta = fast_filled((C,), 0.0, a._dtype, a._device)
+        assert gamma is not None and beta is not None
         _call_mojo(
             _NNExtension,
             "GroupNorm",
@@ -6513,7 +6969,9 @@ def fast_aten_native_group_norm(input, weight, bias, N, C, HxW, group, eps):
     return NOT_HANDLED
 
 
-def _area_pixel_scale(in_size, out_size, align_corners, scale):
+def _area_pixel_scale(
+    in_size: int, out_size: int, align_corners: bool, scale: float | None
+) -> float:
     """torch area_pixel_compute_scale for one axis."""
     if align_corners:
         return (in_size - 1) / (out_size - 1) if out_size > 1 else 0.0
@@ -6523,8 +6981,12 @@ def _area_pixel_scale(in_size, out_size, align_corners, scale):
 
 
 def fast_aten_upsample_bilinear2d(
-    input, output_size, align_corners, scales_h=None, scales_w=None
-):
+    input: torch.Tensor,
+    output_size: object,
+    align_corners: bool,
+    scales_h: float | None = None,
+    scales_w: float | None = None,
+) -> TorchMojoTensor | _NotHandled:
     a = _tc(input)
     osize = _pair(output_size)
     if (
@@ -6576,8 +7038,8 @@ SDPA_CAUSAL_B_COLS = 3
 
 
 def _try_sdpa_causal_bmm(
-    a: MojoTensorLike, b: MojoTensorLike, transpose_b: bool, causal_mode: int
-) -> object:
+    a: TorchMojoTensor, b: TorchMojoTensor, transpose_b: bool, causal_mode: int
+) -> TorchMojoTensor | None:
     """Batched GEMM that skips the contraction indices a causal mask kills.
 
     ``a`` is ``(batch, m, k)`` and ``b`` is ``(batch, n, k)`` when
@@ -6619,7 +7081,7 @@ def _try_sdpa_causal_bmm(
         or not mode_supported
     ):
         return None
-    out = _alloc((batch, m, n), a._dtype, a._device)
+    out = _alloc((batch, m, n), a._dtype, _device_of(a))
     _call_mojo(
         _MatmulExtension,
         "CausalBmm",
@@ -6629,7 +7091,7 @@ def _try_sdpa_causal_bmm(
             b._ptr,
             (batch, m, n, k, int(bool(transpose_b)), int(causal_mode)),
             a._dtype.value,
-            _ctx_ptr(a._device),
+            _ctx_ptr(_device_of(a)),
         ),
         arg_dtypes=(a._dtype, b._dtype),
         output_dtypes=(out._dtype,),
@@ -6639,7 +7101,14 @@ def _try_sdpa_causal_bmm(
     return out
 
 
-def _sdpa_math_forward_with_dropout(query, key, value, is_causal, scale, dropout_p):
+def _sdpa_math_forward_with_dropout(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    is_causal: bool,
+    scale: float | None,
+    dropout_p: object,
+) -> tuple[TorchMojoTensor, TorchMojoTensor, TorchMojoTensor | None] | _NotHandled:
     """Decomposed SDPA returning output, pre-dropout probabilities, and mask.
 
     Dropout is deliberately composed between softmax and the value BMM.  The
@@ -6675,6 +7144,7 @@ def _sdpa_math_forward_with_dropout(query, key, value, is_causal, scale, dropout
     q = _tc(q)
     k = _tc(k)
     v = _tc(v)
+    assert q is not None and k is not None and v is not None
     b, h, q_len, head_dim = q._shape
     kv_len = k._shape[2]
     scale_val = scale if scale is not None else 1.0 / math.sqrt(head_dim)
@@ -6829,15 +7299,17 @@ def _sdpa_math_forward_with_dropout(query, key, value, is_causal, scale, dropout
         # remain nonfinite instead of being overwritten by zeros.  The mask
         # is still saved so backward applies the same mask/scale arithmetic,
         # and neither path reserves RNG state at this endpoint.
-        effective_probs = fast_aten_mul(probs, 0.0)
+        zeroed_probs = fast_aten_mul(probs, 0.0)
         dropout_mask = fast_filled(probs._shape, False, DType.bool, probs._device)
-        if effective_probs is NOT_HANDLED or dropout_mask is None:
+        if not isinstance(zeroed_probs, TorchMojoTensor) or dropout_mask is None:
             return NOT_HANDLED
+        effective_probs = zeroed_probs
     elif dropout_p > 0.0:
         dropout_result = fast_aten_native_dropout(probs, dropout_p, True)
-        if dropout_result is NOT_HANDLED:
+        if not isinstance(dropout_result, tuple):
             return NOT_HANDLED
         effective_probs, dropout_mask = dropout_result
+        assert isinstance(effective_probs, TorchMojoTensor)
         del dropout_result
 
     if metal_causal:
@@ -6887,6 +7359,7 @@ def _sdpa_math_forward_with_dropout(query, key, value, is_causal, scale, dropout
                 flags={"TRANSPOSE_B": False},
                 keepalive=(out, effective_probs, v),
             )
+        assert isinstance(out, TorchMojoTensor)
     # P_drop is not saved: backward cheaply reconstructs it from P and the bool
     # mask, avoiding one persistent f32 (B,H,L,S) allocation per layer.
     del effective_probs
@@ -6911,7 +7384,14 @@ def _sdpa_math_forward_with_dropout(query, key, value, is_causal, scale, dropout
     return out4, probs4, mask4
 
 
-def _sdpa_masked_math_forward(query, key, value, attn_mask, is_causal, scale):
+def _sdpa_masked_math_forward(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attn_mask: torch.Tensor,
+    is_causal: bool,
+    scale: float | None,
+) -> tuple[TorchMojoTensor, TorchMojoTensor] | _NotHandled:
     """Decomposed SDPA with an explicit attention mask -> ``(output, probs)``.
 
     ATen turns the mask into an additive bias on the *already scaled* scores: a
@@ -6958,6 +7438,7 @@ def _sdpa_masked_math_forward(query, key, value, attn_mask, is_causal, scale):
     q = _tc(q)
     k = _tc(k)
     v = _tc(v)
+    assert q is not None and k is not None and v is not None
     q3_shape = (b * h, q_len, head_dim)
     kv3_shape = (b * h, kv_len, head_dim)
     q3 = _view_of(q, q3_shape, _row_major_strides(q3_shape), q._offset, contiguous=True)
@@ -6968,7 +7449,7 @@ def _sdpa_masked_math_forward(query, key, value, attn_mask, is_causal, scale):
         v, kv3_shape, _row_major_strides(kv3_shape), v._offset, contiguous=True
     )
     scores3 = _fast_aten_bmm_transpose_b(q3, k3)
-    if scores3 is NOT_HANDLED:
+    if not isinstance(scores3, TorchMojoTensor):
         return NOT_HANDLED
     score_shape = (b, h, q_len, kv_len)
     scores4 = _view_of(
@@ -6977,14 +7458,14 @@ def _sdpa_masked_math_forward(query, key, value, attn_mask, is_causal, scale):
     scale_val = float(scale) if scale is not None else 1.0 / math.sqrt(head_dim)
     scaled = fast_aten_mul(scores4, scale_val)
     del scores3, scores4
-    if scaled is NOT_HANDLED:
+    if not isinstance(scaled, TorchMojoTensor):
         return NOT_HANDLED
     if mask._dtype == DType.bool:
         biased = fast_aten_where(mask, scaled, float("-inf"))
     else:
         biased = fast_aten_add(scaled, mask)
     del scaled
-    if biased is NOT_HANDLED:
+    if not isinstance(biased, TorchMojoTensor):
         return NOT_HANDLED
     # A mask that broadcasts to anything other than the score matrix is not a
     # valid SDPA mask; the elementwise kernels would silently expand instead.
@@ -6992,7 +7473,7 @@ def _sdpa_masked_math_forward(query, key, value, attn_mask, is_causal, scale):
         return NOT_HANDLED
     probs4 = fast_aten__softmax(biased, -1, False)
     del biased
-    if probs4 is NOT_HANDLED or not probs4._is_contiguous:
+    if not isinstance(probs4, TorchMojoTensor) or not probs4._is_contiguous:
         return NOT_HANDLED
     probs3_shape = (b * h, q_len, kv_len)
     probs3 = _view_of(
@@ -7004,7 +7485,7 @@ def _sdpa_masked_math_forward(query, key, value, attn_mask, is_causal, scale):
     )
     out3 = fast_aten_bmm(probs3, v3)
     del probs3, q3, k3, v3
-    if out3 is NOT_HANDLED:
+    if not isinstance(out3, TorchMojoTensor):
         return NOT_HANDLED
     out_shape = (b, h, q_len, head_dim)
     out4 = _view_of(
@@ -7014,17 +7495,17 @@ def _sdpa_masked_math_forward(query, key, value, attn_mask, is_causal, scale):
 
 
 def _fa4_16bit_d64_causal_inputs(
-    query,
-    key,
-    value,
-    attn_mask=None,
-    dropout_p=0.0,
-    is_causal=False,
-    scale=None,
-    enable_gqa=False,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attn_mask: torch.Tensor | None = None,
+    dropout_p: float = 0.0,
+    is_causal: bool = False,
+    scale: float | None = None,
+    enable_gqa: bool = False,
     *,
     allow_any_seqlen: bool = False,
-):
+) -> tuple[TorchMojoTensor, TorchMojoTensor, TorchMojoTensor] | None:
     """Return eligible public BHTD inputs (bf16 or f16) without doing any
     device work.
 
@@ -7088,7 +7569,7 @@ def _fa4_16bit_d64_causal_inputs(
     return q, k, v
 
 
-def _fa4_strided_bthd_layout(tensor) -> bool:
+def _fa4_strided_bthd_layout(tensor: TorchMojoTensor) -> bool:
     """Whether a physical BTHD view is safe for FA4's strided TMA ABI.
 
     The pointer is already adjusted to logical ``[0, 0, 0, 0]`` and strides
@@ -7127,7 +7608,7 @@ def _fa4_strided_bthd_layout(tensor) -> bool:
     )
 
 
-def _fa4_bhsd_layout(tensor) -> bool:
+def _fa4_bhsd_layout(tensor: TorchMojoTensor) -> bool:
     """Whether the PUBLIC (B, H, S, D) tensor is eligible for the
     BHSD-native TMA path -- no BTHD materialization needed at all.
 
@@ -7148,17 +7629,19 @@ def _fa4_bhsd_layout(tensor) -> bool:
     )
 
 
-def _fa4_native_bthd(tensor):
+def _fa4_native_bthd(tensor: torch.Tensor) -> TorchMojoTensor | None:
     """Expose public BHTD storage as FA4-native BTHD, copying if required."""
     physical = fast_aten_transpose(tensor, 1, 2)
-    if physical is NOT_HANDLED:
+    if not isinstance(physical, TorchMojoTensor):
         return None
     if _fa4_strided_bthd_layout(physical):
         return physical
     return _tc(physical)
 
 
-def _fa4_prepare_qkv_bridge(q_native, k_native, v_native):
+def _fa4_prepare_qkv_bridge(
+    q_native: TorchMojoTensor, k_native: TorchMojoTensor, v_native: TorchMojoTensor
+) -> tuple[tuple[TorchMojoTensor, TorchMojoTensor, TorchMojoTensor], bool] | None:
     """Return prepared Q/K/V plus whether their strided ABI is required."""
     qkv = (q_native, k_native, v_native)
     needs_strided_bridge = any(not tensor._is_contiguous for tensor in qkv)
@@ -7167,15 +7650,18 @@ def _fa4_prepare_qkv_bridge(q_native, k_native, v_native):
     if needs_strided_bridge:
         # Defensive path for callers of the private backward helper.  Normal
         # forward preparation has already copied every unsupported view.
-        qkv = tuple(_tc(tensor) for tensor in qkv)
-        if any(tensor is None for tensor in qkv):
+        materialized = tuple(_tc(tensor) for tensor in qkv)
+        if any(tensor is None for tensor in materialized):
             return None
+        qkv = cast(
+            "tuple[TorchMojoTensor, TorchMojoTensor, TorchMojoTensor]", materialized
+        )
     return qkv, False
 
 
 def _fa4_symbol(
     fa4_ops: object, direction: str, dtype: DType, head_dim: int, variant: str = ""
-) -> object:
+) -> Callable[..., object]:
     """Resolve one FA4 Mojo-exported entry point by name.
 
     Mirrors the ``flash_attention_{direction}_{bf16,f16}_d{64,128}_causal{variant}``
@@ -7194,14 +7680,23 @@ def _fa4_symbol(
 
 
 def fast_fa4_16bit_d64_causal_forward(
-    query,
-    key,
-    value,
-    attn_mask=None,
-    dropout_p=0.0,
-    is_causal=False,
-    scale=None,
-    enable_gqa=False,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attn_mask: torch.Tensor | None = None,
+    dropout_p: float = 0.0,
+    is_causal: bool = False,
+    scale: float | None = None,
+    enable_gqa: bool = False,
+) -> (
+    tuple[
+        TorchMojoTensor,
+        TorchMojoTensor,
+        TorchMojoTensor,
+        TorchMojoTensor,
+        TorchMojoTensor,
+    ]
+    | _NotHandled
 ):
     """Run vendored FA4 (bf16 or f16, head_dim 64 or 128) and return
     output/LSE plus saved physical inputs.
@@ -7234,7 +7729,13 @@ def fast_fa4_16bit_d64_causal_forward(
     from torch_mojo_backend.eager_flash_attention import load_fa4_ops
 
     fa4_ops = load_fa4_ops()
+    assert isinstance(inputs, tuple)
     q, k, v = inputs
+    assert (
+        isinstance(q, TorchMojoTensor)
+        and isinstance(k, TorchMojoTensor)
+        and isinstance(v, TorchMojoTensor)
+    )
     qkv_dtype = q._dtype
     batch, heads, seqlen, head_dim = q._shape
     bhsd_eligible = _fa4_bhsd_layout(q) and _fa4_bhsd_layout(k) and _fa4_bhsd_layout(v)
@@ -7325,14 +7826,22 @@ def fast_fa4_16bit_d64_causal_forward(
             keepalive=(q_native, k_native, v_native, out_native, logsumexp),
         )
     output = fast_aten_transpose(out_native, 1, 2)
-    if output is NOT_HANDLED:
+    # isinstance, not `is`: ty doesn't narrow identity checks against a
+    # custom singleton instance the way it does for `is None`.
+    if isinstance(output, _NotHandled):
         raise RuntimeError("FA4 output could not be exposed as a BHTD view")
     return output, logsumexp, q_native, k_native, v_native
 
 
 def fast_fa4_16bit_d64_causal_backward(
-    q_native, k_native, v_native, output, logsumexp, grad_output, scale
-):
+    q_native: TorchMojoTensor,
+    k_native: TorchMojoTensor,
+    v_native: TorchMojoTensor,
+    output: torch.Tensor,
+    logsumexp: TorchMojoTensor,
+    grad_output: torch.Tensor,
+    scale: float,
+) -> tuple[TorchMojoTensor, TorchMojoTensor, TorchMojoTensor] | _NotHandled:
     """Enqueue FA4 preprocess/main/convert and return public BHTD grads
     (bf16 or f16, matching Q/K/V's shared dtype)."""
     from torch_mojo_backend.eager_flash_attention import load_fa4_ops
@@ -7448,7 +7957,13 @@ def fast_fa4_16bit_d64_causal_backward(
     grad_query = fast_aten_transpose(dq_native, 1, 2)
     grad_key = fast_aten_transpose(dk_native, 1, 2)
     grad_value = fast_aten_transpose(dv_native, 1, 2)
-    if any(grad is NOT_HANDLED for grad in (grad_query, grad_key, grad_value)):
+    # isinstance (not `is`, which ty won't narrow here) on each name directly
+    # (not a generator, which can't narrow the names it closes over either).
+    if (
+        isinstance(grad_query, _NotHandled)
+        or isinstance(grad_key, _NotHandled)
+        or isinstance(grad_value, _NotHandled)
+    ):
         raise RuntimeError("FA4 gradients could not be exposed as BHTD views")
     return grad_query, grad_key, grad_value
 
@@ -7465,7 +7980,7 @@ def fast_fa4_16bit_d64_causal_backward(
 _FUSED_FA_MAX_HEAD_DIM = 256
 
 
-def _fa_strides(t: MojoTensorLike) -> tuple[int, int, int]:
+def _fa_strides(t: _SpecTensor) -> tuple[int, int, int]:
     """``t``'s (batch, head, seq) element strides for the fused kernels.
 
     The head_dim stride is not passed: it must be 1, and ``_fused_fa_inputs`` is
@@ -7505,8 +8020,15 @@ def _alloc_bthd(
 
 
 def _fused_fa_inputs(
-    query, key, value, attn_mask, dropout_p, is_causal, scale, enable_gqa
-):
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attn_mask: torch.Tensor | None,
+    dropout_p: object,
+    is_causal: bool,
+    scale: float | None,
+    enable_gqa: bool,
+) -> tuple[TorchMojoTensor, TorchMojoTensor, TorchMojoTensor] | None:
     """Eligible BHTD inputs for the fused gfx942 kernels, or None.
 
     The kernels read Q, K and V through their own (batch, head, seq) strides, so
@@ -7576,14 +8098,23 @@ def _fused_fa_inputs(
 
 
 def fast_fused_flash_attention_forward(
-    query,
-    key,
-    value,
-    attn_mask=None,
-    dropout_p=0.0,
-    is_causal=False,
-    scale=None,
-    enable_gqa=False,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attn_mask: torch.Tensor | None = None,
+    dropout_p: float = 0.0,
+    is_causal: bool = False,
+    scale: float | None = None,
+    enable_gqa: bool = False,
+) -> (
+    tuple[
+        TorchMojoTensor,
+        TorchMojoTensor,
+        TorchMojoTensor,
+        TorchMojoTensor,
+        TorchMojoTensor,
+    ]
+    | _NotHandled
 ):
     """Fused forward returning ``(output, lse, q, k, v)``, or NOT_HANDLED.
 
@@ -7600,9 +8131,14 @@ def fast_fused_flash_attention_forward(
     eligible = _fused_fa_inputs(
         query, key, value, attn_mask, dropout_p, is_causal, scale, enable_gqa
     )
-    if eligible is None:
+    if not isinstance(eligible, tuple):
         return NOT_HANDLED
     q, k, v = eligible
+    assert (
+        isinstance(q, TorchMojoTensor)
+        and isinstance(k, TorchMojoTensor)
+        and isinstance(v, TorchMojoTensor)
+    )
     batch, heads, seq_q, head_dim = q._shape
     seq_kv = k._shape[2]
     scale_val = float(scale) if scale is not None else 1.0 / math.sqrt(head_dim)
@@ -7633,8 +8169,15 @@ def fast_fused_flash_attention_forward(
 
 
 def fast_fused_flash_attention_backward(
-    grad_output, query, key, value, output, lse, is_causal, scale
-):
+    grad_output: torch.Tensor,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    output: torch.Tensor,
+    lse: torch.Tensor,
+    is_causal: bool,
+    scale: float | None,
+) -> tuple[TorchMojoTensor, TorchMojoTensor, TorchMojoTensor] | _NotHandled:
     """Fused backward returning ``(dq, dk, dv)``, or NOT_HANDLED.
 
     ``query``/``key``/``value``/``output``/``lse`` must be exactly what the
@@ -7709,54 +8252,73 @@ def fast_fused_flash_attention_backward(
     return grad_query, grad_key, grad_value
 
 
-def _sdpa_math_forward(query, key, value, is_causal, scale):
+def _sdpa_math_forward(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    is_causal: bool,
+    scale: float | None,
+) -> tuple[TorchMojoTensor, TorchMojoTensor] | _NotHandled:
     """Dropout-free compatibility wrapper returning ``(output, probs)``."""
     result = _sdpa_math_forward_with_dropout(query, key, value, is_causal, scale, 0.0)
-    if result is NOT_HANDLED:
+    if not isinstance(result, tuple):
         return NOT_HANDLED
     output, probabilities, _ = result
     return output, probabilities
 
 
 def fast_aten__scaled_dot_product_attention_math(
-    query,
-    key,
-    value,
-    attn_mask=None,
-    dropout_p=0.0,
-    is_causal=False,
-    dropout_mask=None,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attn_mask: torch.Tensor | None = None,
+    dropout_p: float = 0.0,
+    is_causal: bool = False,
+    dropout_mask: torch.Tensor | None = None,
     *,
-    scale=None,
-    enable_gqa=False,
-):
+    scale: float | None = None,
+    enable_gqa: bool = False,
+) -> tuple[TorchMojoTensor, TorchMojoTensor] | _NotHandled:
     if dropout_p != 0.0 or dropout_mask is not None or enable_gqa:
         return NOT_HANDLED
     if attn_mask is not None:
         return _sdpa_masked_math_forward(query, key, value, attn_mask, is_causal, scale)
     result = _sdpa_math_forward(query, key, value, is_causal, scale)
-    if result is NOT_HANDLED:
+    if not isinstance(result, tuple):
         return NOT_HANDLED
     out, probs = result
     return out, probs
 
 
 def fast_aten__scaled_dot_product_flash_attention(
-    query,
-    key,
-    value,
-    dropout_p=0.0,
-    is_causal=False,
-    return_debug_mask=False,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    dropout_p: float = 0.0,
+    is_causal: bool = False,
+    return_debug_mask: bool = False,
     *,
-    scale=None,
+    scale: float | None = None,
+) -> (
+    tuple[
+        TorchMojoTensor,
+        TorchMojoTensor,
+        None,
+        None,
+        int,
+        int,
+        TorchMojoTensor,
+        TorchMojoTensor,
+        TorchMojoTensor,
+    ]
+    | _NotHandled
 ):
     if dropout_p != 0.0 or return_debug_mask:
         return NOT_HANDLED
     result = fast_fa4_16bit_d64_causal_forward(
         query, key, value, None, 0.0, is_causal, scale, False
     )
-    if result is NOT_HANDLED:
+    if not isinstance(result, tuple):
         return NOT_HANDLED
     out, logsumexp, q_native, k_native, v_native = result
     # This direct ATen forward does not own the autograd saves used by the
@@ -7765,8 +8327,11 @@ def fast_aten__scaled_dot_product_flash_attention(
     # order instead of retaining three full activations.
     del q_native, k_native, v_native
     q = _t(query)
+    k = _t(key)
+    # The forward above succeeded, so both are mojo tensors.
+    assert q is not None and k is not None
     sq = q._shape[2]
-    sk = _t(key)._shape[2]
+    sk = k._shape[2]
     dev = q._device
     # Dense CUDA returns undefined cumulative-sequence tensors, uint64 RNG
     # state/offset tensors, and an empty debug mask when dropout/debugging are
@@ -7780,23 +8345,23 @@ def fast_aten__scaled_dot_product_flash_attention(
 
 
 def fast_aten__scaled_dot_product_flash_attention_backward(
-    grad_out,
-    query,
-    key,
-    value,
-    out,
-    logsumexp,
-    cum_seq_q,
-    cum_seq_k,
-    max_q,
-    max_k,
-    dropout_p,
-    is_causal,
-    philox_seed,
-    philox_offset,
+    grad_out: torch.Tensor,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    out: torch.Tensor,
+    logsumexp: torch.Tensor,
+    cum_seq_q: torch.Tensor | None,
+    cum_seq_k: torch.Tensor | None,
+    max_q: object,
+    max_k: object,
+    dropout_p: float,
+    is_causal: bool,
+    philox_seed: torch.Tensor,
+    philox_offset: torch.Tensor,
     *,
-    scale=None,
-):
+    scale: float | None = None,
+) -> tuple[TorchMojoTensor, TorchMojoTensor, TorchMojoTensor] | _NotHandled:
     """Dense lower-op autograd bridge for the vendored bf16/f16 FA4 kernel.
 
     Deliberately omits ``allow_any_seqlen=True``: this is the actual bwd
@@ -7856,7 +8421,7 @@ def fast_aten__scaled_dot_product_flash_attention_backward(
         recomputed = fast_fa4_16bit_d64_causal_forward(
             q, k, v, None, 0.0, True, scale, False
         )
-        if recomputed is NOT_HANDLED:
+        if not isinstance(recomputed, tuple):
             return NOT_HANDLED
         recomputed_output, recomputed_lse, _, _, _ = recomputed
         output = recomputed_output
@@ -7885,24 +8450,36 @@ def fast_aten__scaled_dot_product_flash_attention_backward(
 
 
 def fast_aten__scaled_dot_product_efficient_attention(
-    query,
-    key,
-    value,
-    attn_bias,
-    compute_log_sumexp,
-    dropout_p=0.0,
-    is_causal=False,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attn_bias: torch.Tensor | None,
+    compute_log_sumexp: bool,
+    dropout_p: float = 0.0,
+    is_causal: bool = False,
     *,
-    scale=None,
+    scale: float | None = None,
+) -> (
+    tuple[
+        TorchMojoTensor,
+        TorchMojoTensor | None,
+        TorchMojoTensor | None,
+        TorchMojoTensor | None,
+    ]
+    | _NotHandled
 ):
     if dropout_p != 0.0 or attn_bias is not None:
         return NOT_HANDLED
     out = fast_aten_scaled_dot_product_attention(
         query, key, value, None, 0.0, is_causal, scale, False
     )
-    if out is NOT_HANDLED:
+    # isinstance, not `is`: ty doesn't narrow identity checks against a
+    # custom singleton instance the way it does for `is None`.
+    if isinstance(out, _NotHandled):
         return NOT_HANDLED
     q = _t(query)
+    # The SDPA call above succeeded, so query is a mojo tensor.
+    assert q is not None
     b, h, sq, _ = q._shape
     dev = q._device
     lse_len = sq if compute_log_sumexp else 0
@@ -7920,7 +8497,7 @@ def fast_sdpa_dropout_softmax_backward(
     score_scale: object,
     is_causal: bool = False,
     query_length: int = 0,
-) -> object:
+) -> TorchMojoTensor | _NotHandled:
     """Fuse SDPA dropout backward, softmax backward, and score scaling.
 
     The helper owns public-tensor validation, ordinary output allocation, and
@@ -7960,7 +8537,7 @@ def fast_sdpa_dropout_softmax_backward(
         return NOT_HANDLED
 
     has_mask = mask is not None
-    if has_mask and (
+    if mask is not None and (
         mask._device != probs._device
         or mask._dtype != DType.bool
         or tuple(mask._shape) != tuple(probs._shape)
@@ -7979,13 +8556,19 @@ def fast_sdpa_dropout_softmax_backward(
     # In the no-dropout path the scale is semantically dead.  Canonicalizing
     # it also keeps nonnumeric or nonfinite caller metadata away from the raw
     # Float64 bridge without rejecting an otherwise valid operation.
-    bridge_dropout_scale = float(dropout_scale) if has_mask else 1.0
+    bridge_dropout_scale = (
+        float(dropout_scale)
+        if mask is not None and isinstance(dropout_scale, int | float)
+        else 1.0
+    )
     bridge_score_scale = float(score_scale)
 
     probs = _tc(probs)
     grad = _tc(grad)
-    if has_mask:
+    assert probs is not None and grad is not None
+    if mask is not None:
         mask = _tc(mask)
+        assert mask is not None
     out = _alloc(probs._shape, probs._dtype, probs._device)
     if out._numel == 0:
         return out
@@ -7999,7 +8582,7 @@ def fast_sdpa_dropout_softmax_backward(
             out._ptr,
             probs._ptr,
             grad._ptr,
-            mask._ptr if has_mask else 0,
+            mask._ptr if mask is not None else 0,
             rows,
             cols,
             int(query_length) if is_causal else 0,
@@ -8010,7 +8593,8 @@ def fast_sdpa_dropout_softmax_backward(
             probs._dtype.value,
             _ctx_ptr(probs._device),
         ),
-        arg_dtypes=(probs._dtype, grad._dtype) + ((mask._dtype,) if has_mask else ()),
+        arg_dtypes=(probs._dtype, grad._dtype)
+        + ((mask._dtype,) if mask is not None else ()),
         output_dtypes=(out._dtype,),
         flags={"HAS_MASK": has_mask, "CAUSAL": bool(is_causal)},
         keepalive=(out, probs, grad, mask),
@@ -8072,7 +8656,7 @@ def fast_sdpa_backward(
     ):
         return NOT_HANDLED
     has_mask = mask is not None
-    if has_mask and (
+    if mask is not None and (
         mask._device != probs._device
         or mask._dtype != DType.bool
         or tuple(mask._shape) != tuple(probs._shape)
@@ -8117,12 +8701,18 @@ def fast_sdpa_backward(
     if not _sdpa_backward_bridge_available():
         return NOT_HANDLED
 
-    bridge_dropout_scale = float(dropout_scale) if has_mask else 1.0
+    bridge_dropout_scale = (
+        float(dropout_scale)
+        if mask is not None and isinstance(dropout_scale, int | float)
+        else 1.0
+    )
     causal = 1 if is_causal else 0
     probs = _tc(probs)
     grad = _tc(grad)
-    if has_mask:
+    assert probs is not None and grad is not None
+    if mask is not None:
         mask = _tc(mask)
+        assert mask is not None
     device = probs._device
     ctx = _ctx_ptr(device)
     dt = DType.float32.value
@@ -8137,13 +8727,13 @@ def fast_sdpa_backward(
                 grad_value._ptr,
                 probs._ptr,
                 grad._ptr,
-                mask._ptr if has_mask else 0,
+                mask._ptr if mask is not None else 0,
                 (batch_heads, kv_len, head_dim, q_len, int(has_mask), causal),
                 bridge_dropout_scale,
                 ctx,
             ),
             arg_dtypes=(probs._dtype, grad._dtype)
-            + ((mask._dtype,) if has_mask else ()),
+            + ((mask._dtype,) if mask is not None else ()),
             output_dtypes=(grad_value._dtype,),
             flags={"HAS_MASK": has_mask, "CAUSAL": bool(is_causal)},
             keepalive=(grad_value, probs, grad, mask),
@@ -8153,6 +8743,7 @@ def fast_sdpa_backward(
     grad_key = None
     if need_query or need_key:
         v = _tc(_t(value))
+        assert v is not None
         grad_probs = _alloc((batch_heads, q_len, kv_len), DType.float32, device)
         if causal:
             _call_mojo(
@@ -8197,7 +8788,7 @@ def fast_sdpa_backward(
                 grad_scores._ptr,
                 probs._ptr,
                 grad_probs._ptr,
-                mask._ptr if has_mask else 0,
+                mask._ptr if mask is not None else 0,
                 batch_heads * q_len,
                 kv_len,
                 int(has_mask),
@@ -8208,7 +8799,7 @@ def fast_sdpa_backward(
                 ctx,
             ),
             arg_dtypes=(probs._dtype, grad_probs._dtype)
-            + ((mask._dtype,) if has_mask else ()),
+            + ((mask._dtype,) if mask is not None else ()),
             output_dtypes=(grad_scores._dtype,),
             flags={"HAS_MASK": has_mask, "CAUSAL": bool(is_causal)},
             keepalive=(grad_scores, probs, grad_probs, mask),
@@ -8216,6 +8807,7 @@ def fast_sdpa_backward(
         del grad_probs
         if need_query:
             k = _tc(_t(key))
+            assert k is not None
             grad_query = _alloc(q3_shape, DType.float32, device)
             if causal:
                 _call_mojo(
@@ -8254,6 +8846,7 @@ def fast_sdpa_backward(
             del k
         if need_key:
             q = _tc(_t(query))
+            assert q is not None
             grad_key = _alloc(kv3_shape, DType.float32, device)
             _call_mojo(
                 _SdpaBackwardExtension,
@@ -8283,7 +8876,7 @@ def fast_sdpa_backward(
 # ---------------------------------------------------------------------------
 
 
-def _tf32_dense_2d_layout(tensor: MojoTensorLike) -> bool | None:
+def _tf32_dense_2d_layout(tensor: _SpecTensor) -> bool | None:
     """Return the physical-transpose flag for an exact dense 2-D layout."""
     if len(tensor._shape) != 2:
         return None
@@ -8296,7 +8889,7 @@ def _tf32_dense_2d_layout(tensor: MojoTensorLike) -> bool | None:
     return None
 
 
-def _tf32_dense_batched_layout(tensor: MojoTensorLike) -> tuple[bool, int] | None:
+def _tf32_dense_batched_layout(tensor: _SpecTensor) -> tuple[bool, int] | None:
     """Classify dense matrices separated by a non-overlapping batch stride, or
     a broadcast operand (batch stride 0 -- one dense matrix shared by every
     batch item, as `expand()` or a stride-0 `unsqueeze` produces, e.g. conv's
@@ -8334,7 +8927,9 @@ def _tf32_dense_batched_layout(tensor: MojoTensorLike) -> tuple[bool, int] | Non
     return physical_transpose, batch_stride
 
 
-def _gemm16_alignment_favors_split(a, b, *, transpose_b: bool = False) -> bool:
+def _gemm16_alignment_favors_split(
+    a: torch.Tensor, b: torch.Tensor, *, transpose_b: bool = False
+) -> bool:
     """Conservative pre-check: could gemm16 possibly route this shape through
     a v3/v4 tensor-core route (aligned or split-K), regardless of bias?
 
@@ -8368,7 +8963,14 @@ def _gemm16_alignment_favors_split(a, b, *, transpose_b: bool = False) -> bool:
     return m % 64 == 0 and n % 64 == 0 and k % 64 == 0
 
 
-def _try_gemm16_mm(a, b, bias=None, *, transpose_b=False, output_shape=None):
+def _try_gemm16_mm(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    *,
+    transpose_b: bool = False,
+    output_shape: tuple[int, ...] | None = None,
+) -> TorchMojoTensor | None:
     """Enqueue the dense H100 16-bit tensor-core GEMM, or return ``None``.
 
     The bridge consumes and produces the operand dtype (bfloat16 or float16;
@@ -8449,7 +9051,14 @@ def _try_gemm16_mm(a, b, bias=None, *, transpose_b=False, output_shape=None):
     return out
 
 
-def _try_tf32_gemm(a, b, bias=None, *, transpose_b=False, output_shape=None):
+def _try_tf32_gemm(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    bias: torch.Tensor | None = None,
+    *,
+    transpose_b: bool = False,
+    output_shape: tuple[int, ...] | None = None,
+) -> TorchMojoTensor | None:
     """Enqueue the opt-in dense H100 TF32 GEMM, or return ``None``.
 
     This helper owns only host validation/allocation and the raw bridge call;
@@ -8533,7 +9142,9 @@ def _try_tf32_gemm(a, b, bias=None, *, transpose_b=False, output_shape=None):
     return out
 
 
-def _try_gemm16_bmm(a, b, *, transpose_b=False):
+def _try_gemm16_bmm(
+    a: torch.Tensor, b: torch.Tensor, *, transpose_b: bool = False
+) -> TorchMojoTensor | None:
     """Enqueue the dense H100 16-bit tensor-core BMM over packed or padded
     batches, or return ``None`` (dtypes: ``_GEMM16_DTYPES``)."""
     lhs = _t(a)
@@ -8593,7 +9204,9 @@ def _try_gemm16_bmm(a, b, *, transpose_b=False):
     return out
 
 
-def _try_tf32_bmm(a, b, *, transpose_b=False):
+def _try_tf32_bmm(
+    a: torch.Tensor, b: torch.Tensor, *, transpose_b: bool = False
+) -> TorchMojoTensor | None:
     """Enqueue the dormant dense H100 TF32 BMM, or return ``None``.
 
     This bias-free ABI accepts packed or independently padded batches of
@@ -8660,7 +9273,9 @@ def _try_tf32_bmm(a, b, *, transpose_b=False):
     return out
 
 
-def _try_gemm16_linear(input, weight, bias=None):
+def _try_gemm16_linear(
+    input: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor | None = None
+) -> TorchMojoTensor | None:
     """Route a dense rank >= 2 16-bit projection through GEMM without copies.
 
     Every gemm16 tensor-core route (the v3/v4 warp-specialized, TMA, and
@@ -8706,7 +9321,7 @@ def _try_gemm16_linear(input, weight, bias=None):
         )
         if mm_out is not None:
             biased = fast_aten_add(mm_out, bias)
-            if biased is not NOT_HANDLED:
+            if isinstance(biased, TorchMojoTensor):
                 return biased
     # Either the shape can never reach a fast route regardless of bias (see
     # _gemm16_alignment_favors_split), or the fast add declined for this
@@ -8717,7 +9332,9 @@ def _try_gemm16_linear(input, weight, bias=None):
     )
 
 
-def _try_tf32_linear(input, weight, bias=None):
+def _try_tf32_linear(
+    input: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor | None = None
+) -> TorchMojoTensor | None:
     """Route a dense rank >= 2 linear projection through TF32 without copies.
 
     The TF32 GEMM ABI is two-dimensional.  A contiguous higher-rank linear
@@ -8755,7 +9372,7 @@ def _try_tf32_linear(input, weight, bias=None):
     )
 
 
-def fast_aten_mm(x, y):
+def fast_aten_mm(x: torch.Tensor, y: torch.Tensor) -> TorchMojoTensor | _NotHandled:
     out = _try_gemm16_mm(x, y)
     if out is not None:
         return out
@@ -8766,7 +9383,14 @@ def fast_aten_mm(x, y):
     return out if out is not None else NOT_HANDLED
 
 
-def fast_aten_addmm(input, mat1, mat2, *, beta=1.0, alpha=1.0):
+def fast_aten_addmm(
+    input: torch.Tensor,
+    mat1: torch.Tensor,
+    mat2: torch.Tensor,
+    *,
+    beta: AtenScalar = 1.0,
+    alpha: AtenScalar = 1.0,
+) -> TorchMojoTensor | _NotHandled:
     # beta/alpha scaling isn't implemented by the fast path (falls through).
     if beta == 1 and alpha == 1:
         # See _try_gemm16_linear: every gemm16 tensor-core route declines
@@ -8797,7 +9421,9 @@ def fast_aten_addmm(input, mat1, mat2, *, beta=1.0, alpha=1.0):
     return NOT_HANDLED
 
 
-def fast_aten_linear(input, weight, bias=None):
+def fast_aten_linear(
+    input: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor | None = None
+) -> TorchMojoTensor | _NotHandled:
     # Keep linear as a concrete backend op alongside fast_aten_linear_backward.
     # The GEMM kernel reads B transposed for free, so the weight is never
     # materialized in transposed layout.
@@ -8846,18 +9472,29 @@ def fast_aten_linear(input, weight, bias=None):
     if vector._shape[0] == 0:
         if vector_bias is not None:
             return fast_aten_clone(vector_bias)
-        return fast_filled((output_features,), 0.0, vector._dtype, vector._device)
+        filled = fast_filled((output_features,), 0.0, vector._dtype, vector._device)
+        return filled if filled is not None else NOT_HANDLED
 
-    matrix = fast_aten_view(_tc(vector), (1, vector._shape[0]))
-    if matrix is NOT_HANDLED:
+    contiguous_vector = _tc(vector)
+    assert contiguous_vector is not None
+    matrix = fast_aten_view(contiguous_vector, (1, vector._shape[0]))
+    if not isinstance(matrix, TorchMojoTensor):
         return NOT_HANDLED
     out = fast_aten_linear(matrix, weight, bias)
-    if out is NOT_HANDLED:
+    if not isinstance(out, TorchMojoTensor):
         return NOT_HANDLED
     return fast_aten_view(out, (out._shape[-1],))
 
 
-def fast_aten_linear_backward(self, grad_output, weight, output_mask):
+def fast_aten_linear_backward(
+    self: torch.Tensor,
+    grad_output: torch.Tensor,
+    weight: torch.Tensor,
+    output_mask: Sequence[bool],
+) -> (
+    tuple[TorchMojoTensor | None, TorchMojoTensor | None, TorchMojoTensor | None]
+    | _NotHandled
+):
     input = _t(self)
     grad = _t(grad_output)
     matrix_weight = _t(weight)
@@ -8890,7 +9527,7 @@ def fast_aten_linear_backward(self, grad_output, weight, output_mask):
     # allocation; requesting bias also requires the weight-gradient GEMM.
     need_parameter_grads = mask[1] or mask[2]
 
-    def zeros(shape):
+    def zeros(shape: tuple[int, ...]) -> TorchMojoTensor | None:
         if math.prod(shape) == 0:
             return _alloc(shape, input._dtype, input._device)
         return fast_filled(shape, 0.0, input._dtype, input._device)
@@ -8908,9 +9545,10 @@ def fast_aten_linear_backward(self, grad_output, weight, output_mask):
             else None,
         )
 
-    grad = _tc(grad)
-    grad_matrix = fast_aten_view(grad, (rows, output_features))
-    if grad_matrix is NOT_HANDLED:
+    contiguous_grad = _tc(grad)
+    assert contiguous_grad is not None
+    grad_matrix = fast_aten_view(contiguous_grad, (rows, output_features))
+    if not isinstance(grad_matrix, TorchMojoTensor):
         return NOT_HANDLED
 
     grad_input = None
@@ -8918,11 +9556,11 @@ def fast_aten_linear_backward(self, grad_output, weight, output_mask):
         if input_features == 0:
             grad_input = _alloc(input._shape, input._dtype, input._device)
         else:
-            grad_input = fast_aten_mm(grad_matrix, matrix_weight)
-            if grad_input is NOT_HANDLED:
+            mm_result = fast_aten_mm(grad_matrix, matrix_weight)
+            if not isinstance(mm_result, TorchMojoTensor):
                 return NOT_HANDLED
-            grad_input = fast_aten_view(grad_input, input._shape)
-            if grad_input is NOT_HANDLED:
+            grad_input = fast_aten_view(mm_result, input._shape)
+            if not isinstance(grad_input, TorchMojoTensor):
                 return NOT_HANDLED
 
     grad_weight = None
@@ -8930,21 +9568,23 @@ def fast_aten_linear_backward(self, grad_output, weight, output_mask):
         if input_features == 0:
             grad_weight = _alloc(matrix_weight._shape, input._dtype, input._device)
         else:
-            input_matrix = fast_aten_view(_tc(input), (rows, input_features))
-            if input_matrix is NOT_HANDLED:
+            contiguous_input = _tc(input)
+            assert contiguous_input is not None
+            input_matrix = fast_aten_view(contiguous_input, (rows, input_features))
+            if not isinstance(input_matrix, TorchMojoTensor):
                 return NOT_HANDLED
             grad_transposed = fast_aten_transpose(grad_matrix, 0, 1)
-            if grad_transposed is NOT_HANDLED:
+            if not isinstance(grad_transposed, TorchMojoTensor):
                 return NOT_HANDLED
             grad_weight = fast_aten_mm(grad_transposed, input_matrix)
-            if grad_weight is NOT_HANDLED:
+            if not isinstance(grad_weight, TorchMojoTensor):
                 return NOT_HANDLED
 
     grad_bias = None
     if need_parameter_grads:
         if mask[2]:
             grad_bias = fast_aten_sum(grad_matrix, dim=[0], keepdim=False)
-            if grad_bias is NOT_HANDLED:
+            if not isinstance(grad_bias, TorchMojoTensor):
                 return NOT_HANDLED
         else:
             grad_bias = _alloc((output_features,), input._dtype, input._device)
@@ -8952,7 +9592,9 @@ def fast_aten_linear_backward(self, grad_output, weight, output_mask):
     return grad_input, grad_weight, grad_bias
 
 
-def fast_aten_bmm(input, mat2):
+def fast_aten_bmm(
+    input: torch.Tensor, mat2: torch.Tensor
+) -> TorchMojoTensor | _NotHandled:
     out = _try_gemm16_bmm(input, mat2)
     if out is not None:
         return out
@@ -8963,7 +9605,9 @@ def fast_aten_bmm(input, mat2):
     return out if out is not None else NOT_HANDLED
 
 
-def _fast_aten_bmm_transpose_b(input, mat2):
+def _fast_aten_bmm_transpose_b(
+    input: torch.Tensor, mat2: torch.Tensor
+) -> TorchMojoTensor | _NotHandled:
     """Batched ``input @ mat2.transpose(-2, -1)`` without a transpose copy.
 
     This is an internal eager-autograd helper rather than an ATen registration:
@@ -8989,8 +9633,16 @@ def _fast_aten_bmm_transpose_b(input, mat2):
 
 
 def fast_aten_convolution(
-    input, weight, bias, stride, padding, dilation, transposed, output_padding, groups
-):
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    stride: Sequence[int],
+    padding: Sequence[int],
+    dilation: Sequence[int],
+    transposed: bool,
+    output_padding: Sequence[int],
+    groups: object,
+) -> TorchMojoTensor | _NotHandled:
     a = _tc(input)
     w = _tc(weight)
     bias_t = _tc(bias) if bias is not None else None
@@ -9008,7 +9660,9 @@ def fast_aten_convolution(
         and len(w._shape) == 4
         and isinstance(groups, int)
         and groups >= 1
-        and None not in (strides, pads, dils)
+        and strides is not None
+        and pads is not None
+        and dils is not None
         and 0 not in a._shape
     ):
         n, c, in_h, in_w = a._shape
@@ -9145,15 +9799,15 @@ def fast_aten_convolution(
 
 
 def fast_aten_scaled_dot_product_attention(
-    query,
-    key,
-    value,
-    attn_mask=None,
-    dropout_p=0.0,
-    is_causal=False,
-    scale=None,
-    enable_gqa=False,
-):
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attn_mask: torch.Tensor | None = None,
+    dropout_p: float = 0.0,
+    is_causal: bool = False,
+    scale: float | None = None,
+    enable_gqa: bool = False,
+) -> TorchMojoTensor | _NotHandled:
     if attn_mask is not None:
         # None of the fused attention kernels take a mask operand, so a masked
         # call goes straight to the decomposed masked forward.
@@ -9162,7 +9816,7 @@ def fast_aten_scaled_dot_product_attention(
         result = _sdpa_masked_math_forward(
             query, key, value, attn_mask, is_causal, scale
         )
-        if result is NOT_HANDLED:
+        if not isinstance(result, tuple):
             return NOT_HANDLED
         out, _ = result
         return out
@@ -9170,7 +9824,7 @@ def fast_aten_scaled_dot_product_attention(
     fa4_result = fast_fa4_16bit_d64_causal_forward(
         query, key, value, attn_mask, dropout_p, is_causal, scale, enable_gqa
     )
-    if fa4_result is not NOT_HANDLED:
+    if isinstance(fa4_result, tuple):
         output, logsumexp, q_native, k_native, v_native = fa4_result
         del logsumexp, q_native, k_native, v_native
         return output
@@ -9178,7 +9832,7 @@ def fast_aten_scaled_dot_product_attention(
     fused = fast_fused_flash_attention_forward(
         query, key, value, attn_mask, dropout_p, is_causal, scale, enable_gqa
     )
-    if fused is not NOT_HANDLED:
+    if isinstance(fused, tuple):
         output, lse, q_used, k_used, v_used = fused
         del lse, q_used, k_used, v_used
         return output
@@ -9249,7 +9903,7 @@ def fast_aten_scaled_dot_product_attention(
         result = _sdpa_math_forward_with_dropout(
             q, k, v, is_causal, scale, float(dropout_p)
         )
-        if result is NOT_HANDLED:
+        if not isinstance(result, tuple):
             return NOT_HANDLED
         out, _, _ = result
         return out
@@ -9262,7 +9916,9 @@ def fast_aten_scaled_dot_product_attention(
 # ---------------------------------------------------------------------------
 
 
-def fast_aten__softmax(input, dim, half_to_float=False):
+def fast_aten__softmax(
+    input: torch.Tensor, dim: object, half_to_float: bool = False
+) -> TorchMojoTensor | _NotHandled:
     t = _t(input)
     if (
         t is None
@@ -9278,22 +9934,27 @@ def fast_aten__softmax(input, dim, half_to_float=False):
         t = _cast_tensor(t, DType.float32)
     rank = len(t._shape)
     if rank == 0:
-        return fast_filled((), 1.0, t._dtype, t._device)
+        filled = fast_filled((), 1.0, t._dtype, t._device)
+        return filled if filled is not None else NOT_HANDLED
     dim %= rank
     if dim != rank - 1:
         # softmax(x, d) = softmax(x.transpose(d, -1), -1).transpose(d, -1);
         # both transposes are zero-copy, the inner one materializes once.
         # (t is already fp32 here if half_to_float was set, so pass False.)
         swapped = fast_aten_transpose(t, dim, rank - 1)
+        if not isinstance(swapped, TorchMojoTensor):
+            return NOT_HANDLED
         result = fast_aten__softmax(swapped, rank - 1, False)
-        if result is NOT_HANDLED:
+        if not isinstance(result, TorchMojoTensor):
             return NOT_HANDLED
         return fast_aten_transpose(result, dim, rank - 1)
     result = _try_spec_unary("SoftmaxSpec", t, module_name="nn_ops")
     return result if result is not None else NOT_HANDLED
 
 
-def fast_aten_softmax(input, dim=-1, dtype=None):
+def fast_aten_softmax(
+    input: torch.Tensor, dim: object = -1, dtype: torch.dtype | None = None
+) -> TorchMojoTensor | _NotHandled:
     if dtype is not None:
         return NOT_HANDLED
     return fast_aten__softmax(input, dim, False)
@@ -9305,8 +9966,12 @@ def fast_aten_softmax(input, dim=-1, dtype=None):
 
 
 def fast_aten_embedding(
-    input, weight, padding_idx=-1, scale_grad_by_freq=False, sparse=False
-):
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    padding_idx: int = -1,
+    scale_grad_by_freq: bool = False,
+    sparse: bool = False,
+) -> TorchMojoTensor | _NotHandled:
     # `input` is the weight table, `weight` the indices (aten naming).
     table = _t(input)
     idx = _t(weight)
@@ -9325,6 +9990,7 @@ def fast_aten_embedding(
     # table's context.
     table = _tc(table)
     idx = _tc(idx)
+    assert table is not None and idx is not None
     row_len = table._shape[1]
     out_shape = tuple(idx._shape) + (row_len,)
     out = _alloc(out_shape, table._dtype, table._device)
@@ -9350,8 +10016,12 @@ def fast_aten_embedding(
 
 
 def fast_aten_embedding_dense_backward(
-    grad_output, indices, num_weights, padding_idx, scale_grad_by_freq
-):
+    grad_output: torch.Tensor,
+    indices: torch.Tensor,
+    num_weights: object,
+    padding_idx: object,
+    scale_grad_by_freq: bool,
+) -> TorchMojoTensor | _NotHandled:
     """FP32/int64 GPU embedding backward through the Fable-owned kernel."""
     grad = _t(grad_output)
     idx = _t(indices)
@@ -9388,6 +10058,7 @@ def fast_aten_embedding_dense_backward(
 
     grad = _tc(grad)
     idx = _tc(idx)
+    assert grad is not None and idx is not None
     grad_weight = _alloc((num_weights, embedding_dim), DType.float32, grad._device)
     if grad_weight._numel > 0:
         # This call includes complete output zeroing and accumulation, stays on
@@ -9419,7 +10090,9 @@ def fast_aten_embedding_dense_backward(
 # ---------------------------------------------------------------------------
 
 
-def fast_filled(shape, value, dtype: DType, device):
+def fast_filled(
+    shape: Sequence[int], value: object, dtype: DType, device: Device
+) -> TorchMojoTensor | None:
     """A TorchMojoTensor of `shape` filled with `value`, or None."""
     if isinstance(value, bool):
         value = int(value)
@@ -9442,7 +10115,9 @@ def fast_filled(shape, value, dtype: DType, device):
 _ARANGE_DTYPES = _FILL_DTYPES[:-1]
 
 
-def fast_arange(numel, start, step, dtype: DType, device):
+def fast_arange(
+    numel: int, start: float, step: float, dtype: DType, device: Device
+) -> TorchMojoTensor | None:
     """A 1-D TorchMojoTensor holding start + i*step (device kernel), or None.
 
     The caller resolves torch's arange semantics (numel, dtype). Inputs arrive
@@ -9471,17 +10146,15 @@ def fast_arange(numel, start, step, dtype: DType, device):
 # ---------------------------------------------------------------------------
 
 
-def fast_aten__local_scalar_dense(tensor):
+def fast_aten__local_scalar_dense(tensor: torch.Tensor) -> object:
     t = _t(tensor)
     if t is None or t._numel != 1:
         return NOT_HANDLED
     _call_queue.drain()  # host read: queued launches must land first
-    return eager_kernels.tensor_holder.read_scalar(
-        _ctx_ptr(t._device), t._ptr, t._dtype.value
-    )
+    return _tensor_holder().read_scalar(_ctx_ptr(t._device), t._ptr, t._dtype.value)
 
 
-def _instrument_call_counts():
+def _instrument_call_counts() -> None:
     """Give every fast op a test-only call counter, mirroring what
     `aten_functions.map_to` does, so `CallChecker` can assert that an op
     was handled by either implementation."""
@@ -9491,14 +10164,17 @@ def _instrument_call_counts():
         if not name.startswith("fast_aten"):
             continue
 
-        def make_wrapper(wrapped):
-            @functools.wraps(wrapped)
-            def wrapper(*args, **kwargs):
-                wrapper.call_count += 1
+        def make_wrapper(wrapped: Callable[..., object]) -> CountedCallable:
+            def wrapper(*args: object, **kwargs: object) -> object:
+                result.call_count += 1
                 return wrapped(*args, **kwargs)
 
-            wrapper.call_count = 0
-            return wrapper
+            # functools.wraps's stub can't carry the extra call_count
+            # attribute; update_wrapper does the same __name__/__doc__ copy.
+            functools.update_wrapper(wrapper, wrapped)
+            result = cast(CountedCallable, wrapper)
+            result.call_count = 0
+            return result
 
         globals()[name] = make_wrapper(func)
 

--- a/torch_mojo_backend/eager_kernels/call_queue.py
+++ b/torch_mojo_backend/eager_kernels/call_queue.py
@@ -66,7 +66,11 @@ from torch_mojo_backend.is_running_tests import IS_RUNNING_TESTS
 class _BuildJob(Protocol):
     """The background build of one specialization."""
 
-    def wait(self) -> None: ...
+    # Both call sites use this purely for the blocking side effect (and the
+    # exception it raises on build failure) and discard the return value,
+    # so implementations are free to return whatever they like (e.g.
+    # _AsyncLoadJob.wait() returns the loaded module).
+    def wait(self) -> object: ...
 
 
 @runtime_checkable
@@ -75,7 +79,11 @@ class _QueueUnit(Protocol):
     the loaded native module once its build lands (None while building),
     and `request_async()` starts or joins that build."""
 
-    ext: ModuleType | None
+    # A property (read-only), not a plain attribute: `_DefinedUnit.ext` is
+    # itself a read-only @property, and a Protocol's plain-attribute member
+    # requires write-compatibility a read-only property can't offer.
+    @property
+    def ext(self) -> ModuleType | None: ...
 
     def request_async(self) -> _BuildJob: ...
 
@@ -283,9 +291,11 @@ def _order_queue_launch_locked() -> None:
 def _exec(item: _QueueItem) -> None:
     unit, fn, args, _enqueuer, _keepalive, _nbytes = item
     if unit is None:
-        fn(*args)  # type: ignore[misc]  # exactly one of unit/fn is set
+        assert fn is not None  # exactly one of unit/fn is set
+        fn(*args)
         return
-    unit.ext.call(*args)  # type: ignore[union-attr]  # readiness checked by caller
+    assert unit.ext is not None  # readiness checked by caller
+    unit.ext.call(*args)
 
 
 def _pop_locked() -> _QueueItem:

--- a/torch_mojo_backend/eager_kernels/output_specs.py
+++ b/torch_mojo_backend/eager_kernels/output_specs.py
@@ -13,7 +13,7 @@ imports ``aten_fast``.
 """
 
 from dataclasses import dataclass
-from typing import TypeVar
+from typing import Protocol, TypeVar, cast
 
 import torch
 from max.driver import Device
@@ -35,20 +35,33 @@ class _TensorOutputSpec:
     device: Device
 
 
-def _alloc(shape: tuple[int, ...], dtype: DType, device: Device) -> torch.Tensor:
+class _AllocFn(Protocol):
+    def __call__(
+        self, shape: tuple[int, ...], dtype: DType, device: Device
+    ) -> torch.Tensor: ...
+
+
+def _bootstrap_alloc(
+    shape: tuple[int, ...], dtype: DType, device: Device
+) -> torch.Tensor:
     """``TorchMojoTensor._alloc``, resolved on first use.
 
     ``mojo_device`` imports ``eager_kernels``, never the other way round, so
-    the allocator cannot be imported at module scope. Rebinding this global on
-    the first call keeps that direction intact and leaves the steady state at
-    one plain attribute lookup (the same trick as ``_ctx_ptr``). Tensors are
-    typed ``torch.Tensor`` here for the same import-direction reason.
+    the allocator cannot be imported at module scope. Rebinding the `_alloc`
+    global on the first call keeps that direction intact and leaves the
+    steady state at one plain attribute lookup (the same trick as
+    ``_ctx_ptr``). Tensors are typed ``torch.Tensor`` here for the same
+    import-direction reason. `_alloc` is a plain variable (not `def`-bound)
+    so this rebind type-checks against its declared `_AllocFn` type.
     """
     global _alloc
     from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
 
-    _alloc = TorchMojoTensor._alloc
+    _alloc = cast(_AllocFn, TorchMojoTensor._alloc)
     return _alloc(shape, dtype, device)
+
+
+_alloc: _AllocFn = _bootstrap_alloc
 
 
 def _allocate_output_spec(spec: _TensorOutputSpec) -> torch.Tensor:

--- a/torch_mojo_backend/flags.py
+++ b/torch_mojo_backend/flags.py
@@ -3,7 +3,7 @@ import os
 POSITIVE_VALUES = ("1", "true", "yes")
 
 
-def profiling_enabled():
+def profiling_enabled() -> bool:
     """
     Check if profiling is enabled by looking for the environment variable.
     """
@@ -13,7 +13,7 @@ def profiling_enabled():
     return x in POSITIVE_VALUES or py_x in POSITIVE_VALUES
 
 
-def verbose_enabled():
+def verbose_enabled() -> bool:
     """
     Check if verbose mode is enabled by looking for the environment variable.
     """
@@ -23,7 +23,7 @@ def verbose_enabled():
     return x in POSITIVE_VALUES or py_x in POSITIVE_VALUES
 
 
-def debug_graph():
+def debug_graph() -> bool:
     """
     Check if graph debugging is enabled by looking for the environment variable.
     """

--- a/torch_mojo_backend/mojo_device/apple_optimizations.py
+++ b/torch_mojo_backend/mojo_device/apple_optimizations.py
@@ -9,7 +9,9 @@ def _enable_apple_fast_add() -> None:
     """
     from torch_mojo_backend.eager_kernels import aten_fast
 
-    aten_fast.fast_aten_add = aten_fast.fast_aten_add_apple
+    # Deliberate module-attribute monkeypatch; ty compares the two
+    # same-signature `def`s nominally, so this can never structurally match.
+    aten_fast.fast_aten_add = aten_fast.fast_aten_add_apple  # ty: ignore[invalid-assignment]
 
 
 def register_apple_optimizations() -> None:

--- a/torch_mojo_backend/mojo_device/aten_ops/autograd_preflight.py
+++ b/torch_mojo_backend/mojo_device/aten_ops/autograd_preflight.py
@@ -52,11 +52,12 @@ def _preflight_unsupported_backward(
     def preflighted(
         *args: object, **kwargs: object
     ) -> TorchMojoTensor | tuple[TorchMojoTensor, ...]:
-        operands = [
-            args[index]
-            for index in grad_operands
-            if index < len(args) and isinstance(args[index], torch.Tensor)
-        ]
+        operands: list[torch.Tensor] = []
+        for index in grad_operands:
+            if index < len(args):
+                arg = args[index]
+                if isinstance(arg, torch.Tensor):
+                    operands.append(arg)
         if len(operands) < len(grad_operands):
             # The PrivateUse1 boxed kernel passes every positional schema
             # argument positionally, so this is unreachable today. If some call
@@ -211,8 +212,12 @@ def mojo_device_convolution(
 
 
 def mojo_device_embedding(
-    weight, indices, padding_idx=-1, scale_grad_by_freq=False, sparse=False
-):
+    weight: torch.Tensor,
+    indices: torch.Tensor,
+    padding_idx: int = -1,
+    scale_grad_by_freq: bool = False,
+    sparse: bool = False,
+) -> TorchMojoTensor:
     """Native-autograd embedding with a forward-time autograd-mode preflight.
 
     An exception raised while the autograd engine runs a backward node aborts
@@ -281,26 +286,30 @@ def _linear_backward_unsupported_reason(
     supported = getattr(aten_fast, "_FLOAT_DTYPES", None)
     if supported is None:
         return None
-    try:
-        if input._dtype not in supported:
-            covered = ", ".join(
-                str(dtype).removeprefix("DType.") for dtype in supported
-            )
-            return (
-                f"linear_backward covers {covered} only, and these operands "
-                f"are {input.dtype}"
-            )
-        if weight._dtype != input._dtype or (
-            bias is not None and bias._dtype != input._dtype
-        ):
-            return (
-                "linear_backward requires input, weight and bias to share one "
-                f"dtype, and these are {input.dtype}/{weight.dtype}"
-                + ("" if bias is None else f"/{bias.dtype}")
-            )
-    except AttributeError:
-        # A non-mojo operand: the forward below reports that far better.
+    # getattr rather than a bare `.tensor._dtype` + except AttributeError: a
+    # non-mojo operand (no `_dtype`) is reported far better by the forward
+    # below, so it falls through to None the same way the old except did.
+    input_dtype = getattr(input, "_dtype", None)
+    weight_dtype = getattr(weight, "_dtype", None)
+    bias_dtype = getattr(bias, "_dtype", None) if bias is not None else None
+    if (
+        input_dtype is None
+        or weight_dtype is None
+        or (bias is not None and bias_dtype is None)
+    ):
         return None
+    if input_dtype not in supported:
+        covered = ", ".join(str(dtype).removeprefix("DType.") for dtype in supported)
+        return (
+            f"linear_backward covers {covered} only, and these operands "
+            f"are {input.dtype}"
+        )
+    if weight_dtype != input_dtype or (bias is not None and bias_dtype != input_dtype):
+        return (
+            "linear_backward requires input, weight and bias to share one "
+            f"dtype, and these are {input.dtype}/{weight.dtype}"
+            + ("" if bias is None else f"/{bias.dtype}")
+        )
     return None
 
 

--- a/torch_mojo_backend/mojo_device/aten_ops/factories.py
+++ b/torch_mojo_backend/mojo_device/aten_ops/factories.py
@@ -1,7 +1,9 @@
 """Tensor factories: empty/new_*/full/ones/zeros/scalar_tensor/arange."""
 
 import math
+from collections.abc import Sequence
 
+import max.driver as max_driver
 import torch
 from max.experimental.torch.torch import torch_dtype_to_max
 
@@ -14,51 +16,85 @@ from torch_mojo_backend.mojo_device.torch_mojo_tensor import (
 from .support import _copy_into_tensor, _fast, _unsupported, max_dtype_to_torch_dtype
 
 
+def _require_device(device: torch.device | None) -> torch.device:
+    """The dispatcher always resolves a factory op's device before calling
+    into this PrivateUse1 registration; `None` here would already be a
+    crash inside `find_equivalent_max_device`, just with a worse message."""
+    assert device is not None, "expected a resolved mojo device from the dispatcher"
+    return device
+
+
 def mojo_device_empty_memory_format(
-    size, *, dtype=None, layout=None, device=None, pin_memory=None, memory_format=None
+    size: Sequence[int],
+    *,
+    dtype: torch.dtype | None = None,
+    layout: torch.layout | None = None,
+    device: torch.device | None = None,
+    pin_memory: bool | None = None,
+    memory_format: torch.memory_format | None = None,
 ) -> TorchMojoTensor:
     dtype = torch.get_default_dtype() if dtype is None else dtype
     return TorchMojoTensor._alloc(
-        tuple(size), torch_dtype_to_max(dtype), find_equivalent_max_device(device)
+        tuple(size),
+        torch_dtype_to_max(dtype),
+        find_equivalent_max_device(_require_device(device)),
     )
 
 
 def empty_strided(
-    size, stride, *, dtype=None, layout=None, device=None, pin_memory=None
+    size: Sequence[int],
+    stride: Sequence[int],
+    *,
+    dtype: torch.dtype | None = None,
+    layout: torch.layout | None = None,
+    device: torch.device | None = None,
+    pin_memory: bool | None = None,
 ) -> TorchMojoTensor:
     # The requested strides are ignored: allocation is always contiguous
     # (matching the previous behavior; our metadata is self-consistent).
     dtype = torch.get_default_dtype() if dtype is None else dtype
     return TorchMojoTensor._alloc(
-        tuple(size), torch_dtype_to_max(dtype), find_equivalent_max_device(device)
+        tuple(size),
+        torch_dtype_to_max(dtype),
+        find_equivalent_max_device(_require_device(device)),
     )
 
 
 def mojo_device_empty_permuted(
-    size, physical_layout, *, dtype=None, layout=None, device=None, pin_memory=None
+    size: Sequence[int],
+    physical_layout: Sequence[int],
+    *,
+    dtype: torch.dtype | None = None,
+    layout: torch.layout | None = None,
+    device: torch.device | None = None,
+    pin_memory: bool | None = None,
 ) -> TorchMojoTensor:
     # Uninitialized memory: a contiguous allocation of `size` is valid.
     dtype = torch.get_default_dtype() if dtype is None else dtype
     return TorchMojoTensor._alloc(
-        tuple(size), torch_dtype_to_max(dtype), find_equivalent_max_device(device)
+        tuple(size),
+        torch_dtype_to_max(dtype),
+        find_equivalent_max_device(_require_device(device)),
     )
 
 
 def mojo_device_empty_like(
     self: TorchMojoTensor,
     *,
-    dtype=None,
-    layout=None,
-    device=None,
-    pin_memory=None,
-    memory_format=None,
+    dtype: torch.dtype | None = None,
+    layout: torch.layout | None = None,
+    device: torch.device | None = None,
+    pin_memory: bool | None = None,
+    memory_format: torch.memory_format | None = None,
 ) -> TorchMojoTensor:
     max_dtype = self._dtype if dtype is None else torch_dtype_to_max(dtype)
     mojo_device = self._device if device is None else find_equivalent_max_device(device)
     return TorchMojoTensor._alloc(self._shape, max_dtype, mojo_device)
 
 
-def _new_factory_device(self: TorchMojoTensor, device):
+def _new_factory_device(
+    self: TorchMojoTensor, device: torch.device | None
+) -> max_driver.Device:
     """Target MAX device for a `new_*` factory. torch passes `self`'s device
     (whose torch-side index is the phantom 0) when the caller doesn't
     override it, so default to `self`'s real MAX device; only an explicit
@@ -73,12 +109,12 @@ def _new_factory_device(self: TorchMojoTensor, device):
 
 def mojo_device_new_empty(
     self: TorchMojoTensor,
-    size,
+    size: Sequence[int],
     *,
-    dtype=None,
-    layout=None,
-    device=None,
-    pin_memory=None,
+    dtype: torch.dtype | None = None,
+    layout: torch.layout | None = None,
+    device: torch.device | None = None,
+    pin_memory: bool | None = None,
 ) -> TorchMojoTensor:
     max_dtype = self._dtype if dtype is None else torch_dtype_to_max(dtype)
     return TorchMojoTensor._alloc(
@@ -88,12 +124,12 @@ def mojo_device_new_empty(
 
 def mojo_device_new_zeros(
     self: TorchMojoTensor,
-    size,
+    size: Sequence[int],
     *,
-    dtype=None,
-    layout=None,
-    device=None,
-    pin_memory=None,
+    dtype: torch.dtype | None = None,
+    layout: torch.layout | None = None,
+    device: torch.device | None = None,
+    pin_memory: bool | None = None,
 ) -> TorchMojoTensor:
     max_dtype = self._dtype if dtype is None else torch_dtype_to_max(dtype)
     result = _fast().fast_filled(size, 0, max_dtype, _new_factory_device(self, device))
@@ -104,12 +140,12 @@ def mojo_device_new_zeros(
 
 def mojo_device_new_ones(
     self: TorchMojoTensor,
-    size,
+    size: Sequence[int],
     *,
-    dtype=None,
-    layout=None,
-    device=None,
-    pin_memory=None,
+    dtype: torch.dtype | None = None,
+    layout: torch.layout | None = None,
+    device: torch.device | None = None,
+    pin_memory: bool | None = None,
 ) -> TorchMojoTensor:
     max_dtype = self._dtype if dtype is None else torch_dtype_to_max(dtype)
     result = _fast().fast_filled(size, 1, max_dtype, _new_factory_device(self, device))
@@ -120,13 +156,13 @@ def mojo_device_new_ones(
 
 def mojo_device_new_full(
     self: TorchMojoTensor,
-    size,
-    fill_value,
+    size: Sequence[int],
+    fill_value: bool | int | float,
     *,
-    dtype=None,
-    layout=None,
-    device=None,
-    pin_memory=None,
+    dtype: torch.dtype | None = None,
+    layout: torch.layout | None = None,
+    device: torch.device | None = None,
+    pin_memory: bool | None = None,
 ) -> TorchMojoTensor:
     max_dtype = self._dtype if dtype is None else torch_dtype_to_max(dtype)
     result = _fast().fast_filled(
@@ -137,14 +173,19 @@ def mojo_device_new_full(
     return result
 
 
-def _fast_filled_tensor(size, value, dtype, device):
+def _fast_filled_tensor(
+    size: Sequence[int],
+    value: bool | int | float,
+    dtype: torch.dtype,
+    device: torch.device | None,
+) -> TorchMojoTensor:
     """Filled-tensor factory (alloc + Fill), or raises."""
     try:
         max_dtype = torch_dtype_to_max(dtype)
     except (KeyError, ValueError):
         raise _unsupported("aten::full (dtype)", (dtype,)) from None
     result = _fast().fast_filled(
-        size, value, max_dtype, find_equivalent_max_device(device)
+        size, value, max_dtype, find_equivalent_max_device(_require_device(device))
     )
     if result is None:
         raise _unsupported("aten::full", (size, value, dtype))
@@ -152,7 +193,13 @@ def _fast_filled_tensor(size, value, dtype, device):
 
 
 def mojo_device_full(
-    size, fill_value, *, dtype=None, layout=None, device=None, pin_memory=None
+    size: Sequence[int],
+    fill_value: bool | int | float,
+    *,
+    dtype: torch.dtype | None = None,
+    layout: torch.layout | None = None,
+    device: torch.device | None = None,
+    pin_memory: bool | None = None,
 ) -> TorchMojoTensor:
     if dtype is not None:
         resolved = dtype
@@ -167,13 +214,13 @@ def mojo_device_full(
 
 def mojo_device_full_like(
     self: TorchMojoTensor,
-    fill_value,
+    fill_value: bool | int | float,
     *,
-    dtype=None,
-    layout=None,
-    device=None,
-    pin_memory=None,
-    memory_format=None,
+    dtype: torch.dtype | None = None,
+    layout: torch.layout | None = None,
+    device: torch.device | None = None,
+    pin_memory: bool | None = None,
+    memory_format: torch.memory_format | None = None,
 ) -> TorchMojoTensor:
     max_dtype = self._dtype if dtype is None else torch_dtype_to_max(dtype)
     mojo_device = self._device if device is None else find_equivalent_max_device(device)
@@ -184,7 +231,12 @@ def mojo_device_full_like(
 
 
 def mojo_device_ones(
-    size, *, dtype=None, layout=None, device=None, pin_memory=None
+    size: Sequence[int],
+    *,
+    dtype: torch.dtype | None = None,
+    layout: torch.layout | None = None,
+    device: torch.device | None = None,
+    pin_memory: bool | None = None,
 ) -> TorchMojoTensor:
     resolved = torch.get_default_dtype() if dtype is None else dtype
     return _fast_filled_tensor(size, 1, resolved, device)
@@ -193,17 +245,22 @@ def mojo_device_ones(
 def mojo_device_ones_like(
     self: TorchMojoTensor,
     *,
-    dtype=None,
-    layout=None,
-    device=None,
-    pin_memory=None,
-    memory_format=None,
+    dtype: torch.dtype | None = None,
+    layout: torch.layout | None = None,
+    device: torch.device | None = None,
+    pin_memory: bool | None = None,
+    memory_format: torch.memory_format | None = None,
 ) -> TorchMojoTensor:
     return mojo_device_full_like(self, 1, dtype=dtype, device=device)
 
 
 def mojo_device_zeros(
-    size, *, dtype=None, layout=None, device=None, pin_memory=None
+    size: Sequence[int],
+    *,
+    dtype: torch.dtype | None = None,
+    layout: torch.layout | None = None,
+    device: torch.device | None = None,
+    pin_memory: bool | None = None,
 ) -> TorchMojoTensor:
     resolved = torch.get_default_dtype() if dtype is None else dtype
     return _fast_filled_tensor(size, 0, resolved, device)
@@ -212,28 +269,43 @@ def mojo_device_zeros(
 def mojo_device_zeros_like(
     self: TorchMojoTensor,
     *,
-    dtype=None,
-    layout=None,
-    device=None,
-    pin_memory=None,
-    memory_format=None,
+    dtype: torch.dtype | None = None,
+    layout: torch.layout | None = None,
+    device: torch.device | None = None,
+    pin_memory: bool | None = None,
+    memory_format: torch.memory_format | None = None,
 ) -> TorchMojoTensor:
     return mojo_device_full_like(self, 0, dtype=dtype, device=device)
 
 
 def mojo_device_scalar_tensor(
-    s, dtype=None, layout=None, device=None, pin_memory=None
+    s: bool | int | float,
+    dtype: torch.dtype | None = None,
+    layout: torch.layout | None = None,
+    device: torch.device | None = None,
+    pin_memory: bool | None = None,
 ) -> TorchMojoTensor:
     resolved = torch.float32 if dtype is None else dtype
     return _fast_filled_tensor((), s, resolved, device)
 
 
-def _host_arange_tensor(start, end, step, dtype: torch.dtype | None) -> torch.Tensor:
+def _host_arange_tensor(
+    start: bool | int | float,
+    end: bool | int | float,
+    step: bool | int | float,
+    dtype: torch.dtype | None,
+) -> torch.Tensor:
     """torch.arange built on the host (exact torch semantics)."""
     return torch.arange(start, end, step, dtype=dtype)
 
 
-def _device_arange(start, end, step, dtype: torch.dtype | None, device):
+def _device_arange(
+    start: bool | int | float,
+    end: bool | int | float,
+    step: bool | int | float,
+    dtype: torch.dtype | None,
+    device: torch.device | None,
+) -> TorchMojoTensor | None:
     """torch.arange computed by a device kernel, or None to use the host
     path. HF generation loops call torch.arange(..., device=...) every
     step; the host path costs a blocking H2D copy (full queue drain) per
@@ -261,7 +333,11 @@ def _device_arange(start, end, step, dtype: torch.dtype | None, device):
     else:
         numel = max(0, math.ceil((float(end) - float(start)) / float(step)))
     return _fast().fast_arange(
-        numel, start, step, max_dtype, find_equivalent_max_device(device)
+        numel,
+        start,
+        step,
+        max_dtype,
+        find_equivalent_max_device(_require_device(device)),
     )
 
 
@@ -271,7 +347,14 @@ _MAX_EXACT_F64_INT = 2**53
 
 
 def mojo_device_arange(
-    start, end=None, step=1, *, dtype=None, layout=None, device=None, pin_memory=None
+    start: bool | int | float,
+    end: bool | int | float | None = None,
+    step: bool | int | float = 1,
+    *,
+    dtype: torch.dtype | None = None,
+    layout: torch.layout | None = None,
+    device: torch.device | None = None,
+    pin_memory: bool | None = None,
 ) -> TorchMojoTensor:
     if end is None:
         start, end = 0, start
@@ -280,10 +363,18 @@ def mojo_device_arange(
         return result
     # Build on the host with exact torch semantics, then one H2D copy.
     cpu = _host_arange_tensor(start, end, step, dtype)
-    return TorchMojoTensor._from_cpu(cpu, find_equivalent_max_device(device))
+    return TorchMojoTensor._from_cpu(
+        cpu, find_equivalent_max_device(_require_device(device))
+    )
 
 
-def mojo_device_arange_start_out(start, end, step=1, *, out) -> TorchMojoTensor:
+def mojo_device_arange_start_out(
+    start: bool | int | float,
+    end: bool | int | float,
+    step: bool | int | float = 1,
+    *,
+    out: TorchMojoTensor,
+) -> TorchMojoTensor:
     # torch.arange(start, end, step, device=...) dispatches to the out
     # variant with a pre-allocated `out` of the right size and dtype.
     torch_dtype = max_dtype_to_torch_dtype(out._dtype)

--- a/torch_mojo_backend/mojo_device/aten_ops/foreach.py
+++ b/torch_mojo_backend/mojo_device/aten_ops/foreach.py
@@ -18,7 +18,7 @@ def inplace_dispatcher(op_name: str, fast_name: str) -> Callable:
     packet_name, _, overload_name = op_name.removeprefix("aten::").partition(".")
     aten_op = getattr(getattr(torch.ops.aten, packet_name), overload_name or "default")
 
-    def dispatcher(self, *args, **kwargs):
+    def dispatcher(self: list[torch.Tensor], *args: object, **kwargs: object) -> None:
         aten_fast = _fast()
         result = getattr(aten_fast, fast_name)(self, *args, **kwargs)
         if result is aten_fast.NOT_HANDLED:
@@ -36,7 +36,9 @@ def inplace_dispatcher(op_name: str, fast_name: str) -> Callable:
     return dispatcher
 
 
-def mojo_device__foreach_mul__tensor(self, other):
+def mojo_device__foreach_mul__tensor(
+    self: list[torch.Tensor], other: torch.Tensor
+) -> None:
     aten_fast = _fast()
     result = aten_fast.fast_aten__foreach_mul__tensor(self, other)
     if result is aten_fast.NOT_HANDLED:
@@ -55,7 +57,11 @@ def mojo_device__foreach_mul__tensor(self, other):
     return None
 
 
-def mojo_device__foreach_norm_scalar(self, ord=2, dtype=None):
+def mojo_device__foreach_norm_scalar(
+    self: list[torch.Tensor],
+    ord: bool | int | float = 2,
+    dtype: torch.dtype | None = None,
+) -> list[torch.Tensor]:
     aten_fast = _fast()
     result = aten_fast.fast_aten__foreach_norm(self, ord, dtype=dtype)
     if result is aten_fast.NOT_HANDLED:
@@ -67,7 +73,7 @@ def mojo_device__foreach_norm_scalar(self, ord=2, dtype=None):
     return result
 
 
-def mojo_device__foreach_sqrt(self):
+def mojo_device__foreach_sqrt(self: list[torch.Tensor]) -> list[torch.Tensor]:
     aten_fast = _fast()
     result = aten_fast.fast_aten__foreach_sqrt(self)
     if result is aten_fast.NOT_HANDLED:

--- a/torch_mojo_backend/mojo_device/aten_ops/inplace.py
+++ b/torch_mojo_backend/mojo_device/aten_ops/inplace.py
@@ -11,7 +11,7 @@ from .support import (
 
 
 def mojo_device_add_(
-    self: TorchMojoTensor, other, alpha: int | float = 1.0
+    self: TorchMojoTensor, other: TorchMojoTensor, alpha: int | float = 1.0
 ) -> TorchMojoTensor:
     # `alpha` is a Scalar in the schema, not a float: unlike the `float`
     # arguments of, say, native_batch_norm, PyTorch's argument parser does not
@@ -22,7 +22,9 @@ def mojo_device_add_(
     return result
 
 
-def mojo_device_fill__scalar(self: TorchMojoTensor, value) -> TorchMojoTensor:
+def mojo_device_fill__scalar(
+    self: TorchMojoTensor, value: bool | int | float
+) -> TorchMojoTensor:
     result = _fast().fast_aten_fill__scalar(self, value)
     if result is None:
         raise _unsupported("aten::fill_.Scalar", (self, value))
@@ -30,7 +32,7 @@ def mojo_device_fill__scalar(self: TorchMojoTensor, value) -> TorchMojoTensor:
 
 
 def mojo_device_masked_fill_(
-    self: TorchMojoTensor, mask: TorchMojoTensor, value
+    self: TorchMojoTensor, mask: TorchMojoTensor, value: bool | int | float
 ) -> TorchMojoTensor:
     result = _fast().fast_aten_masked_fill_(self, mask, value)
     if result is None:
@@ -38,7 +40,7 @@ def mojo_device_masked_fill_(
     return result
 
 
-def mojo_device_mul_(self: TorchMojoTensor, other) -> TorchMojoTensor:
+def mojo_device_mul_(self: TorchMojoTensor, other: TorchMojoTensor) -> TorchMojoTensor:
     result = _fast().fast_aten_mul_(self, other)
     if result is None:
         raise _unsupported("aten::mul_.Tensor", (self, other))

--- a/torch_mojo_backend/mojo_device/aten_ops/reductions.py
+++ b/torch_mojo_backend/mojo_device/aten_ops/reductions.py
@@ -31,6 +31,9 @@ def mojo_device_min_dim_min(
     """Out-variant of torch.min along a dim: writes values into `min` and
     int64 indices into `min_indices` (resizing via payload rebind when the
     pre-allocated shapes don't match, like the other out-variants)."""
+    assert min is not None and min_indices is not None, (
+        "the out= dispatcher always supplies both output tensors"
+    )
     aten_fast = _fast()
     result = aten_fast.fast_aten_min_dim(input, dim, keepdim)
     if result is aten_fast.NOT_HANDLED:

--- a/torch_mojo_backend/mojo_device/aten_ops/rng.py
+++ b/torch_mojo_backend/mojo_device/aten_ops/rng.py
@@ -8,7 +8,10 @@ from .support import _copy_into_tensor, _unsupported, max_dtype_to_torch_dtype
 
 
 def mojo_device_normal_(
-    self: TorchMojoTensor, mean: float = 0.0, std: float = 1.0, generator=None
+    self: TorchMojoTensor,
+    mean: float = 0.0,
+    std: float = 1.0,
+    generator: torch.Generator | None = None,
 ) -> TorchMojoTensor:
     if generator is not None:
         raise _unsupported("aten::normal_ (generator)", (self,))

--- a/torch_mojo_backend/mojo_device/aten_ops/support.py
+++ b/torch_mojo_backend/mojo_device/aten_ops/support.py
@@ -7,8 +7,11 @@ implementation module ever has to import another one.
 """
 
 from collections.abc import Callable
+from types import ModuleType
+from typing import NoReturn
 
 import torch
+from max.dtype import DType
 
 from torch_mojo_backend.mojo_device.torch_mojo_tensor import (
     TorchMojoTensor,
@@ -25,7 +28,7 @@ _COMPOSITE_EXPLICIT_AUTOGRAD = torch._C.DispatchKeySet(
 _aten_fast_module = None
 
 
-def _fast():
+def _fast() -> ModuleType:
     """The aten_fast module.
 
     Imported lazily: the first import triggers the (cached) Mojo kernel
@@ -39,13 +42,13 @@ def _fast():
     return _aten_fast_module
 
 
-def max_dtype_to_torch_dtype(dtype):
+def max_dtype_to_torch_dtype(dtype: DType) -> torch.dtype:
     from max.experimental.torch import max_dtype_to_torch
 
     return max_dtype_to_torch(dtype)
 
 
-def _describe_args(args, kwargs) -> str:
+def _describe_args(args: tuple[object, ...], kwargs: dict[str, object]) -> str:
     descs = []
     for a in list(args) + list(kwargs.values()):
         if isinstance(a, TorchMojoTensor):
@@ -55,7 +58,9 @@ def _describe_args(args, kwargs) -> str:
     return ", ".join(descs) or "none"
 
 
-def _unsupported(op_name: str, args=(), kwargs=None) -> NotImplementedError:
+def _unsupported(
+    op_name: str, args: tuple[object, ...] = (), kwargs: dict[str, object] | None = None
+) -> NotImplementedError:
     return NotImplementedError(
         f"{op_name} is not supported by mojo eager mode for these inputs "
         f"(tensor args: {_describe_args(args, kwargs or {})}). The graph "
@@ -106,7 +111,7 @@ def _eager_impl(fast_name: str, op_name: str) -> Callable:
     fast_fn: Callable | None = None
     not_handled = None
 
-    def dispatcher(*args, **kwargs):
+    def dispatcher(*args: object, **kwargs: object) -> object:
         nonlocal fast_fn, not_handled
         if fast_fn is None:
             aten_fast = _fast()
@@ -126,7 +131,7 @@ def _not_implemented(op_name: str) -> Callable:
     unregistered) so users get an actionable message, and so the remaining
     surface is greppable."""
 
-    def raiser(*args, **kwargs):
+    def raiser(*args: object, **kwargs: object) -> NoReturn:
         raise _unsupported(op_name, args, kwargs)
 
     return raiser
@@ -145,11 +150,15 @@ def _copy_into_tensor(dst: TorchMojoTensor, src: TorchMojoTensor) -> None:
     aten_fast._copy_into(dst, src)
 
 
-def _out_variant(op_name: str, fast_name: str, *, dtype_policy: str = "safe_cast"):
+def _out_variant(
+    op_name: str, fast_name: str, *, dtype_policy: str = "safe_cast"
+) -> Callable:
     """Wrap a functional fast implementation as an out= variant: compute,
     then copy into `out` (strided-safe)."""
 
-    def dispatcher(*args, out: TorchMojoTensor, **kwargs):
+    def dispatcher(
+        *args: object, out: TorchMojoTensor, **kwargs: object
+    ) -> TorchMojoTensor:
         if not isinstance(out, TorchMojoTensor):
             raise RuntimeError(f"{op_name}: expected out to be a mojo tensor")
 

--- a/torch_mojo_backend/mojo_device/aten_ops/transfer.py
+++ b/torch_mojo_backend/mojo_device/aten_ops/transfer.py
@@ -1,9 +1,12 @@
 """Data transfer: H2D / D2H / D2D and dtype/device copies."""
 
+from typing import Protocol, cast, runtime_checkable
+
+import max.driver
 import torch
 from max.experimental.torch.torch import torch_dtype_to_max
 
-from torch_mojo_backend.mojo_device import cuda_peer
+from torch_mojo_backend.mojo_device import cuda_peer, torch_mojo_device_module
 from torch_mojo_backend.mojo_device.torch_mojo_tensor import (
     TorchMojoTensor,
     _copy_strided_into,
@@ -14,7 +17,23 @@ from torch_mojo_backend.mojo_device.torch_mojo_tensor import (
 from .support import _copy_into_tensor, _fast, max_dtype_to_torch_dtype
 
 
-def _upload_on_device(src: torch.Tensor, dest_ptr: int, dest_device) -> bool:
+@runtime_checkable
+class _TensorHolderModule(Protocol):
+    """The Mojo `tensor_holder` extension's Python-callable surface this
+    module needs -- it's a compiled-on-first-use native module (no stubs
+    possible), reached via `eager_kernels`' PEP 562 `__getattr__`."""
+
+    def copy_d2d(
+        self, ctx_ptr: int, dst_ptr: int, src_ptr: int, nbytes: int
+    ) -> None: ...
+    def copy_from_host(
+        self, ctx_ptr: int, dev_ptr: int, host_ptr: int, nbytes: int
+    ) -> object: ...
+
+
+def _upload_on_device(
+    src: torch.Tensor, dest_ptr: int, dest_device: max.driver.Device
+) -> bool:
     """Copy a foreign CUDA tensor straight into `dest_ptr`, or return False.
 
     Both allocations are device memory in one process, so when they sit on the
@@ -50,14 +69,17 @@ def _upload_on_device(src: torch.Tensor, dest_ptr: int, dest_device) -> bool:
 
     deferred_compile.drain()
     torch.cuda.synchronize()
-    eager_kernels.tensor_holder.copy_d2d(
+    holder = cast(_TensorHolderModule, eager_kernels.tensor_holder)
+    holder.copy_d2d(
         eager_kernels._ctx_ptr(dest_device), dest_ptr, src.data_ptr(), nbytes
     )
-    torch.mojo.synchronize()
+    torch_mojo_device_module.synchronize()
     return True
 
 
-def mojo_device__copy_from(self, dest, non_blocking: bool = False):
+def mojo_device__copy_from(
+    self: torch.Tensor, dest: torch.Tensor, non_blocking: bool = False
+) -> torch.Tensor:
     src_is_mojo = isinstance(self, TorchMojoTensor)
     dest_is_mojo = isinstance(dest, TorchMojoTensor)
 
@@ -99,7 +121,8 @@ def mojo_device__copy_from(self, dest, non_blocking: bool = False):
             if dest._numel > 0:
                 from torch_mojo_backend import eager_kernels
 
-                transfer_owner = eager_kernels.tensor_holder.copy_from_host(
+                holder = cast(_TensorHolderModule, eager_kernels.tensor_holder)
+                transfer_owner = holder.copy_from_host(
                     eager_kernels._ctx_ptr(dest._device),
                     dest._ptr,
                     cpu.data_ptr(),
@@ -119,7 +142,7 @@ def mojo_device__copy_from(self, dest, non_blocking: bool = False):
 
 
 def mojo_device__to_copy(
-    tensor,
+    tensor: torch.Tensor,
     *,
     dtype: torch.dtype | None = None,
     layout: torch.layout | None = None,
@@ -127,7 +150,7 @@ def mojo_device__to_copy(
     pin_memory: bool | None = None,
     non_blocking: bool = False,
     memory_format: torch.memory_format | None = None,
-):
+) -> torch.Tensor:
     aten_fast = _fast()
     if not isinstance(tensor, TorchMojoTensor):
         # Any non-mojo tensor moving onto mojo_device (optionally casting
@@ -136,6 +159,7 @@ def mojo_device__to_copy(
         # data_ptr() to alloc_from_host, which reads it as HOST memory -- so a
         # CUDA pointer segfaulted the process instead of raising.  Cast before
         # the bounce: on a downcast that shrinks the transfer.
+        assert device is not None, "moving onto mojo_device always names a device"
         t = tensor.detach()
         if dtype is not None and t.dtype != dtype:
             t = t.to(dtype)

--- a/torch_mojo_backend/mojo_device/deferred_compile.py
+++ b/torch_mojo_backend/mojo_device/deferred_compile.py
@@ -50,7 +50,7 @@ from torch_mojo_backend.eager_kernels import call_queue
 _DEVICE_LOCK = call_queue._LOCK
 
 
-def _direct(func: object, args: tuple, kwargs: dict) -> object:
+def _direct(func: torch._ops.OpOverload, args: tuple, kwargs: dict) -> object:
     """Execute one aten op through the PrivateUse1 kernels."""
     with _DEVICE_LOCK:
         call_queue.order_direct_launch()
@@ -74,7 +74,7 @@ def _crosses_device(args: tuple, kwargs: dict) -> bool:
     return len(devices) > 1
 
 
-def dispatch(func: object, args: tuple, kwargs: dict) -> object:
+def dispatch(func: torch._ops.OpOverload, args: tuple, kwargs: dict) -> object:
     """Entry point called from TorchMojoTensor.__torch_dispatch__."""
     if not call_queue.enabled():
         return _direct(func, args, kwargs)

--- a/torch_mojo_backend/mojo_device/device_streams.py
+++ b/torch_mojo_backend/mojo_device/device_streams.py
@@ -18,22 +18,30 @@ default-stream-ordered); nothing is fenced implicitly.
 """
 
 import threading
-from types import ModuleType
+from typing import TYPE_CHECKING, Protocol
 
 import max.driver
 
-# The Mojo extension carrying the fence-event functions, resolved on first
-# use so that importing this module never triggers a Mojo kernel build.
-_tensor_holder: ModuleType | None = None
+if TYPE_CHECKING:
+    from torch_mojo_backend.mojo_device.torch_mojo_tensor import _TensorHolderModule
 
 
-def _holder_mod() -> ModuleType:
-    global _tensor_holder
-    if _tensor_holder is None:
-        from torch_mojo_backend import eager_kernels
+def _holder_mod() -> "_TensorHolderModule":
+    # Lazy: importing this module must not trigger a Mojo kernel build.
+    from torch_mojo_backend.mojo_device.torch_mojo_tensor import (
+        _holder_mod as holder_mod,
+    )
 
-        _tensor_holder = eager_kernels.tensor_holder
-    return _tensor_holder
+    return holder_mod()
+
+
+class _ForeignUseRecorder(Protocol):
+    """`torch_mojo_tensor._HolderOwner`, structurally (importing it here would
+    be circular)."""
+
+    def record_foreign_use(
+        self, stream_ctx_ptr: int, event: object, owner_ctx_ptr: int
+    ) -> None: ...
 
 
 def default_stream_ctx_ptr(device: max.driver.Device) -> int:
@@ -158,7 +166,7 @@ def default_stream(device: max.driver.Device) -> Stream:
 
 
 def record_use(
-    holder: object, stream: Stream, owner_ctx_ptr: int | None = None
+    holder: _ForeignUseRecorder, stream: Stream, owner_ctx_ptr: int | None = None
 ) -> None:
     """Order `holder`'s eventual free after `stream` work enqueued so far.
 
@@ -181,7 +189,7 @@ def record_use(
 
 
 def record_use_on_stream_ctx(
-    holder: object, stream_ctx_ptr: int, owner_ctx_ptr: int
+    holder: _ForeignUseRecorder, stream_ctx_ptr: int, owner_ctx_ptr: int
 ) -> None:
     """``record_use`` for a bare stream context pointer instead of a Stream.
 

--- a/torch_mojo_backend/mojo_device/dlpack.py
+++ b/torch_mojo_backend/mojo_device/dlpack.py
@@ -15,8 +15,15 @@ runs, which is the same refcount-based ownership the rest of the eager
 backend relies on.
 """
 
-import ctypes
+# ctypes._CData / ctypes._Pointer are typeshed-only names (not real runtime
+# attributes of the ctypes module); deferred evaluation keeps annotations
+# that reference them from crashing at import time.
+from __future__ import annotations
 
+import ctypes
+from collections.abc import Callable, Sequence
+
+import max.driver
 from max.dtype import DType
 
 
@@ -118,7 +125,13 @@ class _ExportState:
         "released",
     )
 
-    def __init__(self, managed, shape_arr, holder, registry):
+    def __init__(
+        self,
+        managed: _DLManagedTensor,
+        shape_arr: ctypes.Array,
+        holder: object,
+        registry: dict[int, _ExportState],
+    ) -> None:
         self.managed = managed
         self.shape_arr = shape_arr
         self.holder = holder
@@ -136,13 +149,13 @@ _live_exports: dict[int, _ExportState] = {}
 
 
 def _release_export(
-    handle,
+    handle: ctypes._Pointer[_DLManagedTensor],
     *,
-    addressof=ctypes.addressof,
-    cast=ctypes.cast,
-    py_object=ctypes.py_object,
-    py_decref=_pyapi.Py_DecRef,
-):
+    addressof: Callable[[ctypes._CData], int] = ctypes.addressof,
+    cast: Callable[[int, type[ctypes.py_object]], ctypes.py_object] = ctypes.cast,
+    py_object: type[ctypes.py_object] = ctypes.py_object,
+    py_decref: Callable[[object], None] = _pyapi.Py_DecRef,
+) -> None:
     """Release the producer reference owned by ``manager_ctx`` exactly once.
 
     All helpers needed during release are captured as defaults. An old ctypes
@@ -167,7 +180,12 @@ def _release_export(
     py_decref(state)
 
 
-def _deleter_impl(handle, release_export=_release_export):
+def _deleter_impl(
+    handle: ctypes._Pointer[_DLManagedTensor],
+    release_export: Callable[
+        [ctypes._Pointer[_DLManagedTensor]], None
+    ] = _release_export,
+) -> None:
     release_export(handle)
 
 
@@ -175,15 +193,15 @@ _managed_deleter = _DLManagedTensorDeleter(_deleter_impl)
 
 
 def _capsule_destructor_impl(
-    capsule_ptr,
+    capsule_ptr: object,
     *,
-    capsule_name=_CAPSULE_NAME,
-    capsule_is_valid=_pyapi.PyCapsule_IsValid,
-    capsule_get_pointer=_pyapi.PyCapsule_GetPointer,
-    cast=ctypes.cast,
-    managed_pointer=ctypes.POINTER(_DLManagedTensor),
-    release_export=_release_export,
-):
+    capsule_name: bytes = _CAPSULE_NAME,
+    capsule_is_valid: Callable[[object, bytes], bool] = _pyapi.PyCapsule_IsValid,
+    capsule_get_pointer: Callable[[object, bytes], int] = _pyapi.PyCapsule_GetPointer,
+    cast: Callable[..., object] = ctypes.cast,
+    managed_pointer: object = ctypes.POINTER(_DLManagedTensor),
+    release_export: Callable[..., None] = _release_export,
+) -> None:
     # A consumer that adopted the memory renames the capsule to
     # "used_dltensor" and becomes responsible for calling the deleter; if
     # the capsule dies still named "dltensor" it was never consumed and the
@@ -196,7 +214,7 @@ def _capsule_destructor_impl(
 _capsule_destructor = _PyCapsule_Destructor(_capsule_destructor_impl)
 
 
-def dlpack_device(device) -> tuple[int, int]:
+def dlpack_device(device: max.driver.Device) -> tuple[int, int]:
     """The DLPack (device_type, device_id) pair for a max.driver.Device."""
     if device.label == "cpu":
         return (_DLPACK_DEVICE_TYPE_OF["cpu"], 0)
@@ -206,7 +224,13 @@ def dlpack_device(device) -> tuple[int, int]:
     return (device_type, device.id)
 
 
-def make_capsule(holder, data_ptr: int, shape, dtype: DType, device):
+def make_capsule(
+    holder: object,
+    data_ptr: int,
+    shape: Sequence[int],
+    dtype: DType,
+    device: max.driver.Device,
+) -> object:
     """A "dltensor" PyCapsule for a contiguous device allocation.
 
     `holder` is any Python object whose refcount keeps the allocation

--- a/torch_mojo_backend/mojo_device/log_aten_calls.py
+++ b/torch_mojo_backend/mojo_device/log_aten_calls.py
@@ -1,11 +1,20 @@
+from collections.abc import Sequence
+
+import torch
 from torch.utils._python_dispatch import TorchDispatchMode
 
 
 class LoggingMode(TorchDispatchMode):
-    def __torch_dispatch__(self, func, types, args=(), kwargs=None):
+    def __torch_dispatch__(
+        self,
+        func: torch._ops.OpOverload,
+        types: Sequence[type],
+        args: tuple[object, ...] = (),
+        kwargs: dict[str, object] | None = None,
+    ) -> object:
         print(f"Aten function called: {func}")
         return func(*args, **kwargs or {})
 
 
-def log_aten_calls():
+def log_aten_calls() -> None:
     LoggingMode().__enter__()

--- a/torch_mojo_backend/mojo_device/mojo_device_aten_ops.py
+++ b/torch_mojo_backend/mojo_device/mojo_device_aten_ops.py
@@ -16,8 +16,10 @@ function in the matching `aten_ops/` module.
 
 import functools
 from collections.abc import Callable
+from typing import cast
 
 import torch_mojo_backend.is_running_tests
+from torch_mojo_backend.types import CountedCallable
 
 from .aten_ops import foreach
 from .aten_ops.autograd_preflight import (
@@ -86,10 +88,10 @@ _aten_ops_registry: list[tuple[str, Callable]] = []
 # counter so `CallChecker` can assert the backend's impl for a given op ran
 # — uniformly for fast, custom, and out-variant registrations (see
 # torch_mojo_backend/testing.py). Keyed by the aten op name.
-EAGER_CALL_COUNTERS: dict[str, Callable] = {}
+EAGER_CALL_COUNTERS: dict[str, CountedCallable] = {}
 
 
-def register_aten_op(op_name: str):
+def register_aten_op(op_name: str) -> Callable[[Callable], Callable]:
     """Decorator to mark a function for aten op registration.
 
     Args:
@@ -99,15 +101,19 @@ def register_aten_op(op_name: str):
     def decorator(func: Callable) -> Callable:
         if torch_mojo_backend.is_running_tests.IS_RUNNING_TESTS:
 
-            @functools.wraps(func)
-            def counted(*args, **kwargs):
-                counted.call_count += 1
+            def counted(*args: object, **kwargs: object) -> object:
+                result.call_count += 1
                 return func(*args, **kwargs)
 
-            counted.call_count = 0
-            EAGER_CALL_COUNTERS[op_name] = counted
-            _aten_ops_registry.append((op_name, counted))
-            return counted
+            # functools.wraps's stub types its result as a plain callable
+            # with no room for the extra `call_count` attribute; update_wrapper
+            # does the same __name__/__doc__/__wrapped__ copy without that.
+            functools.update_wrapper(counted, func)
+            result = cast(CountedCallable, counted)
+            result.call_count = 0
+            EAGER_CALL_COUNTERS[op_name] = result
+            _aten_ops_registry.append((op_name, result))
+            return result
         _aten_ops_registry.append((op_name, func))
         return func
 

--- a/torch_mojo_backend/mojo_device/mojo_device_autocast.py
+++ b/torch_mojo_backend/mojo_device/mojo_device_autocast.py
@@ -7,18 +7,22 @@ while normalization and NLL run in FP32. Unlisted operations fall through.
 """
 
 import functools
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 
 import torch
 
 _registered = False
-_fallback_library = None
-_aten_library = None
+_fallback_library: torch.library.Library | None = None
+_aten_library: torch.library.Library | None = None
 
-_AUTOCAST_KEYSET = torch._C.DispatchKeySet(torch._C.DispatchKey.AutocastPrivateUse1)
+# torch/_C/__init__.pyi's DispatchKey stub lists PrivateUse1, AutogradPrivateUse1
+# etc. but omits AutocastPrivateUse1, even though it exists at runtime.
+_AUTOCAST_KEYSET = torch._C.DispatchKeySet(
+    torch._C.DispatchKey.AutocastPrivateUse1  # ty: ignore[unresolved-attribute]
+)
 
 
-def _cast_mojo_floating(value, dtype):
+def _cast_mojo_floating(value: object, dtype: torch.dtype) -> object:
     """Recursively cast eligible Mojo floating tensors, leaving metadata alone."""
     if isinstance(value, torch.Tensor):
         if (
@@ -38,25 +42,29 @@ def _cast_mojo_floating(value, dtype):
     return value
 
 
-def _policy_wrapper(op, dtype_getter):
+def _policy_wrapper(
+    op: torch._ops.OpOverload, dtype_getter: Callable[[], torch.dtype]
+) -> Callable[..., object]:
     @functools.wraps(op)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: object, **kwargs: object) -> object:
         # Casts themselves must redispatch below AutocastPrivateUse1, otherwise
         # their internal _to_copy calls would re-enter this policy layer.
         with torch._C._ExcludeDispatchKeyGuard(_AUTOCAST_KEYSET):
             dtype = dtype_getter()
-            return op(
-                *_cast_mojo_floating(args, dtype), **_cast_mojo_floating(kwargs, dtype)
-            )
+            cast_args = _cast_mojo_floating(args, dtype)
+            cast_kwargs = _cast_mojo_floating(kwargs, dtype)
+            assert isinstance(cast_args, tuple)
+            assert isinstance(cast_kwargs, dict)
+            return op(*cast_args, **cast_kwargs)
 
     return wrapper
 
 
-def _lower_precision_wrapper(op):
+def _lower_precision_wrapper(op: torch._ops.OpOverload) -> Callable[..., object]:
     return _policy_wrapper(op, lambda: torch.get_autocast_dtype("mojo"))
 
 
-def _fp32_wrapper(op):
+def _fp32_wrapper(op: torch._ops.OpOverload) -> Callable[..., object]:
     return _policy_wrapper(op, lambda: torch.float32)
 
 

--- a/torch_mojo_backend/mojo_device/mojo_device_autograd.py
+++ b/torch_mojo_backend/mojo_device/mojo_device_autograd.py
@@ -8,7 +8,9 @@ values that hooks deliberately unpack onto the host.
 """
 
 import math
-from typing import TypeVar
+from collections.abc import Sequence
+from types import ModuleType
+from typing import Protocol, TypeVar, runtime_checkable
 
 import torch
 
@@ -21,7 +23,7 @@ _ResultT = TypeVar("_ResultT")
 _registered = False
 
 
-def _fast():
+def _fast() -> ModuleType:
     from torch_mojo_backend.eager_kernels import aten_fast
 
     return aten_fast
@@ -36,7 +38,7 @@ def _require_handled(result: _ResultT | None, operation: str) -> _ResultT:
     return result
 
 
-def _contiguous_view(tensor: TorchMojoTensor, shape) -> TorchMojoTensor:
+def _contiguous_view(tensor: TorchMojoTensor, shape: Sequence[int]) -> TorchMojoTensor:
     tensor = tensor._contig()
     return _require_handled(_fast().fast_aten_view(tensor, tuple(shape)), "view")
 
@@ -70,7 +72,7 @@ class _SavedMojoPayload:
         "is_contiguous",
     )
 
-    def __init__(self, tensor: TorchMojoTensor):
+    def __init__(self, tensor: TorchMojoTensor) -> None:
         self.holder = None if _saved_tensor_hooks_active() else tensor._holder
         self.ptr = tensor._ptr
         self.shape = tensor._shape
@@ -180,7 +182,33 @@ def _saved_tensor_hooks_active() -> bool:
         return False
 
 
-def _restore_saved_mojo_tensors(ctx):
+@runtime_checkable
+class _MojoAutogradCtx(Protocol):
+    """A `torch.autograd.Function` ctx as this module's forward/backward use
+    it: `save_for_backward`/`needs_input_grad`/`set_materialize_grads` are
+    `FunctionCtx`'s real (but unstubbed) members; `saved_payloads`,
+    `saved_names`, `is_causal`, `scale`, `needed_input_gradients` are sidecar
+    attributes this module's own forward methods stash for their backward."""
+
+    saved_tensors: tuple[torch.Tensor, ...]
+    saved_payloads: tuple[_SavedMojoPayload, ...]
+    saved_names: tuple[str, ...]
+    is_causal: bool
+    scale: float | None
+    needed_input_gradients: tuple[bool, ...]
+    needs_input_grad: tuple[bool, ...]
+    # _ScaledDotProductAttentionAutograd's own additional sidecar fields.
+    query_shape: tuple[int, ...]
+    key_shape: tuple[int, ...]
+    value_shape: tuple[int, ...]
+    has_dropout: bool
+    dropout_scale: float
+
+    def save_for_backward(self, *tensors: torch.Tensor) -> None: ...
+    def set_materialize_grads(self, value: bool) -> None: ...
+
+
+def _restore_saved_mojo_tensors(ctx: _MojoAutogradCtx) -> tuple[TorchMojoTensor, ...]:
     saved_tensors = ctx.saved_tensors
     payloads = ctx.saved_payloads
     if len(saved_tensors) != len(payloads):
@@ -202,8 +230,16 @@ class _FusedFlashAttentionAutograd(torch.autograd.Function):
 
     @staticmethod
     def forward(
-        ctx, query, key, value, attn_mask, dropout_p, is_causal, scale, enable_gqa
-    ):
+        ctx: _MojoAutogradCtx,
+        query: TorchMojoTensor,
+        key: TorchMojoTensor,
+        value: TorchMojoTensor,
+        attn_mask: TorchMojoTensor | None,
+        dropout_p: float,
+        is_causal: bool,
+        scale: float | None,
+        enable_gqa: bool,
+    ) -> TorchMojoTensor:
         aten_fast = _fast()
         result = aten_fast.fast_fused_flash_attention_forward(
             query, key, value, attn_mask, dropout_p, is_causal, scale, enable_gqa
@@ -233,7 +269,9 @@ class _FusedFlashAttentionAutograd(torch.autograd.Function):
         return output
 
     @staticmethod
-    def backward(ctx, grad_output):
+    def backward(
+        ctx: _MojoAutogradCtx, grad_output: TorchMojoTensor | None
+    ) -> tuple[TorchMojoTensor | None, ...]:
         if grad_output is None:
             return (None,) * 8
         aten_fast = _fast()
@@ -266,8 +304,16 @@ class _FusedFlashAttentionAutograd(torch.autograd.Function):
 class _ScaledDotProductAttentionAutograd(torch.autograd.Function):
     @staticmethod
     def forward(
-        ctx, query, key, value, attn_mask, dropout_p, is_causal, scale, enable_gqa
-    ):
+        ctx: _MojoAutogradCtx,
+        query: TorchMojoTensor,
+        key: TorchMojoTensor,
+        value: TorchMojoTensor,
+        attn_mask: TorchMojoTensor | None,
+        dropout_p: float,
+        is_causal: bool,
+        scale: float | None,
+        enable_gqa: bool,
+    ) -> TorchMojoTensor:
         if attn_mask is not None or enable_gqa:
             raise NotImplementedError(
                 "Mojo eager SDPA autograd currently supports no attention mask, "
@@ -287,10 +333,10 @@ class _ScaledDotProductAttentionAutograd(torch.autograd.Function):
         need_query, need_key, need_value = (
             bool(ctx.needs_input_grad[index]) for index in range(3)
         )
-        saved = []
-        saved_names = []
+        saved: list[TorchMojoTensor] = []
+        saved_names: list[str] = []
 
-        def save(name, tensor):
+        def save(name: str, tensor: TorchMojoTensor) -> None:
             saved_names.append(name)
             saved.append(tensor)
 
@@ -327,7 +373,9 @@ class _ScaledDotProductAttentionAutograd(torch.autograd.Function):
         return output
 
     @staticmethod
-    def backward(ctx, grad_output):
+    def backward(
+        ctx: _MojoAutogradCtx, grad_output: TorchMojoTensor
+    ) -> tuple[TorchMojoTensor | None, ...]:
         aten_fast = _fast()
         restored = _restore_saved_mojo_tensors(ctx)
         saved = dict(zip(ctx.saved_names, restored, strict=True))
@@ -345,6 +393,8 @@ class _ScaledDotProductAttentionAutograd(torch.autograd.Function):
 
         mask3 = None
         if ctx.has_dropout:
+            # forward sets has_dropout iff it saved a real dropout_mask.
+            assert dropout_mask is not None
             mask3 = _contiguous_view(
                 dropout_mask, (batch_heads, query_length, key_length)
             )
@@ -552,27 +602,35 @@ class _ScaledDotProductAttentionAutograd(torch.autograd.Function):
         if saved:
             raise RuntimeError(f"unused Mojo SDPA saved tensors: {tuple(saved)}")
 
-        grad_query = (
-            _contiguous_view(grad_query3, ctx.query_shape) if need_query else None
-        )
-        grad_key = _contiguous_view(grad_key3, ctx.key_shape) if need_key else None
-        grad_value = (
-            _contiguous_view(grad_value3, ctx.value_shape) if need_value else None
-        )
+        if need_query:
+            assert grad_query3 is not None
+            grad_query = _contiguous_view(grad_query3, ctx.query_shape)
+        else:
+            grad_query = None
+        if need_key:
+            assert grad_key3 is not None
+            grad_key = _contiguous_view(grad_key3, ctx.key_shape)
+        else:
+            grad_key = None
+        if need_value:
+            assert grad_value3 is not None
+            grad_value = _contiguous_view(grad_value3, ctx.value_shape)
+        else:
+            grad_value = None
         return grad_query, grad_key, grad_value, None, None, None, None, None
 
 
 def _scaled_dot_product_attention_autograd(
-    query,
-    key,
-    value,
-    attn_mask=None,
-    dropout_p=0.0,
-    is_causal=False,
+    query: TorchMojoTensor,
+    key: TorchMojoTensor,
+    value: TorchMojoTensor,
+    attn_mask: TorchMojoTensor | None = None,
+    dropout_p: float = 0.0,
+    is_causal: bool = False,
     *,
-    scale=None,
-    enable_gqa=False,
-):
+    scale: float | None = None,
+    enable_gqa: bool = False,
+) -> torch.Tensor:
     needs_backward = torch.is_grad_enabled() and (
         query.requires_grad or key.requires_grad or value.requires_grad
     )

--- a/torch_mojo_backend/mojo_device/register.py
+++ b/torch_mojo_backend/mojo_device/register.py
@@ -1,10 +1,13 @@
+from collections.abc import Callable
 from functools import wraps
 from types import ModuleType
+from typing import TypeVar
 
 import torch
 
 from .mojo_device_aten_ops import _aten_ops_registry
 
+_T = TypeVar("_T")
 _registered = False
 
 
@@ -61,7 +64,7 @@ def _install_torch_accelerator_synchronize(
     torch.accelerator.synchronize = synchronize  # ty: ignore[invalid-assignment]
 
 
-def _install_torch_accelerator_stream_api(torch_mojo_device_module):
+def _install_torch_accelerator_stream_api(torch_mojo_device_module: ModuleType) -> None:
     """Route torch.accelerator.current_stream/set_stream to mojo streams.
 
     Same reason as the synchronize patch above: the Python PrivateUse1
@@ -75,29 +78,36 @@ def _install_torch_accelerator_stream_api(torch_mojo_device_module):
     mojo_device = torch.device("mojo")
 
     @wraps(original_current_stream)
-    def current_stream(device=None):
+    def current_stream(device: torch.device | str | int | None = None) -> torch.Stream:
         if torch.accelerator.current_accelerator() != mojo_device:
             return original_current_stream(device)
         return torch_mojo_device_module.current_stream(device)
 
-    current_stream._torch_mojo_backend = True
-    torch.accelerator.current_stream = current_stream
+    # Same deliberate monkeypatch and sentinel as `synchronize` above.
+    current_stream._torch_mojo_backend = True  # ty: ignore[unresolved-attribute]
+    torch.accelerator.current_stream = current_stream  # ty: ignore[invalid-assignment]
 
     original_set_stream = torch.accelerator.set_stream
 
     @wraps(original_set_stream)
-    def set_stream(stream):
+    def set_stream(stream: torch.Stream) -> None:
         from torch_mojo_backend.mojo_device.streams import Stream as MojoStream
 
         if isinstance(stream, MojoStream):
             return torch_mojo_device_module.set_stream(stream)
         return original_set_stream(stream)
 
-    set_stream._torch_mojo_backend = True
-    torch.accelerator.set_stream = set_stream
+    set_stream._torch_mojo_backend = True  # ty: ignore[unresolved-attribute]
+    torch.accelerator.set_stream = set_stream  # ty: ignore[invalid-assignment]
 
 
-def _install_torch_stream_event_dispatch():
+def _forwarding_constructor(cls: type[_T]) -> Callable[..., _T]:
+    """`cls` as an opaque callable: the metaclasses below forward whatever
+    constructor arguments the caller passed, and only `cls` knows their shape."""
+    return cls
+
+
+def _install_torch_stream_event_dispatch() -> None:
     """Dispatch torch.Stream/torch.Event on mojo devices to real classes.
 
     Construction through the original classes reaches the stub C++ guard and
@@ -112,45 +122,54 @@ def _install_torch_stream_event_dispatch():
 
     original_stream = torch.Stream
     original_event = torch.Event
+    construct_stream = _forwarding_constructor(original_stream)
+    construct_mojo_stream = _forwarding_constructor(mojo_streams.Stream)
+    construct_event = _forwarding_constructor(original_event)
+    construct_mojo_event = _forwarding_constructor(mojo_streams.Event)
 
-    def _wants_mojo(args, kwargs):
+    def _wants_mojo(args: tuple[object, ...], kwargs: dict[str, object]) -> bool:
         device = kwargs.get("device", args[0] if args else None)
         if device is None or isinstance(device, int):
             accelerator = torch.accelerator.current_accelerator()
             return accelerator is not None and accelerator.type == "mojo"
+        if not isinstance(device, str | torch.device):
+            return False  # torch.device() would raise TypeError
         try:
             return torch.device(device).type == "mojo"
         except (TypeError, RuntimeError, ValueError):
             return False
 
     class _StreamMeta(type):
-        def __call__(cls, *args, **kwargs):
+        def __call__(cls, *args: object, **kwargs: object) -> torch.Stream:
             if "stream_id" in kwargs or "device_type" in kwargs:
-                return original_stream(*args, **kwargs)
+                return construct_stream(*args, **kwargs)
             if _wants_mojo(args, kwargs):
-                return mojo_streams.Stream(*args, **kwargs)
-            return original_stream(*args, **kwargs)
+                return construct_mojo_stream(*args, **kwargs)
+            return construct_stream(*args, **kwargs)
 
-        def __instancecheck__(cls, instance):
+        def __instancecheck__(cls, instance: object) -> bool:
             return isinstance(instance, (original_stream, mojo_streams.Stream))
 
     class Stream(metaclass=_StreamMeta):
         _torch_mojo_backend = True
 
     class _EventMeta(type):
-        def __call__(cls, *args, **kwargs):
+        def __call__(
+            cls, *args: object, **kwargs: object
+        ) -> torch.Event | mojo_streams.Event:
             if _wants_mojo(args, kwargs):
-                return mojo_streams.Event(*args, **kwargs)
-            return original_event(*args, **kwargs)
+                return construct_mojo_event(*args, **kwargs)
+            return construct_event(*args, **kwargs)
 
-        def __instancecheck__(cls, instance):
+        def __instancecheck__(cls, instance: object) -> bool:
             return isinstance(instance, (original_event, mojo_streams.Event))
 
     class Event(metaclass=_EventMeta):
         _torch_mojo_backend = True
 
-    torch.Stream = Stream
-    torch.Event = Event
+    # Deliberate replacement of torch's classes by the dispatching wrappers.
+    torch.Stream = Stream  # ty: ignore[invalid-assignment]
+    torch.Event = Event  # ty: ignore[invalid-assignment]
 
 
 def _declare_mojo_tensor_as_plain_tensor() -> None:

--- a/torch_mojo_backend/mojo_device/register.py
+++ b/torch_mojo_backend/mojo_device/register.py
@@ -1,4 +1,5 @@
 from functools import wraps
+from types import ModuleType
 
 import torch
 
@@ -7,7 +8,9 @@ from .mojo_device_aten_ops import _aten_ops_registry
 _registered = False
 
 
-def _install_torch_accelerator_synchronize(torch_mojo_device_module):
+def _install_torch_accelerator_synchronize(
+    torch_mojo_device_module: ModuleType,
+) -> None:
     """Route generic accelerator synchronization to the Mojo device module.
 
     PyTorch's Python PrivateUse1 guard does not yet forward synchronizeDevice
@@ -27,10 +30,11 @@ def _install_torch_accelerator_synchronize(torch_mojo_device_module):
         )
 
     @wraps(original_synchronize)
-    def synchronize(device=None):
+    def synchronize(device: torch.device | str | int | None = None) -> None:
         current = torch.accelerator.current_accelerator()
         if current != mojo_device:
-            return original_synchronize(device)
+            original_synchronize(device)
+            return
 
         if device is None:
             device_index = torch_mojo_device_module.current_device()
@@ -47,10 +51,14 @@ def _install_torch_accelerator_synchronize(torch_mojo_device_module):
                 if selected.index is None
                 else selected.index
             )
-        return torch_mojo_device_module.synchronize(device_index)
+        torch_mojo_device_module.synchronize(device_index)
 
-    synchronize._torch_mojo_backend = True
-    torch.accelerator.synchronize = synchronize
+    # Deliberate monkeypatch of torch.accelerator.synchronize: the sentinel
+    # attribute is how this function detects, on a later call, that its own
+    # replacement (not the original) is already installed. ty can't type an
+    # ad hoc attribute on a stdlib callable.
+    synchronize._torch_mojo_backend = True  # ty: ignore[unresolved-attribute]
+    torch.accelerator.synchronize = synchronize  # ty: ignore[invalid-assignment]
 
 
 def _install_torch_accelerator_stream_api(torch_mojo_device_module):
@@ -145,7 +153,7 @@ def _install_torch_stream_event_dispatch():
     torch.Event = Event
 
 
-def _declare_mojo_tensor_as_plain_tensor():
+def _declare_mojo_tensor_as_plain_tensor() -> None:
     """Add TorchMojoTensor to torch's HANDLED_TYPES allowlists.
 
     TorchMojoTensor's wrapper dispatch is transparent to numerical operations;
@@ -171,7 +179,7 @@ def _declare_mojo_tensor_as_plain_tensor():
       "unsupported operand type(s) for +: 'FunctionalTensor' and
       'TorchMojoTensor'".
     """
-    from collections.abc import Sequence
+    from collections.abc import Mapping, Sequence
 
     import torch._functorch._aot_autograd.runtime_wrappers as runtime_wrappers
     import torch._subclasses.fake_tensor as fake_tensor_module
@@ -184,15 +192,26 @@ def _declare_mojo_tensor_as_plain_tensor():
     from .torch_mojo_tensor import TorchMojoTensor
 
     if TorchMojoTensor not in proxy_tensor.HANDLED_TYPES:
-        proxy_tensor.HANDLED_TYPES = (*proxy_tensor.HANDLED_TYPES, TorchMojoTensor)
+        # Deliberate monkeypatch: torch infers HANDLED_TYPES' type from its
+        # own fixed-length tuple literal, so extending it by one element is
+        # always a "wrong length" mismatch to the checker.
+        proxy_tensor.HANDLED_TYPES = (  # ty: ignore[invalid-assignment]
+            *proxy_tensor.HANDLED_TYPES,
+            TorchMojoTensor,
+        )
     runtime_wrappers.HANDLED_TYPES = proxy_tensor.HANDLED_TYPES
 
     original_check = fake_tensor_module._check_for_subclass_arg
 
-    def check_for_subclass_arg_except_mojo(x):
+    def check_for_subclass_arg_except_mojo(x: object) -> bool:
         return original_check(x) and not isinstance(x, TorchMojoTensor)
 
-    fake_tensor_module._check_for_subclass_arg = check_for_subclass_arg_except_mojo
+    # Deliberate monkeypatch: ty treats each `def` as its own nominal type
+    # even with an identical signature, so this never structurally matches
+    # the attribute it replaces.
+    fake_tensor_module._check_for_subclass_arg = (  # ty: ignore[invalid-assignment]
+        check_for_subclass_arg_except_mojo
+    )
 
     # Once past the subclass check, lifting a real mojo tensor constant
     # still fails: the const-propagation path is gated on `type(out) is
@@ -202,7 +221,13 @@ def _declare_mojo_tensor_as_plain_tensor():
     # constant as a graph input like any other mojo tensor.
     original_dispatch_impl = fake_tensor_module.FakeTensorMode._dispatch_impl
 
-    def dispatch_impl_lifting_mojo_constants(self, func, types, args, kwargs):
+    def dispatch_impl_lifting_mojo_constants(
+        self: fake_tensor_module.FakeTensorMode,
+        func: torch._ops.OpOverload,
+        types: Sequence[type],
+        args: Sequence[object],
+        kwargs: Mapping[str, object],
+    ) -> fake_tensor_module.FakeTensor | None:
         if func in self.lift_fns and args and isinstance(args[0], TorchMojoTensor):
             return self.fake_tensor_converter.from_real_tensor(self, args[0])
         return original_dispatch_impl(self, func, types, args, kwargs)
@@ -223,6 +248,8 @@ def _declare_mojo_tensor_as_plain_tensor():
         args: tuple[object, ...] = (),
         kwargs: dict[str, object] | None = None,
     ) -> object:
+        assert isinstance(self, FunctionalTensor)
+        assert isinstance(func, torch._ops.OpOverload)
         return original_tensor_dispatch(
             self, func, as_plain_tensor_types(types), args, kwargs
         )
@@ -238,6 +265,8 @@ def _declare_mojo_tensor_as_plain_tensor():
         args: tuple[object, ...] = (),
         kwargs: dict[str, object] | None = None,
     ) -> object:
+        assert isinstance(self, FunctionalTensorMode)
+        assert isinstance(func, torch._ops.OpOverload)
         return original_mode_dispatch(
             self, func, as_plain_tensor_types(types), args, kwargs
         )
@@ -275,7 +304,7 @@ def _trace_mojo_tensor_as_a_plain_tensor_in_dynamo() -> None:
         table[TorchMojoTensor] = VariableBuilder.wrap_tensor
 
 
-def _keep_mojo_kernels_out_of_fake_tensor_construction():
+def _keep_mojo_kernels_out_of_fake_tensor_construction() -> None:
     """Make FakeTensor construction skip the PrivateUse1 Python kernels.
 
     `FakeTensor.__new__` calls `Tensor._make_subclass(cls, elem, ...,
@@ -299,14 +328,28 @@ def _keep_mojo_kernels_out_of_fake_tensor_construction():
     exclude_privateuse1 = torch._C.DispatchKeySet(torch._C.DispatchKey.PrivateUse1)
     original_new = FakeTensor.__new__
 
-    def fake_new_without_mojo_kernels(cls, *args, **kwargs):
+    def fake_new_without_mojo_kernels(
+        cls: type[FakeTensor], *args: object, **kwargs: object
+    ) -> FakeTensor:
         with torch._C._ExcludeDispatchKeyGuard(exclude_privateuse1):
-            return original_new(cls, *args, **kwargs)
+            # Forwarded blindly (see version-compatibility note above): the
+            # checker can't match object-typed *args/**kwargs against
+            # __new__'s concrete parameter list.
+            return original_new(
+                cls,
+                *args,  # ty: ignore[invalid-argument-type]
+                **kwargs,
+            )
 
-    FakeTensor.__new__ = staticmethod(fake_new_without_mojo_kernels)
+    # Deliberate *args/**kwargs passthrough: FakeTensor.__new__'s real
+    # signature is torch-version-dependent (AGENTS.md: support many
+    # versions), so this wrapper forwards blindly rather than hardcoding it.
+    FakeTensor.__new__ = staticmethod(  # ty: ignore[invalid-assignment]
+        fake_new_without_mojo_kernels
+    )
 
 
-def register_mojo_devices():
+def register_mojo_devices() -> None:
     """Enable the mojo device globally and register all aten ops"""
     from torch.utils.backend_registration import _setup_privateuseone_for_python_backend
 
@@ -344,7 +387,10 @@ def register_mojo_devices():
         foreach_utils._foreach_supported_types,
     ):
         if TorchMojoTensor not in supported_types:
-            supported_types.append(TorchMojoTensor)
+            # Deliberate monkeypatch: torch declared these lists' element
+            # type from their own literal contents (Tensor/Parameter), which
+            # doesn't include our subclass by construction.
+            supported_types.append(TorchMojoTensor)  # ty: ignore[invalid-argument-type]
 
     # Register all collected aten operations
     for op_name, func in _aten_ops_registry:

--- a/torch_mojo_backend/mojo_device/streams.py
+++ b/torch_mojo_backend/mojo_device/streams.py
@@ -30,18 +30,20 @@ import itertools
 import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
+from typing import TypeAlias
 
 import max.driver
 import torch
+from torch._C._autograd import DeviceType
 
 from torch_mojo_backend.mojo_device import device_streams
 
-_PRIVATEUSE1_DEVICE_TYPE = int(torch._C._autograd.DeviceType.PrivateUse1)
+_DeviceLike: TypeAlias = torch.device | str | int | None
+
+_PRIVATEUSE1_DEVICE_TYPE = DeviceType.PrivateUse1.value
 _user_stream_ids = itertools.count()
 _current_stacks = threading.local()  # {device_index: [Stream, ...]} per thread
-# No annotation: beartype's claw checks module-level annotated globals and
-# rejects the forward reference to Stream (defined below).
-_default_streams = {}  # {device_index: Stream}
+_default_streams: dict[int, "Stream"] = {}
 _default_streams_lock = threading.Lock()
 
 
@@ -51,7 +53,7 @@ def _current_device_index() -> int:
     return torch_mojo_device_module.current_device()
 
 
-def _resolve_index(device: object) -> int:
+def _resolve_index(device: _DeviceLike) -> int:
     if device is None:
         return _current_device_index()
     if isinstance(device, int):
@@ -62,7 +64,7 @@ def _resolve_index(device: object) -> int:
     return resolved.index if resolved.index is not None else _current_device_index()
 
 
-def _max_device_of(index: int) -> object:
+def _max_device_of(index: int) -> max.driver.Device:
     from torch_mojo_backend.mojo_device.torch_mojo_tensor import (
         find_equivalent_max_device,
     )
@@ -80,7 +82,7 @@ class Event:
 
     def __init__(
         self,
-        device: object = None,
+        device: _DeviceLike = None,
         *,
         enable_timing: bool = False,
         blocking: bool = False,
@@ -140,7 +142,7 @@ class Event:
         return self._event.elapsed_time(end_event._event)
 
     @classmethod
-    def from_ipc_handle(cls, device: object, handle: bytes) -> "Event":
+    def from_ipc_handle(cls, device: _DeviceLike, handle: bytes) -> "Event":
         raise NotImplementedError(
             "interprocess events are not supported on the mojo device"
         )
@@ -160,9 +162,13 @@ class Stream(torch._C.Stream):
     base's stub PrivateUse1 device-guard no-op.
     """
 
+    _device_stream: device_streams.Stream
+    _index: int
+    priority: int
+
     def __new__(
         cls,
-        device: object = None,
+        device: _DeviceLike = None,
         priority: int = 0,
         *,
         _device_stream: device_streams.Stream | None = None,
@@ -257,7 +263,7 @@ class Stream(torch._C.Stream):
         )
 
 
-def _stream_of(stream: object, index: int) -> device_streams.Stream:
+def _stream_of(stream: torch.Stream, index: int) -> device_streams.Stream:
     """The device stream of ours, or of a stub torch.Stream (= the default
     stream: the stub PrivateUse1 guard can only ever describe that one)."""
     if isinstance(stream, Stream):
@@ -265,7 +271,7 @@ def _stream_of(stream: object, index: int) -> device_streams.Stream:
     return default_stream(index)._device_stream
 
 
-def default_stream(device: object = None) -> Stream:
+def default_stream(device: _DeviceLike = None) -> Stream:
     index = _resolve_index(device)
     with _default_streams_lock:
         stream = _default_streams.get(index)
@@ -278,7 +284,7 @@ def default_stream(device: object = None) -> Stream:
         return stream
 
 
-def current_stream(device: object = None) -> Stream:
+def current_stream(device: _DeviceLike = None) -> Stream:
     index = _resolve_index(device)
     stacks = getattr(_current_stacks, "stacks", None)
     if stacks and stacks.get(index):

--- a/torch_mojo_backend/mojo_device/torch_mojo_device_module.py
+++ b/torch_mojo_backend/mojo_device/torch_mojo_device_module.py
@@ -12,22 +12,22 @@ _rng_states: dict[int, tuple[int, int]] = {}
 _rng_lock = threading.Lock()
 
 
-def cpu():
+def cpu() -> torch.device:
     return torch.device(f"mojo:{len(list(get_accelerators())) - 1}")
 
 
-def _is_in_bad_fork():
+def _is_in_bad_fork() -> bool:
     return False
 
 
-def _normalize_rng_seed(seed) -> int:
+def _normalize_rng_seed(seed: int) -> int:
     value = int(seed)
     if value < -(1 << 63) or value > _UINT64_MASK:
         raise ValueError("Overflow when unpacking long long")
     return value & _UINT64_MASK
 
 
-def _rng_device_index(device=None) -> int:
+def _rng_device_index(device: "int | str | torch.device | None" = None) -> int:
     if device is None:
         index = _current_device
     elif isinstance(device, int):
@@ -42,7 +42,7 @@ def _rng_device_index(device=None) -> int:
     return index
 
 
-def manual_seed_all(seed):
+def manual_seed_all(seed: int) -> None:
     """Reset every Mojo device to the same Philox seed and counter zero."""
     global _rng_default_seed
     normalized = _normalize_rng_seed(seed)
@@ -53,11 +53,11 @@ def manual_seed_all(seed):
             _rng_states[index] = (normalized, 0)
 
 
-def device_count():
+def device_count() -> int:
     return len(list(get_accelerators()))
 
 
-def get_rng_state(device=None):
+def get_rng_state(device: "int | str | torch.device | None" = None) -> torch.Tensor:
     """Return the selected device's exact ``(seed, counter)`` state."""
     index = _rng_device_index(device)
     with _rng_lock:
@@ -66,7 +66,9 @@ def get_rng_state(device=None):
     return torch.tensor(list(encoded), dtype=torch.uint8)
 
 
-def set_rng_state(new_state, device=None):
+def set_rng_state(
+    new_state: torch.Tensor, device: "int | str | torch.device | None" = None
+) -> None:
     """Restore an exact state produced by :func:`get_rng_state`."""
     if not isinstance(new_state, torch.Tensor):
         raise TypeError("Mojo RNG state must be a torch.Tensor")
@@ -81,7 +83,9 @@ def set_rng_state(new_state, device=None):
         _rng_states[index] = (seed, counter)
 
 
-def _reserve_philox_state(device, counter_increment: int) -> tuple[int, int]:
+def _reserve_philox_state(
+    device: "int | str | torch.device | None", counter_increment: int
+) -> tuple[int, int]:
     """Atomically reserve a per-device Philox counter interval.
 
     The caller passes the returned seed/base counter to an asynchronous device
@@ -99,20 +103,20 @@ def _reserve_philox_state(device, counter_increment: int) -> tuple[int, int]:
     return seed, counter
 
 
-def is_available():
+def is_available() -> bool:
     # Always true as there is at least the CPU
     return True
 
 
-def is_initialized():
+def is_initialized() -> bool:
     return True
 
 
-def current_device():
+def current_device() -> int:
     return _current_device
 
 
-def set_device(device_idx: int):
+def set_device(device_idx: int) -> None:
     global _current_device
     if device_idx < 0 or device_idx >= device_count():
         raise ValueError(f"Invalid device index {device_idx}")
@@ -195,7 +199,7 @@ def synchronize(device: "int | str | torch.device | None" = None) -> None:
     _device_synchronize(device)
 
 
-def get_amp_supported_dtype():
+def get_amp_supported_dtype() -> list[torch.dtype]:
     return [torch.float16, torch.bfloat16]  # TODO change
 
 

--- a/torch_mojo_backend/mojo_device/torch_mojo_tensor.py
+++ b/torch_mojo_backend/mojo_device/torch_mojo_tensor.py
@@ -3,8 +3,9 @@ import math
 import sys
 import threading
 from collections import deque
+from collections.abc import Sequence
 from pathlib import Path
-from typing import ClassVar, Protocol, runtime_checkable
+from typing import ClassVar, Protocol, cast, runtime_checkable
 
 import max.driver
 import torch
@@ -20,17 +21,40 @@ from torch_mojo_backend.eager_kernels.output_specs import (
 )
 from torch_mojo_backend.mojo_device import objc_autorelease, torch_mojo_device_module
 
+
+@runtime_checkable
+class _TensorHolderModule(Protocol):
+    """The subset of the JIT-compiled `tensor_holder` Mojo extension this
+    file calls directly. The module itself has no stubs (its source is
+    Mojo, not Python); every member here is a raw PythonObject-in,
+    PythonObject-out native call, so `object` is the honest signature."""
+
+    def alloc(self, ctx_ptr: int, nbytes: int) -> tuple[object, int]: ...
+    def alloc_from_host(
+        self, ctx_ptr: int, data_ptr: int, nbytes: int
+    ) -> tuple[object, int, object]: ...
+    def copy_to_host(
+        self, ctx_ptr: int, src_ptr: int, dst_ptr: int, nbytes: int
+    ) -> object: ...
+    def copy_to_pinned_host(
+        self, ctx_ptr: int, src_ptr: int, nbytes: int
+    ) -> tuple[object, int]: ...
+    def CopyStrided(self, *args: object) -> object: ...
+
+
 # The Mojo extension module (torch_mojo_backend.eager_kernels.tensor_holder),
 # resolved lazily so that importing torch_mojo_backend never triggers a Mojo
 # kernel compile.
-_tensor_holder = None
+_tensor_holder: _TensorHolderModule | None = None
 
 
-def _holder_mod():
+def _holder_mod() -> _TensorHolderModule:
     global _tensor_holder
-    if _tensor_holder is None:
-        _tensor_holder = eager_kernels.tensor_holder
-    return _tensor_holder
+    holder = _tensor_holder
+    if holder is None:
+        holder = cast(_TensorHolderModule, eager_kernels.tensor_holder)
+        _tensor_holder = holder
+    return holder
 
 
 # GPU H2D copies consume a MAX-owned pinned staging allocation asynchronously.
@@ -107,24 +131,27 @@ class _HolderOwner:
             self._wait(self._owner_ctx, event)
 
 
-def _ctx_ptr(device):
+def _ctx_ptr(device: max.driver.Device) -> int:
     # Rebinds this module-level name to the real (cached) implementation on
     # first use, so the lazy import costs one call, not one per call.
     global _ctx_ptr
     from torch_mojo_backend.eager_kernels import _ctx_ptr as real_ctx_ptr
 
-    _ctx_ptr = real_ctx_ptr
+    # Self-rebind via `global`: ty compares the two same-shaped `def`s
+    # nominally, not structurally, and treats reassigning a function to
+    # (what is, at runtime,) itself as unsound.
+    _ctx_ptr = real_ctx_ptr  # ty: ignore[invalid-assignment]
     return real_ctx_ptr(device)
 
 
-def _retain_failed_transfer_owner(device, owner: object) -> object:
+def _retain_failed_transfer_owner(device: max.driver.Device, owner: object) -> object:
     token = object()
     with _FAILED_TRANSFER_OWNERS_LOCK:
         _FAILED_TRANSFER_OWNERS.setdefault(device, []).append((token, owner))
     return token
 
 
-def _forget_failed_transfer_owner(device, token: object) -> None:
+def _forget_failed_transfer_owner(device: max.driver.Device, token: object) -> None:
     with _FAILED_TRANSFER_OWNERS_LOCK:
         retained = _FAILED_TRANSFER_OWNERS.get(device)
         if retained is None:
@@ -134,7 +161,9 @@ def _forget_failed_transfer_owner(device, token: object) -> None:
             _FAILED_TRANSFER_OWNERS.pop(device, None)
 
 
-def _record_h2d_source(device, source: object, non_blocking: bool) -> None:
+def _record_h2d_source(
+    device: max.driver.Device, source: object, non_blocking: bool
+) -> None:
     """Retain a pinned transfer owner until its default-stream H2D ends."""
     # MAX's CPU device uses a worker pool whose copies are not stream-ordered
     # with kernels. The Mojo helper drains it before returning; keep the Python
@@ -171,7 +200,7 @@ def _record_h2d_source(device, source: object, non_blocking: bool) -> None:
         # event keeps its exact source alive until DMA completion.
 
 
-def _release_synchronized_h2d_sources(device) -> None:
+def _release_synchronized_h2d_sources(device: max.driver.Device) -> None:
     """Drop ready sources after the caller synchronized ``device``'s stream.
 
     Another thread may enqueue a transfer between the stream synchronization
@@ -186,7 +215,7 @@ def _release_synchronized_h2d_sources(device) -> None:
             _PENDING_H2D.pop(device, None)
 
 
-def _record_d2h_owner(device, owner: object) -> None:
+def _record_d2h_owner(device: max.driver.Device, owner: object) -> None:
     """Retain a pinned D2H allocation until its default-stream DMA ends."""
     try:
         event = device.default_stream.record_event()
@@ -207,7 +236,7 @@ def _record_d2h_owner(device, owner: object) -> None:
             pending.popleft()
 
 
-def _release_synchronized_d2h_owners(device) -> None:
+def _release_synchronized_d2h_owners(device: max.driver.Device) -> None:
     """Drop pinned D2H owners whose stream events have completed."""
     with _PENDING_D2H_LOCK:
         pending = _PENDING_D2H.get(device)
@@ -240,7 +269,15 @@ class MojoTensorLike(Protocol):
     _device: object
 
 
-def _dispatch_entry(func: object, args: tuple, kwargs: dict) -> object:
+def _device_of(tensor: MojoTensorLike) -> max.driver.Device:
+    """MojoTensorLike._device is `object` for host-contract test doubles
+    (checked invariantly, so even TorchMojoTensor's own concrete Device
+    can't narrow the Protocol member); real operands are always a
+    TorchMojoTensor with a genuine Device."""
+    return cast(max.driver.Device, tensor._device)
+
+
+def _dispatch_entry(func: torch._ops.OpOverload, args: tuple, kwargs: dict) -> object:
     """``deferred_compile.dispatch``, resolved on first use.
 
     ``deferred_compile`` imports the call queue this module feeds, so it
@@ -252,17 +289,31 @@ def _dispatch_entry(func: object, args: tuple, kwargs: dict) -> object:
     global _dispatch_entry
     from . import deferred_compile
 
-    _dispatch_entry = deferred_compile.dispatch
+    # Same nominal-vs-structural self-rebind quirk as _ctx_ptr above, even
+    # though both sides print identically.
+    _dispatch_entry = deferred_compile.dispatch  # ty: ignore[invalid-assignment]
     return _dispatch_entry(func, args, kwargs)
+
+
+@runtime_checkable
+class _SynchronizableStream(Protocol):
+    def synchronize(self) -> None: ...
 
 
 @runtime_checkable
 class _SynchronizableDevice(Protocol):
     """What allocation recovery needs from a device: a default stream it can
     synchronize. ``max.driver.Device`` satisfies it; host-contract tests use
-    lightweight stand-ins."""
+    lightweight stand-ins.
 
-    default_stream: object
+    ``default_stream`` is a ``@property`` (not a plain data attribute) so it
+    is checked covariantly: a data member would be checked invariantly and
+    ``max.driver.Device``'s own concrete ``default_stream`` -> ``DeviceStream``
+    property could never satisfy it.
+    """
+
+    @property
+    def default_stream(self) -> _SynchronizableStream: ...
 
 
 def _alloc_with_recovery(
@@ -281,7 +332,11 @@ def _alloc_with_recovery(
     propagate untouched.
     """
     holder_mod = _holder_mod()
-    ctx_ptr = _ctx_ptr(device)
+    # _ctx_ptr wants a real max.driver.Device; production always passes one
+    # here (only its default_stream is used above), and host-contract tests
+    # that pass a lighter _SynchronizableDevice stand-in monkeypatch
+    # `_ctx_ptr` itself rather than calling into the real implementation.
+    ctx_ptr = _ctx_ptr(cast(max.driver.Device, device))
     try:
         return holder_mod.alloc(ctx_ptr, nbytes)
     except Exception as exc:
@@ -299,14 +354,14 @@ def _alloc_with_recovery(
         return holder_mod.alloc(ctx_ptr, nbytes)
 
 
-def _row_major_strides(shape) -> tuple[int, ...]:
+def _row_major_strides(shape: Sequence[int]) -> tuple[int, ...]:
     strides = [1] * len(shape)
     for i in range(len(shape) - 2, -1, -1):
         strides[i] = strides[i + 1] * shape[i + 1]
     return tuple(strides)
 
 
-def _compute_contiguous(shape, strides) -> bool:
+def _compute_contiguous(shape: Sequence[int], strides: Sequence[int]) -> bool:
     """torch's relaxed contiguity: size-1 dims never break contiguity."""
     expected = 1
     for size, stride in zip(reversed(shape), reversed(strides)):
@@ -320,10 +375,10 @@ def _compute_contiguous(shape, strides) -> bool:
 
 # max DType -> torch dtype, cached as a plain dict: max_dtype_to_torch is
 # called once per tensor wrapper created (~600/decode step).
-_TORCH_DTYPE_OF: dict = {}
+_TORCH_DTYPE_OF: dict[DType, torch.dtype] = {}
 
 
-def _torch_dtype_of(dtype):
+def _torch_dtype_of(dtype: DType) -> torch.dtype:
     td = _TORCH_DTYPE_OF.get(dtype)
     if td is None:
         td = _TORCH_DTYPE_OF[dtype] = max_dtype_to_torch(dtype)
@@ -334,10 +389,10 @@ def _torch_dtype_of(dtype):
 # once per wrapper created so the `device` property is a plain attribute
 # read — which also lets dynamo trace `x.device` inside compiled functions
 # (the property body must not construct max.driver objects).
-_TORCH_DEVICE_OF: dict = {}
+_TORCH_DEVICE_OF: dict[max.driver.Device, torch.device] = {}
 
 
-def _torch_device_of(device):
+def _torch_device_of(device: max.driver.Device) -> torch.device:
     td = _TORCH_DEVICE_OF.get(device)
     if td is None:
         if device == CPU():
@@ -352,7 +407,7 @@ def _torch_device_of(device):
 MAX_RANK = 8
 
 
-def _pad8(values, fill: int) -> tuple[int, ...]:
+def _pad8(values: Sequence[int], fill: int) -> tuple[int, ...]:
     values = tuple(values)
     if len(values) > MAX_RANK:
         raise NotImplementedError(
@@ -382,8 +437,30 @@ class TorchMojoTensor(torch.Tensor):
     output for backward, preserving the Python-side allocation payload.
     """
 
+    # Declared here (not just assigned in `_make`) so the type checker
+    # resolves reads across the codebase; matches `_PAYLOAD_ATTRIBUTES` below.
+    # `_holder`/`_ptr` are opaque handles into the Mojo extension module,
+    # which carries no stubs.
+    _holder: object
+    _ptr: int
+    _shape: tuple[int, ...]
+    _mojo_strides: tuple[int, ...]
+    _offset: int
+    _dtype: DType
+    _itemsize: int
+    _numel: int
+    _device: max.driver.Device
+    _torch_device: torch.device
+    _is_contiguous: bool
+
     @classmethod
-    def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
+    def __torch_dispatch__(
+        cls,
+        func: torch._ops.OpOverload,
+        types: Sequence[type],
+        args: tuple = (),
+        kwargs: dict | None = None,
+    ) -> object:
         """Redispatch wrapper operations to the existing Mojo backend kernels."""
         # Give higher-priority wrappers such as FakeTensor and
         # FunctionalTensor their opportunity to handle mixed-subclass calls.
@@ -402,7 +479,15 @@ class TorchMojoTensor(torch.Tensor):
 
     @classmethod
     def _make(
-        cls, holder, ptr, shape, strides, offset, dtype, device, contiguous=None
+        cls,
+        holder: object,
+        ptr: int,
+        shape: Sequence[int],
+        strides: Sequence[int],
+        offset: int,
+        dtype: DType,
+        device: max.driver.Device,
+        contiguous: bool | None = None,
     ) -> "TorchMojoTensor":
         if not isinstance(holder, _HolderOwner):
             holder = _HolderOwner(holder)
@@ -435,7 +520,7 @@ class TorchMojoTensor(torch.Tensor):
 
     @classmethod
     def _alloc(
-        cls, shape, dtype: DType, device: max.driver.Device
+        cls, shape: Sequence[int], dtype: DType, device: max.driver.Device
     ) -> "TorchMojoTensor":
         """A new contiguous uninitialized tensor (one device allocation)."""
         shape = tuple(shape)
@@ -455,7 +540,12 @@ class TorchMojoTensor(torch.Tensor):
 
     @classmethod
     def _view_of(
-        cls, base: "TorchMojoTensor", shape, strides, offset, contiguous=None
+        cls,
+        base: "TorchMojoTensor",
+        shape: Sequence[int],
+        strides: Sequence[int],
+        offset: int,
+        contiguous: bool | None = None,
     ) -> "TorchMojoTensor":
         """A zero-copy view: shares base's holder, new layout metadata.
 
@@ -584,7 +674,7 @@ class TorchMojoTensor(torch.Tensor):
         """self if already contiguous, else a materialized copy."""
         return self if self._is_contiguous else self._materialize_contiguous()
 
-    def __dlpack__(self, *, stream=None, **_unused):
+    def __dlpack__(self, *, stream: int | None = None, **_unused: object) -> object:
         """Export the device allocation as a "dltensor" capsule.
 
         torch's inherited `__dlpack__` would export the zero-byte meta
@@ -609,12 +699,14 @@ class TorchMojoTensor(torch.Tensor):
             src._holder, src._ptr, src._shape, src._dtype, src._device
         )
 
-    def __dlpack_device__(self):
+    def __dlpack_device__(self) -> tuple[int, int]:
         from torch_mojo_backend.mojo_device import dlpack
 
         return dlpack.dlpack_device(self._device)
 
-    def __coerce_same_metadata_as_tangent__(self, expected_meta, expected_type=None):
+    def __coerce_same_metadata_as_tangent__(
+        self, expected_meta: object, expected_type: type | None = None
+    ) -> "TorchMojoTensor | None":
         """Accept mojo tensors as backward tangents under torch.compile.
 
         AOTAutograd guesses tangent types from fake tensors, which are plain
@@ -626,7 +718,7 @@ class TorchMojoTensor(torch.Tensor):
             return None
         return self
 
-    def __reduce_ex__(self, protocol):
+    def __reduce_ex__(self, protocol: int) -> object:
         """Pickle as a portable plain CPU tensor.
 
         torch.Tensor's reduce would pickle this subclass's `__dict__`, which
@@ -639,7 +731,7 @@ class TorchMojoTensor(torch.Tensor):
             return self._to_cpu_tensor().__reduce_ex__(protocol)
         return super().__reduce_ex__(protocol)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if hasattr(self, "_holder"):
             return f"TorchMojoTensor({self._to_cpu_tensor()!r}, device='{self.device}')"
         return super().__repr__()
@@ -659,7 +751,7 @@ class TorchMojoTensor(torch.Tensor):
     # MAX backend cannot supply). It is also slower than the C++ accessor.
 
     @property
-    def device(self):
+    def device(self) -> torch.device:
         # A plain attribute read so dynamo can trace `x.device` in compiled
         # functions (e.g. `torch.arange(T, device=idx.device)`).
         if hasattr(self, "_torch_device"):
@@ -690,11 +782,18 @@ class TorchMojoTensor(torch.Tensor):
                 )
             _rebind_payload_exact(self, value)
             return
-        torch._C.TensorBase.data.__set__(self, value)
+        # torch's stub types `TensorBase.data` as a plain Tensor (the
+        # instance-level property return), not the getset_descriptor it
+        # actually is when accessed on the class -- real at runtime, just
+        # unmodeled by the stub.
+        torch._C.TensorBase.data.__set__(self, value)  # ty: ignore[unresolved-attribute]
 
     # Only the setter is overridden; reads keep going straight to the C++
     # getset descriptor so nothing about `x.data` changes for dynamo.
-    data = property(torch._C.TensorBase.data.__get__, _set_data)
+    data = property(
+        torch._C.TensorBase.data.__get__,  # ty: ignore[unresolved-attribute]
+        _set_data,
+    )
 
     __torch_function__ = torch._C._disabled_torch_function_impl
 
@@ -723,7 +822,9 @@ class _PermuteCopyExtension(
 
     @classmethod
     def expected_output_specs(cls, tensor: MojoTensorLike) -> _TensorOutputSpec:
-        return _TensorOutputSpec(tuple(tensor._shape), tensor._dtype, tensor._device)
+        return _TensorOutputSpec(
+            tuple(tensor._shape), tensor._dtype, _device_of(tensor)
+        )
 
     @classmethod
     def extension_args(
@@ -731,13 +832,17 @@ class _PermuteCopyExtension(
     ) -> tuple[object, ...]:
         rank = len(tensor._shape)
         pad = 4 - rank
+        # extension_args is only ever called with the concrete wrapper (the
+        # MojoTensorLike param type is for host-contract stand-ins in
+        # make_defines/expected_output_specs, which don't need `_ptr`).
+        mojo_tensor = cast(TorchMojoTensor, tensor)
         return (
             out._ptr,
-            tensor._ptr,
+            mojo_tensor._ptr,
             (1,) * pad + tuple(tensor._shape),
             (0,) * pad + tuple(tensor._mojo_strides),
             tensor._dtype.size_in_bytes,
-            _ctx_ptr(tensor._device),
+            _ctx_ptr(_device_of(tensor)),
         )
 
 
@@ -758,14 +863,16 @@ _PAYLOAD_ATTRIBUTES = (
 )
 
 
-def _resize_tensorimpl(dst: TorchMojoTensor, shape) -> None:
+def _resize_tensorimpl(dst: TorchMojoTensor, shape: Sequence[int]) -> None:
     """Set dst's TensorImpl sizes (and grow its placeholder storage)."""
     torch.ops.aten.resize_.default.redispatch(
         _CPU_KEYSET, dst, shape, memory_format=None
     )
 
 
-def _as_strided_tensorimpl(dst: TorchMojoTensor, shape, strides, offset: int) -> None:
+def _as_strided_tensorimpl(
+    dst: TorchMojoTensor, shape: Sequence[int], strides: Sequence[int], offset: int
+) -> None:
     """State dst's TensorImpl layout exactly. Metadata only, no data moved."""
     torch.ops.aten.as_strided_.default.redispatch(
         _CPU_KEYSET, dst, shape, strides, offset
@@ -846,7 +953,15 @@ def _rebind_payload_exact(dst: TorchMojoTensor, src: TorchMojoTensor) -> None:
     _as_strided_tensorimpl(dst, src._shape, src._mojo_strides, src._offset)
 
 
-def _resize_payload(dst: TorchMojoTensor, shape) -> None:
+@runtime_checkable
+class _HolderWithNbytes(Protocol):
+    """`_holder` is opaque `object` (a Mojo TensorHolder, no Python stubs);
+    this narrows just the one method `_resize_payload` needs from it."""
+
+    def get_nbytes(self) -> int: ...
+
+
+def _resize_payload(dst: TorchMojoTensor, shape: Sequence[int]) -> None:
     """Resize an eager out tensor and keep aliases when storage is sufficient.
 
     PyTorch resets a resized view to contiguous strides at its existing
@@ -861,7 +976,7 @@ def _resize_payload(dst: TorchMojoTensor, shape) -> None:
         return
 
     required_bytes = math.prod(shape) * dst._itemsize
-    allocation_bytes = int(dst._holder.get_nbytes())
+    allocation_bytes = int(cast(_HolderWithNbytes, dst._holder).get_nbytes())
     available_bytes = allocation_bytes - dst._offset * dst._itemsize
     if available_bytes < 0:
         available_bytes = 0
@@ -925,7 +1040,7 @@ def _copy_strided_into(dst: TorchMojoTensor, src: TorchMojoTensor) -> None:
 
 
 @functools.cache
-def get_ordered_accelerators():
+def get_ordered_accelerators() -> list[max.driver.Device]:
     """Get accelerators ordered with GPUs first, then CPU last"""
     from torch_mojo_backend.torch_compile_backend.compiler import get_accelerators
 

--- a/torch_mojo_backend/mojo_device/torch_mojo_tensor.py
+++ b/torch_mojo_backend/mojo_device/torch_mojo_tensor.py
@@ -3,7 +3,7 @@ import math
 import sys
 import threading
 from collections import deque
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import ClassVar, Protocol, cast, runtime_checkable
 
@@ -22,6 +22,13 @@ from torch_mojo_backend.eager_kernels.output_specs import (
 from torch_mojo_backend.mojo_device import objc_autorelease, torch_mojo_device_module
 
 
+class _MojoTensorHolder(Protocol):
+    """The Mojo `TensorHolder` owning one device allocation (no Python stubs)."""
+
+    def data_ptr(self) -> int: ...
+    def get_nbytes(self) -> int: ...
+
+
 @runtime_checkable
 class _TensorHolderModule(Protocol):
     """The subset of the JIT-compiled `tensor_holder` Mojo extension this
@@ -29,10 +36,10 @@ class _TensorHolderModule(Protocol):
     Mojo, not Python); every member here is a raw PythonObject-in,
     PythonObject-out native call, so `object` is the honest signature."""
 
-    def alloc(self, ctx_ptr: int, nbytes: int) -> tuple[object, int]: ...
+    def alloc(self, ctx_ptr: int, nbytes: int) -> tuple[_MojoTensorHolder, int]: ...
     def alloc_from_host(
         self, ctx_ptr: int, data_ptr: int, nbytes: int
-    ) -> tuple[object, int, object]: ...
+    ) -> tuple[_MojoTensorHolder, int, object]: ...
     def copy_to_host(
         self, ctx_ptr: int, src_ptr: int, dst_ptr: int, nbytes: int
     ) -> object: ...
@@ -40,6 +47,11 @@ class _TensorHolderModule(Protocol):
         self, ctx_ptr: int, src_ptr: int, nbytes: int
     ) -> tuple[object, int]: ...
     def CopyStrided(self, *args: object) -> object: ...
+    def copy_d2d(
+        self, ctx_ptr: int, dst_ptr: int, src_ptr: int, nbytes: int
+    ) -> None: ...
+    def fence_event_record(self, ctx_ptr: int) -> object: ...
+    def fence_event_wait(self, ctx_ptr: int, event: object) -> None: ...
 
 
 # The Mojo extension module (torch_mojo_backend.eager_kernels.tensor_holder),
@@ -100,17 +112,29 @@ class _HolderOwner:
 
     __slots__ = ("_holder", "_events", "_owner_ctx", "_wait")
 
-    def __init__(self, holder: object) -> None:
+    # A compile-backend output is owned by its MAX Buffer instead (compiler.py).
+    _holder: _MojoTensorHolder | max.driver.Buffer
+    _events: dict[int, object] | None  # {foreign stream ctx ptr: newest FenceEvent}
+    _owner_ctx: int | None
+    _wait: Callable[[int, object], None] | None
+
+    def __init__(self, holder: "_MojoTensorHolder | max.driver.Buffer") -> None:
         self._holder = holder
-        self._events = None  # {foreign stream ctx ptr: newest FenceEvent}
+        self._events = None
         self._owner_ctx = None
         self._wait = None
 
     def data_ptr(self) -> int:
-        return self._holder.data_ptr()
+        holder = self._holder
+        if isinstance(holder, max.driver.Buffer):
+            return holder._data_ptr()
+        return holder.data_ptr()
 
     def get_nbytes(self) -> int:
-        return self._holder.get_nbytes()
+        holder = self._holder
+        if isinstance(holder, max.driver.Buffer):
+            return holder.num_elements * holder.dtype.size_in_bytes
+        return holder.get_nbytes()
 
     def record_foreign_use(
         self, stream_ctx_ptr: int, event: object, owner_ctx_ptr: int
@@ -124,11 +148,11 @@ class _HolderOwner:
         self._events[stream_ctx_ptr] = event
 
     def __del__(self) -> None:
-        events = self._events
-        if not events or _is_finalizing():
+        events, wait, owner_ctx = self._events, self._wait, self._owner_ctx
+        if not events or wait is None or owner_ctx is None or _is_finalizing():
             return
         for event in events.values():
-            self._wait(self._owner_ctx, event)
+            wait(owner_ctx, event)
 
 
 def _ctx_ptr(device: max.driver.Device) -> int:
@@ -318,7 +342,7 @@ class _SynchronizableDevice(Protocol):
 
 def _alloc_with_recovery(
     device: _SynchronizableDevice, nbytes: int
-) -> tuple[object, int]:
+) -> tuple[_MojoTensorHolder, int]:
     """One device allocation, with the reactive last resort under the budget.
 
     When the allocator refuses, the largest reclaimable set is whatever the
@@ -439,9 +463,7 @@ class TorchMojoTensor(torch.Tensor):
 
     # Declared here (not just assigned in `_make`) so the type checker
     # resolves reads across the codebase; matches `_PAYLOAD_ATTRIBUTES` below.
-    # `_holder`/`_ptr` are opaque handles into the Mojo extension module,
-    # which carries no stubs.
-    _holder: object
+    _holder: _HolderOwner
     _ptr: int
     _shape: tuple[int, ...]
     _mojo_strides: tuple[int, ...]
@@ -480,7 +502,7 @@ class TorchMojoTensor(torch.Tensor):
     @classmethod
     def _make(
         cls,
-        holder: object,
+        holder: "_HolderOwner | _MojoTensorHolder | max.driver.Buffer",
         ptr: int,
         shape: Sequence[int],
         strides: Sequence[int],
@@ -953,14 +975,6 @@ def _rebind_payload_exact(dst: TorchMojoTensor, src: TorchMojoTensor) -> None:
     _as_strided_tensorimpl(dst, src._shape, src._mojo_strides, src._offset)
 
 
-@runtime_checkable
-class _HolderWithNbytes(Protocol):
-    """`_holder` is opaque `object` (a Mojo TensorHolder, no Python stubs);
-    this narrows just the one method `_resize_payload` needs from it."""
-
-    def get_nbytes(self) -> int: ...
-
-
 def _resize_payload(dst: TorchMojoTensor, shape: Sequence[int]) -> None:
     """Resize an eager out tensor and keep aliases when storage is sufficient.
 
@@ -976,7 +990,7 @@ def _resize_payload(dst: TorchMojoTensor, shape: Sequence[int]) -> None:
         return
 
     required_bytes = math.prod(shape) * dst._itemsize
-    allocation_bytes = int(cast(_HolderWithNbytes, dst._holder).get_nbytes())
+    allocation_bytes = int(dst._holder.get_nbytes())
     available_bytes = allocation_bytes - dst._offset * dst._itemsize
     if available_bytes < 0:
         available_bytes = 0

--- a/torch_mojo_backend/testing.py
+++ b/torch_mojo_backend/testing.py
@@ -1,15 +1,17 @@
 import contextlib
 import inspect
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass
+from typing import cast
 
 import torch
 
 from torch_mojo_backend import mojo_backend
+from torch_mojo_backend.types import CountedCallable
 
 
 @contextlib.contextmanager
-def _xfail_if_unsupported(device):
+def _xfail_if_unsupported(device: str) -> Iterator[None]:
     """xfail (rather than fail) when the mojo eager backend raises
     NotImplementedError for an input its fast kernels don't cover.
 
@@ -41,12 +43,12 @@ class CallChecker:
     fast path (eager) — no per-test bookkeeping needed.
     """
 
-    def __init__(self):
-        self._functions_to_check = None
-        self._counts_before_starting_to_check = None
+    def __init__(self) -> None:
+        self._functions_to_check: tuple[CountedCallable, ...] | None = None
+        self._counts_before_starting_to_check: list[int] | None = None
 
     @staticmethod
-    def _fast_twins(func: Callable) -> list[Callable]:
+    def _fast_twins(func: Callable) -> list[CountedCallable]:
         """The aten_fast counterparts of an aten_functions twin.
 
         Matches `fast_<name>` and its variants `fast_<name>_<suffix>` (e.g.
@@ -71,7 +73,7 @@ class CallChecker:
         return twins
 
     @staticmethod
-    def _eager_twins(func: Callable) -> list[Callable]:
+    def _eager_twins(func: Callable) -> list[CountedCallable]:
         """The instrumented mojo registration(s) whose op matches an
         aten_functions twin. Covers ops implemented as custom / out-variant
         registrations (empty_like, mean.out, normal_, ...) that don't route
@@ -106,11 +108,21 @@ class CallChecker:
                 twins.append(counter)
         return twins
 
-    def register(self, *funcs: Callable):
-        expanded: list[Callable] = []
+    def register(self, *funcs: Callable) -> None:
+        """Register the functions expected to run.
+
+        `funcs` are typed `Callable` (each caller's own precise signature,
+        e.g. `aten_functions.aten_min`), not `CountedCallable`: under tests
+        `map_to`/`register_aten_op` always wrap them with a `call_count`
+        attribute, but that fact is deliberately hidden from their static
+        type (see `aten_functions.map_to`) so callers elsewhere keep a
+        precise signature. Cast here, at the one place that relies on it.
+        """
+        expanded: list[CountedCallable] = []
         for func in funcs:
-            if func not in expanded:
-                expanded.append(func)
+            counted_func = cast(CountedCallable, func)
+            if counted_func not in expanded:
+                expanded.append(counted_func)
             for twin in self._fast_twins(func) + self._eager_twins(func):
                 if twin not in expanded:
                     expanded.append(twin)
@@ -119,8 +131,11 @@ class CallChecker:
             f.call_count for f in self._functions_to_check
         ]
 
-    def check_was_called(self):
-        if self._functions_to_check is None:
+    def check_was_called(self) -> None:
+        if (
+            self._functions_to_check is None
+            or self._counts_before_starting_to_check is None
+        ):
             raise ValueError(
                 "No function to check was set, call call_checker.register first"
             )
@@ -141,9 +156,9 @@ def check_functions_are_equivalent(
     device: str | None,
     inputs: list[torch.Tensor],
     fn_compiled: Callable | None = None,
-    rtol=None,
-    atol=None,
-):
+    rtol: float | None = None,
+    atol: float | None = None,
+) -> None:
     fn_compiled = fn_compiled or torch.compile(backend=mojo_backend)(fn)
     if device is not None:
         inputs = [input_tensor.to(device) for input_tensor in inputs]
@@ -184,8 +199,13 @@ def to_device(tensors: list[torch.Tensor], device: str) -> list[torch.Tensor]:
 
 
 def check_outputs(
-    fn: Callable, conf: Conf, inputs: list[torch.Tensor], *, rtol=None, atol=None
-):
+    fn: Callable,
+    conf: Conf,
+    inputs: list[torch.Tensor],
+    *,
+    rtol: float | None = None,
+    atol: float | None = None,
+) -> None:
     # We compare to eager cpu execution
     # We first check if the function has a device argument
     has_device_arg = "device" in inspect.signature(fn).parameters

--- a/torch_mojo_backend/torch_compile_backend/compiler.py
+++ b/torch_mojo_backend/torch_compile_backend/compiler.py
@@ -1,10 +1,11 @@
 import time
 import traceback
 import weakref
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import max.driver
 import max.graph.value
@@ -64,10 +65,10 @@ def global_max_objects() -> GlobalMaxObjects:
     return _global_max_objects
 
 
-def gather_stats_on_graph(gm: torch.fx.GraphModule):
+def gather_stats_on_graph(gm: torch.fx.GraphModule) -> None:
     # count the number of times we see each function.
     # print and sort alphabetically.
-    function_counts = {}
+    function_counts: dict[str, int] = {}
     for node in gm.graph.nodes:
         if node.op == "call_function" or node.op == "call_method":
             name = get_fully_qualified_name(node.target)
@@ -80,13 +81,13 @@ def gather_stats_on_graph(gm: torch.fx.GraphModule):
 
 
 class TensorsBook:
-    def __init__(self):
+    def __init__(self) -> None:
         self.tensors: dict[str, Any] = {}
 
-    def __setitem__(self, name: str, tensor):
+    def __setitem__(self, name: str, tensor: object) -> None:
         self.tensors[name] = tensor
 
-    def convert_to_max(self, something):
+    def convert_to_max(self, something: object) -> object:
         if isinstance(something, torch.fx.Node):
             input_tensor = self.tensors[something.name]
             if isinstance(input_tensor, NotImplementedError):
@@ -129,7 +130,7 @@ class TensorsBook:
         raise ValueError(f"Unsupported type when reading the graph: {type(something)}")
 
 
-def fetch_attr(gm: torch.fx.GraphModule, target: str):
+def fetch_attr(gm: torch.fx.GraphModule, target: str) -> object:
     """Fetch an attribute from the Module hierarchy of self.gm.
     Args:
         target (str): The fully-qualified name of the attribute to fetch
@@ -156,7 +157,7 @@ class _GraphFactory:
         self,
         replace_inputs: dict[str, torch.Tensor] = {},
         force_device: DeviceRef | None = None,
-    ):
+    ) -> None:
         """Creates the MAX graph according to the input fx graph.
 
         Create a new instance for each new graph to be created.
@@ -185,7 +186,7 @@ class _GraphFactory:
         self.replace_inputs = replace_inputs
         self.force_device = force_device
 
-    def initialize_graph(self):
+    def initialize_graph(self) -> None:
         if self.graph is not None:
             raise RuntimeError("Graph has already been initialized.")
 
@@ -215,7 +216,7 @@ class _GraphFactory:
         # torch_device_to_max_device also handles the eager "mojo" device.
         return torch_device_to_max_device(tensor.device)
 
-    def handle_placeholder(self, node: torch.fx.Node):
+    def handle_placeholder(self, node: torch.fx.Node) -> None:
         if node.name in self.replace_inputs:
             # We short-circuit this input and use a constant instead.
             # We still have to place it in the graph inputs list because
@@ -254,7 +255,7 @@ class _GraphFactory:
             )
             self.names_to_input_idx[node.name] = len(self.graph_inputs) - 1
 
-    def handle_call_function(self, node_idx: int, node: torch.fx.Node):
+    def handle_call_function(self, node_idx: int, node: torch.fx.Node) -> None:
         func_args = [self.tensor_book.convert_to_max(x) for x in node.args]
         func_kwargs = {
             k: self.tensor_book.convert_to_max(v) for k, v in node.kwargs.items()
@@ -269,17 +270,20 @@ class _GraphFactory:
             func_to_execute = MAPPING_TORCH_ATEN_TO_MOJO[normalized_name]
             # without hidden keys
             input_tensors = [v for k, v in func_kwargs.items() if not k.startswith("_")]
+            # AutoFunctionalizedV2's `_all_bases` kwarg is the list of mutated
+            # tensor arguments (torch._higher_order_ops.auto_functionalize).
+            all_bases = func_kwargs["_all_bases"]
+            assert isinstance(all_bases, list)
             # We pray the gods that the order is correct here
             # because we only work with positional arguments
-            self.tensor_book[node.name] = func_to_execute(
-                *func_kwargs["_all_bases"], *input_tensors
-            )
+            self.tensor_book[node.name] = func_to_execute(*all_bases, *input_tensors)
             return
         key = node.target
 
         # TODO: refactor this
         if (
-            key not in MAPPING_TORCH_ATEN_TO_MOJO
+            isinstance(key, torch._ops.OpOverload)
+            and key not in MAPPING_TORCH_ATEN_TO_MOJO
             and key.overloadpacket in MAPPING_TORCH_ATEN_TO_MOJO
         ):
             key = key.overloadpacket
@@ -308,8 +312,11 @@ class _GraphFactory:
 
         self.tensor_book[node.name] = func_output
 
-    def handle_get_attr(self, node: torch.fx.Node):
-        attr_value = fetch_attr(node.graph.owning_module, node.target)
+    def handle_get_attr(self, node: torch.fx.Node) -> None:
+        owning_module = node.graph.owning_module
+        assert owning_module is not None
+        assert isinstance(node.target, str)
+        attr_value = fetch_attr(owning_module, node.target)
         if isinstance(attr_value, torch.Tensor):
             # A tensor constant embedded in the graph (e.g. dynamo's
             # lift_fresh of a torch.tensor(...) created inside the traced
@@ -341,14 +348,28 @@ class _GraphFactory:
         because MAX assumes that if your ouput is a Dim(), then you want a max tensor
         as output, not a simple python int.
         """
-        output_tensors = []
+        # create_graph always calls initialize_graph (which sets self.graph)
+        # before any node reaches handle_output.
+        assert self.graph is not None
+        # Elements are whatever convert_to_max returns for a graph-output
+        # leaf: in practice always a previously-converted MAX value (the
+        # Dim branch below is split out separately) -- narrowed with a
+        # single cast at the `graph.output` call below rather than
+        # scattering isinstance checks convert_to_max's broad return
+        # doesn't support per-branch.
+        output_tensors: list[object] = []
 
         # None outputs can be required. So we remember here if
         # we want an output tensor (and we reccord the tensor position)
         # or if we want None.
         output_blueprint: list[tuple[OutputBlueprintKind, int | None]] = []
 
-        for x in node.args[0]:
+        # An "output" fx node's args[0] is the traced function's actual
+        # return value structure, always a list/tuple of Nodes/constants
+        # (aot_autograd graphs always produce a flat tuple).
+        output_args = node.args[0]
+        assert isinstance(output_args, list | tuple)
+        for x in output_args:
             converted = self.tensor_book.convert_to_max(x)
             if converted is None:
                 output_blueprint.append((OutputBlueprintKind.NONE, None))
@@ -363,7 +384,12 @@ class _GraphFactory:
                 )
                 output_tensors.append(converted)
         # Store the none indices for runtime handling
-        self.graph.output(*output_tensors)
+        self.graph.output(
+            *cast(
+                "list[max.graph.value.Value | max.graph.value.TensorValueLike]",
+                output_tensors,
+            )
+        )
         self.graph.__exit__(None, None, None)
         self._graph_open = False
         return output_blueprint
@@ -400,10 +426,15 @@ class _GraphFactory:
                 self.graph.__exit__(None, None, None)
                 self._graph_open = False
             raise
+        # handle_output (which ran to set output_blueprint above) asserts
+        # self.graph is set.
+        assert self.graph is not None
         return self.graph, output_blueprint
 
 
-def _graph_uses_mojo_device(gm: torch.fx.GraphModule, example_inputs: list) -> bool:
+def _graph_uses_mojo_device(
+    gm: torch.fx.GraphModule, example_inputs: list[object]
+) -> bool:
     """Whether this graph computes on the eager "mojo" device.
 
     Checked at compile time (inputs may be fake tensors; factory-only graphs
@@ -453,7 +484,12 @@ def _dim_buffer_to_cpu_tensor(buffer: max.driver.Buffer) -> torch.Tensor:
 
 
 class BaseMaxCompiler:
-    def __init__(self, gm: torch.fx.GraphModule, example_inputs: list, mode=None):
+    def __init__(
+        self,
+        gm: torch.fx.GraphModule,
+        example_inputs: list[object],
+        mode: str | None = None,
+    ) -> None:
         self.gm = gm
         self.mojo_outputs = _graph_uses_mojo_device(gm, example_inputs)
         if profiling_enabled():
@@ -483,17 +519,19 @@ class BaseMaxCompiler:
     def reconstruct_from_blueprint(
         self, max_ouptputs: list[torch.Tensor]
     ) -> list[torch.Tensor | int | float | None]:
-        result = []
+        result: list[torch.Tensor | int | float | None] = []
         for kind, index in self.output_blueprint:
             if kind is OutputBlueprintKind.NONE:
                 result.append(None)
             elif kind is OutputBlueprintKind.TENSOR:
+                assert index is not None
                 result.append(max_ouptputs[index])
             elif kind is OutputBlueprintKind.DIM:
+                assert index is not None
                 result.append(max_ouptputs[index].item())
         return result
 
-    def __call__(self, *args) -> list[torch.Tensor | int | float | None]:
+    def __call__(self, *args: object) -> list[torch.Tensor | int | float | None]:
         # Detach tensors to avoid gradient tracking issues with DLpack
         if profiling_enabled():
             start_inference_time = time.time_ns()
@@ -539,7 +577,7 @@ class BaseMaxCompiler:
 # (catches storage reallocation, e.g. `param.data = ...`), evicted when the
 # tensor dies. Buffers alias the tensor memory, so in-place updates
 # (optimizer steps) are seen without invalidation.
-_buffer_cache: dict[int, tuple] = {}
+_buffer_cache: dict[int, tuple[max.driver.Buffer, int, weakref.finalize]] = {}
 
 
 def _evict_buffer(tensor_id: int) -> None:
@@ -553,7 +591,7 @@ def _data_ptr_of(t: torch.Tensor) -> int:
     return t.data_ptr()
 
 
-def _cached_buffer_for(t: torch.Tensor):
+def _cached_buffer_for(t: torch.Tensor) -> max.driver.Buffer:
     if not t.is_contiguous():
         # A MAX Buffer is dense row-major, and the graph input type only
         # carries a shape, so a strided input has to be materialized. The
@@ -574,24 +612,28 @@ def _cached_buffer_for(t: torch.Tensor):
     return buffer
 
 
-def boxed_func(*args, **kwargs):
-    return make_boxed_func(BaseMaxCompiler(*args, **kwargs).__call__)
+def boxed_func(
+    gm: torch.fx.GraphModule, example_inputs: list[object], mode: str | None = None
+) -> Callable[[list[Any]], Any]:
+    return make_boxed_func(BaseMaxCompiler(gm, example_inputs, mode).__call__)
 
 
 class mojo_backend:
-    def __init__(self, gm: torch.fx.GraphModule, example_inputs: list):
+    def __init__(self, gm: torch.fx.GraphModule, example_inputs: list[object]) -> None:
         self.func_to_execute = aot_autograd(
             fw_compiler=boxed_func, decompositions=DECOMPOSITION_TABLE
         )(gm, example_inputs)
 
-    def __call__(self, *args) -> list[torch.Tensor | int | float | None]:
+    def __call__(self, *args: object) -> list[torch.Tensor | int | float | None]:
         result = self.func_to_execute(*args)
         if isinstance(result, tuple):
             return list(result)
         return result
 
 
-def dummy_compiler(gm: torch.fx.GraphModule, example_inputs: list):
+def dummy_compiler(
+    gm: torch.fx.GraphModule, example_inputs: list[object]
+) -> Callable[[list[Any]], Any]:
     return make_boxed_func(gm.forward)
 
 
@@ -610,8 +652,17 @@ dummy_backend = aot_autograd(fw_compiler=dummy_compiler)
 #   which can take advantage of MAX's automatic kernel fusion.
 def fast_from_dlpack(t: torch.Tensor) -> max.driver.Buffer:
     if t.device.type == "cuda":
+        # Deferred: torch_mojo_tensor imports this module (get_ordered_accelerators
+        # -> compiler.get_accelerators), so importing it back at module scope
+        # would cycle.
+        from torch_mojo_backend.mojo_device.torch_mojo_tensor import (
+            find_equivalent_max_device,
+        )
+
         stream = torch.cuda.current_stream(t.device).cuda_stream
-        device = torch_device_to_max_device(t.device)
+        # _from_dlpack wants a concrete driver Device, not the graph-building
+        # DeviceRef torch_device_to_max_device returns.
+        device = find_equivalent_max_device(t.device)
         data = t.__dlpack__()
         try:
             return max.driver.Buffer._from_dlpack(data, device, stream)

--- a/torch_mojo_backend/torch_compile_backend/compiler.py
+++ b/torch_mojo_backend/torch_compile_backend/compiler.py
@@ -612,9 +612,12 @@ def _cached_buffer_for(t: torch.Tensor) -> max.driver.Buffer:
     return buffer
 
 
+GraphValue = torch.Tensor | int | float | None
+
+
 def boxed_func(
     gm: torch.fx.GraphModule, example_inputs: list[object], mode: str | None = None
-) -> Callable[[list[Any]], Any]:
+) -> Callable[[list[GraphValue]], list[GraphValue]]:
     return make_boxed_func(BaseMaxCompiler(gm, example_inputs, mode).__call__)
 
 
@@ -633,8 +636,8 @@ class mojo_backend:
 
 def dummy_compiler(
     gm: torch.fx.GraphModule, example_inputs: list[object]
-) -> Callable[[list[Any]], Any]:
-    return make_boxed_func(gm.forward)
+) -> Callable[[list[GraphValue]], object]:
+    return make_boxed_func(gm.forward)  # returns whatever the graph returns
 
 
 # Can be used to check if it's the fault of the max backend or not.

--- a/torch_mojo_backend/torch_compile_backend/debug.py
+++ b/torch_mojo_backend/torch_compile_backend/debug.py
@@ -7,8 +7,8 @@ and compare each intermediate result.
 This is not public yet but still useful for debugging.
 """
 
+from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import Any
 
 import max.graph.ops as max_ops
 import torch
@@ -24,20 +24,24 @@ output_directory = Path("/tmp/.torch_mojo_backend_debug")
 output_directory_max = output_directory / "max"
 
 
-def set_print_options(session: engine.InferenceSession):
+def set_print_options(session: engine.InferenceSession) -> None:
     output_directory_max.mkdir(parents=True, exist_ok=True)
     session.set_debug_print_options(
         "BINARY_MAX_CHECKPOINT", output_directory=output_directory_max
     )
 
 
-def add_prints(node_idx: int, func_name: str, func_output: Any):
+def add_prints(node_idx: int, func_name: str, func_output: object) -> None:
     if not debug_graph():
         return
+    outputs: Sequence[TensorValue]
     if isinstance(func_output, TensorValue):
-        func_output = [func_output]
+        outputs = [func_output]
+    else:
+        assert isinstance(func_output, Sequence)
+        outputs = func_output
 
-    for i, output_tensor in enumerate(func_output):
+    for i, output_tensor in enumerate(outputs):
         label = get_tensor_label(node_idx, i, func_name)
         max_ops.print(output_tensor, label)
 
@@ -46,7 +50,7 @@ def get_tensor_label(node_idx: int, i: int, func_name: str) -> str:
     return f"node-idx-{node_idx:09}-output-{i}-function-{func_name}"
 
 
-def pp(x) -> str:
+def pp(x: object) -> str:
     if isinstance(x, torch.Tensor):
         return repr(x)[:-1] + f", shape={x.shape})"
     if isinstance(x, list):
@@ -56,13 +60,18 @@ def pp(x) -> str:
     return repr(x)
 
 
-def make_debug_function(node_idx, old_func, node):
-    def new_function(*func_args, **func_kwargs):
+def make_debug_function(
+    node_idx: int, old_func: Callable[..., object], node: torch.fx.Node
+) -> Callable[..., object]:
+    def new_function(*func_args: object, **func_kwargs: object) -> object:
         print(f"Debugging node {node_idx} function {old_func}")
         result = old_func(*func_args, **func_kwargs)
-        to_check = result
-        if isinstance(to_check, torch.Tensor):
-            to_check = [to_check]
+        to_check: Sequence[object]
+        if isinstance(result, torch.Tensor):
+            to_check = [result]
+        else:
+            assert isinstance(result, Sequence)
+            to_check = result
         for output_idx, tensor in enumerate(to_check):
             if isinstance(tensor, torch.Tensor):
                 # Load the corresponding tensor from MAX
@@ -116,7 +125,7 @@ def make_debug_function(node_idx, old_func, node):
     return new_function
 
 
-def debug_graph_if_required(gm: torch.fx.GraphModule, args):
+def debug_graph_if_required(gm: torch.fx.GraphModule, args: tuple[object, ...]) -> None:
     if not debug_graph():
         return
 

--- a/torch_mojo_backend/torch_compile_backend/exporter.py
+++ b/torch_mojo_backend/torch_compile_backend/exporter.py
@@ -3,6 +3,7 @@
 import max.engine
 import torch
 import torch.export
+from max.graph import DeviceRef
 from torch.export.graph_signature import InputKind
 
 from torch_mojo_backend.aten_functions import DECOMPOSITION_TABLE
@@ -13,7 +14,9 @@ from torch_mojo_backend.torch_compile_backend.compiler import (
 
 
 def export_to_max_graph(
-    model: torch.nn.Module, example_inputs: tuple[torch.Tensor, ...], force_device=None
+    model: torch.nn.Module,
+    example_inputs: tuple[torch.Tensor, ...],
+    force_device: DeviceRef | None = None,
 ) -> max.engine.Model:
     exported_program = torch.export.export(model, example_inputs, strict=True)
     with torch.no_grad():
@@ -22,7 +25,7 @@ def export_to_max_graph(
         )
     state_dict = model.state_dict()
     # embed weights into the graph
-    replace_inputs = {}
+    replace_inputs: dict[str, torch.Tensor] = {}
     for input_spec in exported_program.graph_signature.input_specs:
         if input_spec.kind != InputKind.PARAMETER:
             continue
@@ -31,5 +34,4 @@ def export_to_max_graph(
     factory = _GraphFactory(replace_inputs, force_device=force_device)
     graph, _ = factory.create_graph(exported_program.graph)
 
-    model = global_max_objects().session.load(graph)
-    return model
+    return global_max_objects().session.load(graph)

--- a/torch_mojo_backend/torch_compile_backend/utils.py
+++ b/torch_mojo_backend/torch_compile_backend/utils.py
@@ -23,11 +23,13 @@ def get_fully_qualified_name(func: Callable | str) -> str:
     if isinstance(func, str):
         return f"torch.Tensor.{func}"
     result = ""
-    if hasattr(func, "__module__"):
-        result += func.__module__ + "."
+    module = getattr(func, "__module__", None)
+    if isinstance(module, str):
+        result += module + "."
 
-    if hasattr(func, "__qualname__"):
-        result += func.__qualname__
+    qualname = getattr(func, "__qualname__", None)
+    if isinstance(qualname, str):
+        result += qualname
 
     result += " of type " + str(type(func)) + " "
     return result

--- a/torch_mojo_backend/types.py
+++ b/torch_mojo_backend/types.py
@@ -1,6 +1,26 @@
+from typing import Protocol, runtime_checkable
+
 from max.experimental.tensor import Tensor as MaxEagerTensor
 from max.graph import Dim, TensorValue
 
 MaxTensor = TensorValue | MaxEagerTensor
 Scalar = int | float | Dim
 SymIntType = int | Dim
+
+
+@runtime_checkable
+class CountedCallable(Protocol):
+    """A function wrapped with the test-only call-count instrumentation.
+
+    `map_to` (aten_functions.py), `aten_fast.py`'s per-op wrappers, and
+    `mojo_device_aten_ops.py`'s registration wrap every op with
+    `functools.wraps` plus a `call_count` attribute so tests can assert an
+    op actually ran (see `testing.CallChecker`). `functools.wraps` preserves
+    `__name__` but its stub doesn't know about the extra attribute, so the
+    wrapped callable needs this structural type instead of plain `Callable`.
+    """
+
+    __name__: str
+    call_count: int
+
+    def __call__(self, *args: object, **kwargs: object) -> object: ...

--- a/uv.lock
+++ b/uv.lock
@@ -47,15 +47,6 @@ wheels = [
 ]
 
 [[package]]
-name = "beartype"
-version = "0.22.9"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload-time = "2025-12-13T06:50:30.72Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload-time = "2025-12-13T06:50:28.266Z" },
-]
-
-[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -2387,7 +2378,6 @@ name = "torch-mojo-backend"
 version = "0.3.1"
 source = { editable = "." }
 dependencies = [
-    { name = "beartype" },
     { name = "max" },
     { name = "mojo" },
     { name = "tabulate" },
@@ -2424,11 +2414,11 @@ dev = [
     { name = "setuptools" },
     { name = "tiktoken" },
     { name = "transformers" },
+    { name = "ty" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "beartype", specifier = ">=0.17.0" },
     { name = "max", specifier = "==26.5" },
     { name = "mojo", specifier = "==1.0" },
     { name = "tabulate" },
@@ -2464,6 +2454,7 @@ dev = [
     { name = "setuptools", specifier = ">=80.9.0" },
     { name = "tiktoken", specifier = ">=0.11.0" },
     { name = "transformers", specifier = ">=4.54.1" },
+    { name = "ty", specifier = ">=0.0.77" },
 ]
 
 [[package]]
@@ -2533,6 +2524,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/43/7935f8ea93fcb6680bc10a6fdbf534075c198eeead59150dd5ed68449642/trove_classifiers-2026.1.14.14.tar.gz", hash = "sha256:00492545a1402b09d4858605ba190ea33243d361e2b01c9c296ce06b5c3325f3", size = 16997, upload-time = "2026-01-14T14:54:50.526Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bb/4a/2e5583e544bc437d5e8e54b47db87430df9031b29b48d17f26d129fa60c0/trove_classifiers-2026.1.14.14-py3-none-any.whl", hash = "sha256:1f9553927f18d0513d8e5ff80ab8980b8202ce37ecae0e3274ed2ef11880e74d", size = 14197, upload-time = "2026-01-14T14:54:49.067Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.77"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ef/a2024d1d33d5ba8436677a6fd734f87a137150aba99906fc009f7c5de956/ty-0.0.77.tar.gz", hash = "sha256:8898f3097610f4a772ead6bfad7b204c7d76e8eb3a010c7285b9186278e0fb82", size = 7005734, upload-time = "2026-09-01T00:26:26.901Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/03/930f7454a6d797abc09aebbf537017825ebb08d9f8c2e2d905e74341dbb1/ty-0.0.77-py3-none-linux_armv6l.whl", hash = "sha256:ea76012f1ed387b6fc6500894fb8a7654b724c38713e263a23f12756f00e2469", size = 13241626, upload-time = "2026-09-01T00:25:51.02Z" },
+    { url = "https://files.pythonhosted.org/packages/65/41/7e064045775718673851f6c0e1cfde70d6e380b0db9d91d4484a362f2d67/ty-0.0.77-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:237a58c389e01d65c4693e0394feb0f0adea3fba0345c3b932d209084372f3d3", size = 12830037, upload-time = "2026-09-01T00:25:53.172Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/64/66f0b0dc89bd239922bdf12fa3e6d066aa7a425e8b70414368c4eb44a6e6/ty-0.0.77-py3-none-macosx_11_0_arm64.whl", hash = "sha256:bbb8ae7a753b9a6af25725c314d0eca967e5fde5eebb7a35b04b0d763dfb9d7c", size = 12612071, upload-time = "2026-09-01T00:25:55.116Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/5c/bef8b1f471931a9395792be023613b6cee0ef1449815bf97b18be07f883c/ty-0.0.77-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:603620c063b718ddbe302f83fb0d7c01a13f1941c3b9763512a89c9bbfabba96", size = 12641403, upload-time = "2026-09-01T00:25:57.305Z" },
+    { url = "https://files.pythonhosted.org/packages/43/66/e4d32a0145162f79bc3dd6fca4770f88966c3b5206121ffeecd5f7b05e8b/ty-0.0.77-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03f128cb8b204e22a18f4b01ef0194aa445f4edb080cb7d77621cb2ab353885c", size = 13013526, upload-time = "2026-09-01T00:25:59.278Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/be/33493ee43d4db7d402ceaee55c5d6c22e2b1105f10b1ac5928c220f79650/ty-0.0.77-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:97d1600ef69fc8e3b2310de1915cd34ba3b712fdc730cb02b713520956baec0a", size = 13828076, upload-time = "2026-09-01T00:26:01.343Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/d5/b6335fdc8c09aaaaf6541322076c5a7205fa16c29dbeddc1f24dd89b3894/ty-0.0.77-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dced0924a83b6d945fd48a29aa85e131fb98dc574f4c9a0e7c43d03eff373402", size = 14247770, upload-time = "2026-09-01T00:26:03.388Z" },
+    { url = "https://files.pythonhosted.org/packages/11/64/bbe96c1da26585919ac10f33df1d337d9b498013fc60c5178e76955c2a53/ty-0.0.77-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b14b002233a954115a04932b3a93d75a387569848276cf7bb0b5dc6b040001c4", size = 13926528, upload-time = "2026-09-01T00:26:05.587Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/e2/cdc94e9a1b69e9b7dd0ec3ad3ca75741245b8b5b2e3ffe9b365ca31d8052/ty-0.0.77-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:581adf1ae1e48e00e89ec162913d559ddf75a7805646a13ffd68943c1b5e8daa", size = 13290834, upload-time = "2026-09-01T00:26:07.912Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8c/4929dd8e924ddbd6284dcb3cfbda488bd6cb091e5384f8b7fb5dd3de9122/ty-0.0.77-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9bda523b40e06c643feb6d5d5bcbacc56a2bd9eed3d7cae1119452502bcd69b0", size = 13829048, upload-time = "2026-09-01T00:26:10.093Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f4/441a74ddc5e2db2690264c1ee0e478d46b8e42bd529472fdb1656b63bff2/ty-0.0.77-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4b8b04d8c3af8148e963e950094bd53c8cc4d3a11f5f8764ff8d39627bd6e64a", size = 12803755, upload-time = "2026-09-01T00:26:12.055Z" },
+    { url = "https://files.pythonhosted.org/packages/85/39/875bb7092ee1edb090b62eca74b7311f6416dc3aa7da442b4a1f95408251/ty-0.0.77-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:33a9ff9be488edf4d6fac46c456198cc848d9641f418f1a83aa123825e93c6ec", size = 13028244, upload-time = "2026-09-01T00:26:14.212Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/76/4b0a48f118dca6a32e1609f2d0bea2c3f7be9051af645fe5044ca35cbbb4/ty-0.0.77-py3-none-musllinux_1_2_i686.whl", hash = "sha256:61ad5467206e5ea6531c8aebebf1276c6150989a94a1d5974a84d9e0eeed5c38", size = 13321068, upload-time = "2026-09-01T00:26:16.418Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/46/cd21bc6441df4b221d9e131551bab2a5f9c0b724e60e1c960622ee175128/ty-0.0.77-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1293b94f26d1f330424e3b97c20b434f7e2ac1938287b8588466c75ece6c0b10", size = 13609112, upload-time = "2026-09-01T00:26:18.424Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7b/0da4537a7eca4eb3ca72a2cb4539cfbb6fb3138d1dc4ae7a66299b941fb3/ty-0.0.77-py3-none-win32.whl", hash = "sha256:cb71152bdf56860375c790682cc3efc120aaf8e36f1cd6367773312905e82b50", size = 12573821, upload-time = "2026-09-01T00:26:20.404Z" },
+    { url = "https://files.pythonhosted.org/packages/96/91/aec75b11bfaa5a358f5a505afa6307fc4bee1c5f4c6444e18fa82c25f3be/ty-0.0.77-py3-none-win_amd64.whl", hash = "sha256:86f01d4af8b006c9442a2de0ab949cc24462f8f9431bebc0b73f6166fbbca19f", size = 13154851, upload-time = "2026-09-01T00:26:22.389Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e5/77772f95ff81bf7c817595cd08b52d007acab90dac0f2339faa486e6a525/ty-0.0.77-py3-none-win_arm64.whl", hash = "sha256:942a3bb2a4786c80bd8ef4503e5024046617cdfcc550b56c1acc4817ce7ac144", size = 12992392, upload-time = "2026-09-01T00:26:24.44Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Removes beartype entirely (dependency, the `TORCH_MOJO_BACKEND_BEARTYPE` runtime machinery, the conftest hook, and AGENTS.md's beartype-error-driven hint-finding recipe) and replaces runtime checking with **static, universal enforcement**: `ty` checks the whole repo (green: "All checks passed!"), wired into CI next to pre-commit, and ruff's flake8-annotations rules (ANN, with ANN401 kept ON so `Any`-typed arguments are flagged) require annotations on every `torch_mojo_backend/` signature — closing ty's blind spot where unannotated code silently degrades to `Unknown` and escapes checking.

**Every diagnostic fixed with real types, none silenced**: ~400 signatures annotated across ~70 files (`aten_fast.py` alone: 397 ty diagnostics + 841 missing annotations → 0); six structural `Protocol`s for the stub-less Mojo extension surfaces; a real `_NotHandled` sentinel type replacing `-> object` on fast-op returns (callers narrow via the existing `is NOT_HANDLED` checks); `isinstance`/`assert` narrowing at use sites. Suppression budget: **one** global rule (`invalid-method-override = "ignore"`, justified in pyproject — torch's documented subclass/autograd extension points can't satisfy nominal override checks) and **21 per-line ignores**, each with a one-line reason. `tests/` and `current_bench/` are ANN-exempt (still ty-checked).

**Bugs the types found** (fixed): a crash path on complex Python scalars in `searchsorted`; an `int()` call on a NOT_HANDLED sentinel; two import-breaking annotation `NameError`s — a class ty cannot catch (it doesn't resolve unimported annotation names), which is why validation includes a per-module import smoke test.

**Runtime-neutral, proven**: GPU device/loader/optimizer suites produce identical pass/fail sets vs the pre-migration baseline on the same node (8 failed / 149 passed both sides; all 8 pre-existing environmental — 4 are the ptxas-12.8 matmul class #429 addresses).

Local quirk documented in AGENTS.md: a set `CONDA_PREFIX` breaks ty's environment discovery — run `env -u CONDA_PREFIX uv run ty check` (CI runners are unaffected).

Flagged follow-up (not in this PR): `_reduced_shape` is defined twice in `aten_fast.py`; the first definition is dead code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AbxaDeRuA7yywYEUuZV72
