### PR TITLE
Tighten the ruff and ty configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -296,8 +296,11 @@ This ensures the operation works in both `torch.compile()` and on the `mojo` dev
 ## Type hints
 
 Every function written must have type hints in its signature: annotate all
-arguments and the return type. Do not put type hints in the function body
-(no annotated local variables like `x: Foo = ...`).
+arguments and the return type, except that a function returning nothing is
+left without `-> None` (ruff's `suppress-none-returning` exempts it, and
+`tests/test_no_none_return_annotations.py` bans the spelling). Do not put
+type hints in the function body (no annotated local variables like
+`x: Foo = ...`).
 
 Use `: object` only when no other option is possible. Prefer precise types,
 unions, `Protocol`s (e.g. `MojoTensorLike` for payload-level helpers), or a

--- a/benchmarks/bench_lib/baselines.py
+++ b/benchmarks/bench_lib/baselines.py
@@ -443,7 +443,7 @@ def _without_legacy_aggregates(node: dict[str, object]) -> dict[str, object]:
     }
 
 
-def _transposed(configs: dict[str, dict]) -> dict[str, dict]:
+def _transposed(configs: dict[str, dict[str, object]]) -> dict[str, dict[str, object]]:
     """Formats 3 and 4 nested dtype above op; format 5 nests op above dtype.
 
     Rebuilds each config as ops -> dtypes -> shapes, carrying the shape
@@ -453,13 +453,19 @@ def _transposed(configs: dict[str, dict]) -> dict[str, dict]:
     out = {}
     for config_key, config in configs.items():
         ops = {}
-        for dtype, dtype_block in config.get("dtypes", {}).items():
-            for op, op_block in dtype_block.get("ops", {}).items():
+        dtype_blocks = typing.cast(
+            "dict[str, dict[str, object]]", config.get("dtypes", {})
+        )
+        for dtype, dtype_block in dtype_blocks.items():
+            op_blocks = typing.cast(
+                "dict[str, dict[str, object]]", dtype_block.get("ops", {})
+            )
+            for op, op_block in op_blocks.items():
                 ops.setdefault(op, {})[dtype] = {"shapes": op_block.get("shapes", {})}
         out[config_key] = {
             "ops": {op: {"dtypes": dtypes} for op, dtypes in ops.items()}
         }
-    return out
+    return typing.cast("dict[str, dict[str, object]]", out)
 
 
 def rebuild(path: Path = BASELINES_PATH) -> None:
@@ -476,6 +482,8 @@ def rebuild(path: Path = BASELINES_PATH) -> None:
         stripped = _without_legacy_aggregates(raw)
         # Parsed JSON, shape guaranteed by the format-3/4 contract this
         # migration handles, not something isinstance can verify past "dict".
-        configs = typing.cast("dict[str, dict]", stripped.get("configs", {}))
+        configs = typing.cast(
+            "dict[str, dict[str, object]]", stripped.get("configs", {})
+        )
         raw = {"configs": _transposed(configs), "format": FORMAT_VERSION}
     write(_parse(raw, path), path)

--- a/benchmarks/bench_lib/baselines.py
+++ b/benchmarks/bench_lib/baselines.py
@@ -212,7 +212,7 @@ class BenchKey(typing.NamedTuple):
         return f"{self.op}/{self.dtype}/{self.shape}/{self.layout}"
 
 
-def _check_ratio(value: float, where: str) -> None:
+def _check_ratio(value: float, where: str):
     if not math.isfinite(value) or value <= 0.0:
         raise ValueError(
             f"{where}: a baseline ratio must be a finite positive number "
@@ -396,7 +396,7 @@ def canonical_dump(data: BaselinesFile) -> str:
     return "\n" + text.replace("<", "\\u003c") + "\n"
 
 
-def write(data: BaselinesFile, path: Path = BASELINES_PATH) -> None:
+def write(data: BaselinesFile, path: Path = BASELINES_PATH):
     """Splice `data` into the file's data block, atomically.
 
     The viewer around the block survives byte-for-byte.
@@ -410,7 +410,7 @@ def write(data: BaselinesFile, path: Path = BASELINES_PATH) -> None:
 
 def merge_write(
     hw_key: str, entries: dict[BenchKey, float], path: Path = BASELINES_PATH
-) -> None:
+):
     """Merge `entries` into the file.
 
     Every line not in `entries` survives byte-for-byte: only the measured
@@ -468,7 +468,7 @@ def _transposed(configs: dict[str, dict[str, object]]) -> dict[str, dict[str, ob
     return typing.cast("dict[str, dict[str, object]]", out)
 
 
-def rebuild(path: Path = BASELINES_PATH) -> None:
+def rebuild(path: Path = BASELINES_PATH):
     """Re-canonicalize the data block: prune empty blocks, sort, rewrite.
 
     The escape hatch for the two documented manual situations — resolving

--- a/benchmarks/bench_lib/check.py
+++ b/benchmarks/bench_lib/check.py
@@ -132,14 +132,14 @@ class Bench:
 
     def __init__(
         self, request: pytest.FixtureRequest, hw: Hardware, mojo: torch.device
-    ) -> None:
+    ):
         self._request = request
         self._hw = hw
         self._mojo = mojo
 
     def run(
         self, ref_fn: Callable[[], object], our_fn: Callable[[], object], flops: float
-    ) -> None:
+    ):
         hw = self._hw
         entry_key = bench_key(self._request.node)
         iters = iters_for_flops(flops)
@@ -185,7 +185,7 @@ class Bench:
 
     def _check(
         self, entry_key: baselines.BenchKey, result: Measurement, attempts: int = 1
-    ) -> None:
+    ):
         mode = update_mode(self._request.config)
         data = baselines.load()
         base = baselines.lookup(data, self._hw.key, entry_key)
@@ -250,7 +250,7 @@ class Bench:
         entry_key: baselines.BenchKey,
         ratio: float,
         message: str,
-    ) -> None:
+    ):
         if mode is not None:
             self._record(entry_key, ratio)
             self._note(f"recorded {entry_key}: {message}")
@@ -259,10 +259,10 @@ class Bench:
                 f"NOT recorded (rerun with --update-baselines) {entry_key}: {message}"
             )
 
-    def _record(self, entry_key: baselines.BenchKey, ratio: float) -> None:
+    def _record(self, entry_key: baselines.BenchKey, ratio: float):
         baselines.merge_write(self._hw.key, {entry_key: ratio})
 
-    def _note(self, message: str) -> None:
+    def _note(self, message: str):
         stash = self._request.config.stash
         notes = stash.setdefault(BENCH_NOTES_KEY, [])
         notes.append(message)

--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -37,7 +37,7 @@ from bench_lib.hw import Hardware, detect
 KEY_DUMP_ENV = "TORCH_MOJO_BACKEND_BENCH_DUMP_KEYS"
 
 
-def pytest_collection_finish(session: pytest.Session) -> None:
+def pytest_collection_finish(session: pytest.Session):
     dump = os.environ.get(KEY_DUMP_ENV)
     if not dump:
         return
@@ -49,7 +49,7 @@ def pytest_collection_finish(session: pytest.Session) -> None:
     Path(dump).write_text("".join(f"{key}\n" for key in keys))
 
 
-def pytest_configure(config: pytest.Config) -> None:
+def pytest_configure(config: pytest.Config):
     config.addinivalue_line(
         "markers",
         "bench_op(name): store this benchmark under the given op token in "
@@ -58,7 +58,7 @@ def pytest_configure(config: pytest.Config) -> None:
     )
 
 
-def pytest_addoption(parser: pytest.Parser) -> None:
+def pytest_addoption(parser: pytest.Parser):
     parser.addoption(
         "--update-baselines",
         nargs="?",
@@ -93,7 +93,7 @@ def mojo_device(hw: Hardware) -> torch.device:
 
 
 @pytest.fixture(autouse=True)
-def deterministic_operands() -> None:
+def deterministic_operands():
     # Same operand data in every process: a reproducible measurement should
     # feed reproducible inputs.  Tested on S1-tf32: data content is NOT the
     # driver of the residual ~2% between-process drift (that is allocator /
@@ -113,7 +113,7 @@ def pytest_terminal_summary(
     terminalreporter: TerminalReporter,
     exitstatus: pytest.ExitCode,
     config: pytest.Config,
-) -> None:
+):
     notes = config.stash.get(BENCH_NOTES_KEY, [])
     if not notes:
         return

--- a/benchmarks/test_attention.py
+++ b/benchmarks/test_attention.py
@@ -70,7 +70,7 @@ _FlashForwardOut = tuple[
 @pytest.mark.bench_op("scaled_dot_product_attention")
 def test_sdpa(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     refs, ours, flops = _qkv(shape_id, dtype_id, hw, mojo_device)
     bench.run(
         lambda: F.scaled_dot_product_attention(*refs, is_causal=True),
@@ -84,7 +84,7 @@ def test_sdpa(
 @pytest.mark.bench_op("_scaled_dot_product_flash_attention")
 def test_sdpa_flash(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     refs, ours, flops = _qkv(shape_id, dtype_id, hw, mojo_device)
     bench.run(
         lambda: torch.ops.aten._scaled_dot_product_flash_attention(
@@ -102,7 +102,7 @@ def test_sdpa_flash(
 @pytest.mark.bench_op("_scaled_dot_product_efficient_attention")
 def test_sdpa_efficient(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     refs, ours, flops = _qkv(shape_id, dtype_id, hw, mojo_device)
     bench.run(
         lambda: torch.ops.aten._scaled_dot_product_efficient_attention(
@@ -120,7 +120,7 @@ def test_sdpa_efficient(
 @pytest.mark.bench_op("_scaled_dot_product_attention_math")
 def test_sdpa_math(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     refs, ours, flops = _qkv(shape_id, dtype_id, hw, mojo_device)
     bench.run(
         lambda: torch.ops.aten._scaled_dot_product_attention_math(
@@ -138,7 +138,7 @@ def test_sdpa_math(
 @pytest.mark.bench_op("_scaled_dot_product_flash_attention_backward")
 def test_sdpa_flash_backward(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     refs, ours, flops = _qkv(shape_id, dtype_id, hw, mojo_device)
     b, h, s, d = SHAPES[shape_id]
     g_ref, g_our = both(

--- a/benchmarks/test_attention.py
+++ b/benchmarks/test_attention.py
@@ -51,6 +51,20 @@ def _qkv(
     return (q_ref, k_ref, v_ref), (q_our, k_our, v_our), flops
 
 
+# aten::_scaled_dot_product_flash_attention outputs (max_q / max_k are ints).
+_FlashForwardOut = tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    int,
+    int,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]
+
+
 @pytest.mark.parametrize("dtype_id", ("bf16", "f16"))
 @pytest.mark.parametrize("shape_id", SHAPES)
 @pytest.mark.bench_op("scaled_dot_product_attention")
@@ -131,7 +145,7 @@ def test_sdpa_flash_backward(
         torch.randn(b, h, s, d, dtype=DTYPES[dtype_id]), hw, mojo_device
     )
 
-    def forward(leg: Sequence[torch.Tensor]) -> tuple:
+    def forward(leg: Sequence[torch.Tensor]) -> _FlashForwardOut:
         return torch.ops.aten._scaled_dot_product_flash_attention(
             *leg, 0.0, True, False
         )
@@ -144,7 +158,9 @@ def test_sdpa_flash_backward(
     except NotImplementedError as exc:
         pytest.skip(f"not supported on the mojo device: {exc}")
 
-    def backward(grad: torch.Tensor, leg: Sequence[torch.Tensor], fwd: tuple) -> tuple:
+    def backward(
+        grad: torch.Tensor, leg: Sequence[torch.Tensor], fwd: _FlashForwardOut
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         out, logsumexp, cum_q, cum_k, max_q, max_k, seed, offset, _ = fwd
         return torch.ops.aten._scaled_dot_product_flash_attention_backward(
             grad,

--- a/benchmarks/test_binary.py
+++ b/benchmarks/test_binary.py
@@ -129,7 +129,7 @@ def _pair(
 @pytest.mark.bench_op("bucketize.Tensor")
 def test_bucketize(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     value_shape, boundary_size = BUCKETIZE_SHAPES[shape_id]
     dtype = DTYPES[dtype_id]
     values_ref, values_our = both(
@@ -150,7 +150,7 @@ def test_bucketize(
 @pytest.mark.bench_op("searchsorted.Tensor")
 def test_searchsorted(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     rows, values_per_row, boundary_size = SEARCHSORTED_SHAPES[shape_id]
     dtype = DTYPES[dtype_id]
     boundaries = (
@@ -180,7 +180,7 @@ def test_arith(
     bench: Bench,
     hw: Hardware,
     mojo_device: torch.device,
-) -> None:
+):
     fn = ARITH_OPS[op_name]
     a_ref, b_ref, a_our, b_our = _pair(shape_id, dtype_id, layout, hw, mojo_device)
     bench.run(
@@ -198,7 +198,7 @@ def test_minmax(
     bench: Bench,
     hw: Hardware,
     mojo_device: torch.device,
-) -> None:
+):
     fn = MINMAX_OPS[op_name]
     a_ref, b_ref, a_our, b_our = _pair(shape_id, dtype_id, "contig", hw, mojo_device)
     bench.run(
@@ -218,7 +218,7 @@ def test_compare(
     bench: Bench,
     hw: Hardware,
     mojo_device: torch.device,
-) -> None:
+):
     fn = COMPARE_OPS[op_name]
     a_ref, b_ref, a_our, b_our = _pair(shape_id, dtype_id, "contig", hw, mojo_device)
     if layout == "Scalar":
@@ -245,7 +245,7 @@ def test_bitwise(
     bench: Bench,
     hw: Hardware,
     mojo_device: torch.device,
-) -> None:
+):
     fn = BITWISE_OPS[op_name]
     shape = SHAPES[shape_id]
     a_ref, a_our = both(
@@ -276,7 +276,7 @@ def test_logical(
     bench: Bench,
     hw: Hardware,
     mojo_device: torch.device,
-) -> None:
+):
     fn = LOGICAL_OPS[op_name]
     shape = SHAPES[shape_id]
     a_ref, a_our = both(torch.rand(shape) < 0.5, hw, mojo_device)
@@ -297,7 +297,7 @@ def test_pow(
     bench: Bench,
     hw: Hardware,
     mojo_device: torch.device,
-) -> None:
+):
     a_ref, b_ref, a_our, b_our = _pair(shape_id, dtype_id, "contig", hw, mojo_device)
     if layout == "Scalar":
         bench.run(
@@ -323,7 +323,7 @@ def test_floor_divide(
     bench: Bench,
     hw: Hardware,
     mojo_device: torch.device,
-) -> None:
+):
     a_ref, b_ref, a_our, b_our = _pair(shape_id, dtype_id, "contig", hw, mojo_device)
     if layout == "Scalar":
         bench.run(
@@ -349,7 +349,7 @@ def test_div_trunc_mode(
     bench: Bench,
     hw: Hardware,
     mojo_device: torch.device,
-) -> None:
+):
     """`torch.div(..., rounding_mode="trunc")` -- aten::div.Tensor_mode /
     div.Scalar_mode, a separate kernel (TruncDivSpec) from floor_divide's
     FloorDivSpec above despite the shared `div.Tensor_mode` overload for the
@@ -387,7 +387,7 @@ def test_remainder(
     bench: Bench,
     hw: Hardware,
     mojo_device: torch.device,
-) -> None:
+):
     a_ref, b_ref, a_our, b_our = _pair(shape_id, dtype_id, "contig", hw, mojo_device)
     if layout == "Scalar":
         bench.run(
@@ -408,7 +408,7 @@ def test_remainder(
 @pytest.mark.bench_op("lerp.Scalar")
 def test_lerp(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     a_ref, b_ref, a_our, b_our = _pair(shape_id, dtype_id, "contig", hw, mojo_device)
     bench.run(
         lambda: torch.lerp(a_ref, b_ref, 0.3),
@@ -421,7 +421,7 @@ def test_lerp(
 @pytest.mark.parametrize("shape_id", SHAPES)
 def test_clamp(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     shape = SHAPES[shape_id]
     a_ref, a_our = both(unit_interval(shape, DTYPES[dtype_id]), hw, mojo_device)
     bench.run(
@@ -435,7 +435,7 @@ def test_clamp(
 @pytest.mark.parametrize("shape_id", SHAPES)
 def test_addcdiv(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     shape = SHAPES[shape_id]
     dtype = DTYPES[dtype_id]
     a_ref, a_our = both(unit_interval(shape, dtype), hw, mojo_device)
@@ -452,7 +452,7 @@ def test_addcdiv(
 @pytest.mark.parametrize("shape_id", SHAPES)
 def test_addcmul(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     shape = SHAPES[shape_id]
     dtype = DTYPES[dtype_id]
     a_ref, a_our = both(unit_interval(shape, dtype), hw, mojo_device)
@@ -470,7 +470,7 @@ def test_addcmul(
 @pytest.mark.bench_op("where.self")
 def test_where(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     shape = SHAPES[shape_id]
     dtype = DTYPES[dtype_id]
     mask_ref, mask_our = both(torch.rand(shape) < 0.5, hw, mojo_device)
@@ -493,7 +493,7 @@ def test_masked_fill(
     bench: Bench,
     hw: Hardware,
     mojo_device: torch.device,
-) -> None:
+):
     shape = SHAPES[shape_id]
     dtype = DTYPES[dtype_id]
     a_ref, a_our = both(unit_interval(shape, dtype), hw, mojo_device)
@@ -518,7 +518,7 @@ def test_masked_fill(
 @pytest.mark.bench_op("isin.Tensor_Tensor")
 def test_isin(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     shape = SHAPES[shape_id]
     elements = torch.randint(0, 4096, shape, dtype=DTYPES[dtype_id])
     tests = torch.randint(0, 4096, (512,), dtype=DTYPES[dtype_id])

--- a/benchmarks/test_coverage.py
+++ b/benchmarks/test_coverage.py
@@ -154,7 +154,7 @@ SKIPPED_OPS: dict[str, str] = {
 }
 
 
-def test_every_registered_op_is_classified() -> None:
+def test_every_registered_op_is_classified():
     from torch_mojo_backend.mojo_device import mojo_device_aten_ops as reg
 
     registered = {name for name, _ in reg._aten_ops_registry}
@@ -249,7 +249,7 @@ def _diagnose(orphans: list[str], keys: set[str]) -> str:
     return "\n".join(lines)
 
 
-def test_every_recorded_baseline_is_still_addressable() -> None:
+def test_every_recorded_baseline_is_still_addressable():
     keys = _addressable_keys()
     assert keys, "the collection run found no benchmark nodes at all"
 

--- a/benchmarks/test_data_movement.py
+++ b/benchmarks/test_data_movement.py
@@ -81,7 +81,7 @@ SKIPPED: dict[str, str] = {}
 @pytest.mark.parametrize("shape_id", CAT_SHAPES)
 def test_cat(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     pieces, elems = CAT_SHAPES[shape_id]
     dtype = DTYPES[dtype_id]
     refs, ours = [], []
@@ -98,7 +98,7 @@ def test_cat(
 @pytest.mark.parametrize("shape_id", STACK_SHAPES)
 def test_stack(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     pieces, elems = STACK_SHAPES[shape_id]
     dtype = DTYPES[dtype_id]
     refs, ours = [], []
@@ -117,7 +117,7 @@ def test_stack(
 @pytest.mark.parametrize("shape_id", REPEAT_SHAPES)
 def test_repeat(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     rows, cols, reps = REPEAT_SHAPES[shape_id]
     x_ref, x_our = both(
         torch.randn(rows, cols, dtype=DTYPES[dtype_id]), hw, mojo_device
@@ -139,7 +139,7 @@ def test_clone(
     bench: Bench,
     hw: Hardware,
     mojo_device: torch.device,
-) -> None:
+):
     dtype = DTYPES[dtype_id]
     if layout == "T":
         base_ref, base_our = both(torch.randn(4096, 4096, dtype=dtype), hw, mojo_device)
@@ -154,7 +154,7 @@ def test_clone(
 @pytest.mark.parametrize("shape_id", TRI_SHAPES)
 def test_tril(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     x_ref, x_our = both(
         torch.randn(TRI_SHAPES[shape_id], dtype=DTYPES[dtype_id]), hw, mojo_device
     )
@@ -167,7 +167,7 @@ def test_tril(
 @pytest.mark.parametrize("shape_id", TRI_SHAPES)
 def test_triu(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     x_ref, x_our = both(
         torch.randn(TRI_SHAPES[shape_id], dtype=DTYPES[dtype_id]), hw, mojo_device
     )
@@ -180,7 +180,7 @@ def test_triu(
 @pytest.mark.parametrize("shape_id", (f"N_{ARANGE_N}",))
 def test_arange(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     dtype = DTYPES[dtype_id]
     bench.run(
         lambda: torch.arange(ARANGE_N, dtype=dtype, device=hw.stock_device),
@@ -201,7 +201,7 @@ CAST_TARGETS: dict[str, tuple[str, torch.dtype]] = {
 @pytest.mark.bench_op("_to_copy")
 def test_to_copy_cast(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     shape = (16777216,) if shape_id == "C_16777216" else (357, 789)
     _, target = CAST_TARGETS[dtype_id]
     x_ref, x_our = both(torch.randn(shape, dtype=DTYPES[dtype_id]), hw, mojo_device)

--- a/benchmarks/test_dropout_loss.py
+++ b/benchmarks/test_dropout_loss.py
@@ -45,7 +45,7 @@ SKIPPED: dict[str, str] = {}
 @pytest.mark.bench_op("native_dropout")
 def test_dropout(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     shape = DROPOUT_SHAPES[shape_id]
     x_ref, x_our = both(unit_interval(shape, DTYPES[dtype_id]), hw, mojo_device)
     bench.run(
@@ -60,7 +60,7 @@ def test_dropout(
 @pytest.mark.bench_op("native_dropout_backward")
 def test_dropout_backward(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     shape = DROPOUT_SHAPES[shape_id]
     g_ref, g_our = both(unit_interval(shape, DTYPES[dtype_id]), hw, mojo_device)
     mask_ref, mask_our = both(torch.rand(shape) < 0.5, hw, mojo_device)
@@ -89,7 +89,7 @@ def _nll_case(
 @pytest.mark.bench_op("nll_loss_forward")
 def test_nll_loss(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     lp_ref, lp_our, t_ref, t_our = _nll_case(shape_id, dtype_id, hw, mojo_device)
     bench.run(
         lambda: F.nll_loss(lp_ref, t_ref),
@@ -103,7 +103,7 @@ def test_nll_loss(
 @pytest.mark.bench_op("nll_loss_backward")
 def test_nll_loss_backward(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     lp_ref, lp_our, t_ref, t_our = _nll_case(shape_id, dtype_id, hw, mojo_device)
     # Synthetic grad/total_weight with the exact values nll_loss_forward
     # produces for mean reduction and no class weights (grad 1, total_weight

--- a/benchmarks/test_elementwise.py
+++ b/benchmarks/test_elementwise.py
@@ -75,7 +75,7 @@ def test_unary(
     bench: Bench,
     hw: Hardware,
     mojo_device: torch.device,
-) -> None:
+):
     fn = UNARY_OPS[op_name]
     shape = SHAPES[shape_id]
     x_ref, x_our = both(unit_interval(shape, DTYPES[dtype_id]), hw, mojo_device)
@@ -86,7 +86,7 @@ def test_unary(
 @pytest.mark.parametrize("shape_id", SHAPES)
 def test_bitwise_not(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     shape = SHAPES[shape_id]
     x_ref, x_our = both(
         torch.randint(-1000, 1000, shape, dtype=DTYPES[dtype_id]), hw, mojo_device
@@ -102,7 +102,7 @@ def test_bitwise_not(
 @pytest.mark.parametrize("shape_id", SHAPES)
 def test_logical_not(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     shape = SHAPES[shape_id]
     x_ref, x_our = both(torch.rand(shape) < 0.5, hw, mojo_device)
     bench.run(

--- a/benchmarks/test_embedding.py
+++ b/benchmarks/test_embedding.py
@@ -52,7 +52,7 @@ SKIPPED: dict[str, str] = {}
 @pytest.mark.parametrize("shape_id", EMB_SHAPES)
 def test_embedding(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     vocab, dim, tokens = EMB_SHAPES[shape_id]
     w_ref, w_our = both(
         torch.randn(vocab, dim, dtype=DTYPES[dtype_id]), hw, mojo_device
@@ -70,7 +70,7 @@ def test_embedding(
 @pytest.mark.bench_op("embedding_dense_backward")
 def test_embedding_backward(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     vocab, dim, tokens = EMB_SHAPES[shape_id]
     g_ref, g_our = both(
         torch.randn(tokens, dim, dtype=DTYPES[dtype_id]), hw, mojo_device
@@ -92,7 +92,7 @@ def test_embedding_backward(
 @pytest.mark.bench_op("index.Tensor")
 def test_index(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     rows, width, gathered = INDEX_SHAPES[shape_id]
     x_ref, x_our = both(
         torch.randn(rows, width, dtype=DTYPES[dtype_id]), hw, mojo_device
@@ -122,7 +122,7 @@ def _scatter_case(
 @pytest.mark.bench_op("scatter.src")
 def test_scatter_src(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     ref, our = _scatter_case(shape_id, dtype_id, hw, mojo_device)
     bench.run(
         lambda: ref["base"].scatter(0, ref["index"], ref["src"]),
@@ -136,7 +136,7 @@ def test_scatter_src(
 @pytest.mark.bench_op("scatter.value")
 def test_scatter_value(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     ref, our = _scatter_case(shape_id, dtype_id, hw, mojo_device)
     bench.run(
         lambda: ref["base"].scatter(0, ref["index"], 1.0),
@@ -149,7 +149,7 @@ def test_scatter_value(
 @pytest.mark.parametrize("shape_id", SELECT_SCATTER_SHAPES)
 def test_select_scatter(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     outer, rows, cols = SELECT_SCATTER_SHAPES[shape_id]
     dtype = DTYPES[dtype_id]
     x_ref, x_our = both(torch.randn(outer, rows, cols, dtype=dtype), hw, mojo_device)

--- a/benchmarks/test_foreach.py
+++ b/benchmarks/test_foreach.py
@@ -64,7 +64,7 @@ def _total(shape_id: str) -> float:
 @pytest.mark.bench_op("_foreach_add_.Scalar")
 def test_foreach_add_(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     ((ref, our),) = _lists(shape_id, hw, mojo_device)
     bench.run(
         lambda: torch._foreach_add_(ref, 1e-5),
@@ -78,7 +78,7 @@ def test_foreach_add_(
 @pytest.mark.bench_op("_foreach_addcdiv_.ScalarList")
 def test_foreach_addcdiv_(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     (ref, our), (t1_ref, t1_our), (t2_ref, t2_our) = _lists(
         shape_id, hw, mojo_device, count=3
     )
@@ -95,7 +95,7 @@ def test_foreach_addcdiv_(
 @pytest.mark.bench_op("_foreach_addcmul_.Scalar")
 def test_foreach_addcmul_(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     (ref, our), (t1_ref, t1_our), (t2_ref, t2_our) = _lists(
         shape_id, hw, mojo_device, count=3
     )
@@ -111,7 +111,7 @@ def test_foreach_addcmul_(
 @pytest.mark.bench_op("_foreach_div_.ScalarList")
 def test_foreach_div_(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     ((ref, our),) = _lists(shape_id, hw, mojo_device)
     scalars = [1.0001] * len(ref)
     bench.run(
@@ -126,7 +126,7 @@ def test_foreach_div_(
 @pytest.mark.bench_op("_foreach_lerp_.Scalar")
 def test_foreach_lerp_(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     (ref, our), (end_ref, end_our) = _lists(shape_id, hw, mojo_device, count=2)
     bench.run(
         lambda: torch._foreach_lerp_(ref, end_ref, 0.01),
@@ -140,7 +140,7 @@ def test_foreach_lerp_(
 @pytest.mark.bench_op("_foreach_mul_.Scalar")
 def test_foreach_mul_scalar(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     ((ref, our),) = _lists(shape_id, hw, mojo_device)
     bench.run(
         lambda: torch._foreach_mul_(ref, 1.0001),
@@ -154,7 +154,7 @@ def test_foreach_mul_scalar(
 @pytest.mark.bench_op("_foreach_mul_.Tensor")
 def test_foreach_mul_tensor(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     ((ref, our),) = _lists(shape_id, hw, mojo_device)
     m_ref, m_our = (
         torch.tensor(1.0001).to(hw.stock_device),
@@ -172,7 +172,7 @@ def test_foreach_mul_tensor(
 @pytest.mark.bench_op("_foreach_norm.Scalar")
 def test_foreach_norm(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     ((ref, our),) = _lists(shape_id, hw, mojo_device)
     bench.run(
         lambda: torch._foreach_norm(ref, 2.0),
@@ -186,7 +186,7 @@ def test_foreach_norm(
 @pytest.mark.bench_op("_foreach_sqrt")
 def test_foreach_sqrt(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     ((ref, our),) = _lists(shape_id, hw, mojo_device)
     bench.run(
         lambda: torch._foreach_sqrt(ref),
@@ -200,7 +200,7 @@ def test_foreach_sqrt(
 @pytest.mark.bench_op("_fused_adamw_")
 def test_fused_adamw(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     (
         (params_ref, params_our),
         (grads_ref, grads_our),
@@ -217,7 +217,7 @@ def test_fused_adamw(
         avgs: list[torch.Tensor],
         sqs: list[torch.Tensor],
         steps: list[torch.Tensor],
-    ) -> None:
+    ):
         torch.ops.aten._fused_adamw_(
             params,
             grads,

--- a/benchmarks/test_gemm.py
+++ b/benchmarks/test_gemm.py
@@ -124,7 +124,7 @@ def test_mm(
     bench: Bench,
     hw: Hardware,
     mojo_device: torch.device,
-) -> None:
+):
     m, n, k = SHAPES[shape_id]
     dtype, precision = DTYPES[dtype_id]
     with matmul_precision(precision):
@@ -147,7 +147,7 @@ def test_bmm(
     bench: Bench,
     hw: Hardware,
     mojo_device: torch.device,
-) -> None:
+):
     m, n, k = BMM_SHAPES[shape_id]
     dtype, precision = DTYPES[dtype_id]
     with matmul_precision(precision):
@@ -172,7 +172,7 @@ def test_addmm(
     bench: Bench,
     hw: Hardware,
     mojo_device: torch.device,
-) -> None:
+):
     m, n, k = SHAPES[shape_id]
     dtype, precision = DTYPES[dtype_id]
     with matmul_precision(precision):
@@ -193,7 +193,7 @@ def test_addmm(
 @pytest.mark.parametrize("shape_id", SHAPES)
 def test_linear(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     m, n, k = SHAPES[shape_id]
     dtype, precision = DTYPES[dtype_id]
     with matmul_precision(precision):
@@ -218,7 +218,7 @@ def test_linear(
 @pytest.mark.parametrize("shape_id", SHAPES)
 def test_linear_backward(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     m, n, k = SHAPES[shape_id]
     dtype, precision = DTYPES[dtype_id]
     with matmul_precision(precision):

--- a/benchmarks/test_inplace.py
+++ b/benchmarks/test_inplace.py
@@ -43,7 +43,7 @@ SKIPPED: dict[str, str] = {}
 @pytest.mark.bench_op("add_.Tensor")
 def test_add_(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     shape = SHAPES[shape_id]
     dtype = DTYPES[dtype_id]
     x_ref, x_our = both(unit_interval(shape, dtype), hw, mojo_device)
@@ -58,7 +58,7 @@ def test_add_(
 @pytest.mark.bench_op("mul_.Tensor")
 def test_mul_(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     shape = SHAPES[shape_id]
     dtype = DTYPES[dtype_id]
     x_ref, x_our = both(unit_interval(shape, dtype), hw, mojo_device)
@@ -76,7 +76,7 @@ def test_mul_(
 @pytest.mark.bench_op("relu_")
 def test_relu_(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     shape = SHAPES[shape_id]
     x_ref, x_our = both(unit_interval(shape, DTYPES[dtype_id]), hw, mojo_device)
     bench.run(lambda: x_ref.relu_(), lambda: x_our.relu_(), flops=float(x_ref.numel()))
@@ -87,7 +87,7 @@ def test_relu_(
 @pytest.mark.bench_op("fill_.Scalar")
 def test_fill_(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     shape = SHAPES[shape_id]
     x_ref, x_our = both(unit_interval(shape, DTYPES[dtype_id]), hw, mojo_device)
     bench.run(
@@ -100,7 +100,7 @@ def test_fill_(
 @pytest.mark.bench_op("uniform_")
 def test_uniform_(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     """A generated fill: same write traffic as fill_, plus the generator.
 
     Both legs draw from their own device's default generator (there is no
@@ -128,7 +128,7 @@ def test_masked_fill_(
     bench: Bench,
     hw: Hardware,
     mojo_device: torch.device,
-) -> None:
+):
     shape = SHAPES[shape_id]
     dtype = DTYPES[dtype_id]
     x_ref, x_our = both(unit_interval(shape, dtype), hw, mojo_device)

--- a/benchmarks/test_norm.py
+++ b/benchmarks/test_norm.py
@@ -45,7 +45,7 @@ SKIPPED: dict[str, str] = {}
 @pytest.mark.bench_op("native_layer_norm")
 def test_layer_norm(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     rows, dim = LN_SHAPES[shape_id]
     dtype = DTYPES[dtype_id]
     x_ref, x_our = both(torch.randn(rows, dim, dtype=dtype), hw, mojo_device)
@@ -63,7 +63,7 @@ def test_layer_norm(
 @pytest.mark.bench_op("native_layer_norm_backward")
 def test_layer_norm_backward(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     rows, dim = LN_SHAPES[shape_id]
     dtype = DTYPES[dtype_id]
     x_ref, x_our = both(torch.randn(rows, dim, dtype=dtype), hw, mojo_device)
@@ -111,7 +111,7 @@ def _bn_operands(
 @pytest.mark.bench_op("native_batch_norm")
 def test_batch_norm(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     refs, ours = _bn_operands(shape_id, dtype_id, hw, mojo_device)
     bench.run(
         lambda: torch.ops.aten.native_batch_norm(*refs, True, 0.1, 1e-5),
@@ -125,7 +125,7 @@ def test_batch_norm(
 @pytest.mark.bench_op("_native_batch_norm_legit_no_training")
 def test_batch_norm_inference(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     refs, ours = _bn_operands(shape_id, dtype_id, hw, mojo_device)
     bench.run(
         lambda: torch.ops.aten._native_batch_norm_legit_no_training(*refs, 0.1, 1e-5),
@@ -139,7 +139,7 @@ def test_batch_norm_inference(
 @pytest.mark.bench_op("native_group_norm")
 def test_group_norm(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     n, c, h, w, groups = GN_SHAPES[shape_id]
     dtype = DTYPES[dtype_id]
     x_ref, x_our = both(torch.randn(n, c, h, w, dtype=dtype), hw, mojo_device)

--- a/benchmarks/test_reduction.py
+++ b/benchmarks/test_reduction.py
@@ -76,7 +76,7 @@ def _dim_case(
 @pytest.mark.bench_op("sum.dim_IntList")
 def test_sum(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     x_ref, x_our, dim = _dim_case(shape_id, dtype_id, hw, mojo_device)
     d = 0 if dim is None else dim
     bench.run(
@@ -90,7 +90,7 @@ def test_sum(
 @pytest.mark.parametrize("shape_id", DIM_SHAPES)
 def test_mean(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     x_ref, x_our, dim = _dim_case(shape_id, dtype_id, hw, mojo_device)
     if dim is None:
         bench.run(
@@ -110,7 +110,7 @@ def test_mean(
 @pytest.mark.parametrize("shape_id", FULL_SHAPES)
 def test_max(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     x_ref, x_our = both(
         unit_interval(FULL_SHAPES[shape_id], DTYPES[dtype_id]), hw, mojo_device
     )
@@ -123,7 +123,7 @@ def test_max(
 @pytest.mark.parametrize("shape_id", FULL_SHAPES)
 def test_min(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     x_ref, x_our = both(
         unit_interval(FULL_SHAPES[shape_id], DTYPES[dtype_id]), hw, mojo_device
     )
@@ -136,7 +136,7 @@ def test_min(
 @pytest.mark.parametrize("shape_id", LASTDIM_SHAPES)
 def test_amax(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     shape, dim = LASTDIM_SHAPES[shape_id]
     x_ref, x_our = both(unit_interval(shape, DTYPES[dtype_id]), hw, mojo_device)
     bench.run(
@@ -150,7 +150,7 @@ def test_amax(
 @pytest.mark.parametrize("shape_id", LASTDIM_SHAPES)
 def test_amin(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     shape, dim = LASTDIM_SHAPES[shape_id]
     x_ref, x_our = both(unit_interval(shape, DTYPES[dtype_id]), hw, mojo_device)
     bench.run(
@@ -164,7 +164,7 @@ def test_amin(
 @pytest.mark.parametrize("shape_id", DIM_SHAPES)
 def test_argmax(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     x_ref, x_our, dim = _dim_case(shape_id, dtype_id, hw, mojo_device)
     bench.run(
         lambda: torch.argmax(x_ref, dim=dim),
@@ -177,7 +177,7 @@ def test_argmax(
 @pytest.mark.parametrize("shape_id", DIM_SHAPES)
 def test_argmin(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     x_ref, x_our, dim = _dim_case(shape_id, dtype_id, hw, mojo_device)
     bench.run(
         lambda: torch.argmin(x_ref, dim=dim),
@@ -190,7 +190,7 @@ def test_argmin(
 @pytest.mark.parametrize("shape_id", DIM_SHAPES)
 def test_all(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     shape, dim = DIM_SHAPES[shape_id]
     x_ref, x_our = both(torch.rand(shape) < 0.999, hw, mojo_device)
     if dim is None:
@@ -211,7 +211,7 @@ def test_all(
 @pytest.mark.parametrize("shape_id", DIM_SHAPES)
 def test_any(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     shape, dim = DIM_SHAPES[shape_id]
     x_ref, x_our = both(torch.rand(shape) < 0.001, hw, mojo_device)
     if dim is None:
@@ -233,7 +233,7 @@ def test_any(
 @pytest.mark.bench_op("min.dim")
 def test_min_dim(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     shape, dim = LASTDIM_SHAPES[shape_id]
     x_ref, x_our = both(unit_interval(shape, DTYPES[dtype_id]), hw, mojo_device)
     bench.run(
@@ -248,7 +248,7 @@ def test_min_dim(
 @pytest.mark.bench_op("var.correction")
 def test_var(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     x_ref, x_our, dim = _dim_case(shape_id, dtype_id, hw, mojo_device)
     if dim is None:
         bench.run(
@@ -269,7 +269,7 @@ def test_var(
 @pytest.mark.bench_op("linalg_vector_norm")
 def test_vector_norm(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     x_ref, x_our = both(
         unit_interval(FULL_SHAPES[shape_id], DTYPES[dtype_id]), hw, mojo_device
     )
@@ -284,7 +284,7 @@ def test_vector_norm(
 @pytest.mark.parametrize("shape_id", LASTDIM_SHAPES)
 def test_cumsum(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     shape, dim = LASTDIM_SHAPES[shape_id]
     x_ref, x_our = both(unit_interval(shape, DTYPES[dtype_id]), hw, mojo_device)
     bench.run(
@@ -298,7 +298,7 @@ def test_cumsum(
 @pytest.mark.parametrize("shape_id", FULL_SHAPES)
 def test_nonzero(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     # Fixed 50% density under the seeded fixture: the output size, and so
     # the kernel work, is identical on both legs and across runs.
     x_ref, x_our = both(torch.rand(FULL_SHAPES[shape_id]) < 0.5, hw, mojo_device)

--- a/benchmarks/test_softmax.py
+++ b/benchmarks/test_softmax.py
@@ -43,7 +43,7 @@ SKIPPED: dict[str, str] = {}
 @pytest.mark.bench_op("_softmax")
 def test_softmax(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     x_ref, x_our = both(
         torch.randn(SHAPES[shape_id], dtype=DTYPES[dtype_id]), hw, mojo_device
     )
@@ -59,7 +59,7 @@ def test_softmax(
 @pytest.mark.bench_op("_log_softmax")
 def test_log_softmax(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     x_ref, x_our = both(
         torch.randn(SHAPES[shape_id], dtype=DTYPES[dtype_id]), hw, mojo_device
     )
@@ -75,7 +75,7 @@ def test_log_softmax(
 @pytest.mark.bench_op("_log_softmax_backward_data")
 def test_log_softmax_backward(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     dtype = DTYPES[dtype_id]
     x_ref, x_our = both(torch.randn(SHAPES[shape_id], dtype=dtype), hw, mojo_device)
     g_ref, g_our = both(torch.randn(SHAPES[shape_id], dtype=dtype), hw, mojo_device)
@@ -92,7 +92,7 @@ def test_log_softmax_backward(
 @pytest.mark.parametrize("shape_id", ELEM_SHAPES)
 def test_gelu_backward(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     dtype = DTYPES[dtype_id]
     shape = ELEM_SHAPES[shape_id]
     x_ref, x_our = both(unit_interval(shape, dtype), hw, mojo_device)

--- a/benchmarks/test_vision.py
+++ b/benchmarks/test_vision.py
@@ -55,7 +55,7 @@ SKIPPED: dict[str, str] = {}
 @pytest.mark.bench_op("convolution")
 def test_conv2d(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     n, c_in, h, w, c_out, k, stride, pad = CONV_SHAPES[shape_id]
     dtype = DTYPES[dtype_id]
     x_ref, x_our = both(torch.randn(n, c_in, h, w, dtype=dtype), hw, mojo_device)
@@ -78,7 +78,7 @@ def test_conv2d(
 @pytest.mark.bench_op("_adaptive_avg_pool2d")
 def test_adaptive_avg_pool2d(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     n, c, h, w, out = ADAPTIVE_SHAPES[shape_id]
     x_ref, x_our = both(
         torch.randn(n, c, h, w, dtype=DTYPES[dtype_id]), hw, mojo_device
@@ -95,7 +95,7 @@ def test_adaptive_avg_pool2d(
 @pytest.mark.bench_op("avg_pool2d")
 def test_avg_pool2d(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     n, c, h, w, k, stride, pad = POOL_SHAPES[shape_id]
     x_ref, x_our = both(
         torch.randn(n, c, h, w, dtype=DTYPES[dtype_id]), hw, mojo_device
@@ -112,7 +112,7 @@ def test_avg_pool2d(
 @pytest.mark.bench_op("max_pool2d_with_indices")
 def test_max_pool2d(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     n, c, h, w, k, stride, pad = POOL_SHAPES[shape_id]
     x_ref, x_our = both(
         torch.randn(n, c, h, w, dtype=DTYPES[dtype_id]), hw, mojo_device
@@ -129,7 +129,7 @@ def test_max_pool2d(
 @pytest.mark.bench_op("upsample_bilinear2d")
 def test_upsample_bilinear2d(
     shape_id: str, dtype_id: str, bench: Bench, hw: Hardware, mojo_device: torch.device
-) -> None:
+):
     n, c, h, w = UPSAMPLE_SHAPES[shape_id]
     x_ref, x_our = both(
         torch.randn(n, c, h, w, dtype=DTYPES[dtype_id]), hw, mojo_device

--- a/demo_scripts/gemma3.py
+++ b/demo_scripts/gemma3.py
@@ -8,6 +8,7 @@ import torch
 import torch.nn as nn
 from huggingface_hub import hf_hub_download, snapshot_download
 from safetensors.torch import load_file
+from tokenizers import Tokenizer
 from torch._dynamo import mark_dynamic
 
 from torch_mojo_backend import mojo_backend
@@ -528,11 +529,11 @@ def load_weights_into_gemma(
         )
 
     # Iterate over transformer layers
-    for l in range(param_config["n_layers"]):
+    for layer in range(param_config["n_layers"]):
         # ModuleList.__getitem__ is typed as -> Module; narrow to the
         # concrete type actually stored (Gemma3Model.__init__ only ever
         # puts TransformerBlocks in `blocks`).
-        block = model.blocks[l]
+        block = model.blocks[layer]
         assert isinstance(block, TransformerBlock)
         att = block.att
         assert att.q_norm is not None
@@ -540,65 +541,65 @@ def load_weights_into_gemma(
         # Attention projections
         att.W_query.weight = assign(
             att.W_query.weight,
-            params[f"model.layers.{l}.self_attn.q_proj.weight"],
-            f"model.layers.{l}.self_attn.q_proj.weight",
+            params[f"model.layers.{layer}.self_attn.q_proj.weight"],
+            f"model.layers.{layer}.self_attn.q_proj.weight",
         )
         att.W_key.weight = assign(
             att.W_key.weight,
-            params[f"model.layers.{l}.self_attn.k_proj.weight"],
-            f"model.layers.{l}.self_attn.k_proj.weight",
+            params[f"model.layers.{layer}.self_attn.k_proj.weight"],
+            f"model.layers.{layer}.self_attn.k_proj.weight",
         )
         att.W_value.weight = assign(
             att.W_value.weight,
-            params[f"model.layers.{l}.self_attn.v_proj.weight"],
-            f"model.layers.{l}.self_attn.v_proj.weight",
+            params[f"model.layers.{layer}.self_attn.v_proj.weight"],
+            f"model.layers.{layer}.self_attn.v_proj.weight",
         )
         att.out_proj.weight = assign(
             att.out_proj.weight,
-            params[f"model.layers.{l}.self_attn.o_proj.weight"],
-            f"model.layers.{l}.self_attn.o_proj.weight",
+            params[f"model.layers.{layer}.self_attn.o_proj.weight"],
+            f"model.layers.{layer}.self_attn.o_proj.weight",
         )
         # QK normalization weights
         att.q_norm.scale = assign(
             att.q_norm.scale,
-            params[f"model.layers.{l}.self_attn.q_norm.weight"],
-            f"model.layers.{l}.self_attn.q_norm.weight",
+            params[f"model.layers.{layer}.self_attn.q_norm.weight"],
+            f"model.layers.{layer}.self_attn.q_norm.weight",
         )
         att.k_norm.scale = assign(
             att.k_norm.scale,
-            params[f"model.layers.{l}.self_attn.k_norm.weight"],
-            f"model.layers.{l}.self_attn.k_norm.weight",
+            params[f"model.layers.{layer}.self_attn.k_norm.weight"],
+            f"model.layers.{layer}.self_attn.k_norm.weight",
         )
         # Feed forward weights
         block.ff.fc1.weight = assign(
             block.ff.fc1.weight,
-            params[f"model.layers.{l}.mlp.gate_proj.weight"],
-            f"model.layers.{l}.mlp.gate_proj.weight",
+            params[f"model.layers.{layer}.mlp.gate_proj.weight"],
+            f"model.layers.{layer}.mlp.gate_proj.weight",
         )
         block.ff.fc2.weight = assign(
             block.ff.fc2.weight,
-            params[f"model.layers.{l}.mlp.up_proj.weight"],
-            f"model.layers.{l}.mlp.up_proj.weight",
+            params[f"model.layers.{layer}.mlp.up_proj.weight"],
+            f"model.layers.{layer}.mlp.up_proj.weight",
         )
         block.ff.fc3.weight = assign(
             block.ff.fc3.weight,
-            params[f"model.layers.{l}.mlp.down_proj.weight"],
-            f"model.layers.{l}.mlp.down_proj.weight",
+            params[f"model.layers.{layer}.mlp.down_proj.weight"],
+            f"model.layers.{layer}.mlp.down_proj.weight",
         )
         # LayerNorm weights
         block.input_layernorm.scale = assign(
             block.input_layernorm.scale,
-            params[f"model.layers.{l}.input_layernorm.weight"],
-            f"model.layers.{l}.input_layernorm.weight",
+            params[f"model.layers.{layer}.input_layernorm.weight"],
+            f"model.layers.{layer}.input_layernorm.weight",
         )
         block.post_attention_layernorm.scale = assign(
             block.post_attention_layernorm.scale,
-            params[f"model.layers.{l}.post_attention_layernorm.weight"],
-            f"model.layers.{l}.post_attention_layernorm.weight",
+            params[f"model.layers.{layer}.post_attention_layernorm.weight"],
+            f"model.layers.{layer}.post_attention_layernorm.weight",
         )
         # Pre‑ and post‑feed forward norms
-        pre_key = f"model.layers.{l}.pre_feedforward_layernorm.weight"
-        post_key = f"model.layers.{l}.post_feedforward_layernorm.weight"
+        pre_key = f"model.layers.{layer}.pre_feedforward_layernorm.weight"
+        post_key = f"model.layers.{layer}.post_feedforward_layernorm.weight"
         if pre_key in params:
             block.pre_feedforward_layernorm.scale = assign(
                 block.pre_feedforward_layernorm.scale, params[pre_key], pre_key
@@ -657,9 +658,6 @@ else:
 load_weights_into_gemma(model, GEMMA3_CONFIG_270M, weights_dict)
 model.to(device)
 del weights_dict
-
-
-from tokenizers import Tokenizer
 
 
 class GemmaTokenizer:

--- a/demo_scripts/gemma3.py
+++ b/demo_scripts/gemma3.py
@@ -40,7 +40,7 @@ class GemmaConfig(TypedDict):
 
 
 class FeedForward(nn.Module):
-    def __init__(self, cfg: GemmaConfig) -> None:
+    def __init__(self, cfg: GemmaConfig):
         super().__init__()
         self.fc1 = nn.Linear(
             cfg["emb_dim"], cfg["hidden_dim"], dtype=cfg["dtype"], bias=False
@@ -60,7 +60,7 @@ class FeedForward(nn.Module):
 
 
 class RMSNorm(nn.Module):
-    def __init__(self, emb_dim: int, eps: float = 1e-6, bias: bool = False) -> None:
+    def __init__(self, emb_dim: int, eps: float = 1e-6, bias: bool = False):
         super().__init__()
         self.eps = eps
         # Gemma3 stores zero-centered weights and uses (1 + weight) during forward
@@ -147,7 +147,7 @@ class GroupedQueryAttention(nn.Module):
         qk_norm: bool = False,
         query_pre_attn_scalar: float | None = None,
         dtype: torch.dtype | None = None,
-    ) -> None:
+    ):
         super().__init__()
         assert num_heads % num_kv_groups == 0, (
             "num_heads must be divisible by num_kv_groups"
@@ -235,7 +235,7 @@ class GroupedQueryAttention(nn.Module):
 
 
 class TransformerBlock(nn.Module):
-    def __init__(self, cfg: GemmaConfig, attn_type: str) -> None:
+    def __init__(self, cfg: GemmaConfig, attn_type: str):
         super().__init__()
         self.attn_type = attn_type
 
@@ -298,7 +298,7 @@ class Gemma3Model(nn.Module):
     cos_global: torch.Tensor
     sin_global: torch.Tensor
 
-    def __init__(self, cfg: GemmaConfig) -> None:
+    def __init__(self, cfg: GemmaConfig):
         super().__init__()
         assert (
             cfg["layer_types"] is not None
@@ -506,7 +506,7 @@ model.to(device)
 
 def load_weights_into_gemma(
     model: Gemma3Model, param_config: GemmaConfig, params: dict[str, torch.Tensor]
-) -> None:
+):
     def assign(
         left: torch.Tensor, right: torch.Tensor, tensor_name: str = "unknown"
     ) -> nn.Parameter:
@@ -661,7 +661,7 @@ del weights_dict
 
 
 class GemmaTokenizer:
-    def __init__(self, tokenizer_file_path: str) -> None:
+    def __init__(self, tokenizer_file_path: str):
         tok_file = Path(tokenizer_file_path)
         self._tok = Tokenizer.from_file(str(tok_file))
         # Attempt to identify EOS and padding tokens

--- a/demo_scripts/gpt2.py
+++ b/demo_scripts/gpt2.py
@@ -26,7 +26,7 @@ class GPTConfig:
         n_head: int,
         n_embd: int,
         **kwargs: object,
-    ) -> None:
+    ):
         self.vocab_size = vocab_size
         self.block_size = block_size
         self.n_layer = n_layer
@@ -41,7 +41,7 @@ class CausalSelfAttention(nn.Module):
     # give the type checker anything to infer the attribute's type from.
     bias: torch.Tensor
 
-    def __init__(self, config: GPTConfig) -> None:
+    def __init__(self, config: GPTConfig):
         super().__init__()
         assert config.n_embd % config.n_head == 0
 
@@ -81,7 +81,7 @@ class CausalSelfAttention(nn.Module):
 
 
 class MLP(nn.Module):
-    def __init__(self, config: GPTConfig) -> None:
+    def __init__(self, config: GPTConfig):
         super().__init__()
         self.c_fc = nn.Linear(config.n_embd, 4 * config.n_embd, bias=True)
         self.c_proj = nn.Linear(4 * config.n_embd, config.n_embd, bias=True)
@@ -96,7 +96,7 @@ class MLP(nn.Module):
 
 
 class Block(nn.Module):
-    def __init__(self, config: GPTConfig) -> None:
+    def __init__(self, config: GPTConfig):
         super().__init__()
         self.ln_1 = nn.LayerNorm(config.n_embd)
         self.attn = CausalSelfAttention(config)
@@ -110,7 +110,7 @@ class Block(nn.Module):
 
 
 class GPT2(nn.Module):
-    def __init__(self, config: GPTConfig) -> None:
+    def __init__(self, config: GPTConfig):
         super().__init__()
         assert config.vocab_size is not None
         assert config.block_size is not None
@@ -141,7 +141,7 @@ class GPT2(nn.Module):
                     p, mean=0.0, std=0.02 / math.sqrt(2 * config.n_layer)
                 )
 
-    def _init_weights(self, module: nn.Module) -> None:
+    def _init_weights(self, module: nn.Module):
         if isinstance(module, nn.Linear):
             torch.nn.init.normal_(module.weight, mean=0.0, std=0.02)
             if module.bias is not None:
@@ -324,7 +324,7 @@ def load_tokenizer() -> Tokenizer:
         print("tiktoken not found, using simple character-level tokenizer")
 
         class SimpleTokenizer:
-            def __init__(self) -> None:
+            def __init__(self):
                 self.vocab = {chr(i): i for i in range(256)}
                 self.vocab.update({"<|endoftext|>": 50256})
                 self.inv_vocab = {v: k for k, v in self.vocab.items()}
@@ -338,7 +338,7 @@ def load_tokenizer() -> Tokenizer:
         return SimpleTokenizer()
 
 
-def main() -> None:
+def main():
     device = "cuda" if len(list(get_accelerators())) >= 2 else "cpu"
     print(f"Using device: {device}")
 

--- a/demo_scripts/mnist.py
+++ b/demo_scripts/mnist.py
@@ -29,7 +29,7 @@ os.environ["TORCH_MOJO_BACKEND_VERBOSE"] = "0"
 class SimpleNet(nn.Module):
     """Simple feedforward neural network for MNIST classification."""
 
-    def __init__(self) -> None:
+    def __init__(self):
         super().__init__()
         # Input: 28x28 = 784 pixels
         self.fc1 = nn.Linear(784, 128)
@@ -124,7 +124,7 @@ def evaluate(
     return avg_loss, accuracy
 
 
-def main() -> None:
+def main():
     # Hyperparameters
     batch_size = 64
     test_batch_size = 1000

--- a/demo_scripts/mnist.py
+++ b/demo_scripts/mnist.py
@@ -52,7 +52,7 @@ class SimpleNet(nn.Module):
 def train_epoch(
     model: nn.Module,
     device: torch.device,
-    train_loader: DataLoader,
+    train_loader: DataLoader[tuple[torch.Tensor, torch.Tensor]],
     optimizer: optim.Optimizer,
     criterion: nn.Module,
     epoch: int,
@@ -101,7 +101,7 @@ def train_epoch(
 def evaluate(
     model: nn.Module,
     device: torch.device,
-    test_loader: DataLoader,
+    test_loader: DataLoader[tuple[torch.Tensor, torch.Tensor]],
     criterion: nn.Module,
 ) -> tuple[float, float]:
     """Evaluate the model on test data."""

--- a/demo_scripts/vgg.py
+++ b/demo_scripts/vgg.py
@@ -56,7 +56,7 @@ def load_imagenet_labels() -> list[str]:
     return labels
 
 
-def predict_image(image_path_or_url: str, top_k: int = 5) -> None:
+def predict_image(image_path_or_url: str, top_k: int = 5):
     image = load_image(image_path_or_url)
 
     input_tensor = preprocess(image)

--- a/demo_scripts/vgg_export.py
+++ b/demo_scripts/vgg_export.py
@@ -60,7 +60,7 @@ def load_imagenet_labels() -> list[str]:
     return labels
 
 
-def predict_image(image_path_or_url: str, top_k: int = 5) -> None:
+def predict_image(image_path_or_url: str, top_k: int = 5):
     image = load_image(image_path_or_url)
 
     input_tensor = preprocess(image)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,11 +31,18 @@ target-version = "py311"
 extend-exclude = ["deeplink"]
 
 [tool.ruff.lint]
-select = [
-    "F",   # pyflakes (includes unused imports)
+# extend-select keeps ruff's default rule set (E4, E7, E9, F) enabled.
+extend-select = [
     "UP",  # pyupgrade
     "ANN", # flake8-annotations: every function needs type hints (ty then checks them)
+    "TID252", # relative imports (banned below)
 ]
+
+[tool.ruff.lint.flake8-annotations]
+suppress-none-returning = true
+
+[tool.ruff.lint.flake8-tidy-imports]
+ban-relative-imports = "all"
 
 [tool.ruff.lint.per-file-ignores]
 # ty infers unannotated params/returns as Unknown and never flags their misuse,
@@ -69,6 +76,8 @@ python = ".venv"
 # exits non-zero on warnings too (no `--exit-zero-on-warning` in CI), so
 # this must be "ignore", not "warn", to keep `ty check` green.
 invalid-method-override = "ignore"
+# Bare `dict`/`list`/`Callable` is an unchecked hole: require the arguments.
+missing-type-argument = "error"
 
 [tool.ty.src]
 exclude = [
@@ -85,6 +94,7 @@ exclude = [
 python-preference = "only-managed"
 
 [tool.ruff.format]
+line-ending = "lf"
 skip-magic-trailing-comma = true
 
 [dependency-groups]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+# ruff: noqa: E402 -- the environment variables below must be set before the imports
 import math
 import os
 from collections.abc import Callable

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -186,7 +186,7 @@ def call_checker():
     call_checker_instance.check_was_called()
 
 
-def require_cuda_autograd(device: str) -> None:
+def require_cuda_autograd(device: str):
     """Skip when this process can no longer run a CUDA backward.
 
     `at::getAccelerator()` names exactly one accelerator device type, and it

--- a/tests/models/test_mnist.py
+++ b/tests/models/test_mnist.py
@@ -16,7 +16,7 @@ import torch.nn.functional as F
 from torch_mojo_backend import mojo_backend
 from torch_mojo_backend.testing import check_functions_are_equivalent
 
-from ..conftest import require_cuda_autograd
+from tests.conftest import require_cuda_autograd
 
 # TF32 keeps 10 explicit mantissa bits, so its unit roundoff is 2**-11.
 _TF32_UNIT_ROUNDOFF = 2.0**-11

--- a/tests/test_aten_functions.py
+++ b/tests/test_aten_functions.py
@@ -584,7 +584,9 @@ def test_aten_ones_like(conf: Conf, call_checker: CallChecker, dtype: torch.dtyp
 
 
 @pytest.mark.parametrize("shape", [(1,), (4, 5), (2, 3, 7)])
-def test_aten_ones_like_shape(conf: Conf, call_checker: CallChecker, shape: tuple):
+def test_aten_ones_like_shape(
+    conf: Conf, call_checker: CallChecker, shape: tuple[int, ...]
+):
     call_checker.register(aten_functions.aten_ones_like)
 
     def fn(x):
@@ -1759,7 +1761,9 @@ TRIGON_FUNCTIONS = [aten.asinh, aten.cosh, aten.sinh, aten.tan, aten.tanh]
 
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float64, torch.bfloat16])
 @pytest.mark.parametrize("fn", TRIGON_FUNCTIONS)
-def test_aten_trigon_basic(conf: Conf, fn: Callable, dtype: torch.dtype):
+def test_aten_trigon_basic(
+    conf: Conf, fn: Callable[[torch.Tensor], torch.Tensor], dtype: torch.dtype
+):
     """Test trigonometric functions basic functionality with floating point numbers"""
 
     if dtype == torch.float64 and fn in (aten.asinh, aten.tan):
@@ -1774,7 +1778,7 @@ def test_aten_trigon_basic(conf: Conf, fn: Callable, dtype: torch.dtype):
 
 
 @pytest.mark.parametrize("fn", TRIGON_FUNCTIONS)
-def test_aten_trigon_2d_tensor(conf: Conf, fn: Callable):
+def test_aten_trigon_2d_tensor(conf: Conf, fn: Callable[[torch.Tensor], torch.Tensor]):
     """Test trigonometric functions with 2D tensor"""
 
     x = torch.tensor([[-1.5, -0.5], [0.0, 1.0], [1.5, 2.5]], dtype=torch.float32)
@@ -1782,7 +1786,7 @@ def test_aten_trigon_2d_tensor(conf: Conf, fn: Callable):
 
 
 @pytest.mark.parametrize("fn", TRIGON_FUNCTIONS)
-def test_aten_trigon_3d_tensor(conf: Conf, fn: Callable):
+def test_aten_trigon_3d_tensor(conf: Conf, fn: Callable[[torch.Tensor], torch.Tensor]):
     """Test trigonometric functions with 3D tensor"""
 
     x = torch.randn(2, 3, 4, dtype=torch.float32)
@@ -1790,7 +1794,9 @@ def test_aten_trigon_3d_tensor(conf: Conf, fn: Callable):
 
 
 @pytest.mark.parametrize("fn", TRIGON_FUNCTIONS)
-def test_aten_trigon_large_values(conf: Conf, fn: Callable):
+def test_aten_trigon_large_values(
+    conf: Conf, fn: Callable[[torch.Tensor], torch.Tensor]
+):
     """Test trigonometric functions with large values (may approach infinity)"""
 
     # large values will produce large results due to exponential growth
@@ -1799,7 +1805,9 @@ def test_aten_trigon_large_values(conf: Conf, fn: Callable):
 
 
 @pytest.mark.parametrize("fn", TRIGON_FUNCTIONS)
-def test_aten_trigon_small_values(conf: Conf, fn: Callable):
+def test_aten_trigon_small_values(
+    conf: Conf, fn: Callable[[torch.Tensor], torch.Tensor]
+):
     """Test trigonometric functions with small values near zero"""
 
     # for small x, cosh(x) ≈ 1 + x²/2
@@ -1808,7 +1816,9 @@ def test_aten_trigon_small_values(conf: Conf, fn: Callable):
 
 
 @pytest.mark.parametrize("fn", TRIGON_FUNCTIONS)
-def test_aten_trigon_single_element(conf: Conf, fn: Callable):
+def test_aten_trigon_single_element(
+    conf: Conf, fn: Callable[[torch.Tensor], torch.Tensor]
+):
     """Test trigonometric functions with single element tensor"""
 
     x = torch.tensor([1.5], dtype=torch.float32)
@@ -1816,7 +1826,9 @@ def test_aten_trigon_single_element(conf: Conf, fn: Callable):
 
 
 @pytest.mark.parametrize("fn", TRIGON_FUNCTIONS)
-def test_aten_trigon_scalar_tensor(conf: Conf, fn: Callable):
+def test_aten_trigon_scalar_tensor(
+    conf: Conf, fn: Callable[[torch.Tensor], torch.Tensor]
+):
     """Test trigonometric functions with scalar tensor"""
 
     x = torch.tensor(1.0, dtype=torch.float32)
@@ -2256,7 +2268,7 @@ def test_aten_repeat_interleave_3d(device: str):
 
 
 @pytest.mark.parametrize("shape", [(1, 5), (5, 1), (1, 1)])
-def test_aten_repeat_interleave_edge_cases(device: str, shape: tuple):
+def test_aten_repeat_interleave_edge_cases(device: str, shape: tuple[int, ...]):
     """Test aten.repeat_interleave with edge case shapes"""
 
     def fn(x):
@@ -3051,7 +3063,7 @@ def test_aten_square_basic(conf: Conf, dtype: torch.dtype):
 
 
 @pytest.mark.parametrize("shape", [(5,), (3, 4), (2, 3, 4), (2, 3, 4, 5)])
-def test_aten_square_different_shapes(conf: Conf, shape: tuple):
+def test_aten_square_different_shapes(conf: Conf, shape: tuple[int, ...]):
     """Test aten.square with different tensor shapes"""
 
     def fn(x):
@@ -3200,7 +3212,7 @@ def test_aten_squeeze_empty_dims(device: str):
 
 
 @pytest.mark.parametrize("shape", [(1,), (1, 1), (1, 1, 1)])
-def test_aten_squeeze_edge_cases(device: str, shape: tuple):
+def test_aten_squeeze_edge_cases(device: str, shape: tuple[int, ...]):
     """Test aten.squeeze with edge case shapes"""
 
     def fn(x):
@@ -3232,7 +3244,7 @@ def test_aten_triu_different_diagonals(conf: Conf, diagonal: int):
 
 
 @pytest.mark.parametrize("shape", [(3, 5), (5, 3), (7, 7)])
-def test_aten_triu_rectangular(conf: Conf, shape: tuple):
+def test_aten_triu_rectangular(conf: Conf, shape: tuple[int, ...]):
     """Test aten.triu with rectangular matrices"""
 
     def fn(x):
@@ -3486,7 +3498,9 @@ def test_aten_logical_and_scalar_like(conf: Conf):
 @pytest.mark.parametrize(
     "shape_pair", [((3, 1), (3, 4)), ((1, 4), (3, 4)), ((3, 1, 1), (3, 4, 5))]
 )
-def test_aten_logical_and_broadcasting_shapes(conf: Conf, shape_pair: tuple):
+def test_aten_logical_and_broadcasting_shapes(
+    conf: Conf, shape_pair: tuple[tuple[int, ...], tuple[int, ...]]
+):
     """Test aten.logical_and with various broadcasting shapes"""
 
     def fn(x, y):
@@ -3932,7 +3946,7 @@ def test_aten_var_correction(conf: Conf, correction: int, call_checker: CallChec
 @pytest.mark.parametrize("dim", [(0, 1), (1, 2), (0, 2)])
 @pytest.mark.parametrize("keepdim", [True, False])
 def test_aten_var_multi_dim(
-    conf: Conf, dim: tuple, keepdim: bool, call_checker: CallChecker
+    conf: Conf, dim: tuple[int, ...], keepdim: bool, call_checker: CallChecker
 ):
     """Test aten.var reducing over multiple dimensions"""
     call_checker.register(aten_functions.aten_var)
@@ -3958,7 +3972,7 @@ def test_aten_var_correction_zero_no_dim(conf: Conf, call_checker: CallChecker):
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
 @pytest.mark.parametrize("shape", [(5,), (3, 4), (2, 3, 4)])
 def test_aten_silu(
-    conf: Conf, dtype: torch.dtype, shape: tuple, call_checker: CallChecker
+    conf: Conf, dtype: torch.dtype, shape: tuple[int, ...], call_checker: CallChecker
 ):
     """Test aten.silu (x * sigmoid(x)) across dtypes and shapes"""
     call_checker.register(aten_functions.aten_silu)
@@ -3976,7 +3990,7 @@ def test_aten_silu(
 def test_fill_scalar_basic(
     conf: Conf,
     dtype: torch.dtype,
-    shape: tuple,
+    shape: tuple[int, ...],
     value: float,
     call_checker: CallChecker,
 ):
@@ -4000,7 +4014,11 @@ def test_fill_scalar_basic(
 @pytest.mark.parametrize("shape", [(2, 3), (1, 4, 4)])
 @pytest.mark.parametrize("value", [-5, 42])
 def test_fill_scalar_integer_dtypes(
-    conf: Conf, dtype: torch.dtype, shape: tuple, value: int, call_checker: CallChecker
+    conf: Conf,
+    dtype: torch.dtype,
+    shape: tuple[int, ...],
+    value: int,
+    call_checker: CallChecker,
 ):
     """Test fill.Scalar functionality with integer dtypes"""
     from torch_mojo_backend.eager_kernels import aten_fast

--- a/tests/test_aten_functions.py
+++ b/tests/test_aten_functions.py
@@ -218,7 +218,7 @@ def test_scaled_dot_product_attention_bool_mask(conf: Conf, call_checker: CallCh
 @pytest.mark.parametrize("mask_batch", [1, 2])
 def test_scaled_dot_product_attention_cross_attention_4d_mask(
     conf: Conf, call_checker: CallChecker, mask_batch: int
-) -> None:
+):
     """Cross attention (key length != query length) with a rank-4 mask.
 
     ``mask_batch=1`` additionally exercises a mask that broadcasts over the
@@ -2444,7 +2444,7 @@ def test_aten_bucketize_tensor(
     dtype: torch.dtype,
     right: bool,
     out_int32: bool,
-) -> None:
+):
     register_mojo_devices()
     call_checker.register(aten_functions.aten_bucketize)
 
@@ -2468,7 +2468,7 @@ def test_aten_searchsorted_batched(
     dtype: torch.dtype,
     side: str,
     out_int32: bool,
-) -> None:
+):
     register_mojo_devices()
     call_checker.register(aten_functions.aten_searchsorted)
 
@@ -2487,7 +2487,7 @@ def test_aten_searchsorted_batched(
 )
 def test_aten_searchsorted_sorter(
     mojo_device: str, call_checker: CallChecker, dtype: torch.dtype
-) -> None:
+):
     register_mojo_devices()
     call_checker.register(aten_functions.aten_searchsorted)
 
@@ -2515,7 +2515,7 @@ def test_aten_searchsorted_dtype_promotion(
     call_checker: CallChecker,
     boundary_dtype: torch.dtype,
     value_dtype: torch.dtype,
-) -> None:
+):
     register_mojo_devices()
     call_checker.register(aten_functions.aten_searchsorted)
 
@@ -2530,7 +2530,7 @@ def test_aten_searchsorted_dtype_promotion(
 @pytest.mark.parametrize("out_int32", [False, True])
 def test_aten_searchsorted_and_bucketize_scalar_overloads(
     conf: Conf, call_checker: CallChecker, out_int32: bool
-) -> None:
+):
     call_checker.register(
         aten_functions.aten_searchsorted, aten_functions.aten_bucketize
     )
@@ -2552,7 +2552,7 @@ def test_aten_searchsorted_and_bucketize_scalar_overloads(
 @pytest.mark.parametrize("right", [False, True])
 def test_aten_searchsorted_and_bucketize_empty_edges(
     conf: Conf, call_checker: CallChecker, right: bool
-) -> None:
+):
     call_checker.register(
         aten_functions.aten_searchsorted, aten_functions.aten_bucketize
     )
@@ -2591,7 +2591,7 @@ def test_aten_searchsorted_and_bucketize_empty_edges(
 
 def test_aten_searchsorted_and_bucketize_eager_cpu_and_gpu(
     mojo_device: str, call_checker: CallChecker
-) -> None:
+):
     register_mojo_devices()
     call_checker.register(
         aten_functions.aten_searchsorted, aten_functions.aten_bucketize
@@ -2613,7 +2613,7 @@ def test_aten_searchsorted_and_bucketize_eager_cpu_and_gpu(
 @pytest.mark.parametrize("right", [False, True])
 def test_aten_searchsorted_and_bucketize_nan_boundaries_eager(
     mojo_device: str, call_checker: CallChecker, right: bool
-) -> None:
+):
     register_mojo_devices()
     call_checker.register(
         aten_functions.aten_searchsorted, aten_functions.aten_bucketize
@@ -2635,7 +2635,7 @@ def test_aten_searchsorted_and_bucketize_nan_boundaries_eager(
 @pytest.mark.parametrize("out_int32", [False, True])
 def test_aten_searchsorted_and_bucketize_out_variants(
     mojo_device: str, call_checker: CallChecker, out_int32: bool
-) -> None:
+):
     register_mojo_devices()
     call_checker.register(
         aten_functions.aten_searchsorted, aten_functions.aten_bucketize
@@ -2681,7 +2681,7 @@ def test_aten_searchsorted_and_bucketize_out_variants(
 
 def test_aten_searchsorted_and_bucketize_errors(
     mojo_device: str, call_checker: CallChecker
-) -> None:
+):
     register_mojo_devices()
     call_checker.register(
         aten_functions.aten_searchsorted, aten_functions.aten_bucketize
@@ -2717,9 +2717,7 @@ def test_aten_searchsorted_and_bucketize_errors(
         aten.bucketize.Tensor(values, boundaries.unsqueeze(0))
 
 
-def test_aten_searchsorted_and_bucketize_compile_backend(
-    call_checker: CallChecker,
-) -> None:
+def test_aten_searchsorted_and_bucketize_compile_backend(call_checker: CallChecker):
     call_checker.register(
         aten_functions.aten_searchsorted, aten_functions.aten_bucketize
     )
@@ -2754,7 +2752,7 @@ def test_aten_searchsorted_and_bucketize_compile_backend(
 @pytest.mark.parametrize("right", [False, True])
 def test_aten_searchsorted_and_bucketize_nan_boundaries_compile_backend(
     call_checker: CallChecker, right: bool
-) -> None:
+):
     call_checker.register(
         aten_functions.aten_searchsorted, aten_functions.aten_bucketize
     )
@@ -2772,7 +2770,7 @@ def test_aten_searchsorted_and_bucketize_nan_boundaries_compile_backend(
     check_outputs(fn, Conf("cpu", True), [boundaries, values])
 
 
-def test_aten_searchsorted_compile_backend_declines_unchecked_sorter() -> None:
+def test_aten_searchsorted_compile_backend_declines_unchecked_sorter():
     def fn(
         boundaries: torch.Tensor, values: torch.Tensor, sorter: torch.Tensor
     ) -> torch.Tensor:

--- a/tests/test_call_queue.py
+++ b/tests/test_call_queue.py
@@ -75,7 +75,7 @@ class _StalledBuild:
     """Make one loaded unit look like it is still compiling, releasable on
     demand — a deterministic stand-in for a slow `mojo build`."""
 
-    def __init__(self, unit: eager_kernels._DefinedUnit) -> None:
+    def __init__(self, unit: eager_kernels._DefinedUnit):
         unit.load_blocking()  # make sure the real defined extension exists
         self._unit = unit
         self._module = unit.module
@@ -99,7 +99,7 @@ class _StalledBuild:
     def _request(self) -> "_FakeJob":
         return self._job
 
-    def release(self) -> None:
+    def release(self):
         unit = self._unit
         if unit.module is None:
             unit.module = self._module
@@ -108,10 +108,10 @@ class _StalledBuild:
 
 
 class _FakeJob:
-    def __init__(self, stall: _StalledBuild) -> None:
+    def __init__(self, stall: _StalledBuild):
         self._stall = stall
 
-    def wait(self) -> None:
+    def wait(self):
         # A blocking drain releases the "build" (as a finished compile would).
         self._stall.release()
 
@@ -126,7 +126,7 @@ class _StalledUnits:
     the test never waits on a compiler.
     """
 
-    def __init__(self, monkeypatch: pytest.MonkeyPatch, limit: int | None) -> None:
+    def __init__(self, monkeypatch: pytest.MonkeyPatch, limit: int | None):
         loader = eager_kernels.MOJO_EXTENSION_LOADER
         original = loader.unit_canonical
         self.stalls: list[_StalledBuild] = []
@@ -145,7 +145,7 @@ class _StalledUnits:
 
         monkeypatch.setattr(loader, "unit_canonical", unit_canonical)
 
-    def release(self) -> None:
+    def release(self):
         for stall in self.stalls:
             stall.release()
 
@@ -165,12 +165,12 @@ def _prepare_add(
 
 
 class _FakeExtension:
-    def __init__(self, log: list[str], error: BaseException | None = None) -> None:
+    def __init__(self, log: list[str], error: BaseException | None = None):
         self._log = log
         self._error = error
         self.calls = 0
 
-    def call(self, label: str) -> None:
+    def call(self, label: str):
         self.calls += 1
         self._log.append(label)
         if self._error is not None:
@@ -187,7 +187,7 @@ class _FakeUnit:
         ready: bool = False,
         error: BaseException | None = None,
         build_error: BaseException | None = None,
-    ) -> None:
+    ):
         self.extension: _FakeExtension = _FakeExtension(log, error)
         self.ext: object | None = self.extension if ready else None
         self.build_error = build_error
@@ -197,12 +197,12 @@ class _FakeUnit:
         self.builds += 1
         return self  # doubles as its own job: `wait()` completes the build
 
-    def wait(self) -> None:
+    def wait(self):
         if self.build_error is not None:
             raise self.build_error
         self.ready()
 
-    def ready(self) -> None:
+    def ready(self):
         self.ext = self.extension
 
 
@@ -220,7 +220,7 @@ class _Buffer:
 # Queue contracts, host-only
 
 
-def test_launch_error_ends_the_episode_at_the_next_drain(isolated_queue) -> None:
+def test_launch_error_ends_the_episode_at_the_next_drain(isolated_queue):
     """Rule 5, through the public entry points.
 
     A launch error is held (``pump()`` never raises), the rest of the queue
@@ -264,9 +264,7 @@ def test_launch_error_ends_the_episode_at_the_next_drain(isolated_queue) -> None
     assert log == ["first", "failing", "after"]
 
 
-def test_build_failure_behind_a_queued_launch_surfaces_from_drain(
-    isolated_queue,
-) -> None:
+def test_build_failure_behind_a_queued_launch_surfaces_from_drain(isolated_queue):
     """The other way a deferred launch fails: its .so never builds."""
     log: list[str] = []
     failure = ImportError("mojo build failed for elementwise_ops")
@@ -287,7 +285,7 @@ def test_build_failure_behind_a_queued_launch_surfaces_from_drain(
     assert retained() is None  # the abandoned tail released its references
 
 
-def test_queued_launch_out_of_memory_is_still_reported_as_such(isolated_queue) -> None:
+def test_queued_launch_out_of_memory_is_still_reported_as_such(isolated_queue):
     """OOM translation must survive deferral: the launch that exhausts the
     allocator now happens at drain time, far from the aten call that
     produced it, and it must still arrive as ``torch.OutOfMemoryError``."""
@@ -308,7 +306,7 @@ def test_queued_launch_out_of_memory_is_still_reported_as_such(isolated_queue) -
 
 def test_thread_switch_synchronizes_once_and_keeps_fifo(
     isolated_queue, monkeypatch: pytest.MonkeyPatch
-) -> None:
+):
     """Rule 4: device work is ordered only within one enqueuing thread, so a
     launch from another thread synchronizes first — and still launches the
     queue in enqueue order, not its own order."""
@@ -334,7 +332,7 @@ def test_thread_switch_synchronizes_once_and_keeps_fifo(
 
     failures: list[BaseException] = []
 
-    def drain_from_another_thread() -> None:
+    def drain_from_another_thread():
         try:
             call_queue.drain()
         except BaseException as exc:  # pragma: no cover - reported below
@@ -350,7 +348,7 @@ def test_thread_switch_synchronizes_once_and_keeps_fifo(
     assert call_queue._DEVICE_THREAD[0] is worker
 
 
-def test_a_drain_reached_from_inside_a_launch_does_not_reorder(isolated_queue) -> None:
+def test_a_drain_reached_from_inside_a_launch_does_not_reorder(isolated_queue):
     """A launch can re-enter the queue: releasing a holder or synchronizing
     the device calls back into ``drain()``. That nested call must be a
     no-op, or the item already popped launches after its successors and
@@ -360,7 +358,7 @@ def test_a_drain_reached_from_inside_a_launch_does_not_reorder(isolated_queue) -
     queued = weakref.ref(follower_buffer := _Buffer())
 
     class _ReentrantExtension:
-        def call(self, label: str) -> None:
+        def call(self, label: str):
             log.append(f"{label}:enter")
             call_queue.drain()
             call_queue.pump()
@@ -387,7 +385,7 @@ def test_a_drain_reached_from_inside_a_launch_does_not_reorder(isolated_queue) -
     assert in_flight() is None and queued() is None  # released at launch
 
 
-def test_external_calls_hold_their_fifo_position(isolated_queue) -> None:
+def test_external_calls_hold_their_fifo_position(isolated_queue):
     """Rule 6: an always-loaded device call (tensor_holder, fa4) is
     launchable at once but must not overtake queued producers of its
     inputs, and its keep-alive is explicit."""
@@ -407,14 +405,14 @@ def test_external_calls_hold_their_fifo_position(isolated_queue) -> None:
     assert retained() is None  # released once its launch ran
 
 
-def test_external_call_runs_inline_when_nothing_is_queued(isolated_queue) -> None:
+def test_external_call_runs_inline_when_nothing_is_queued(isolated_queue):
     log: list[str] = []
     call_queue.external_call(log.append, ("now",), ())
     assert log == ["now"]
     assert not call_queue.active()
 
 
-def test_a_cold_launch_retains_the_output_it_writes_into(isolated_queue) -> None:
+def test_a_cold_launch_retains_the_output_it_writes_into(isolated_queue):
     """Rule 3, per item: the SDPA/flash-attention autograd nodes run above
     __torch_dispatch__ and drop their intermediates as soon as they queue a
     launch against them — the queued item itself must keep them alive."""
@@ -435,7 +433,7 @@ def test_a_cold_launch_retains_the_output_it_writes_into(isolated_queue) -> None
 
 def test_failed_allocation_drains_synchronizes_and_retries_once(
     isolated_queue, monkeypatch: pytest.MonkeyPatch
-) -> None:
+):
     """The reactive layer under the budget: a device-OOM allocation drains
     the queue (releasing what its items retain), synchronizes the device so
     the stream-ordered frees land, and retries exactly once. Non-OOM errors
@@ -453,7 +451,7 @@ def test_failed_allocation_drains_synchronizes_and_retries_once(
     oom = Exception("CUDA call failed: CUDA_ERROR_OUT_OF_MEMORY (out of memory)")
 
     class _FlakyHolder:
-        def __init__(self, failures: list[BaseException]) -> None:
+        def __init__(self, failures: list[BaseException]):
             self.failures = failures
             self.calls = 0
 
@@ -501,14 +499,14 @@ def test_failed_allocation_drains_synchronizes_and_retries_once(
 
 def test_budget_is_computed_from_free_device_memory(
     isolated_queue, monkeypatch: pytest.MonkeyPatch
-) -> None:
+):
     """Without the env override, the bound adapts to the device: half the
     smallest free-VRAM figure across the accelerators, floored at 1 GiB,
     falling back to 8 GiB when nothing can report memory statistics."""
     import torch_mojo_backend
 
     class _FakeAccelerator:
-        def __init__(self, free: int) -> None:
+        def __init__(self, free: int):
             self.stats = {"free_memory": free, "total_memory": free}
 
     gib = 1024 * 1024 * 1024
@@ -543,7 +541,7 @@ def test_budget_is_computed_from_free_device_memory(
 
 def test_retention_budget_bounds_cold_run_ahead(
     isolated_queue, monkeypatch: pytest.MonkeyPatch
-) -> None:
+):
     """Rule 3's bound: a read-free cold storm may not retain unbounded
     bytes. The enqueue that crosses the budget waits the builds out and
     launches everything, releasing the retention — the fix for the 70+ GB
@@ -578,7 +576,7 @@ def test_retention_budget_bounds_cold_run_ahead(
 
 def test_retention_budget_holds_launch_errors_for_the_next_drain(
     isolated_queue, monkeypatch: pytest.MonkeyPatch
-) -> None:
+):
     """The budget drain serves memory, not a value: a launch failure inside
     it is held and raised by the next real drain(), per rule 5."""
 
@@ -611,7 +609,7 @@ def test_retention_budget_holds_launch_errors_for_the_next_drain(
 )
 def test_mode_knobs_are_value_tested_not_truthiness_tested(
     monkeypatch: pytest.MonkeyPatch, knob: str, value: str, expected: bool
-) -> None:
+):
     """A knob set to "0" must never mean "on" (the deleted
     ``TMB_NO_TRIGGER_DEFER`` did exactly that), and the answer is memoized,
     so it only changes when ``refresh()`` says so."""
@@ -623,7 +621,7 @@ def test_mode_knobs_are_value_tested_not_truthiness_tested(
     assert call_queue.enabled() is expected
 
 
-def test_queue_disabled_under_suite_by_default() -> None:
+def test_queue_disabled_under_suite_by_default():
     assert len(list(get_accelerators())) >= 0  # touch the backend
     assert not call_queue.enabled()
 
@@ -716,7 +714,7 @@ def test_queue_orders_across_threads(mojo_gpu, forced_queue):
     results: list[torch.Tensor] = []
     failures: list[BaseException] = []
 
-    def double_on_another_thread(y: torch.Tensor) -> None:
+    def double_on_another_thread(y: torch.Tensor):
         try:
             results.append((y * 2.0).cpu())
         except BaseException as exc:  # pragma: no cover - reported below

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -24,7 +24,7 @@ from torch_mojo_backend import (
 )
 from torch_mojo_backend.testing import check_functions_are_equivalent
 
-from .conftest import require_cuda_autograd
+from tests.conftest import require_cuda_autograd
 
 
 # MAX lowers an fp32 matmul to TF32 tensor cores on NVIDIA GPUs while torch

--- a/tests/test_eager_kernel_loader.py
+++ b/tests/test_eager_kernel_loader.py
@@ -20,7 +20,7 @@ class _NativeCallModule(Protocol):
     call: Callable[..., object]
 
 
-def test_defines_are_canonical_independent_of_mapping_order() -> None:
+def test_defines_are_canonical_independent_of_mapping_order():
     first = {
         "OP": "AddSpec",
         "DTYPE_ARG_1": "bfloat16",
@@ -47,7 +47,7 @@ def test_defines_are_canonical_independent_of_mapping_order() -> None:
     ) == eager_kernels.defines_cache_string(second)
 
 
-def test_exact_call_defines_use_ordered_argument_and_output_roles() -> None:
+def test_exact_call_defines_use_ordered_argument_and_output_roles():
     defines = eager_kernels.exact_call_defines(
         "WhereSelect",
         ("bool", "float32", "bfloat16"),
@@ -67,15 +67,13 @@ def test_exact_call_defines_use_ordered_argument_and_output_roles() -> None:
 
 
 @pytest.mark.parametrize("name", ["op", "HAS-DASH", "1_DTYPE", ""])
-def test_define_names_must_be_explicit_compiler_identifiers(name: str) -> None:
+def test_define_names_must_be_explicit_compiler_identifiers(name: str):
     with pytest.raises(ValueError, match="define name"):
         eager_kernels.normalize_defines({name: "value"})
 
 
 @pytest.mark.parametrize("value", [None, 1.5, object()])
-def test_define_values_reject_types_outside_the_compiler_contract(
-    value: object,
-) -> None:
+def test_define_values_reject_types_outside_the_compiler_contract(value: object):
     normalize_value = inspect.unwrap(eager_kernels._normalize_define_value)
     with pytest.raises(TypeError, match="must be bool, int, or str"):
         normalize_value(value)
@@ -83,7 +81,7 @@ def test_define_values_reject_types_outside_the_compiler_contract(
 
 def test_build_extension_compiles_original_source(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+):
     package_dir = tmp_path / "eager_kernels"
     package_dir.mkdir()
     source = package_dir / "sample_ops.mojo"
@@ -149,7 +147,7 @@ _GATED_SOURCE = (
 
 def test_loader_reuses_one_variant_per_distinct_define_set(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+):
     """One .so per distinct define set, and exactly one.
 
     The key is the defines as sent, so order must not matter but any
@@ -212,7 +210,7 @@ def test_loader_reuses_one_variant_per_distinct_define_set(
 
 def test_source_hash_includes_loader_cache_abi(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+):
     source = tmp_path / "sample_ops.mojo"
     source.write_text("def PyInit_sample_ops():\n    pass\n")
     monkeypatch.setattr(eager_kernels, "_PACKAGE_DIR", tmp_path)
@@ -225,7 +223,7 @@ def test_source_hash_includes_loader_cache_abi(
 
 def test_source_hash_includes_compiler_toolchain_identity(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+):
     source = tmp_path / "sample_ops.mojo"
     source.write_text("def PyInit_sample_ops():\n    pass\n")
     monkeypatch.setattr(eager_kernels, "_PACKAGE_DIR", tmp_path)
@@ -238,7 +236,7 @@ def test_source_hash_includes_compiler_toolchain_identity(
 
 def test_nested_module_hash_includes_private_and_shared_dependencies(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+):
     package_dir = tmp_path / "eager_kernels"
     operation_dir = package_dir / "sample_ops"
     operation_dir.mkdir(parents=True)
@@ -264,7 +262,7 @@ def test_nested_module_hash_includes_private_and_shared_dependencies(
 
 def test_defined_unit_memoizes_one_failed_build_across_all_waiters(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+):
     source = tmp_path / "elementwise_ops.mojo"
     source.write_text("def PyInit_elementwise_ops():\n    pass\n")
     defines = eager_kernels.normalize_defines(
@@ -347,7 +345,7 @@ class _ElementwiseAdd(eager_kernels.MojoExtension[_TensorMetadata, _TensorMetada
 
 def test_descriptor_prepares_output_metadata_without_loading_and_has_no_state(
     monkeypatch: pytest.MonkeyPatch,
-) -> None:
+):
     def unexpected_build(
         source: Path, defines: eager_kernels.CanonicalDefines | None
     ) -> Path:
@@ -376,7 +374,7 @@ def test_descriptor_prepares_output_metadata_without_loading_and_has_no_state(
         _ElementwiseAdd()
 
 
-def test_prepared_call_invokes_only_constant_call_entrypoint() -> None:
+def test_prepared_call_invokes_only_constant_call_entrypoint():
     calls: list[tuple[object, ...]] = []
     module = ModuleType("defined_elementwise_add")
 
@@ -405,18 +403,18 @@ def test_prepared_call_invokes_only_constant_call_entrypoint() -> None:
     assert not hasattr(module, "AddSpec")
 
 
-def test_prepared_calls_enqueue_in_fifo_order(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_prepared_calls_enqueue_in_fifo_order(monkeypatch: pytest.MonkeyPatch):
     launches: list[str] = []
 
     class FakeJob:
-        def wait(self) -> None:
+        def wait(self):
             return None
 
     class QueuedUnit:
         """The whole contract the queue needs of a unit: a module once its
         build lands, and a job to wait on until then."""
 
-        def __init__(self) -> None:
+        def __init__(self):
             self.ext: ModuleType | None = None
             self.job = FakeJob()
 
@@ -452,7 +450,7 @@ def test_prepared_calls_enqueue_in_fifo_order(monkeypatch: pytest.MonkeyPatch) -
 
     module = ModuleType("queued_elementwise_add")
 
-    def call(label: str) -> None:
+    def call(label: str):
         launches.append(label)
 
     cast(_NativeCallModule, module).call = call
@@ -463,7 +461,7 @@ def test_prepared_calls_enqueue_in_fifo_order(monkeypatch: pytest.MonkeyPatch) -
     assert not queue.active()
 
 
-def test_spec_descriptor_canonical_defines_match_make_defines() -> None:
+def test_spec_descriptor_canonical_defines_match_make_defines():
     """The memoized canonical defines must stay field-for-field equal to the
     literal ``make_defines`` dicts: the define-gate scanner reads the dicts,
     the hot path uses the memo, and the two must never drift."""

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -30,13 +30,13 @@ class _MojoBackendModule(Protocol):
     mechanism (`_setup_privateuseone_for_python_backend`), so no static stub
     knows about it."""
 
-    def manual_seed_all(self, seed: int) -> None: ...
+    def manual_seed_all(self, seed: int): ...
     def get_rng_state(
         self, device: torch.device | int | None = None
     ) -> torch.Tensor: ...
     def set_rng_state(
         self, new_state: torch.Tensor, device: torch.device | int | None = None
-    ) -> None: ...
+    ): ...
 
 
 def _torch_mojo() -> _MojoBackendModule:
@@ -95,7 +95,7 @@ def _spy_defined_native_calls(
 def _replace_defined_native_calls(
     monkeypatch: pytest.MonkeyPatch,
     replacements: dict[tuple[str, str], Callable[..., object]],
-) -> None:
+):
     """Replace selected constant `call` entry points without compiling them."""
     from torch_mojo_backend import eager_kernels
 
@@ -4968,7 +4968,7 @@ _ARGREDUCE_SPLIT_SHAPES = (4095, 4096, 8193, 1 << 20)
 
 def _assert_argreduce_matches(
     device: str, cpu_tensor: torch.Tensor, dim: int | None = None
-) -> None:
+):
     device_tensor = cpu_tensor.to(device)
     for fn in _ARGREDUCE_FNS:
         expected = fn(cpu_tensor) if dim is None else fn(cpu_tensor, dim=dim)
@@ -4980,16 +4980,14 @@ def _assert_argreduce_matches(
 
 
 @pytest.mark.parametrize("size", _ARGREDUCE_SPLIT_SHAPES)
-def test_fast_argreduce_full_reduction_across_split_sizes(
-    mojo_gpu: str, size: int
-) -> None:
+def test_fast_argreduce_full_reduction_across_split_sizes(mojo_gpu: str, size: int):
     """A full reduction is one output: it always takes the split path."""
     generator = torch.Generator().manual_seed(20260811)
     _assert_argreduce_matches(mojo_gpu, torch.randn(size, generator=generator))
 
 
 @pytest.mark.parametrize("size", _ARGREDUCE_SPLIT_SHAPES)
-def test_fast_argreduce_ties_take_the_lowest_index(mojo_gpu: str, size: int) -> None:
+def test_fast_argreduce_ties_take_the_lowest_index(mojo_gpu: str, size: int):
     """Every element equal, and the extremum repeated at known positions:
     both must answer with the FIRST of them however the axis was split."""
     _assert_argreduce_matches(mojo_gpu, torch.full((size,), 3.5))
@@ -5006,7 +5004,7 @@ def test_fast_argreduce_ties_take_the_lowest_index(mojo_gpu: str, size: int) -> 
 
 
 @pytest.mark.parametrize("size", (1000, 1 << 20))
-def test_fast_argreduce_nan_beats_every_number(mojo_gpu: str, size: int) -> None:
+def test_fast_argreduce_nan_beats_every_number(mojo_gpu: str, size: int):
     """torch propagates NaN: the index of the first NaN is the answer."""
     generator = torch.Generator().manual_seed(20260811)
     for position in (0, 3, size // 2, size - 1):
@@ -5022,7 +5020,7 @@ def test_fast_argreduce_nan_beats_every_number(mojo_gpu: str, size: int) -> None
 
 
 @pytest.mark.parametrize("size", (1000, 1 << 20))
-def test_fast_argreduce_saturated_identity_values(mojo_gpu: str, size: int) -> None:
+def test_fast_argreduce_saturated_identity_values(mojo_gpu: str, size: int):
     """A row of the identity element (-inf for argmax, +inf for argmin) still
     has an answer: index 0.  A lane seeded with the identity and a strict
     comparison would report "nothing found" here."""
@@ -5033,7 +5031,7 @@ def test_fast_argreduce_saturated_identity_values(mojo_gpu: str, size: int) -> N
 @pytest.mark.parametrize(
     "dtype", [torch.float32, torch.float16, torch.bfloat16, torch.int32, torch.int64]
 )
-def test_fast_argreduce_dtypes(mojo_gpu: str, dtype: torch.dtype) -> None:
+def test_fast_argreduce_dtypes(mojo_gpu: str, dtype: torch.dtype):
     generator = torch.Generator().manual_seed(20260811)
     if dtype.is_floating_point:
         values = torch.randn(3, 5000, generator=generator).to(dtype)
@@ -5057,9 +5055,7 @@ def test_fast_argreduce_dtypes(mojo_gpu: str, dtype: torch.dtype) -> None:
         ((70000, 2, 32), 1),  # outer past the 65535 cap on grid.y / grid.z
     ],
 )
-def test_fast_argreduce_strided_axis(
-    mojo_gpu: str, shape: tuple[int, ...], dim: int
-) -> None:
+def test_fast_argreduce_strided_axis(mojo_gpu: str, shape: tuple[int, ...], dim: int):
     """Non-trailing reduce dims: the strided kernel reads the source in place
     above the coalescing floor and the materialized route runs below it, and
     both must agree with torch (including on ties)."""
@@ -5074,9 +5070,7 @@ def test_fast_argreduce_strided_axis(
     _assert_argreduce_matches(mojo_gpu, with_nan, dim=dim)
 
 
-def test_fast_argreduce_strided_direct_gate_matches_the_kernel_regime(
-    mojo_gpu: str,
-) -> None:
+def test_fast_argreduce_strided_direct_gate_matches_the_kernel_regime(mojo_gpu: str):
     """The Python gate and the Mojo kernel must agree about which layouts go
     in place: a queued launch cannot fall back."""
     from torch_mojo_backend.eager_kernels.aten_fast import (
@@ -5106,7 +5100,7 @@ def test_fast_argreduce_strided_direct_gate_matches_the_kernel_regime(
     assert not _arg_strided_direct_ok("ArgmaxSpec", cube, (0, 2))
 
 
-def test_fast_argreduce_views_and_keepdim(mojo_gpu: str) -> None:
+def test_fast_argreduce_views_and_keepdim(mojo_gpu: str):
     generator = torch.Generator().manual_seed(20260811)
     base = torch.randn(64, 128, generator=generator)
     for view in (base.t(), base[:, 3:70], base[::2, ::3]):
@@ -6951,7 +6945,7 @@ def test_matmul_spec_device_oom_is_not_disguised_as_unsupported(
     lhs = fake_tensor((2, 3))
     rhs = fake_tensor((3, 4))
 
-    def raise_allocator_oom(*_args: object, **_kwargs: object) -> None:
+    def raise_allocator_oom(*_args: object, **_kwargs: object):
         raise NotImplementedError(
             "CUDA call failed: CUDA_ERROR_OUT_OF_MEMORY (out of memory)"
         )
@@ -7385,7 +7379,7 @@ def _gemm16_operands(
 @pytest.mark.parametrize("layout", _GEMM16_LAYOUTS)
 def test_gemm16_float16_mm_matches_fp32_reference_on_every_layout(
     mojo_h100: torch.device, layout: str
-) -> None:
+):
     """float16 reaches the tensor-core family, not the generic tiled GEMM.
 
     The tolerance is the point of the assertion: the kernels accumulate in
@@ -7415,7 +7409,7 @@ def test_gemm16_float16_mm_matches_fp32_reference_on_every_layout(
 @pytest.mark.parametrize("op", ["mm", "addmm", "linear", "bmm", "bmm_transpose_b"])
 def test_gemm16_float16_every_entry_point_launches_the_bridge(
     mojo_h100: torch.device, monkeypatch: pytest.MonkeyPatch, op: str
-) -> None:
+):
     """mm / addmm / linear / bmm all route float16 through the same bridge."""
     from torch_mojo_backend.eager_kernels import aten_fast
 
@@ -7462,7 +7456,7 @@ def test_gemm16_float16_every_entry_point_launches_the_bridge(
 
 def test_gemm16_float16_and_bfloat16_are_separate_specializations(
     mojo_h100: torch.device, monkeypatch: pytest.MonkeyPatch
-) -> None:
+):
     """One source, one .so per dtype: the define travels, the kernel does not.
 
     Mixing the two dtypes in one call must decline rather than reinterpret the
@@ -7485,9 +7479,7 @@ def test_gemm16_float16_and_bfloat16_are_separate_specializations(
     assert len(calls[("gemm16_matmul_ops.mojo", "Gemm16")]) == 2
 
 
-def test_gemm16_float16_linear_backward_matches_fp32_reference(
-    mojo_h100: torch.device,
-) -> None:
+def test_gemm16_float16_linear_backward_matches_fp32_reference(mojo_h100: torch.device):
     """linear_backward's dgrad/wgrad pair is the NN and TN route in float16."""
     from torch_mojo_backend.eager_kernels import aten_fast
 
@@ -9193,9 +9185,7 @@ def _f32_transposed_dense_pair(
     return host, dev
 
 
-def _assert_f32_seq_k_close(
-    actual: torch.Tensor, expected: torch.Tensor, k: int
-) -> None:
+def _assert_f32_seq_k_close(actual: torch.Tensor, expected: torch.Tensor, k: int):
     """Compare an fp32 GEMM against an fp64 oracle with the sequential-over-k
     fp32 accumulation tolerance (random-walk rounding grows ~sqrt(k))."""
     assert actual.dtype == torch.float32
@@ -9231,7 +9221,7 @@ def _assert_f32_seq_k_close(
 )
 def test_f32_tn_transposed_a_route_matches_fp64_oracle(
     mojo_h100: str, monkeypatch: pytest.MonkeyPatch, m: int, n: int, k: int, offset: int
-) -> None:
+):
     """Every dispatch regime of the sm_90 fp32 TN route against fp64."""
     generator = torch.Generator().manual_seed(20260808)
     host_a, mojo_a = _f32_transposed_dense_pair(generator, m, k, offset, mojo_h100)
@@ -9254,7 +9244,7 @@ def test_f32_tn_transposed_a_route_matches_fp64_oracle(
     _assert_f32_seq_k_close(actual.cpu(), expected, k)
 
 
-def test_f32_tn_route_declined_regimes_stay_correct(mojo_h100: str) -> None:
+def test_f32_tn_route_declined_regimes_stay_correct(mojo_h100: str):
     """Regimes the TN route declines (m == 1, bias, TT, bmm) keep the
     scratch-copy path and stay correct."""
     generator = torch.Generator().manual_seed(20260808)
@@ -9303,7 +9293,7 @@ def test_f32_tn_route_declined_regimes_stay_correct(mojo_h100: str) -> None:
         torch.set_float32_matmul_precision(old_precision)
 
 
-def test_f32_tn_route_linear_weight_gradient(mojo_h100: str) -> None:
+def test_f32_tn_route_linear_weight_gradient(mojo_h100: str):
     """nn.Linear backward produces the dW = dY^T @ X layout the route claims;
     the full autograd round trip must stay correct."""
     generator = torch.Generator().manual_seed(20260808)

--- a/tests/test_eager_optimizer_ops.py
+++ b/tests/test_eager_optimizer_ops.py
@@ -9,7 +9,7 @@ from torch_mojo_backend.testing import CallChecker
 pytestmark = pytest.mark.xdist_group(name="group1")
 
 
-def _watch_eager_op(call_checker: CallChecker, op_name: str) -> None:
+def _watch_eager_op(call_checker: CallChecker, op_name: str):
     """Require the exact PrivateUse1 registration, not a decomposition twin."""
     from torch_mojo_backend.mojo_device.mojo_device_aten_ops import EAGER_CALL_COUNTERS
 

--- a/tests/test_fa4_host_wiring.py
+++ b/tests/test_fa4_host_wiring.py
@@ -57,7 +57,7 @@ def _mt(tensor: SimpleNamespace | None) -> TorchMojoTensor:
 
 def test_fa4_rejects_ineligible_regimes_before_loading_or_device_work(
     monkeypatch: pytest.MonkeyPatch,
-) -> None:
+):
     import torch_mojo_backend.eager_flash_attention as package
 
     monkeypatch.setattr(aten_fast, "_t", lambda tensor: tensor)
@@ -100,7 +100,7 @@ def test_fa4_rejects_ineligible_regimes_before_loading_or_device_work(
 
 def test_fa4_forward_bridge_uses_dynamic_bthd_allocations(
     monkeypatch: pytest.MonkeyPatch,
-) -> None:
+):
     import torch_mojo_backend.eager_flash_attention as package
 
     device = _device()
@@ -188,7 +188,7 @@ def test_fa4_forward_bridge_uses_dynamic_bthd_allocations(
 
 def test_fa4_forward_bridge_selects_f16_kernel_symbol_and_allocation(
     monkeypatch: pytest.MonkeyPatch,
-) -> None:
+):
     """f16 Q/K/V select the f16 bridge symbol and f16 output allocation.
 
     Mirrors ``test_fa4_forward_bridge_uses_dynamic_bthd_allocations`` above,
@@ -291,7 +291,7 @@ def test_fa4_forward_bridge_selects_f16_kernel_symbol_and_allocation(
     ]
 
 
-def test_fa4_rejects_mixed_bf16_f16_inputs(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_fa4_rejects_mixed_bf16_f16_inputs(monkeypatch: pytest.MonkeyPatch):
     """Q/K/V must share one dtype from {bf16, f16} -- mixing is not eligible."""
     monkeypatch.setattr(aten_fast, "_t", lambda tensor: tensor)
     device = _device()
@@ -306,7 +306,7 @@ def test_fa4_rejects_mixed_bf16_f16_inputs(monkeypatch: pytest.MonkeyPatch) -> N
     )
 
 
-def test_fa4_strided_layout_contract_is_strict() -> None:
+def test_fa4_strided_layout_contract_is_strict():
     shape = (2, 256, 12, 64)
     token_stride = 3 * shape[2] * shape[3]
     strides = (shape[1] * token_stride, token_stride, 64, 1)
@@ -348,7 +348,7 @@ def test_fa4_strided_layout_contract_is_strict() -> None:
 
 def test_fa4_canonical_fused_qkv_uses_zero_copy_strided_forward_bridge(
     monkeypatch: pytest.MonkeyPatch,
-) -> None:
+):
     import torch_mojo_backend.eager_flash_attention as package
 
     device = _device()
@@ -451,7 +451,7 @@ def test_fa4_canonical_fused_qkv_uses_zero_copy_strided_forward_bridge(
 
 def test_fa4_offset_view_public_layout_copies_and_uses_contiguous_fallback(
     monkeypatch: pytest.MonkeyPatch,
-) -> None:
+):
     """A public (B, H, S, D) tensor that is fully contiguous but whose base
     pointer is NOT 16-byte aligned (e.g. a sliced/offset view into a larger
     buffer) must be rejected by ``_fa4_bhsd_layout`` and fall back to the
@@ -536,7 +536,7 @@ def test_fa4_offset_view_public_layout_copies_and_uses_contiguous_fallback(
 
 def test_fa4_forward_bridge_uses_bhsd_native_path_for_aligned_contiguous_public_qkv(
     monkeypatch: pytest.MonkeyPatch,
-) -> None:
+):
     """A public (B, H, S, D) tensor that is fully contiguous AND 16-byte
     aligned skips BTHD materialization entirely: no transpose, no copy, and
     the output is allocated directly in the (B, H, S, D) layout and
@@ -614,7 +614,7 @@ def test_fa4_forward_bridge_uses_bhsd_native_path_for_aligned_contiguous_public_
     ]
 
 
-def test_fa4_bhsd_layout_requires_contiguity_and_16_byte_alignment() -> None:
+def test_fa4_bhsd_layout_requires_contiguity_and_16_byte_alignment():
     base = _tensor("q", shape=(3, 12, 256, 64), ptr=0x1000)
     assert aten_fast._fa4_bhsd_layout(_mt(base))
 
@@ -636,7 +636,7 @@ def test_fa4_bhsd_layout_requires_contiguity_and_16_byte_alignment() -> None:
 
 def test_direct_flash_aten_returns_real_lse_and_cuda_shaped_auxiliaries(
     monkeypatch: pytest.MonkeyPatch,
-) -> None:
+):
     device = _device()
     query, key, value = (
         _tensor(name, shape=(2, 8, 256, 64), device=device, ptr=ptr)
@@ -696,7 +696,7 @@ def test_direct_flash_aten_returns_real_lse_and_cuda_shaped_auxiliaries(
 
 def test_direct_flash_backward_materializes_strided_logsumexp(
     monkeypatch: pytest.MonkeyPatch,
-) -> None:
+):
     device = _device()
     shape = (2, 4, 128, 64)
     query, key, value = (
@@ -776,7 +776,7 @@ def test_direct_flash_backward_materializes_strided_logsumexp(
 
 def test_fa4_saved_variable_recompute_rederives_natives_independently(
     monkeypatch: pytest.MonkeyPatch,
-) -> None:
+):
     """Regression test for the SavedVariable-recompute fallback (``out``/
     ``logsumexp`` unpacked as bare tensors without their Python payload).
 
@@ -888,7 +888,7 @@ def test_fa4_saved_variable_recompute_rederives_natives_independently(
 
 def test_fa4_combined_backward_bridge_allocates_exact_scratch(
     monkeypatch: pytest.MonkeyPatch,
-) -> None:
+):
     import torch_mojo_backend.eager_flash_attention as package
 
     device = _device()
@@ -989,7 +989,7 @@ def test_fa4_combined_backward_bridge_allocates_exact_scratch(
 
 def test_fa4_canonical_fused_qkv_uses_strided_backward_bridge(
     monkeypatch: pytest.MonkeyPatch,
-) -> None:
+):
     import torch_mojo_backend.eager_flash_attention as package
 
     device = _device()
@@ -1119,7 +1119,7 @@ def test_fa4_canonical_fused_qkv_uses_strided_backward_bridge(
 
 def test_fa4_eligible_backward_routes_to_native_flash_with_public_inputs(
     monkeypatch: pytest.MonkeyPatch,
-) -> None:
+):
     """An eligible FA4 call that needs gradients goes to the lower ATen pair.
 
     The custom SDPA Function used to own the FA4 saves itself; PyTorch's
@@ -1168,7 +1168,7 @@ def test_fa4_eligible_backward_routes_to_native_flash_with_public_inputs(
     assert flash_calls == [((*public, 0.0, True, False), {"scale": 0.125})]
 
 
-def test_vendored_fa4_sources_have_no_torch_cuda_or_internal_sync() -> None:
+def test_vendored_fa4_sources_have_no_torch_cuda_or_internal_sync():
     source_dir = Path(aten_fast.__file__).parents[1] / "eager_flash_attention"
     source_by_name = {path.name: path.read_text() for path in source_dir.glob("*.mojo")}
     sources = "\n".join(source_by_name.values())

--- a/tests/test_fa4_selfload_ptx_ordering.py
+++ b/tests/test_fa4_selfload_ptx_ordering.py
@@ -115,9 +115,7 @@ def _line_numbers(pattern: re.Pattern[str], text: str) -> list[int]:
     return [i for i, line in enumerate(text.splitlines()) if pattern.search(line)]
 
 
-def _assert_every_event_follows_a_wait(
-    events: list[tuple[int, str]], event_label: str
-) -> None:
+def _assert_every_event_follows_a_wait(events: list[tuple[int, str]], event_label: str):
     """Walk (line_no, kind) events in line order: every 'event_label' kind
     must have a 'wait' kind since the previous 'event_label' (or since the
     start of the region, for the first one)."""
@@ -142,7 +140,7 @@ def _assert_every_event_follows_a_wait(
     )
 
 
-def test_selfload_refills_follow_their_wait_group(selfload_ptx: str) -> None:
+def test_selfload_refills_follow_their_wait_group(selfload_ptx: str):
     """Every K/V refill TMA copy is textually ordered after a wgmma.wait_group.
 
     The prologue's initial fill (Q plus the first PREFETCH tile-pairs) has
@@ -173,7 +171,7 @@ def test_selfload_refills_follow_their_wait_group(selfload_ptx: str) -> None:
     _assert_every_event_follows_a_wait(expect_events, "mbarrier.arrive.expect_tx")
 
 
-def test_selfload_rejects_d128_at_compile_time() -> None:
+def test_selfload_rejects_d128_at_compile_time():
     """Scope enforcement, not just documentation: instantiating the
     self-loading kernel at head_dim=128 must fail the BUILD (ported from
     agent A2's review artifact, d128_guard_v7.mojo)."""

--- a/tests/test_fa4_selfload_soak.py
+++ b/tests/test_fa4_selfload_soak.py
@@ -68,7 +68,7 @@ def selfload_soak_binary(tmp_path_factory: pytest.TempPathFactory) -> Path:
     return out_path
 
 
-def test_selfload_soak_no_race(selfload_soak_binary: Path) -> None:
+def test_selfload_soak_no_race(selfload_soak_binary: Path):
     """64 back-to-back self-load launches per shape must be bitwise
     deterministic and match the phase-2b kernel within tolerance."""
     result = subprocess.run(

--- a/tests/test_high_level_ops.py
+++ b/tests/test_high_level_ops.py
@@ -139,7 +139,7 @@ def test_new_ones_dtype(device: str):
     check_functions_are_equivalent(fn, device, [a])
 
 
-def test_operator_add(conf: Conf, tensor_shapes: tuple):
+def test_operator_add(conf: Conf, tensor_shapes: tuple[int, ...]):
     def fn(x, y):
         return x + y
 
@@ -149,7 +149,7 @@ def test_operator_add(conf: Conf, tensor_shapes: tuple):
     check_outputs(fn, conf, [a, b])
 
 
-def test_subtraction(conf: Conf, tensor_shapes: tuple):
+def test_subtraction(conf: Conf, tensor_shapes: tuple[int, ...]):
     def fn(x, y):
         return x - y
 
@@ -159,7 +159,7 @@ def test_subtraction(conf: Conf, tensor_shapes: tuple):
     check_outputs(fn, conf, [a, b])
 
 
-def test_subtraction_different_dtypes(conf: Conf, tensor_shapes: tuple):
+def test_subtraction_different_dtypes(conf: Conf, tensor_shapes: tuple[int, ...]):
     def fn(x, y):
         return x - y
 
@@ -169,7 +169,7 @@ def test_subtraction_different_dtypes(conf: Conf, tensor_shapes: tuple):
     check_outputs(fn, conf, [a, b])
 
 
-def test_multiplication(conf: Conf, tensor_shapes: tuple):
+def test_multiplication(conf: Conf, tensor_shapes: tuple[int, ...]):
     def fn(x, y):
         return x * y
 
@@ -179,7 +179,7 @@ def test_multiplication(conf: Conf, tensor_shapes: tuple):
     check_outputs(fn, conf, [a, b])
 
 
-def test_multiplication_int32(conf: Conf, tensor_shapes: tuple):
+def test_multiplication_int32(conf: Conf, tensor_shapes: tuple[int, ...]):
     def fn(x, y):
         return x * y
 
@@ -189,7 +189,7 @@ def test_multiplication_int32(conf: Conf, tensor_shapes: tuple):
     check_outputs(fn, conf, [a, b])
 
 
-def test_division(device: str, tensor_shapes: tuple):
+def test_division(device: str, tensor_shapes: tuple[int, ...]):
     def fn(x, y):
         return x / y
 
@@ -199,7 +199,7 @@ def test_division(device: str, tensor_shapes: tuple):
     check_functions_are_equivalent(fn, device, [a, b])
 
 
-def test_floor_division(device: str, tensor_shapes: tuple):
+def test_floor_division(device: str, tensor_shapes: tuple[int, ...]):
     def fn(x, y):
         return x // y
 
@@ -209,7 +209,7 @@ def test_floor_division(device: str, tensor_shapes: tuple):
     check_functions_are_equivalent(fn, device, [a, b])
 
 
-def test_power(device: str, tensor_shapes: tuple):
+def test_power(device: str, tensor_shapes: tuple[int, ...]):
     def fn(x, y):
         return x**y
 
@@ -219,7 +219,7 @@ def test_power(device: str, tensor_shapes: tuple):
     check_functions_are_equivalent(fn, device, [a, b])
 
 
-def test_modulo(device: str, tensor_shapes: tuple):
+def test_modulo(device: str, tensor_shapes: tuple[int, ...]):
     def fn(x, y):
         return x % y
 
@@ -229,7 +229,7 @@ def test_modulo(device: str, tensor_shapes: tuple):
     check_functions_are_equivalent(fn, device, [a, b])
 
 
-def test_abs(conf: Conf, tensor_shapes: tuple):
+def test_abs(conf: Conf, tensor_shapes: tuple[int, ...]):
     def fn(x):
         return torch.abs(x)
 
@@ -238,7 +238,7 @@ def test_abs(conf: Conf, tensor_shapes: tuple):
     check_outputs(fn, conf, [a])
 
 
-def test_floor(conf: Conf, tensor_shapes: tuple):
+def test_floor(conf: Conf, tensor_shapes: tuple[int, ...]):
     def fn(x):
         return torch.floor(x)
 
@@ -275,7 +275,7 @@ def test_tensor_floor_method(conf: Conf):
     check_outputs(fn, conf, [x])
 
 
-def test_cos(conf: Conf, tensor_shapes: tuple):
+def test_cos(conf: Conf, tensor_shapes: tuple[int, ...]):
     def fn(x):
         return torch.cos(x)
 
@@ -284,7 +284,7 @@ def test_cos(conf: Conf, tensor_shapes: tuple):
     check_outputs(fn, conf, [a])
 
 
-def test_sin(conf: Conf, tensor_shapes: tuple):
+def test_sin(conf: Conf, tensor_shapes: tuple[int, ...]):
     def fn(x):
         return torch.sin(x)
 
@@ -293,7 +293,7 @@ def test_sin(conf: Conf, tensor_shapes: tuple):
     check_outputs(fn, conf, [a])
 
 
-def test_tanh(conf: Conf, tensor_shapes: tuple):
+def test_tanh(conf: Conf, tensor_shapes: tuple[int, ...]):
     def fn(x):
         return torch.tanh(x)
 
@@ -302,7 +302,7 @@ def test_tanh(conf: Conf, tensor_shapes: tuple):
     check_outputs(fn, conf, [a])
 
 
-def test_sign(conf: Conf, tensor_shapes: tuple):
+def test_sign(conf: Conf, tensor_shapes: tuple[int, ...]):
     def fn(x):
         return torch.sign(x)
 
@@ -325,7 +325,7 @@ def test_sign_different_dtypes(conf: Conf, dtype):
     check_outputs(fn, conf, [a])
 
 
-def test_atanh(conf: Conf, tensor_shapes: tuple):
+def test_atanh(conf: Conf, tensor_shapes: tuple[int, ...]):
     def fn(x):
         return torch.atanh(x)
 
@@ -698,7 +698,7 @@ def test_torch_max_with_dim_positional(device: str, shapes, dims, func):
 
 
 @pytest.mark.parametrize("func", [torch.min, torch.max])
-def test_torch_max_elementwise(conf: Conf, tensor_shapes: tuple, func):
+def test_torch_max_elementwise(conf: Conf, tensor_shapes: tuple[int, ...], func):
     def fn(x, y):
         return func(x, y)
 
@@ -709,7 +709,7 @@ def test_torch_max_elementwise(conf: Conf, tensor_shapes: tuple, func):
 
 
 @pytest.mark.parametrize("func", [torch.minimum, torch.maximum])
-def test_minimum_maximum(conf: Conf, tensor_shapes: tuple, func):
+def test_minimum_maximum(conf: Conf, tensor_shapes: tuple[int, ...], func):
     """Only works with elementwise min/max of two tensors."""
 
     def fn(x, y):
@@ -721,7 +721,7 @@ def test_minimum_maximum(conf: Conf, tensor_shapes: tuple, func):
     check_outputs(fn, conf, [a, b])
 
 
-def test_relu(conf: Conf, tensor_shapes: tuple):
+def test_relu(conf: Conf, tensor_shapes: tuple[int, ...]):
     def fn(x):
         return F.relu(x)
 
@@ -730,7 +730,7 @@ def test_relu(conf: Conf, tensor_shapes: tuple):
     check_outputs(fn, conf, [a])
 
 
-def test_cat(conf: Conf, tensor_shapes: tuple):
+def test_cat(conf: Conf, tensor_shapes: tuple[int, ...]):
     def fn(x, y):
         return torch.cat([x, y], dim=0)
 
@@ -754,7 +754,7 @@ def test_cat_skips_legacy_empty(conf: Conf):
     check_outputs(fn, conf, [empty, x, y])
 
 
-def test_combination_add_mul(conf: Conf, tensor_shapes: tuple):
+def test_combination_add_mul(conf: Conf, tensor_shapes: tuple[int, ...]):
     def fn(x, y, z):
         return (x + y) * z
 
@@ -765,7 +765,7 @@ def test_combination_add_mul(conf: Conf, tensor_shapes: tuple):
     check_outputs(fn, conf, [a, b, c])
 
 
-def test_combination_sub_div(conf: Conf, tensor_shapes: tuple):
+def test_combination_sub_div(conf: Conf, tensor_shapes: tuple[int, ...]):
     def fn(x, y, z):
         return (x - y) / z
 
@@ -776,7 +776,7 @@ def test_combination_sub_div(conf: Conf, tensor_shapes: tuple):
     check_outputs(fn, conf, [a, b, c])
 
 
-def test_combination_trig_arithmetic(conf: Conf, tensor_shapes: tuple):
+def test_combination_trig_arithmetic(conf: Conf, tensor_shapes: tuple[int, ...]):
     def fn(x, y):
         return torch.sin(x) + torch.cos(y)
 
@@ -786,7 +786,7 @@ def test_combination_trig_arithmetic(conf: Conf, tensor_shapes: tuple):
     check_outputs(fn, conf, [a, b])
 
 
-def test_combination_abs_mul_add(conf: Conf, tensor_shapes: tuple):
+def test_combination_abs_mul_add(conf: Conf, tensor_shapes: tuple[int, ...]):
     def fn(x, y, z):
         return torch.abs(x) * y + z
 
@@ -797,7 +797,7 @@ def test_combination_abs_mul_add(conf: Conf, tensor_shapes: tuple):
     check_outputs(fn, conf, [a, b, c])
 
 
-def test_combination_pow_mod(device: str, tensor_shapes: tuple):
+def test_combination_pow_mod(device: str, tensor_shapes: tuple[int, ...]):
     def fn(x, y):
         return (x**2) % y
 
@@ -807,7 +807,7 @@ def test_combination_pow_mod(device: str, tensor_shapes: tuple):
     check_functions_are_equivalent(fn, device, [a, b])
 
 
-def test_complex_combination(conf: Conf, tensor_shapes: tuple):
+def test_complex_combination(conf: Conf, tensor_shapes: tuple[int, ...]):
     def fn(x, y, z):
         return torch.abs(torch.sin(x) * y + torch.cos(z))
 
@@ -1019,7 +1019,7 @@ def test_conv2d_asymmetric_kernel(conf: Conf):
 
 
 @pytest.mark.parametrize("size", [(1, 1, 4, 4), (3, 8, 32, 32), (2, 16, 64, 64)])
-def test_conv2d_different_input_sizes(conf: Conf, size: tuple):
+def test_conv2d_different_input_sizes(conf: Conf, size: tuple[int, ...]):
     """Test conv2d with different input tensor sizes"""
 
     def fn(x, w):
@@ -1176,7 +1176,7 @@ def test_conv1d_large_kernel(conf: Conf):
 
 
 @pytest.mark.parametrize("size", [(1, 1, 8), (3, 8, 32), (2, 16, 64)])
-def test_conv1d_different_input_sizes(conf: Conf, size: tuple):
+def test_conv1d_different_input_sizes(conf: Conf, size: tuple[int, ...]):
     """Test conv1d with different input tensor sizes"""
 
     def fn(x, w):
@@ -1997,7 +1997,7 @@ def test_tensor_trig_with_transpose(conf: Conf):
     check_outputs(fn, conf, [x])
 
 
-def test_tensor_cos_sin_different_shapes(conf: Conf, tensor_shapes: tuple):
+def test_tensor_cos_sin_different_shapes(conf: Conf, tensor_shapes: tuple[int, ...]):
     """Test tensor.cos() and tensor.sin() with different tensor shapes"""
 
     def fn_cos(x):
@@ -2093,7 +2093,7 @@ def test_tensor_pow_broadcast(conf: Conf):
     check_outputs(fn, conf, [x, y])
 
 
-def test_tensor_pow_different_shapes(conf: Conf, tensor_shapes: tuple):
+def test_tensor_pow_different_shapes(conf: Conf, tensor_shapes: tuple[int, ...]):
     """Test tensor.pow() with different tensor shapes"""
 
     def fn(x):
@@ -2316,7 +2316,7 @@ def test_complex_to_operations(device: str):
     check_functions_are_equivalent(fn, device, [x])
 
 
-def test_mean_no_dim(conf: Conf, tensor_shapes: tuple):
+def test_mean_no_dim(conf: Conf, tensor_shapes: tuple[int, ...]):
     """Test mean without specifying dimensions (reduce all)"""
 
     def fn(x):
@@ -2327,7 +2327,7 @@ def test_mean_no_dim(conf: Conf, tensor_shapes: tuple):
     check_outputs(fn, conf, [a])
 
 
-def test_mean_single_dim(device: str, tensor_shapes: tuple):
+def test_mean_single_dim(device: str, tensor_shapes: tuple[int, ...]):
     """Test mean with single dimension"""
 
     def fn(x):
@@ -2338,7 +2338,7 @@ def test_mean_single_dim(device: str, tensor_shapes: tuple):
     check_functions_are_equivalent(fn, device, [a])
 
 
-def test_mean_negative_dim(device: str, tensor_shapes: tuple):
+def test_mean_negative_dim(device: str, tensor_shapes: tuple[int, ...]):
     """Test mean with negative dimension"""
 
     def fn(x):
@@ -2349,7 +2349,7 @@ def test_mean_negative_dim(device: str, tensor_shapes: tuple):
     check_functions_are_equivalent(fn, device, [a])
 
 
-def test_mean_keepdim_true(device: str, tensor_shapes: tuple):
+def test_mean_keepdim_true(device: str, tensor_shapes: tuple[int, ...]):
     """Test mean with keepdim=True"""
 
     def fn(x):
@@ -2382,7 +2382,7 @@ def test_mean_multiple_dims_keepdim(device: str):
     check_functions_are_equivalent(fn, device, [a])
 
 
-def test_tensor_mean_method(conf: Conf, tensor_shapes: tuple):
+def test_tensor_mean_method(conf: Conf, tensor_shapes: tuple[int, ...]):
     """Test tensor.mean() method"""
 
     def fn(x):
@@ -2393,7 +2393,7 @@ def test_tensor_mean_method(conf: Conf, tensor_shapes: tuple):
     check_outputs(fn, conf, [a])
 
 
-def test_tensor_mean_method_with_dim(device: str, tensor_shapes: tuple):
+def test_tensor_mean_method_with_dim(device: str, tensor_shapes: tuple[int, ...]):
     """Test tensor.mean(dim) method"""
 
     def fn(x):
@@ -2422,7 +2422,7 @@ def test_mean_3d_tensor_change_dtype(device: str):
     check_functions_are_equivalent(fn, device, [a])
 
 
-def test_mean_combined_with_arithmetic(device: str, tensor_shapes: tuple):
+def test_mean_combined_with_arithmetic(device: str, tensor_shapes: tuple[int, ...]):
     """Test mean combined with arithmetic operations"""
 
     def fn(x, y):
@@ -2485,7 +2485,7 @@ def test_tensor_sqrt_method(conf: Conf):
     check_outputs(fn, conf, [x])
 
 
-def test_rsqrt_different_shapes(conf: Conf, tensor_shapes: tuple):
+def test_rsqrt_different_shapes(conf: Conf, tensor_shapes: tuple[int, ...]):
     """Test rsqrt with different tensor shapes"""
 
     def fn(x):
@@ -2496,7 +2496,7 @@ def test_rsqrt_different_shapes(conf: Conf, tensor_shapes: tuple):
     check_outputs(fn, conf, [x])
 
 
-def test_sqrt_different_shapes(conf: Conf, tensor_shapes: tuple):
+def test_sqrt_different_shapes(conf: Conf, tensor_shapes: tuple[int, ...]):
     """Test sqrt with different tensor shapes"""
 
     def fn(x):
@@ -3217,7 +3217,7 @@ def test_double_negation(conf: Conf):
     check_outputs(fn, conf, [x])
 
 
-def test_negation_different_shapes(conf: Conf, tensor_shapes: tuple):
+def test_negation_different_shapes(conf: Conf, tensor_shapes: tuple[int, ...]):
     """Test negation with different tensor shapes"""
 
     def fn(x):
@@ -3796,7 +3796,7 @@ def test_torch_clamp_max_only(conf: Conf, shapes):
     check_outputs(fn, conf, [a])
 
 
-def test_torch_clamp_tensor_bounds(device: str, tensor_shapes: tuple):
+def test_torch_clamp_tensor_bounds(device: str, tensor_shapes: tuple[int, ...]):
     """Test torch.clamp with tensor bounds (min and max as tensors)."""
 
     def fn(x, min_tensor, mojo_tensor):
@@ -4720,7 +4720,7 @@ def test_any_dtypes_with_dim(device: str, dtype, dim):
 
 
 @pytest.mark.parametrize("tensor_shapes", [(2, 3), (1, 5), (4,), (2, 3, 4)])
-def test_full_like_basic(conf: Conf, tensor_shapes: tuple):
+def test_full_like_basic(conf: Conf, tensor_shapes: tuple[int, ...]):
     """Test torch.full_like with different shapes and fill values"""
 
     def fn(x):
@@ -4791,7 +4791,7 @@ def test_full_like_negative_fill(conf: Conf):
 
 
 @pytest.mark.parametrize("tensor_shapes", [(1, 1), (10,), (2, 2, 2, 2)])
-def test_full_like_edge_cases(conf: Conf, tensor_shapes: tuple):
+def test_full_like_edge_cases(conf: Conf, tensor_shapes: tuple[int, ...]):
     """Test torch.full_like with edge case shapes"""
 
     def fn(x):
@@ -4989,7 +4989,7 @@ def test_scaled_dot_product_attention_with_scale(device: str):
 
 
 @pytest.mark.parametrize("dims", [(0, 1), (1, 0)])
-def test_permute_2d(conf: Conf, dims: tuple):
+def test_permute_2d(conf: Conf, dims: tuple[int, ...]):
     """Test torch.permute with 2D tensors"""
 
     def fn(x):
@@ -5003,7 +5003,7 @@ def test_permute_2d(conf: Conf, dims: tuple):
 @pytest.mark.parametrize(
     "dims", [(0, 1, 2), (0, 2, 1), (1, 0, 2), (1, 2, 0), (2, 0, 1), (2, 1, 0)]
 )
-def test_permute_3d(conf: Conf, dims: tuple):
+def test_permute_3d(conf: Conf, dims: tuple[int, ...]):
     """Test torch.permute with 3D tensors - all permutations"""
 
     def fn(x):
@@ -5073,7 +5073,7 @@ def test_permute_reverse_order(conf: Conf):
 
 
 @pytest.mark.parametrize("tensor_shapes", [(5,), (1, 10), (2, 3, 4), (1, 2, 3, 4, 5)])
-def test_permute_different_shapes(conf: Conf, tensor_shapes: tuple):
+def test_permute_different_shapes(conf: Conf, tensor_shapes: tuple[int, ...]):
     """Test permute with various tensor shapes"""
 
     def fn(x):
@@ -5391,7 +5391,7 @@ def test_tensor_nonzero_method(device: str):
 
 
 @pytest.mark.parametrize("tensor_shapes", [(2,), (3, 4), (2, 3, 4)])
-def test_nonzero_different_shapes(device: str, tensor_shapes: tuple):
+def test_nonzero_different_shapes(device: str, tensor_shapes: tuple[int, ...]):
     """Test nonzero with different tensor shapes"""
 
     def fn(x):
@@ -5612,7 +5612,7 @@ def test_interpolate_large_upsampling(device: str):
 
 
 @pytest.mark.parametrize("size", [(5, 5), (7, 9), (16, 16)])
-def test_interpolate_various_output_sizes(device: str, size: tuple):
+def test_interpolate_various_output_sizes(device: str, size: tuple[int, ...]):
     """Test F.interpolate with various output sizes"""
 
     def fn(x):

--- a/tests/test_mojo_autocast.py
+++ b/tests/test_mojo_autocast.py
@@ -24,7 +24,7 @@ def mojo_h100():
     return "mojo:0"
 
 
-def test_mojo_autocast_fallback_and_required_policies_are_registered() -> None:
+def test_mojo_autocast_fallback_and_required_policies_are_registered():
     # Exists at runtime; missing from torch's own DispatchKey stub.
     assert torch._C._dispatch_has_backend_fallback(
         getattr(torch._C.DispatchKey, "AutocastPrivateUse1")
@@ -47,7 +47,7 @@ def test_mojo_autocast_fallback_and_required_policies_are_registered() -> None:
         ), name
 
 
-def test_mojo_bf16_autocast_linear_loss_and_grad_dtypes(mojo_h100) -> None:
+def test_mojo_bf16_autocast_linear_loss_and_grad_dtypes(mojo_h100):
     generator = torch.Generator().manual_seed(20260718)
     host_input = torch.randn(8, 16, generator=generator)
     host_weight = torch.randn(11, 16, generator=generator)
@@ -71,7 +71,7 @@ def test_mojo_bf16_autocast_linear_loss_and_grad_dtypes(mojo_h100) -> None:
         assert torch.isfinite(tensor.grad.cpu()).all()
 
 
-def test_mojo_bf16_autocast_layernorm_and_fa4_dtypes(mojo_h100) -> None:
+def test_mojo_bf16_autocast_layernorm_and_fa4_dtypes(mojo_h100):
     generator = torch.Generator().manual_seed(20260718)
     layer_input = torch.randn(4, 64, generator=generator).to(mojo_h100)
     layer_weight = torch.randn(64, generator=generator).to(mojo_h100)

--- a/tests/test_mojo_device.py
+++ b/tests/test_mojo_device.py
@@ -991,7 +991,7 @@ def function_equivalent_on_both_devices(
         out1 = func(*args, device=device, **kwargs)
         out2 = func(*args, device="cpu", **kwargs)
     if isinstance(out1, list | tuple):
-        assert type(out1) == type(out2)
+        assert type(out1) is type(out2)
     else:
         assert isinstance(out1, torch.Tensor)
         assert isinstance(out2, torch.Tensor)

--- a/tests/test_mojo_exception_hygiene.py
+++ b/tests/test_mojo_exception_hygiene.py
@@ -30,7 +30,7 @@ _SWALLOW_RE = re.compile(
 )
 
 
-def test_no_success_reporting_exception_handlers() -> None:
+def test_no_success_reporting_exception_handlers():
     sources = sorted(_BACKEND_DIR.rglob("*.mojo"))
     assert sources, f"no .mojo sources found under {_BACKEND_DIR}"
     offenders = []

--- a/tests/test_no_none_return_annotations.py
+++ b/tests/test_no_none_return_annotations.py
@@ -1,0 +1,29 @@
+"""Ban `-> None` return annotations.
+
+Ruff's `suppress-none-returning` (pyproject.toml) exempts functions that
+return nothing from the ANN rules, so the annotation carries no information
+and is left off everywhere; this keeps it from creeping back.
+"""
+
+import re
+from pathlib import Path
+
+_REPO_DIR = Path(__file__).parent.parent
+_SCANNED_DIRS = ("torch_mojo_backend", "tests", "benchmarks", "demo_scripts")
+_NONE_RETURN_RE = re.compile(r"\)\s*->\s*None\s*:")
+
+
+def test_no_none_return_annotations():
+    sources = sorted(
+        path
+        for directory in _SCANNED_DIRS
+        for path in (_REPO_DIR / directory).rglob("*.py")
+    )
+    assert sources, f"no .py sources found under {_REPO_DIR}"
+    offenders = []
+    for path in sources:
+        text = path.read_text()
+        for match in _NONE_RETURN_RE.finditer(text):
+            line = text.count("\n", 0, match.start()) + 1
+            offenders.append(f"{path.relative_to(_REPO_DIR)}:{line}")
+    assert not offenders, "`-> None` return annotations found:\n" + "\n".join(offenders)

--- a/tests/test_out_variant_resize.py
+++ b/tests/test_out_variant_resize.py
@@ -9,7 +9,7 @@ from torch_mojo_backend.testing import CallChecker
 pytestmark = pytest.mark.xdist_group(name="group1")
 
 
-def _watch_eager_op(call_checker: CallChecker, op_name: str) -> None:
+def _watch_eager_op(call_checker: CallChecker, op_name: str):
     from torch_mojo_backend.mojo_device.mojo_device_aten_ops import EAGER_CALL_COUNTERS
 
     call_checker.register(EAGER_CALL_COUNTERS[op_name])

--- a/tests/test_sdpa_host_wiring.py
+++ b/tests/test_sdpa_host_wiring.py
@@ -37,7 +37,7 @@ def _patch_saved_and_views(
     monkeypatch: pytest.MonkeyPatch,
     saved: tuple[_Token, ...],
     views: list[tuple[str, tuple[int, ...]]],
-) -> None:
+):
     monkeypatch.setattr(autograd, "_restore_saved_mojo_tensors", lambda _ctx: saved)
 
     def contiguous_view(tensor: _Token, shape) -> _Token:
@@ -65,7 +65,7 @@ def _query_gradient_context(has_dropout: bool) -> SimpleNamespace:
     )
 
 
-def test_sdpa_backward_bridge_is_lazy_registered() -> None:
+def test_sdpa_backward_bridge_is_lazy_registered():
     from torch_mojo_backend.eager_kernels import aten_fast
 
     assert aten_fast._SdpaBackwardExtension.MOJO_FILE.name == "sdpa_backward_ops.mojo"
@@ -73,7 +73,7 @@ def test_sdpa_backward_bridge_is_lazy_registered() -> None:
 
 def test_missing_sdpa_kernel_module_returns_not_handled_before_device_work(
     monkeypatch: pytest.MonkeyPatch, tmp_path
-) -> None:
+):
     from torch_mojo_backend.eager_kernels import aten_fast
 
     device = object()
@@ -114,7 +114,7 @@ def test_missing_sdpa_kernel_module_returns_not_handled_before_device_work(
 @pytest.mark.parametrize("has_dropout", [False, True])
 def test_sdpa_query_gradient_prefers_fused_dropout_softmax_backward(
     monkeypatch: pytest.MonkeyPatch, has_dropout: bool
-) -> None:
+):
     ctx = _query_gradient_context(has_dropout)
     saved = tuple(_Token(name) for name in ctx.saved_names)
     views: list[tuple[str, tuple[int, ...]]] = []
@@ -175,7 +175,7 @@ def test_sdpa_query_gradient_prefers_fused_dropout_softmax_backward(
 @pytest.mark.parametrize("has_dropout", [False, True])
 def test_sdpa_fused_not_handled_preserves_decomposition_order(
     monkeypatch: pytest.MonkeyPatch, has_dropout: bool
-) -> None:
+):
     ctx = _query_gradient_context(has_dropout)
     saved = tuple(_Token(name) for name in ctx.saved_names)
     views: list[tuple[str, tuple[int, ...]]] = []
@@ -245,7 +245,7 @@ def test_sdpa_fused_not_handled_preserves_decomposition_order(
 @pytest.mark.parametrize("has_dropout", [False, True])
 def test_sdpa_value_only_gradient_skips_fused_score_gradient(
     monkeypatch: pytest.MonkeyPatch, has_dropout: bool
-) -> None:
+):
     names = ["probabilities"]
     if has_dropout:
         names.append("dropout_mask")

--- a/tests/test_tensor_spec_oom.py
+++ b/tests/test_tensor_spec_oom.py
@@ -51,7 +51,7 @@ def test_tensor_spec_fallbacks_propagate_device_oom(
     def as_tensor(candidate: object) -> object | None:
         return candidate if any(candidate is tensor for tensor in tensors) else None
 
-    def raise_allocator_oom(*_args: object, **_kwargs: object) -> None:
+    def raise_allocator_oom(*_args: object, **_kwargs: object):
         raise NotImplementedError(_CUDA_OOM)
 
     def load_oom_module(
@@ -116,7 +116,7 @@ def test_tensor_spec_unsupported_metadata_still_uses_fallback(
     device = CPU()
     tensor = fake_mojo_tensor(device)
 
-    def raise_unsupported(*_args: object, **_kwargs: object) -> None:
+    def raise_unsupported(*_args: object, **_kwargs: object):
         raise NotImplementedError("mojo spec neg: strided input is unsupported")
 
     def load_unsupported_module(

--- a/torch_mojo_backend/aten_functions.py
+++ b/torch_mojo_backend/aten_functions.py
@@ -126,7 +126,7 @@ def torch_device_to_max_device(x: torch.device) -> DeviceRef:
 # handle_call_function. Lets multi-output mappings check which outputs are
 # actually consumed (e.g. native_layer_norm's mean/rstd are dead in
 # inference graphs, enabling the fused kernel).
-CURRENT_FX_NODE: contextvars.ContextVar = contextvars.ContextVar(
+CURRENT_FX_NODE: contextvars.ContextVar[torch.fx.Node | None] = contextvars.ContextVar(
     "CURRENT_FX_NODE", default=None
 )
 

--- a/torch_mojo_backend/custom_torch_ops_in_mojo/torch_custom_ops.py
+++ b/torch_mojo_backend/custom_torch_ops_in_mojo/torch_custom_ops.py
@@ -20,7 +20,7 @@ class _SignedTorchOp(Protocol):
 
     __signature__: inspect.Signature
 
-    def __call__(self, *args: torch.Tensor, **kwargs: torch.Tensor) -> None: ...
+    def __call__(self, *args: torch.Tensor, **kwargs: torch.Tensor): ...
 
 
 def make_torch_op_from_mojo(
@@ -57,9 +57,7 @@ def make_torch_op_from_mojo(
 
     torch_mojo_backend.torch_compile_backend.compiler._global_max_objects = None
 
-    def mojo_custom_op_with_signature(
-        *args: torch.Tensor, **kwargs: torch.Tensor
-    ) -> None:
+    def mojo_custom_op_with_signature(*args: torch.Tensor, **kwargs: torch.Tensor):
         mojo_custom_op(*args, **kwargs)
 
     signed_op = cast(_SignedTorchOp, mojo_custom_op_with_signature)

--- a/torch_mojo_backend/custom_torch_ops_in_mojo/torch_custom_ops.py
+++ b/torch_mojo_backend/custom_torch_ops_in_mojo/torch_custom_ops.py
@@ -24,7 +24,11 @@ class _SignedTorchOp(Protocol):
 
 
 def make_torch_op_from_mojo(
-    path_to_kernels: Path, mojo_custom_op_str: str, allocate_outputs_fn: Callable
+    path_to_kernels: Path,
+    mojo_custom_op_str: str,
+    allocate_outputs_fn: Callable[
+        ..., torch.Tensor | tuple[torch.Tensor, ...] | list[torch.Tensor]
+    ],
 ) -> Callable[..., torch.Tensor | tuple[torch.Tensor, ...] | list[torch.Tensor]]:
     ops = CustomOpLibrary(path_to_kernels)
     mojo_custom_op = ops.__getattr__(mojo_custom_op_str)

--- a/torch_mojo_backend/eager_kernels/__init__.py
+++ b/torch_mojo_backend/eager_kernels/__init__.py
@@ -54,18 +54,18 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
-from typing import IO, ClassVar, Generic, TypeVar, cast
+from typing import IO, ClassVar, Generic, NoReturn, TypeVar, cast
 
 from max import driver
 from max.dtype import DType
 
-from . import call_queue
+from torch_mojo_backend.eager_kernels import call_queue
 
 _PACKAGE_DIR = Path(__file__).parent
 _CACHE_DIR = _PACKAGE_DIR / "__mojocache__"
 
 
-_MOJO_EXE_CACHE: list = []
+_MOJO_EXE_CACHE: list[Path] = []
 
 
 def _find_mojo() -> Path:
@@ -728,7 +728,7 @@ _ExtensionResult = TypeVar("_ExtensionResult")
 
 @dataclass(frozen=True)
 class PreparedExtensionCall(Generic[_OutputSpecs, _ExtensionResult]):
-    extension: type["MojoExtension"]
+    extension: type["MojoExtension[_OutputSpecs, _ExtensionResult]"]
     defines: CanonicalDefines
     output_specs: _OutputSpecs
     args: tuple[object, ...]
@@ -765,7 +765,7 @@ class MojoExtension(ABC, Generic[_OutputSpecs, _ExtensionResult]):
     __slots__ = ()
     MOJO_FILE: ClassVar[Path]
 
-    def __new__(cls) -> "MojoExtension":
+    def __new__(cls) -> NoReturn:
         raise TypeError(
             f"{cls.__name__} is a stateless descriptor and cannot be instantiated"
         )

--- a/torch_mojo_backend/eager_kernels/__init__.py
+++ b/torch_mojo_backend/eager_kernels/__init__.py
@@ -429,7 +429,7 @@ _BUILD_NOTICE_LOCK = threading.Lock()
 _BUILD_NOTICE_SHOWN = False
 
 
-def _trace(message: str) -> None:
+def _trace(message: str):
     """Build tracing, on by default; TORCH_MOJO_BACKEND_TRACE=0 silences it.
 
     No timestamp: a raw `t=<monotonic>` told a reader nothing on its own --
@@ -441,7 +441,7 @@ def _trace(message: str) -> None:
         sys.stderr.write(f"[TRACE] {message}\n")
 
 
-def _announce_build() -> None:
+def _announce_build():
     """One notice per process, not one per specialization.
 
     A cold process compiles dozens of variants across up to `_pool_size()`
@@ -588,12 +588,12 @@ def _resolve_mojo_file(mojo_file: Path) -> Path:
 
 
 class _AsyncLoadJob:
-    def __init__(self, unit: "_DefinedUnit") -> None:
+    def __init__(self, unit: "_DefinedUnit"):
         self.unit = unit
         self.done = threading.Event()
         self.error: BaseException | None = None
 
-    def run(self) -> None:
+    def run(self):
         try:
             with _ASYNC_BUILD_SLOTS:
                 self.unit.load_blocking()
@@ -612,7 +612,7 @@ class _AsyncLoadJob:
 
 
 class _DefinedUnit:
-    def __init__(self, mojo_file: Path, defines: CanonicalDefines) -> None:
+    def __init__(self, mojo_file: Path, defines: CanonicalDefines):
         self.mojo_file = mojo_file
         self.defines = defines
         self.lock = threading.Lock()
@@ -683,7 +683,7 @@ class _DefinedUnit:
 class MojoExtensionLoader:
     """Stateful build/module cache shared by stateless operation classes."""
 
-    def __init__(self) -> None:
+    def __init__(self):
         self._lock = threading.Lock()
         self._units: dict[tuple[Path, CanonicalDefines], _DefinedUnit] = {}
         self._requests: dict[tuple[Path, CanonicalDefines], _DefinedUnit] = {}
@@ -748,7 +748,7 @@ class PreparedExtensionCall(Generic[_OutputSpecs, _ExtensionResult]):
         extension_args: tuple[object, ...],
         keepalive: tuple[object, ...],
         loader: MojoExtensionLoader | None = None,
-    ) -> None:
+    ):
         """Queue a non-returning `call(..., out)` into preallocated outputs.
 
         `keepalive` names the objects whose buffers `extension_args`'

--- a/torch_mojo_backend/eager_kernels/activation_backward_ops/__init__.py
+++ b/torch_mojo_backend/eager_kernels/activation_backward_ops/__init__.py
@@ -1,3 +1,5 @@
-from .activation_backward_ops import ActivationBackwardExtension
+from torch_mojo_backend.eager_kernels.activation_backward_ops.activation_backward_ops import (
+    ActivationBackwardExtension,
+)
 
 __all__ = ["ActivationBackwardExtension"]

--- a/torch_mojo_backend/eager_kernels/activation_forward_ops/__init__.py
+++ b/torch_mojo_backend/eager_kernels/activation_forward_ops/__init__.py
@@ -1,3 +1,5 @@
-from .activation_forward_ops import ActivationForwardExtension
+from torch_mojo_backend.eager_kernels.activation_forward_ops.activation_forward_ops import (
+    ActivationForwardExtension,
+)
 
 __all__ = ["ActivationForwardExtension"]

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -34,6 +34,24 @@ from max.experimental.torch import max_dtype_to_torch
 
 from torch_mojo_backend import eager_kernels, is_running_tests
 from torch_mojo_backend.eager_kernels import call_queue as _call_queue
+from torch_mojo_backend.eager_kernels import _ctx_ptr
+from torch_mojo_backend.eager_kernels.output_specs import (
+    _allocate_output_spec,
+    _submit_prepared_into,
+    _TensorOutputSpec,
+)
+from torch_mojo_backend.mojo_device.torch_mojo_device_module import (
+    _reserve_philox_state,
+)
+from torch_mojo_backend.mojo_device.torch_mojo_tensor import (
+    MojoTensorLike,
+    TorchMojoTensor,
+    _copy_strided_into,
+    _pad8,
+    _resize_payload,
+    _row_major_strides,
+)
+from torch_mojo_backend.types import CountedCallable
 from torch_mojo_backend.eager_kernels.activation_backward_ops import (
     ActivationBackwardExtension as _ActivationBackwardExtension,
 )
@@ -136,26 +154,6 @@ def _call_mojo(
     except Exception as exc:
         _raise_if_device_oom(exc)
         raise
-
-
-from torch_mojo_backend.eager_kernels import _ctx_ptr
-from torch_mojo_backend.eager_kernels.output_specs import (
-    _allocate_output_spec,
-    _submit_prepared_into,
-    _TensorOutputSpec,
-)
-from torch_mojo_backend.mojo_device.torch_mojo_device_module import (
-    _reserve_philox_state,
-)
-from torch_mojo_backend.mojo_device.torch_mojo_tensor import (
-    MojoTensorLike,
-    TorchMojoTensor,
-    _copy_strided_into,
-    _pad8,
-    _resize_payload,
-    _row_major_strides,
-)
-from torch_mojo_backend.types import CountedCallable
 
 
 @runtime_checkable
@@ -1613,7 +1611,7 @@ def _try_spec_binary_into(
     if dtype == DType.bool and spec_fn_name not in _SPEC_BOOL_OK_NAMES:
         return None
     if spec_fn_name not in _SPEC_CMP_NAMES:
-        if spec_fn_name in _SPEC_FLOAT_ONLY_NAMES and not kdtype in (
+        if spec_fn_name in _SPEC_FLOAT_ONLY_NAMES and kdtype not in (
             DType.float32,
             DType.float16,
             DType.bfloat16,
@@ -2129,8 +2127,8 @@ _call_queue.set_error_translator(_raise_if_device_oom)
 
 
 def _spec_matmul_out_shape(
-    spec_fn_name: str, ts: list, transpose_b: int
-) -> tuple | None:
+    spec_fn_name: str, ts: list[MojoTensorLike], transpose_b: int
+) -> tuple[int, ...] | None:
     """Output shape for a queueable matmul spec launch, or None when any
     Mojo-side check might fail (a queued launch cannot fall back).
 
@@ -2165,7 +2163,7 @@ def _spec_matmul_out_shape(
         return None
     k = a._shape[-1]
     n, kb = (b._shape[0], b._shape[1]) if transpose_b else (b._shape[1], b._shape[0])
-    if kb != k or k == 0 or n == 0 or a._numel == 0:
+    if kb != k or k == 0 or n == 0 or 0 in a._shape:
         return None
     if spec_fn_name == "MatmulBiasSpec":
         bias = ts[2]
@@ -8195,8 +8193,8 @@ def fast_fused_flash_attention_backward(
     k = _t(key)
     v = _t(value)
     o = _t(output)
-    l = _t(lse)
-    if g is None or q is None or k is None or v is None or o is None or l is None:
+    lse_t = _t(lse)
+    if g is None or q is None or k is None or v is None or o is None or lse_t is None:
         return NOT_HANDLED
     if g._dtype != q._dtype or tuple(g._shape) != tuple(q._shape):
         return NOT_HANDLED
@@ -8229,7 +8227,7 @@ def fast_fused_flash_attention_backward(
             k._ptr,
             v._ptr,
             o._ptr,
-            l._ptr,
+            lse_t._ptr,
             (batch, heads, seq_q, seq_kv, head_dim),
             _fa_strides(g)
             + _fa_strides(q)
@@ -8244,10 +8242,10 @@ def fast_fused_flash_attention_backward(
             q._dtype.value,
             _ctx_ptr(q._device),
         ),
-        arg_dtypes=(g._dtype, q._dtype, k._dtype, v._dtype, o._dtype, l._dtype),
+        arg_dtypes=(g._dtype, q._dtype, k._dtype, v._dtype, o._dtype, lse_t._dtype),
         output_dtypes=(grad_query._dtype, grad_key._dtype, grad_value._dtype),
         flags={"CAUSAL": bool(is_causal)},
-        keepalive=(grad_query, grad_key, grad_value, g, q, k, v, o, l),
+        keepalive=(grad_query, grad_key, grad_value, g, q, k, v, o, lse_t),
     )
     return grad_query, grad_key, grad_value
 

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -817,7 +817,7 @@ def _foreach_launch(
     scalars: Sequence[float] = (),
     aux: tuple[int, ...] = (),
     keepalive: tuple[object, ...] = (),
-) -> None:
+):
     """One launch of the batched foreach family for a whole TensorList.
 
     `lists` are the parallel operand lists in the order the Mojo bridge
@@ -2106,7 +2106,7 @@ def _try_spec_reduce(
     return result
 
 
-def _raise_if_device_oom(exc: BaseException) -> None:
+def _raise_if_device_oom(exc: BaseException):
     """Keep TensorSpec fallbacks from disguising allocator exhaustion.
 
     Mojo TensorSpec dispatch reports both unsupported metadata and runtime
@@ -2352,7 +2352,7 @@ def _on_gpu(t: _SpecTensor) -> bool:
     return _device_of(t).label == "gpu"
 
 
-def _alert_not_deterministic(caller: str) -> None:
+def _alert_not_deterministic(caller: str):
     """Match PyTorch's deterministic-algorithm error/warn-only contract."""
     if not torch.are_deterministic_algorithms_enabled():
         return
@@ -2375,7 +2375,7 @@ def _alert_not_deterministic(caller: str) -> None:
     )
 
 
-def _copy_into(dst: TorchMojoTensor, src: TorchMojoTensor) -> None:
+def _copy_into(dst: TorchMojoTensor, src: TorchMojoTensor):
     """dst[...] = src[...] for equal shapes/dtypes, any strides on both."""
     if dst._numel == 0:
         return
@@ -2547,7 +2547,7 @@ def _launch_where_bcast(
     operands: tuple[TorchMojoTensor, TorchMojoTensor, TorchMojoTensor],
     meta: tuple[list[int], list[int], list[list[int]]],
     dtype: DType,
-) -> None:
+):
     out_shape, dims, strides = meta
     params = tuple(dims) + tuple(s for st in strides for s in st)
     _call_mojo(
@@ -2573,7 +2573,7 @@ def _launch_masked_fill_scalar(
     value: float,
     meta: tuple[list[int], list[int], list[list[int]]],
     dtype: DType,
-) -> None:
+):
     """masked_fill(_).Scalar's fast path: `value` is baked into the launch
     as an argument, never materialized into a device buffer first (that
     used to cost a whole extra Fill kernel launch -- see MaskedFillScalar's
@@ -10152,7 +10152,7 @@ def fast_aten__local_scalar_dense(tensor: torch.Tensor) -> object:
     return _tensor_holder().read_scalar(_ctx_ptr(t._device), t._ptr, t._dtype.value)
 
 
-def _instrument_call_counts() -> None:
+def _instrument_call_counts():
     """Give every fast op a test-only call counter, mirroring what
     `aten_functions.map_to` does, so `CallChecker` can assert that an op
     was handled by either implementation."""

--- a/torch_mojo_backend/eager_kernels/call_queue.py
+++ b/torch_mojo_backend/eager_kernels/call_queue.py
@@ -95,18 +95,27 @@ class _QueueUnit(Protocol):
 # raw `args` name — retained until the item launches (rule 3) — and the
 # device bytes that retention holds, pre-computed for the run-ahead budget.
 _QueueItem = tuple[
-    _QueueUnit | None, Callable[..., object] | None, tuple, threading.Thread, tuple, int
+    _QueueUnit | None,
+    Callable[..., object] | None,
+    tuple[object, ...],
+    threading.Thread,
+    tuple[object, ...],
+    int,
 ]
 
 _LOCK = threading.RLock()  # queue + every device touch (see rule 6)
 _QUEUE: deque[_QueueItem] = deque()
 _HELD_ERROR: list[BaseException] = []
-_DEVICE_THREAD: list = [None]  # last thread to issue device work (rule 4)
-_QUEUE_LAUNCH_THREAD: list = [None]  # last thread to launch FROM the queue
-_ERROR_TRANSLATOR: list = [None]
-_ENABLED: list = [None]  # memoized enabled(); refresh() invalidates
+_DEVICE_THREAD: list[threading.Thread | None] = [
+    None
+]  # last thread to issue device work (rule 4)
+_QUEUE_LAUNCH_THREAD: list[threading.Thread | None] = [
+    None
+]  # last thread to launch FROM the queue
+_ERROR_TRANSLATOR: list[Callable[[BaseException], None] | None] = [None]
+_ENABLED: list[bool | None] = [None]  # memoized enabled(); refresh() invalidates
 _RETAINED_BYTES: list[int] = [0]  # bytes held by queued items (rule 3 budget)
-_BUDGET_BYTES: list = [None]  # memoized budget; refresh() invalidates
+_BUDGET_BYTES: list[int | None] = [None]  # memoized budget; refresh() invalidates
 _TLS = threading.local()  # .in_launch
 
 # Run-ahead bound. During a cold storm the host can enqueue whole training
@@ -449,7 +458,9 @@ def _launch_prefix(unit: _QueueUnit | None) -> bool:
     return True
 
 
-def kernel_call_into(unit: _QueueUnit, args: tuple, keepalive: tuple) -> None:
+def kernel_call_into(
+    unit: _QueueUnit, args: tuple[object, ...], keepalive: tuple[object, ...]
+) -> None:
     """Queue a descriptor call whose outputs were preallocated in Python.
     The call writes into them and returns nothing — always queueable
     regardless of the *Spec naming convention.
@@ -470,7 +481,9 @@ def kernel_call_into(unit: _QueueUnit, args: tuple, keepalive: tuple) -> None:
         _enforce_budget_locked()
 
 
-def external_call(fn: Callable[..., object], args: tuple, keepalive: tuple) -> None:
+def external_call(
+    fn: Callable[..., object], args: tuple[object, ...], keepalive: tuple[object, ...]
+) -> None:
     """An ungated device call (tensor_holder, fa4): always launchable, but
     must hold its FIFO position behind queued producers of its inputs.
 

--- a/torch_mojo_backend/eager_kernels/call_queue.py
+++ b/torch_mojo_backend/eager_kernels/call_queue.py
@@ -153,7 +153,7 @@ def enabled() -> bool:
     return cached
 
 
-def refresh() -> None:
+def refresh():
     """Re-read the mode environment variables on the next `enabled()`."""
     _ENABLED[0] = None
     _BUDGET_BYTES[0] = None
@@ -219,7 +219,7 @@ def active() -> bool:
     return bool(_QUEUE)
 
 
-def set_error_translator(fn: Callable[[BaseException], None]) -> None:
+def set_error_translator(fn: Callable[[BaseException], None]):
     """Install the hook that retypes a device error raised by a *deferred*
     launch (aten_fast installs `_raise_if_device_oom`, so an allocator
     exhaustion still surfaces as `torch.OutOfMemoryError` even when the
@@ -243,14 +243,14 @@ def _translate(exc: BaseException) -> BaseException:
 # Execution
 
 
-def _device_only_synchronize() -> None:
+def _device_only_synchronize():
     """The device barrier that never drains: safe inside the launch path."""
     from torch_mojo_backend.mojo_device import torch_mojo_device_module as _dm
 
     _dm._device_synchronize()
 
 
-def order_direct_launch() -> None:
+def order_direct_launch():
     """A direct (non-queued) launch is about to run on the current thread.
 
     Direct launches are issued by the thread that runs the op, so they are
@@ -275,7 +275,7 @@ def order_direct_launch() -> None:
     _DEVICE_THREAD[0] = me
 
 
-def _order_queue_launch_locked() -> None:
+def _order_queue_launch_locked():
     """The queue is about to launch, on the current thread, items other
     threads may have enqueued — the replay pattern that empirically read
     stale results without a barrier (rule 4). Synchronize once, before
@@ -297,7 +297,7 @@ def _order_queue_launch_locked() -> None:
     _DEVICE_THREAD[0] = me
 
 
-def _exec(item: _QueueItem) -> None:
+def _exec(item: _QueueItem):
     unit, fn, args, _enqueuer, _keepalive, _nbytes = item
     if unit is None:
         assert fn is not None  # exactly one of unit/fn is set
@@ -324,7 +324,7 @@ def _abandon_locked(exc: BaseException) -> BaseException:
     return _translate(exc)
 
 
-def _pump_locked() -> None:
+def _pump_locked():
     """Launch the longest ready prefix; stop at a head whose unit is still
     building. Held errors stay held until the next drain."""
     if _HELD_ERROR or not _QUEUE:
@@ -349,7 +349,7 @@ def _pump_locked() -> None:
             return
 
 
-def _drain_over_budget_locked() -> None:
+def _drain_over_budget_locked():
     """Rule 3's bound: queued items retain more device bytes than the budget
     allows, so stop running ahead — wait builds out and launch until the
     retention is released. This drain serves memory, not a value: a launch
@@ -374,7 +374,7 @@ def _drain_over_budget_locked() -> None:
             return
 
 
-def _enforce_budget_locked() -> None:
+def _enforce_budget_locked():
     """Drain when the just-appended item pushed retention past the budget.
     Skipped inside a launch (a reentrant enqueue must never re-enter the
     queue) — the outer launch path is already emptying it."""
@@ -389,7 +389,7 @@ def _enforce_budget_locked() -> None:
             _TLS.in_launch = False
 
 
-def pump() -> None:
+def pump():
     """Launch whatever is ready. Non-blocking: never waits on a build."""
     if not _QUEUE or getattr(_TLS, "in_launch", False):
         return
@@ -401,7 +401,7 @@ def pump() -> None:
         _TLS.in_launch = False
 
 
-def drain() -> None:
+def drain():
     """Launch everything (waiting out builds); re-raise launch errors.
     Called before any host read of device values.
 
@@ -460,7 +460,7 @@ def _launch_prefix(unit: _QueueUnit | None) -> bool:
 
 def kernel_call_into(
     unit: _QueueUnit, args: tuple[object, ...], keepalive: tuple[object, ...]
-) -> None:
+):
     """Queue a descriptor call whose outputs were preallocated in Python.
     The call writes into them and returns nothing — always queueable
     regardless of the *Spec naming convention.
@@ -483,7 +483,7 @@ def kernel_call_into(
 
 def external_call(
     fn: Callable[..., object], args: tuple[object, ...], keepalive: tuple[object, ...]
-) -> None:
+):
     """An ungated device call (tensor_holder, fa4): always launchable, but
     must hold its FIFO position behind queued producers of its inputs.
 

--- a/torch_mojo_backend/eager_kernels/conv_ops/__init__.py
+++ b/torch_mojo_backend/eager_kernels/conv_ops/__init__.py
@@ -1,3 +1,3 @@
-from .conv_ops import ConvExtension
+from torch_mojo_backend.eager_kernels.conv_ops.conv_ops import ConvExtension
 
 __all__ = ["ConvExtension"]

--- a/torch_mojo_backend/eager_kernels/data_movement_ops/__init__.py
+++ b/torch_mojo_backend/eager_kernels/data_movement_ops/__init__.py
@@ -1,3 +1,5 @@
-from .data_movement_ops import DataMovementExtension
+from torch_mojo_backend.eager_kernels.data_movement_ops.data_movement_ops import (
+    DataMovementExtension,
+)
 
 __all__ = ["DataMovementExtension"]

--- a/torch_mojo_backend/eager_kernels/dropout_ops/__init__.py
+++ b/torch_mojo_backend/eager_kernels/dropout_ops/__init__.py
@@ -1,3 +1,3 @@
-from .dropout_ops import DropoutExtension
+from torch_mojo_backend.eager_kernels.dropout_ops.dropout_ops import DropoutExtension
 
 __all__ = ["DropoutExtension"]

--- a/torch_mojo_backend/eager_kernels/elementwise_ops/__init__.py
+++ b/torch_mojo_backend/eager_kernels/elementwise_ops/__init__.py
@@ -1,3 +1,5 @@
-from .elementwise_ops import ElementwiseExtension
+from torch_mojo_backend.eager_kernels.elementwise_ops.elementwise_ops import (
+    ElementwiseExtension,
+)
 
 __all__ = ["ElementwiseExtension"]

--- a/torch_mojo_backend/eager_kernels/embedding_backward_ops/__init__.py
+++ b/torch_mojo_backend/eager_kernels/embedding_backward_ops/__init__.py
@@ -1,3 +1,5 @@
-from .embedding_backward_ops import EmbeddingBackwardExtension
+from torch_mojo_backend.eager_kernels.embedding_backward_ops.embedding_backward_ops import (
+    EmbeddingBackwardExtension,
+)
 
 __all__ = ["EmbeddingBackwardExtension"]

--- a/torch_mojo_backend/eager_kernels/flash_attention_ops/__init__.py
+++ b/torch_mojo_backend/eager_kernels/flash_attention_ops/__init__.py
@@ -1,3 +1,5 @@
-from .flash_attention_ops import FlashAttentionExtension
+from torch_mojo_backend.eager_kernels.flash_attention_ops.flash_attention_ops import (
+    FlashAttentionExtension,
+)
 
 __all__ = ["FlashAttentionExtension"]

--- a/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/__init__.py
+++ b/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/__init__.py
@@ -1,3 +1,5 @@
-from .gemm16_matmul_ops import Gemm16MatmulExtension
+from torch_mojo_backend.eager_kernels.gemm16_matmul_ops.gemm16_matmul_ops import (
+    Gemm16MatmulExtension,
+)
 
 __all__ = ["Gemm16MatmulExtension"]

--- a/torch_mojo_backend/eager_kernels/logic_ops/__init__.py
+++ b/torch_mojo_backend/eager_kernels/logic_ops/__init__.py
@@ -1,3 +1,3 @@
-from .logic_ops import LogicExtension
+from torch_mojo_backend.eager_kernels.logic_ops.logic_ops import LogicExtension
 
 __all__ = ["LogicExtension"]

--- a/torch_mojo_backend/eager_kernels/loss_ops/__init__.py
+++ b/torch_mojo_backend/eager_kernels/loss_ops/__init__.py
@@ -1,3 +1,3 @@
-from .loss_ops import LossExtension
+from torch_mojo_backend.eager_kernels.loss_ops.loss_ops import LossExtension
 
 __all__ = ["LossExtension"]

--- a/torch_mojo_backend/eager_kernels/matmul_ops/__init__.py
+++ b/torch_mojo_backend/eager_kernels/matmul_ops/__init__.py
@@ -1,3 +1,3 @@
-from .matmul_ops import MatmulExtension
+from torch_mojo_backend.eager_kernels.matmul_ops.matmul_ops import MatmulExtension
 
 __all__ = ["MatmulExtension"]

--- a/torch_mojo_backend/eager_kernels/nn_ops/__init__.py
+++ b/torch_mojo_backend/eager_kernels/nn_ops/__init__.py
@@ -1,3 +1,3 @@
-from .nn_ops import NNExtension
+from torch_mojo_backend.eager_kernels.nn_ops.nn_ops import NNExtension
 
 __all__ = ["NNExtension"]

--- a/torch_mojo_backend/eager_kernels/normalization_backward_ops/__init__.py
+++ b/torch_mojo_backend/eager_kernels/normalization_backward_ops/__init__.py
@@ -1,3 +1,5 @@
-from .normalization_backward_ops import NormalizationBackwardExtension
+from torch_mojo_backend.eager_kernels.normalization_backward_ops.normalization_backward_ops import (
+    NormalizationBackwardExtension,
+)
 
 __all__ = ["NormalizationBackwardExtension"]

--- a/torch_mojo_backend/eager_kernels/normalization_forward_ops/__init__.py
+++ b/torch_mojo_backend/eager_kernels/normalization_forward_ops/__init__.py
@@ -1,3 +1,5 @@
-from .normalization_forward_ops import NormalizationForwardExtension
+from torch_mojo_backend.eager_kernels.normalization_forward_ops.normalization_forward_ops import (
+    NormalizationForwardExtension,
+)
 
 __all__ = ["NormalizationForwardExtension"]

--- a/torch_mojo_backend/eager_kernels/optimizer_ops/__init__.py
+++ b/torch_mojo_backend/eager_kernels/optimizer_ops/__init__.py
@@ -1,3 +1,5 @@
-from .optimizer_ops import OptimizerExtension
+from torch_mojo_backend.eager_kernels.optimizer_ops.optimizer_ops import (
+    OptimizerExtension,
+)
 
 __all__ = ["OptimizerExtension"]

--- a/torch_mojo_backend/eager_kernels/random_ops/__init__.py
+++ b/torch_mojo_backend/eager_kernels/random_ops/__init__.py
@@ -1,3 +1,3 @@
-from .random_ops import RandomExtension
+from torch_mojo_backend.eager_kernels.random_ops.random_ops import RandomExtension
 
 __all__ = ["RandomExtension"]

--- a/torch_mojo_backend/eager_kernels/reduction_ops/__init__.py
+++ b/torch_mojo_backend/eager_kernels/reduction_ops/__init__.py
@@ -1,3 +1,5 @@
-from .reduction_ops import ReductionExtension
+from torch_mojo_backend.eager_kernels.reduction_ops.reduction_ops import (
+    ReductionExtension,
+)
 
 __all__ = ["ReductionExtension"]

--- a/torch_mojo_backend/eager_kernels/sdpa_backward_ops/__init__.py
+++ b/torch_mojo_backend/eager_kernels/sdpa_backward_ops/__init__.py
@@ -1,3 +1,5 @@
-from .sdpa_backward_ops import SDPABackwardExtension
+from torch_mojo_backend.eager_kernels.sdpa_backward_ops.sdpa_backward_ops import (
+    SDPABackwardExtension,
+)
 
 __all__ = ["SDPABackwardExtension"]

--- a/torch_mojo_backend/eager_kernels/searchsorted_ops/__init__.py
+++ b/torch_mojo_backend/eager_kernels/searchsorted_ops/__init__.py
@@ -1,3 +1,5 @@
-from .searchsorted_ops import SearchsortedExtension
+from torch_mojo_backend.eager_kernels.searchsorted_ops.searchsorted_ops import (
+    SearchsortedExtension,
+)
 
 __all__ = ["SearchsortedExtension"]

--- a/torch_mojo_backend/eager_kernels/softmax_backward_ops/__init__.py
+++ b/torch_mojo_backend/eager_kernels/softmax_backward_ops/__init__.py
@@ -1,3 +1,5 @@
-from .softmax_backward_ops import SoftmaxBackwardExtension
+from torch_mojo_backend.eager_kernels.softmax_backward_ops.softmax_backward_ops import (
+    SoftmaxBackwardExtension,
+)
 
 __all__ = ["SoftmaxBackwardExtension"]

--- a/torch_mojo_backend/eager_kernels/tf32_matmul_ops/__init__.py
+++ b/torch_mojo_backend/eager_kernels/tf32_matmul_ops/__init__.py
@@ -1,3 +1,5 @@
-from .tf32_matmul_ops import TF32MatmulExtension
+from torch_mojo_backend.eager_kernels.tf32_matmul_ops.tf32_matmul_ops import (
+    TF32MatmulExtension,
+)
 
 __all__ = ["TF32MatmulExtension"]

--- a/torch_mojo_backend/mojo_device/apple_optimizations.py
+++ b/torch_mojo_backend/mojo_device/apple_optimizations.py
@@ -1,7 +1,7 @@
 from torch_mojo_backend.torch_compile_backend.utils import get_accelerators
 
 
-def _enable_apple_fast_add() -> None:
+def _enable_apple_fast_add():
     """Select the isolated Metal contiguous-add implementation.
 
     Patching once during device registration keeps CUDA and ROCm on the
@@ -14,7 +14,7 @@ def _enable_apple_fast_add() -> None:
     aten_fast.fast_aten_add = aten_fast.fast_aten_add_apple  # ty: ignore[invalid-assignment]
 
 
-def register_apple_optimizations() -> None:
+def register_apple_optimizations():
     """Install optional integrations that are profitable only on Apple GPUs."""
     if any(device.api == "metal" for device in get_accelerators()):
         _enable_apple_fast_add()

--- a/torch_mojo_backend/mojo_device/aten_ops/autograd_preflight.py
+++ b/torch_mojo_backend/mojo_device/aten_ops/autograd_preflight.py
@@ -15,7 +15,12 @@ import torch
 
 from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
 
-from .support import _eager_impl, _fast, _refuse_unsupported_backward, _unsupported
+from torch_mojo_backend.mojo_device.aten_ops.support import (
+    _eager_impl,
+    _fast,
+    _refuse_unsupported_backward,
+    _unsupported,
+)
 
 # Most of these ops have no autograd escape other than turning grad off: their
 # parameters legitimately require grad during training, so unlike batch norm
@@ -37,7 +42,7 @@ def _preflight_unsupported_backward(
     backward_op: str,
     grad_operands: Sequence[int],
     workaround: str = _GRAD_OFF_ONLY,
-) -> Callable[..., TorchMojoTensor | tuple[TorchMojoTensor, ...]]:
+) -> Callable[..., object]:
     """`aten_fast.<fast_name>`, fronted by the forward-time autograd refusal.
 
     One entry per op whose whole native backward is missing, which is the
@@ -49,9 +54,7 @@ def _preflight_unsupported_backward(
     """
     dispatch = _eager_impl(fast_name, op_name)
 
-    def preflighted(
-        *args: object, **kwargs: object
-    ) -> TorchMojoTensor | tuple[TorchMojoTensor, ...]:
+    def preflighted(*args: object, **kwargs: object) -> object:
         operands: list[torch.Tensor] = []
         for index in grad_operands:
             if index < len(args):

--- a/torch_mojo_backend/mojo_device/aten_ops/blas.py
+++ b/torch_mojo_backend/mojo_device/aten_ops/blas.py
@@ -2,7 +2,10 @@
 
 import torch
 
-from .support import _COMPOSITE_EXPLICIT_AUTOGRAD, _fast
+from torch_mojo_backend.mojo_device.aten_ops.support import (
+    _COMPOSITE_EXPLICIT_AUTOGRAD,
+    _fast,
+)
 
 
 def mojo_device_addr(

--- a/torch_mojo_backend/mojo_device/aten_ops/factories.py
+++ b/torch_mojo_backend/mojo_device/aten_ops/factories.py
@@ -13,7 +13,12 @@ from torch_mojo_backend.mojo_device.torch_mojo_tensor import (
     find_equivalent_max_device,
 )
 
-from .support import _copy_into_tensor, _fast, _unsupported, max_dtype_to_torch_dtype
+from torch_mojo_backend.mojo_device.aten_ops.support import (
+    _copy_into_tensor,
+    _fast,
+    _unsupported,
+    max_dtype_to_torch_dtype,
+)
 
 
 def _require_device(device: torch.device | None) -> torch.device:

--- a/torch_mojo_backend/mojo_device/aten_ops/foreach.py
+++ b/torch_mojo_backend/mojo_device/aten_ops/foreach.py
@@ -8,10 +8,13 @@ from collections.abc import Callable
 
 import torch
 
-from .support import _COMPOSITE_EXPLICIT_AUTOGRAD, _fast
+from torch_mojo_backend.mojo_device.aten_ops.support import (
+    _COMPOSITE_EXPLICIT_AUTOGRAD,
+    _fast,
+)
 
 
-def inplace_dispatcher(op_name: str, fast_name: str) -> Callable:
+def inplace_dispatcher(op_name: str, fast_name: str) -> Callable[..., None]:
     """Dispatcher for a mutable ()-returning foreach op: batched fast path,
     with ATen's exact sequential semantics as the fallback (redispatched
     below this PrivateUse1 registration, like `_foreach_mul_.Tensor`)."""

--- a/torch_mojo_backend/mojo_device/aten_ops/foreach.py
+++ b/torch_mojo_backend/mojo_device/aten_ops/foreach.py
@@ -21,43 +21,32 @@ def inplace_dispatcher(op_name: str, fast_name: str) -> Callable[..., None]:
     packet_name, _, overload_name = op_name.removeprefix("aten::").partition(".")
     aten_op = getattr(getattr(torch.ops.aten, packet_name), overload_name or "default")
 
-    def dispatcher(self: list[torch.Tensor], *args: object, **kwargs: object) -> None:
+    def dispatcher(self: list[torch.Tensor], *args: object, **kwargs: object):
         aten_fast = _fast()
         result = getattr(aten_fast, fast_name)(self, *args, **kwargs)
         if result is aten_fast.NOT_HANDLED:
-            result = aten_op.redispatch(
-                _COMPOSITE_EXPLICIT_AUTOGRAD, self, *args, **kwargs
-            )
-            # This explicit redispatch runs below ADInplaceOrView, so the
-            # TensorList version update is manual on both paths (mutable
-            # TensorList schemas returning () get no automatic bump).
-            torch.autograd.graph.increment_version(self)
-            return result
+            aten_op.redispatch(_COMPOSITE_EXPLICIT_AUTOGRAD, self, *args, **kwargs)
+        # This explicit redispatch runs below ADInplaceOrView, so the
+        # TensorList version update is manual on both paths (mutable
+        # TensorList schemas returning () get no automatic bump).
         torch.autograd.graph.increment_version(self)
-        return None
 
     return dispatcher
 
 
-def mojo_device__foreach_mul__tensor(
-    self: list[torch.Tensor], other: torch.Tensor
-) -> None:
+def mojo_device__foreach_mul__tensor(self: list[torch.Tensor], other: torch.Tensor):
     aten_fast = _fast()
     result = aten_fast.fast_aten__foreach_mul__tensor(self, other)
     if result is aten_fast.NOT_HANDLED:
-        result = torch.ops.aten._foreach_mul_.Tensor.redispatch(
-            _COMPOSITE_EXPLICIT_AUTOGRAD, self, other
-        )
         # This explicit redispatch runs below ADInplaceOrView. A true wrapper
         # subclass therefore needs the same manual TensorList version update
         # as the direct Mojo kernel path.
-        torch.autograd.graph.increment_version(self)
-        return result
-
+        torch.ops.aten._foreach_mul_.Tensor.redispatch(
+            _COMPOSITE_EXPLICIT_AUTOGRAD, self, other
+        )
     # Mutable TensorList schemas returning () do not receive an automatic
     # version bump. Match CUDA, including empty and duplicate list entries.
     torch.autograd.graph.increment_version(self)
-    return None
 
 
 def mojo_device__foreach_norm_scalar(

--- a/torch_mojo_backend/mojo_device/aten_ops/inplace.py
+++ b/torch_mojo_backend/mojo_device/aten_ops/inplace.py
@@ -2,7 +2,7 @@
 
 from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
 
-from .support import (
+from torch_mojo_backend.mojo_device.aten_ops.support import (
     _copy_into_tensor,
     _fast,
     _refuse_unsupported_backward,

--- a/torch_mojo_backend/mojo_device/aten_ops/reductions.py
+++ b/torch_mojo_backend/mojo_device/aten_ops/reductions.py
@@ -5,7 +5,11 @@ from torch_mojo_backend.mojo_device.torch_mojo_tensor import (
     _resize_payload,
 )
 
-from .support import _copy_into_tensor, _fast, _unsupported
+from torch_mojo_backend.mojo_device.aten_ops.support import (
+    _copy_into_tensor,
+    _fast,
+    _unsupported,
+)
 
 
 def mojo_device_min_dim(

--- a/torch_mojo_backend/mojo_device/aten_ops/rng.py
+++ b/torch_mojo_backend/mojo_device/aten_ops/rng.py
@@ -4,7 +4,11 @@ import torch
 
 from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
 
-from .support import _copy_into_tensor, _unsupported, max_dtype_to_torch_dtype
+from torch_mojo_backend.mojo_device.aten_ops.support import (
+    _copy_into_tensor,
+    _unsupported,
+    max_dtype_to_torch_dtype,
+)
 
 
 def mojo_device_normal_(

--- a/torch_mojo_backend/mojo_device/aten_ops/streams.py
+++ b/torch_mojo_backend/mojo_device/aten_ops/streams.py
@@ -9,7 +9,7 @@ from torch_mojo_backend.mojo_device.aten_ops.support import _unsupported
 
 
 # aten::record_stream(Tensor(a!) self, Stream s) -> ()
-def mojo_device_record_stream(self: TorchMojoTensor, s: torch._C.Stream) -> None:
+def mojo_device_record_stream(self: TorchMojoTensor, s: torch._C.Stream):
     """Order ``self``'s eventual free after work already on stream ``s``.
 
     A thin adapter onto ``device_streams.record_use_on_stream_ctx``: the

--- a/torch_mojo_backend/mojo_device/aten_ops/streams.py
+++ b/torch_mojo_backend/mojo_device/aten_ops/streams.py
@@ -5,7 +5,7 @@ import torch
 from torch_mojo_backend.mojo_device import device_streams
 from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
 
-from .support import _unsupported
+from torch_mojo_backend.mojo_device.aten_ops.support import _unsupported
 
 
 # aten::record_stream(Tensor(a!) self, Stream s) -> ()

--- a/torch_mojo_backend/mojo_device/aten_ops/support.py
+++ b/torch_mojo_backend/mojo_device/aten_ops/support.py
@@ -74,7 +74,7 @@ def _refuse_unsupported_backward(
     backward_op: str,
     operands: tuple[torch.Tensor | None, ...],
     workaround: str,
-) -> None:
+):
     """Refuse, from the forward, a call whose autograd node we cannot run.
 
     An exception raised while the autograd engine runs a *native* backward node
@@ -137,7 +137,7 @@ def _not_implemented(op_name: str) -> Callable[..., NoReturn]:
     return raiser
 
 
-def _copy_into_tensor(dst: TorchMojoTensor, src: TorchMojoTensor) -> None:
+def _copy_into_tensor(dst: TorchMojoTensor, src: TorchMojoTensor):
     """dst[...] = src[...] with dtype cast + broadcast, any strides."""
     aten_fast = _fast()
     if src._dtype != dst._dtype:

--- a/torch_mojo_backend/mojo_device/aten_ops/support.py
+++ b/torch_mojo_backend/mojo_device/aten_ops/support.py
@@ -106,9 +106,9 @@ def _refuse_unsupported_backward(
     )
 
 
-def _eager_impl(fast_name: str, op_name: str) -> Callable:
+def _eager_impl(fast_name: str, op_name: str) -> Callable[..., object]:
     """Bind an op to its aten_fast implementation; raise on NOT_HANDLED."""
-    fast_fn: Callable | None = None
+    fast_fn: Callable[..., object] | None = None
     not_handled = None
 
     def dispatcher(*args: object, **kwargs: object) -> object:
@@ -125,7 +125,7 @@ def _eager_impl(fast_name: str, op_name: str) -> Callable:
     return dispatcher
 
 
-def _not_implemented(op_name: str) -> Callable:
+def _not_implemented(op_name: str) -> Callable[..., NoReturn]:
     """Explicit raiser for ops that used to run through the graph fallback
     and have no fast implementation yet. Registered (instead of left
     unregistered) so users get an actionable message, and so the remaining
@@ -152,7 +152,7 @@ def _copy_into_tensor(dst: TorchMojoTensor, src: TorchMojoTensor) -> None:
 
 def _out_variant(
     op_name: str, fast_name: str, *, dtype_policy: str = "safe_cast"
-) -> Callable:
+) -> Callable[..., TorchMojoTensor]:
     """Wrap a functional fast implementation as an out= variant: compute,
     then copy into `out` (strided-safe)."""
 

--- a/torch_mojo_backend/mojo_device/aten_ops/transfer.py
+++ b/torch_mojo_backend/mojo_device/aten_ops/transfer.py
@@ -14,7 +14,11 @@ from torch_mojo_backend.mojo_device.torch_mojo_tensor import (
     find_equivalent_max_device,
 )
 
-from .support import _copy_into_tensor, _fast, max_dtype_to_torch_dtype
+from torch_mojo_backend.mojo_device.aten_ops.support import (
+    _copy_into_tensor,
+    _fast,
+    max_dtype_to_torch_dtype,
+)
 
 
 @runtime_checkable

--- a/torch_mojo_backend/mojo_device/aten_ops/transfer.py
+++ b/torch_mojo_backend/mojo_device/aten_ops/transfer.py
@@ -27,9 +27,7 @@ class _TensorHolderModule(Protocol):
     module needs -- it's a compiled-on-first-use native module (no stubs
     possible), reached via `eager_kernels`' PEP 562 `__getattr__`."""
 
-    def copy_d2d(
-        self, ctx_ptr: int, dst_ptr: int, src_ptr: int, nbytes: int
-    ) -> None: ...
+    def copy_d2d(self, ctx_ptr: int, dst_ptr: int, src_ptr: int, nbytes: int): ...
     def copy_from_host(
         self, ctx_ptr: int, dev_ptr: int, host_ptr: int, nbytes: int
     ) -> object: ...

--- a/torch_mojo_backend/mojo_device/deferred_compile.py
+++ b/torch_mojo_backend/mojo_device/deferred_compile.py
@@ -95,7 +95,7 @@ def dispatch(
     return _direct(func, args, kwargs)
 
 
-def drain() -> None:
+def drain():
     """Public: wait for all pending kernel launches (device synchronize).
 
     The single façade for the queue's drain — device code that reads tensor

--- a/torch_mojo_backend/mojo_device/deferred_compile.py
+++ b/torch_mojo_backend/mojo_device/deferred_compile.py
@@ -50,7 +50,9 @@ from torch_mojo_backend.eager_kernels import call_queue
 _DEVICE_LOCK = call_queue._LOCK
 
 
-def _direct(func: torch._ops.OpOverload, args: tuple, kwargs: dict) -> object:
+def _direct(
+    func: torch._ops.OpOverload, args: tuple[object, ...], kwargs: dict[str, object]
+) -> object:
     """Execute one aten op through the PrivateUse1 kernels."""
     with _DEVICE_LOCK:
         call_queue.order_direct_launch()
@@ -62,7 +64,7 @@ def _direct(func: torch._ops.OpOverload, args: tuple, kwargs: dict) -> object:
 _DEVICE_CROSSING_OPS = frozenset({"aten::_to_copy", "aten::copy_"})
 
 
-def _crosses_device(args: tuple, kwargs: dict) -> bool:
+def _crosses_device(args: tuple[object, ...], kwargs: dict[str, object]) -> bool:
     """True when a copy/cast actually moves bytes between devices. A
     same-device cast (autocast!) is an ordinary data op that stays in the
     queue; only a real crossing runs an out-of-queue H2D/D2H transfer."""
@@ -70,11 +72,14 @@ def _crosses_device(args: tuple, kwargs: dict) -> bool:
     devices = {a.device.type for a in flat_args if isinstance(a, torch.Tensor)}
     target = kwargs.get("device")
     if target is not None:
+        assert isinstance(target, str | torch.device | int)
         devices.add(torch.device(target).type)
     return len(devices) > 1
 
 
-def dispatch(func: torch._ops.OpOverload, args: tuple, kwargs: dict) -> object:
+def dispatch(
+    func: torch._ops.OpOverload, args: tuple[object, ...], kwargs: dict[str, object]
+) -> object:
     """Entry point called from TorchMojoTensor.__torch_dispatch__."""
     if not call_queue.enabled():
         return _direct(func, args, kwargs)

--- a/torch_mojo_backend/mojo_device/device_streams.py
+++ b/torch_mojo_backend/mojo_device/device_streams.py
@@ -41,7 +41,7 @@ class _ForeignUseRecorder(Protocol):
 
     def record_foreign_use(
         self, stream_ctx_ptr: int, event: object, owner_ctx_ptr: int
-    ) -> None: ...
+    ): ...
 
 
 def default_stream_ctx_ptr(device: max.driver.Device) -> int:
@@ -67,7 +67,7 @@ class Stream:
 
     def __init__(
         self, device: max.driver.Device, name: str, wrap_default: bool = False
-    ) -> None:
+    ):
         if device.api == "cpu":
             raise NotImplementedError(
                 "side streams require an accelerator; the CPU device runs "
@@ -86,14 +86,14 @@ class Stream:
         # (NCCL). Ordering never uses it — that goes through ctx_ptr.
         self.handle = self._stream.native_stream_handle
 
-    def wait_default_stream(self) -> None:
+    def wait_default_stream(self):
         """Order this stream after the default stream (drain the kernel-call
         queue first — see rule 1 above)."""
         if self.is_default:
             return
         self._stream.wait_for(self.device)
 
-    def wait_stream(self, other: "Stream") -> None:
+    def wait_stream(self, other: "Stream"):
         """Order later work here after everything `other` has right now.
 
         Tail-at-call-time semantics — the free fence wants the different
@@ -102,7 +102,7 @@ class Stream:
         if other is not self:
             self._stream.wait_for(other._stream)
 
-    def make_default_stream_wait(self) -> None:
+    def make_default_stream_wait(self):
         """Order subsequent default-stream work after this stream's work."""
         if self.is_default:
             return
@@ -111,7 +111,7 @@ class Stream:
     # `object` rather than a real type on the two fence-event methods: the
     # class (`tensor_holder.FenceEvent`) only exists once the Mojo extension
     # has been built and imported, so there is nothing to annotate against.
-    def wait_fence_event(self, event: object) -> None:
+    def wait_fence_event(self, event: object):
         _holder_mod().fence_event_wait(self.ctx_ptr, event)
 
     def record_fence_event(self) -> object:
@@ -137,7 +137,7 @@ class Stream:
         """
         return self._stream.record_event().is_ready()
 
-    def synchronize(self) -> None:
+    def synchronize(self):
         self._stream.synchronize()
 
 
@@ -167,7 +167,7 @@ def default_stream(device: max.driver.Device) -> Stream:
 
 def record_use(
     holder: _ForeignUseRecorder, stream: Stream, owner_ctx_ptr: int | None = None
-) -> None:
+):
     """Order `holder`'s eventual free after `stream` work enqueued so far.
 
     The record_stream analog for this backend. MAX frees a buffer
@@ -190,7 +190,7 @@ def record_use(
 
 def record_use_on_stream_ctx(
     holder: _ForeignUseRecorder, stream_ctx_ptr: int, owner_ctx_ptr: int
-) -> None:
+):
     """``record_use`` for a bare stream context pointer instead of a Stream.
 
     ``aten::record_stream`` hands an opaque ``(device, stream_id)`` pair, and

--- a/torch_mojo_backend/mojo_device/dlpack.py
+++ b/torch_mojo_backend/mojo_device/dlpack.py
@@ -128,7 +128,7 @@ class _ExportState:
     def __init__(
         self,
         managed: _DLManagedTensor,
-        shape_arr: ctypes.Array,
+        shape_arr: ctypes.Array[ctypes.c_int64],
         holder: object,
         registry: dict[int, _ExportState],
     ) -> None:

--- a/torch_mojo_backend/mojo_device/dlpack.py
+++ b/torch_mojo_backend/mojo_device/dlpack.py
@@ -131,7 +131,7 @@ class _ExportState:
         shape_arr: ctypes.Array[ctypes.c_int64],
         holder: object,
         registry: dict[int, _ExportState],
-    ) -> None:
+    ):
         self.managed = managed
         self.shape_arr = shape_arr
         self.holder = holder
@@ -155,7 +155,7 @@ def _release_export(
     cast: Callable[[int, type[ctypes.py_object]], ctypes.py_object] = ctypes.cast,
     py_object: type[ctypes.py_object] = ctypes.py_object,
     py_decref: Callable[[object], None] = _pyapi.Py_DecRef,
-) -> None:
+):
     """Release the producer reference owned by ``manager_ctx`` exactly once.
 
     All helpers needed during release are captured as defaults. An old ctypes
@@ -185,7 +185,7 @@ def _deleter_impl(
     release_export: Callable[
         [ctypes._Pointer[_DLManagedTensor]], None
     ] = _release_export,
-) -> None:
+):
     release_export(handle)
 
 
@@ -201,7 +201,7 @@ def _capsule_destructor_impl(
     cast: Callable[..., object] = ctypes.cast,
     managed_pointer: object = ctypes.POINTER(_DLManagedTensor),
     release_export: Callable[..., None] = _release_export,
-) -> None:
+):
     # A consumer that adopted the memory renames the capsule to
     # "used_dltensor" and becomes responsible for calling the deleter; if
     # the capsule dies still named "dltensor" it was never consumed and the

--- a/torch_mojo_backend/mojo_device/log_aten_calls.py
+++ b/torch_mojo_backend/mojo_device/log_aten_calls.py
@@ -16,5 +16,5 @@ class LoggingMode(TorchDispatchMode):
         return func(*args, **kwargs or {})
 
 
-def log_aten_calls() -> None:
+def log_aten_calls():
     LoggingMode().__enter__()

--- a/torch_mojo_backend/mojo_device/mojo_device_aten_ops.py
+++ b/torch_mojo_backend/mojo_device/mojo_device_aten_ops.py
@@ -21,8 +21,8 @@ from typing import cast
 import torch_mojo_backend.is_running_tests
 from torch_mojo_backend.types import CountedCallable
 
-from .aten_ops import foreach
-from .aten_ops.autograd_preflight import (
+from torch_mojo_backend.mojo_device.aten_ops import foreach
+from torch_mojo_backend.mojo_device.aten_ops.autograd_preflight import (
     mojo_device__adaptive_avg_pool2d,
     mojo_device__scaled_dot_product_efficient_attention,
     mojo_device__softmax,
@@ -42,8 +42,8 @@ from .aten_ops.autograd_preflight import (
     mojo_device_tanh,
     mojo_device_upsample_bilinear2d,
 )
-from .aten_ops.blas import mojo_device_addr
-from .aten_ops.factories import (
+from torch_mojo_backend.mojo_device.aten_ops.blas import mojo_device_addr
+from torch_mojo_backend.mojo_device.aten_ops.factories import (
     empty_strided,
     mojo_device_arange,
     mojo_device_arange_start_out,
@@ -62,12 +62,12 @@ from .aten_ops.factories import (
     mojo_device_zeros,
     mojo_device_zeros_like,
 )
-from .aten_ops.foreach import (
+from torch_mojo_backend.mojo_device.aten_ops.foreach import (
     mojo_device__foreach_mul__tensor,
     mojo_device__foreach_norm_scalar,
     mojo_device__foreach_sqrt,
 )
-from .aten_ops.inplace import (
+from torch_mojo_backend.mojo_device.aten_ops.inplace import (
     mojo_device_add_,
     mojo_device_fill__scalar,
     mojo_device_masked_fill_,
@@ -75,14 +75,24 @@ from .aten_ops.inplace import (
     mojo_device_relu_,
     mojo_device_zero_,
 )
-from .aten_ops.reductions import mojo_device_min_dim, mojo_device_min_dim_min
-from .aten_ops.rng import mojo_device_normal_
-from .aten_ops.streams import mojo_device_record_stream
-from .aten_ops.support import _eager_impl, _not_implemented, _out_variant
-from .aten_ops.transfer import mojo_device__copy_from, mojo_device__to_copy
+from torch_mojo_backend.mojo_device.aten_ops.reductions import (
+    mojo_device_min_dim,
+    mojo_device_min_dim_min,
+)
+from torch_mojo_backend.mojo_device.aten_ops.rng import mojo_device_normal_
+from torch_mojo_backend.mojo_device.aten_ops.streams import mojo_device_record_stream
+from torch_mojo_backend.mojo_device.aten_ops.support import (
+    _eager_impl,
+    _not_implemented,
+    _out_variant,
+)
+from torch_mojo_backend.mojo_device.aten_ops.transfer import (
+    mojo_device__copy_from,
+    mojo_device__to_copy,
+)
 
 # Global registry for functions to register
-_aten_ops_registry: list[tuple[str, Callable]] = []
+_aten_ops_registry: list[tuple[str, Callable[..., object]]] = []
 
 # Under tests, each registered op's dispatcher is wrapped with a call
 # counter so `CallChecker` can assert the backend's impl for a given op ran
@@ -91,14 +101,16 @@ _aten_ops_registry: list[tuple[str, Callable]] = []
 EAGER_CALL_COUNTERS: dict[str, CountedCallable] = {}
 
 
-def register_aten_op(op_name: str) -> Callable[[Callable], Callable]:
+def register_aten_op(
+    op_name: str,
+) -> Callable[[Callable[..., object]], Callable[..., object]]:
     """Decorator to mark a function for aten op registration.
 
     Args:
         op_name: The aten operation name (e.g., "aten::add.Tensor")
     """
 
-    def decorator(func: Callable) -> Callable:
+    def decorator(func: Callable[..., object]) -> Callable[..., object]:
         if torch_mojo_backend.is_running_tests.IS_RUNNING_TESTS:
 
             def counted(*args: object, **kwargs: object) -> object:

--- a/torch_mojo_backend/mojo_device/mojo_device_aten_ops.py
+++ b/torch_mojo_backend/mojo_device/mojo_device_aten_ops.py
@@ -132,27 +132,25 @@ def register_aten_op(
     return decorator
 
 
-def _register_fast(op_name: str, fast_name: str) -> None:
+def _register_fast(op_name: str, fast_name: str):
     """Bind an op to `aten_fast.<fast_name>`."""
     register_aten_op(op_name)(_eager_impl(fast_name, op_name))
 
 
-def _register_out(
-    op_name: str, fast_name: str, *, dtype_policy: str = "safe_cast"
-) -> None:
+def _register_out(op_name: str, fast_name: str, *, dtype_policy: str = "safe_cast"):
     """Bind an `out=` overload to a functional `aten_fast.<fast_name>`."""
     register_aten_op(op_name)(
         _out_variant(op_name, fast_name, dtype_policy=dtype_policy)
     )
 
 
-def _register_foreach_inplace(op_name: str, fast_name: str) -> None:
+def _register_foreach_inplace(op_name: str, fast_name: str):
     """Bind a mutable ()-returning foreach op, ATen's sequential semantics as
     the fallback."""
     register_aten_op(op_name)(foreach.inplace_dispatcher(op_name, fast_name))
 
 
-def _register_missing(op_name: str) -> None:
+def _register_missing(op_name: str):
     """Register an explicit raiser for an op with no fast implementation yet,
     so users get an actionable message and the remaining surface stays
     greppable."""

--- a/torch_mojo_backend/mojo_device/mojo_device_autocast.py
+++ b/torch_mojo_backend/mojo_device/mojo_device_autocast.py
@@ -68,7 +68,7 @@ def _fp32_wrapper(op: torch._ops.OpOverload) -> Callable[..., object]:
     return _policy_wrapper(op, lambda: torch.float32)
 
 
-def register_autocast_ops() -> None:
+def register_autocast_ops():
     """Install fallthrough plus the explicit CUDA-matching GPT policies."""
     global _registered, _fallback_library, _aten_library
     if _registered:

--- a/torch_mojo_backend/mojo_device/mojo_device_autograd.py
+++ b/torch_mojo_backend/mojo_device/mojo_device_autograd.py
@@ -72,7 +72,7 @@ class _SavedMojoPayload:
         "is_contiguous",
     )
 
-    def __init__(self, tensor: TorchMojoTensor) -> None:
+    def __init__(self, tensor: TorchMojoTensor):
         self.holder = None if _saved_tensor_hooks_active() else tensor._holder
         self.ptr = tensor._ptr
         self.shape = tensor._shape
@@ -204,8 +204,8 @@ class _MojoAutogradCtx(Protocol):
     has_dropout: bool
     dropout_scale: float
 
-    def save_for_backward(self, *tensors: torch.Tensor) -> None: ...
-    def set_materialize_grads(self, value: bool) -> None: ...
+    def save_for_backward(self, *tensors: torch.Tensor): ...
+    def set_materialize_grads(self, value: bool): ...
 
 
 def _restore_saved_mojo_tensors(ctx: _MojoAutogradCtx) -> tuple[TorchMojoTensor, ...]:
@@ -336,7 +336,7 @@ class _ScaledDotProductAttentionAutograd(torch.autograd.Function):
         saved: list[TorchMojoTensor] = []
         saved_names: list[str] = []
 
-        def save(name: str, tensor: TorchMojoTensor) -> None:
+        def save(name: str, tensor: TorchMojoTensor):
             saved_names.append(name)
             saved.append(tensor)
 
@@ -689,7 +689,7 @@ def _scaled_dot_product_attention_autograd(
     )
 
 
-def register_autograd_ops() -> None:
+def register_autograd_ops():
     """Install concrete AutogradPrivateUse1 kernels once."""
     global _registered
     if _registered:

--- a/torch_mojo_backend/mojo_device/mojo_device_autograd.py
+++ b/torch_mojo_backend/mojo_device/mojo_device_autograd.py
@@ -14,7 +14,7 @@ from typing import Protocol, TypeVar, runtime_checkable
 
 import torch
 
-from .torch_mojo_tensor import TorchMojoTensor
+from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
 
 # _require_handled passes its argument through unchanged, including the
 # symbolic stand-ins host-contract tests route through it.
@@ -665,7 +665,7 @@ def _scaled_dot_product_attention_autograd(
     # check above is metadata-only and safe on pending tensors. Buffers
     # these paths allocate afterwards are retained per queued item (queue
     # rule 3), so no extra bookkeeping is owed here.
-    from . import deferred_compile
+    from torch_mojo_backend.mojo_device import deferred_compile
 
     deferred_compile.drain()
     if not needs_backward:

--- a/torch_mojo_backend/mojo_device/objc_autorelease.py
+++ b/torch_mojo_backend/mojo_device/objc_autorelease.py
@@ -40,7 +40,7 @@ if sys.platform == "darwin":
 _state = threading.local()
 
 
-def note_op_dispatched() -> None:
+def note_op_dispatched():
     """Count one dispatched op; cycle this thread's pool every interval."""
     if _libobjc is None:
         return

--- a/torch_mojo_backend/mojo_device/register.py
+++ b/torch_mojo_backend/mojo_device/register.py
@@ -5,7 +5,7 @@ from typing import TypeVar
 
 import torch
 
-from .mojo_device_aten_ops import _aten_ops_registry
+from torch_mojo_backend.mojo_device.mojo_device_aten_ops import _aten_ops_registry
 
 _T = TypeVar("_T")
 _registered = False
@@ -208,7 +208,7 @@ def _declare_mojo_tensor_as_plain_tensor() -> None:
         FunctionalTensorMode,
     )
 
-    from .torch_mojo_tensor import TorchMojoTensor
+    from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
 
     if TorchMojoTensor not in proxy_tensor.HANDLED_TYPES:
         # Deliberate monkeypatch: torch infers HANDLED_TYPES' type from its
@@ -316,7 +316,7 @@ def _trace_mojo_tensor_as_a_plain_tensor_in_dynamo() -> None:
     """
     from torch._dynamo.variables.builder import VariableBuilder
 
-    from .torch_mojo_tensor import TorchMojoTensor
+    from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
 
     for trace_numpy in (False, True):
         table = VariableBuilder._type_dispatch_impl(trace_numpy)
@@ -372,7 +372,7 @@ def register_mojo_devices() -> None:
     """Enable the mojo device globally and register all aten ops"""
     from torch.utils.backend_registration import _setup_privateuseone_for_python_backend
 
-    from . import torch_mojo_device_module
+    from torch_mojo_backend.mojo_device import torch_mojo_device_module
 
     # since it's so recent we import it here.
     global _registered
@@ -399,7 +399,7 @@ def register_mojo_devices() -> None:
     import torch.optim.optimizer as optimizer_module
     import torch.utils._foreach_utils as foreach_utils
 
-    from .torch_mojo_tensor import TorchMojoTensor
+    from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
 
     for supported_types in (
         optimizer_module._foreach_supported_types,
@@ -415,11 +415,15 @@ def register_mojo_devices() -> None:
     for op_name, func in _aten_ops_registry:
         torch.library.impl(op_name, "privateuseone")(func)
 
-    from .mojo_device_autograd import register_autograd_ops
+    from torch_mojo_backend.mojo_device.mojo_device_autograd import (
+        register_autograd_ops,
+    )
 
     register_autograd_ops()
 
-    from .mojo_device_autocast import register_autocast_ops
+    from torch_mojo_backend.mojo_device.mojo_device_autocast import (
+        register_autocast_ops,
+    )
 
     register_autocast_ops()
 
@@ -427,7 +431,9 @@ def register_mojo_devices() -> None:
     _trace_mojo_tensor_as_a_plain_tensor_in_dynamo()
     _keep_mojo_kernels_out_of_fake_tensor_construction()
 
-    from .apple_optimizations import register_apple_optimizations
+    from torch_mojo_backend.mojo_device.apple_optimizations import (
+        register_apple_optimizations,
+    )
 
     register_apple_optimizations()
 

--- a/torch_mojo_backend/mojo_device/register.py
+++ b/torch_mojo_backend/mojo_device/register.py
@@ -11,9 +11,7 @@ _T = TypeVar("_T")
 _registered = False
 
 
-def _install_torch_accelerator_synchronize(
-    torch_mojo_device_module: ModuleType,
-) -> None:
+def _install_torch_accelerator_synchronize(torch_mojo_device_module: ModuleType):
     """Route generic accelerator synchronization to the Mojo device module.
 
     PyTorch's Python PrivateUse1 guard does not yet forward synchronizeDevice
@@ -33,7 +31,7 @@ def _install_torch_accelerator_synchronize(
         )
 
     @wraps(original_synchronize)
-    def synchronize(device: torch.device | str | int | None = None) -> None:
+    def synchronize(device: torch.device | str | int | None = None):
         current = torch.accelerator.current_accelerator()
         if current != mojo_device:
             original_synchronize(device)
@@ -64,7 +62,7 @@ def _install_torch_accelerator_synchronize(
     torch.accelerator.synchronize = synchronize  # ty: ignore[invalid-assignment]
 
 
-def _install_torch_accelerator_stream_api(torch_mojo_device_module: ModuleType) -> None:
+def _install_torch_accelerator_stream_api(torch_mojo_device_module: ModuleType):
     """Route torch.accelerator.current_stream/set_stream to mojo streams.
 
     Same reason as the synchronize patch above: the Python PrivateUse1
@@ -90,12 +88,13 @@ def _install_torch_accelerator_stream_api(torch_mojo_device_module: ModuleType) 
     original_set_stream = torch.accelerator.set_stream
 
     @wraps(original_set_stream)
-    def set_stream(stream: torch.Stream) -> None:
+    def set_stream(stream: torch.Stream):
         from torch_mojo_backend.mojo_device.streams import Stream as MojoStream
 
         if isinstance(stream, MojoStream):
-            return torch_mojo_device_module.set_stream(stream)
-        return original_set_stream(stream)
+            torch_mojo_device_module.set_stream(stream)
+        else:
+            original_set_stream(stream)
 
     set_stream._torch_mojo_backend = True  # ty: ignore[unresolved-attribute]
     torch.accelerator.set_stream = set_stream  # ty: ignore[invalid-assignment]
@@ -107,7 +106,7 @@ def _forwarding_constructor(cls: type[_T]) -> Callable[..., _T]:
     return cls
 
 
-def _install_torch_stream_event_dispatch() -> None:
+def _install_torch_stream_event_dispatch():
     """Dispatch torch.Stream/torch.Event on mojo devices to real classes.
 
     Construction through the original classes reaches the stub C++ guard and
@@ -172,7 +171,7 @@ def _install_torch_stream_event_dispatch() -> None:
     torch.Event = Event  # ty: ignore[invalid-assignment]
 
 
-def _declare_mojo_tensor_as_plain_tensor() -> None:
+def _declare_mojo_tensor_as_plain_tensor():
     """Add TorchMojoTensor to torch's HANDLED_TYPES allowlists.
 
     TorchMojoTensor's wrapper dispatch is transparent to numerical operations;
@@ -293,7 +292,7 @@ def _declare_mojo_tensor_as_plain_tensor() -> None:
     FunctionalTensorMode.__torch_dispatch__ = functional_mode_dispatch
 
 
-def _trace_mojo_tensor_as_a_plain_tensor_in_dynamo() -> None:
+def _trace_mojo_tensor_as_a_plain_tensor_in_dynamo():
     """Let TorchDynamo model a mojo tensor as an ordinary device tensor.
 
     ``VariableBuilder`` only builds a ``TensorVariable`` for a tensor
@@ -323,7 +322,7 @@ def _trace_mojo_tensor_as_a_plain_tensor_in_dynamo() -> None:
         table[TorchMojoTensor] = VariableBuilder.wrap_tensor
 
 
-def _keep_mojo_kernels_out_of_fake_tensor_construction() -> None:
+def _keep_mojo_kernels_out_of_fake_tensor_construction():
     """Make FakeTensor construction skip the PrivateUse1 Python kernels.
 
     `FakeTensor.__new__` calls `Tensor._make_subclass(cls, elem, ...,
@@ -368,7 +367,7 @@ def _keep_mojo_kernels_out_of_fake_tensor_construction() -> None:
     )
 
 
-def register_mojo_devices() -> None:
+def register_mojo_devices():
     """Enable the mojo device globally and register all aten ops"""
     from torch.utils.backend_registration import _setup_privateuseone_for_python_backend
 

--- a/torch_mojo_backend/mojo_device/streams.py
+++ b/torch_mojo_backend/mojo_device/streams.py
@@ -87,7 +87,7 @@ class Event:
         enable_timing: bool = False,
         blocking: bool = False,
         interprocess: bool = False,
-    ) -> None:
+    ):
         if interprocess:
             raise NotImplementedError(
                 "interprocess events are not supported on the mojo device"
@@ -107,7 +107,7 @@ class Event:
             return None
         return torch.device("mojo", self._device_index)
 
-    def record(self, stream: "Stream | None" = None) -> None:
+    def record(self, stream: "Stream | None" = None):
         if stream is None:
             stream = current_stream(self._device_index)
         device_stream = stream._device_stream
@@ -120,7 +120,7 @@ class Event:
         self._fence = device_stream.record_fence_event()
         self._device_index = stream.device_index
 
-    def wait(self, stream: "Stream | None" = None) -> None:
+    def wait(self, stream: "Stream | None" = None):
         if self._fence is None:
             raise RuntimeError("Event must be recorded before it can be waited on")
         if stream is None:
@@ -130,7 +130,7 @@ class Event:
     def query(self) -> bool:
         return True if self._event is None else self._event.is_ready()
 
-    def synchronize(self) -> None:
+    def synchronize(self):
         if self._event is not None:
             self._event.synchronize()
 
@@ -188,7 +188,7 @@ class Stream(torch._C.Stream):
         self.priority = 0
         return self
 
-    def __init__(self, *args: object, **kwargs: object) -> None:
+    def __init__(self, *args: object, **kwargs: object):
         # Everything happens in __new__ (the base type is a C type whose
         # tp_new takes the three identity fields); accept and ignore the
         # constructor arguments so `Stream(device, priority=...)` works.
@@ -217,13 +217,13 @@ class Stream(torch._C.Stream):
     def query(self) -> bool:
         return self._device_stream.query()
 
-    def synchronize(self) -> None:
+    def synchronize(self):
         self._device_stream.synchronize()
 
-    def wait_event(self, event: Event) -> None:
+    def wait_event(self, event: Event):
         event.wait(self)
 
-    def wait_stream(self, other: "Stream | torch.Stream") -> None:
+    def wait_stream(self, other: "Stream | torch.Stream"):
         """Order this stream after everything enqueued on `other` so far."""
         self._device_stream.wait_stream(_stream_of(other, self._index))
 
@@ -243,7 +243,7 @@ class Stream(torch._C.Stream):
         stacks.setdefault(self._index, []).append(self)
         return self
 
-    def __exit__(self, *exc_info: object) -> None:
+    def __exit__(self, *exc_info: object):
         _current_stacks.stacks[self._index].pop()
 
     def __eq__(self, other: object) -> bool:
@@ -292,7 +292,7 @@ def current_stream(device: _DeviceLike = None) -> Stream:
     return default_stream(index)
 
 
-def set_stream(stream: Stream) -> None:
+def set_stream(stream: Stream):
     """Make `stream` this thread's ambient current stream (no nesting)."""
     stacks = getattr(_current_stacks, "stacks", None)
     if stacks is None:

--- a/torch_mojo_backend/mojo_device/torch_mojo_device_module.py
+++ b/torch_mojo_backend/mojo_device/torch_mojo_device_module.py
@@ -2,7 +2,7 @@ import threading
 
 import torch
 
-from ..torch_compile_backend.utils import get_accelerators
+from torch_mojo_backend.torch_compile_backend.utils import get_accelerators
 
 _current_device = 0
 _UINT64_MASK = (1 << 64) - 1
@@ -176,7 +176,7 @@ def _device_synchronize(device: "int | str | torch.device | None" = None) -> Non
     is nothing of theirs to wait for; only the *other* thread's issued work
     must land first, which is exactly a stream synchronize.
     """
-    from .torch_mojo_tensor import (
+    from torch_mojo_backend.mojo_device.torch_mojo_tensor import (
         _release_synchronized_d2h_owners,
         _release_synchronized_h2d_sources,
         find_equivalent_max_device,
@@ -193,7 +193,7 @@ def synchronize(device: "int | str | torch.device | None" = None) -> None:
     owners. Pending kernel launches count as work, so the queue drains
     first — a caller of ``torch.mojo.synchronize()`` is entitled to assume
     every op it issued has actually run on the device."""
-    from . import deferred_compile
+    from torch_mojo_backend.mojo_device import deferred_compile
 
     deferred_compile.drain()
     _device_synchronize(device)
@@ -215,7 +215,9 @@ def memory_stats(device: "int | str | torch.device | None" = None) -> dict[str, 
     ``torch.cuda.memory_stats`` on a CUDA build; callers that want a number
     for this device get honest ones here.
     """
-    from .torch_mojo_tensor import find_equivalent_max_device
+    from torch_mojo_backend.mojo_device.torch_mojo_tensor import (
+        find_equivalent_max_device,
+    )
 
     stats = find_equivalent_max_device(_resolve_sync_device(device)).stats
     return {name: int(value) for name, value in dict(stats).items()}
@@ -237,9 +239,9 @@ def memory_summary(
 # for Python PrivateUse1 backends. See mojo_device/streams.py.
 from torch_mojo_backend.mojo_device.streams import (  # noqa: E402
     Event as Event,
+    Stream as Stream,
+    current_stream as current_stream,
+    default_stream as default_stream,
+    set_stream as set_stream,
+    stream as stream,
 )
-from torch_mojo_backend.mojo_device.streams import Stream as Stream
-from torch_mojo_backend.mojo_device.streams import current_stream as current_stream
-from torch_mojo_backend.mojo_device.streams import default_stream as default_stream
-from torch_mojo_backend.mojo_device.streams import set_stream as set_stream
-from torch_mojo_backend.mojo_device.streams import stream as stream

--- a/torch_mojo_backend/mojo_device/torch_mojo_device_module.py
+++ b/torch_mojo_backend/mojo_device/torch_mojo_device_module.py
@@ -42,7 +42,7 @@ def _rng_device_index(device: "int | str | torch.device | None" = None) -> int:
     return index
 
 
-def manual_seed_all(seed: int) -> None:
+def manual_seed_all(seed: int):
     """Reset every Mojo device to the same Philox seed and counter zero."""
     global _rng_default_seed
     normalized = _normalize_rng_seed(seed)
@@ -68,7 +68,7 @@ def get_rng_state(device: "int | str | torch.device | None" = None) -> torch.Ten
 
 def set_rng_state(
     new_state: torch.Tensor, device: "int | str | torch.device | None" = None
-) -> None:
+):
     """Restore an exact state produced by :func:`get_rng_state`."""
     if not isinstance(new_state, torch.Tensor):
         raise TypeError("Mojo RNG state must be a torch.Tensor")
@@ -116,7 +116,7 @@ def current_device() -> int:
     return _current_device
 
 
-def set_device(device_idx: int) -> None:
+def set_device(device_idx: int):
     global _current_device
     if device_idx < 0 or device_idx >= device_count():
         raise ValueError(f"Invalid device index {device_idx}")
@@ -129,7 +129,7 @@ class device:
     module when loading a checkpoint with ``map_location="mojo"``
     (``torch._utils._to`` enters ``device_module.device(...)``)."""
 
-    def __init__(self, device: "int | str | torch.device | None") -> None:
+    def __init__(self, device: "int | str | torch.device | None"):
         if device is None:
             self.idx = -1
             return
@@ -139,7 +139,7 @@ class device:
         torch_device = torch.device(device)
         self.idx = -1 if torch_device.index is None else torch_device.index
 
-    def __enter__(self) -> None:
+    def __enter__(self):
         self.prev_idx = _current_device
         if self.idx >= 0 and self.idx != _current_device:
             set_device(self.idx)
@@ -161,7 +161,7 @@ def _resolve_sync_device(device: "int | str | torch.device | None") -> torch.dev
     return torch_device
 
 
-def _device_synchronize(device: "int | str | torch.device | None" = None) -> None:
+def _device_synchronize(device: "int | str | torch.device | None" = None):
     """Device-only barrier: wait for already-launched work and release the
     completed asynchronous transfer owners.
 
@@ -188,7 +188,7 @@ def _device_synchronize(device: "int | str | torch.device | None" = None) -> Non
     _release_synchronized_d2h_owners(max_device)
 
 
-def synchronize(device: "int | str | torch.device | None" = None) -> None:
+def synchronize(device: "int | str | torch.device | None" = None):
     """Public: wait for work and release completed asynchronous transfer
     owners. Pending kernel launches count as work, so the queue drains
     first — a caller of ``torch.mojo.synchronize()`` is entitled to assume

--- a/torch_mojo_backend/mojo_device/torch_mojo_tensor.py
+++ b/torch_mojo_backend/mojo_device/torch_mojo_tensor.py
@@ -47,11 +47,9 @@ class _TensorHolderModule(Protocol):
         self, ctx_ptr: int, src_ptr: int, nbytes: int
     ) -> tuple[object, int]: ...
     def CopyStrided(self, *args: object) -> object: ...
-    def copy_d2d(
-        self, ctx_ptr: int, dst_ptr: int, src_ptr: int, nbytes: int
-    ) -> None: ...
+    def copy_d2d(self, ctx_ptr: int, dst_ptr: int, src_ptr: int, nbytes: int): ...
     def fence_event_record(self, ctx_ptr: int) -> object: ...
-    def fence_event_wait(self, ctx_ptr: int, event: object) -> None: ...
+    def fence_event_wait(self, ctx_ptr: int, event: object): ...
 
 
 # The Mojo extension module (torch_mojo_backend.eager_kernels.tensor_holder),
@@ -125,7 +123,7 @@ class _HolderOwner:
     _owner_ctx: int | None
     _wait: Callable[[int, object], None] | None
 
-    def __init__(self, holder: "_MojoTensorHolder | max.driver.Buffer") -> None:
+    def __init__(self, holder: "_MojoTensorHolder | max.driver.Buffer"):
         self._holder = holder
         self._events = None
         self._owner_ctx = None
@@ -145,7 +143,7 @@ class _HolderOwner:
 
     def record_foreign_use(
         self, stream_ctx_ptr: int, event: object, owner_ctx_ptr: int
-    ) -> None:
+    ):
         if self._events is None:
             self._events = {}
             self._wait = _holder_mod().fence_event_wait
@@ -154,7 +152,7 @@ class _HolderOwner:
         # replaced event is released when this rebinding drops it.
         self._events[stream_ctx_ptr] = event
 
-    def __del__(self) -> None:
+    def __del__(self):
         events, wait, owner_ctx = self._events, self._wait, self._owner_ctx
         if not events or wait is None or owner_ctx is None or _is_finalizing():
             return
@@ -182,7 +180,7 @@ def _retain_failed_transfer_owner(device: max.driver.Device, owner: object) -> o
     return token
 
 
-def _forget_failed_transfer_owner(device: max.driver.Device, token: object) -> None:
+def _forget_failed_transfer_owner(device: max.driver.Device, token: object):
     with _FAILED_TRANSFER_OWNERS_LOCK:
         retained = _FAILED_TRANSFER_OWNERS.get(device)
         if retained is None:
@@ -192,9 +190,7 @@ def _forget_failed_transfer_owner(device: max.driver.Device, token: object) -> N
             _FAILED_TRANSFER_OWNERS.pop(device, None)
 
 
-def _record_h2d_source(
-    device: max.driver.Device, source: object, non_blocking: bool
-) -> None:
+def _record_h2d_source(device: max.driver.Device, source: object, non_blocking: bool):
     """Retain a pinned transfer owner until its default-stream H2D ends."""
     # MAX's CPU device uses a worker pool whose copies are not stream-ordered
     # with kernels. The Mojo helper drains it before returning; keep the Python
@@ -231,7 +227,7 @@ def _record_h2d_source(
         # event keeps its exact source alive until DMA completion.
 
 
-def _release_synchronized_h2d_sources(device: max.driver.Device) -> None:
+def _release_synchronized_h2d_sources(device: max.driver.Device):
     """Drop ready sources after the caller synchronized ``device``'s stream.
 
     Another thread may enqueue a transfer between the stream synchronization
@@ -246,7 +242,7 @@ def _release_synchronized_h2d_sources(device: max.driver.Device) -> None:
             _PENDING_H2D.pop(device, None)
 
 
-def _record_d2h_owner(device: max.driver.Device, owner: object) -> None:
+def _record_d2h_owner(device: max.driver.Device, owner: object):
     """Retain a pinned D2H allocation until its default-stream DMA ends."""
     try:
         event = device.default_stream.record_event()
@@ -267,7 +263,7 @@ def _record_d2h_owner(device: max.driver.Device, owner: object) -> None:
             pending.popleft()
 
 
-def _release_synchronized_d2h_owners(device: max.driver.Device) -> None:
+def _release_synchronized_d2h_owners(device: max.driver.Device):
     """Drop pinned D2H owners whose stream events have completed."""
     with _PENDING_D2H_LOCK:
         pending = _PENDING_D2H.get(device)
@@ -330,7 +326,7 @@ def _dispatch_entry(
 
 @runtime_checkable
 class _SynchronizableStream(Protocol):
-    def synchronize(self) -> None: ...
+    def synchronize(self): ...
 
 
 @runtime_checkable
@@ -789,7 +785,7 @@ class TorchMojoTensor(torch.Tensor):
             return self._torch_device
         return super().device
 
-    def _set_data(self, value: torch.Tensor) -> None:
+    def _set_data(self, value: torch.Tensor):
         """``tensor.data = other`` for a wrapper whose payload is in Python.
 
         The C++ setter reaches ``Variable::set_data``, which shallow-copies
@@ -894,7 +890,7 @@ _PAYLOAD_ATTRIBUTES = (
 )
 
 
-def _resize_tensorimpl(dst: TorchMojoTensor, shape: Sequence[int]) -> None:
+def _resize_tensorimpl(dst: TorchMojoTensor, shape: Sequence[int]):
     """Set dst's TensorImpl sizes (and grow its placeholder storage)."""
     torch.ops.aten.resize_.default.redispatch(
         _CPU_KEYSET, dst, shape, memory_format=None
@@ -903,14 +899,14 @@ def _resize_tensorimpl(dst: TorchMojoTensor, shape: Sequence[int]) -> None:
 
 def _as_strided_tensorimpl(
     dst: TorchMojoTensor, shape: Sequence[int], strides: Sequence[int], offset: int
-) -> None:
+):
     """State dst's TensorImpl layout exactly. Metadata only, no data moved."""
     torch.ops.aten.as_strided_.default.redispatch(
         _CPU_KEYSET, dst, shape, strides, offset
     )
 
 
-def _move_payload_attributes(dst: TorchMojoTensor, src: TorchMojoTensor) -> None:
+def _move_payload_attributes(dst: TorchMojoTensor, src: TorchMojoTensor):
     for name in _PAYLOAD_ATTRIBUTES:
         setattr(dst, name, getattr(src, name))
     # Any cached spec describes the old allocation or layout. Rebuild it on
@@ -932,7 +928,7 @@ def _storage_extent(tensor: TorchMojoTensor) -> int:
     )
 
 
-def _rebind_payload(dst: TorchMojoTensor, src: TorchMojoTensor) -> None:
+def _rebind_payload(dst: TorchMojoTensor, src: TorchMojoTensor):
     """Move ``src``'s eager payload into ``dst`` without changing identity.
 
     Both the Python payload and the real TensorImpl must move together. A
@@ -952,7 +948,7 @@ def _rebind_payload(dst: TorchMojoTensor, src: TorchMojoTensor) -> None:
     _move_payload_attributes(dst, src)
 
 
-def _rebind_payload_exact(dst: TorchMojoTensor, src: TorchMojoTensor) -> None:
+def _rebind_payload_exact(dst: TorchMojoTensor, src: TorchMojoTensor):
     """``_rebind_payload`` that also reproduces src's strides and offset.
 
     ``_rebind_payload`` moves the payload and resizes the TensorImpl, but
@@ -984,7 +980,7 @@ def _rebind_payload_exact(dst: TorchMojoTensor, src: TorchMojoTensor) -> None:
     _as_strided_tensorimpl(dst, src._shape, src._mojo_strides, src._offset)
 
 
-def _resize_payload(dst: TorchMojoTensor, shape: Sequence[int]) -> None:
+def _resize_payload(dst: TorchMojoTensor, shape: Sequence[int]):
     """Resize an eager out tensor and keep aliases when storage is sufficient.
 
     PyTorch resets a resized view to contiguous strides at its existing
@@ -1019,7 +1015,7 @@ def _resize_payload(dst: TorchMojoTensor, shape: Sequence[int]) -> None:
     _rebind_payload(dst, replacement)
 
 
-def _copy_strided_enqueue(dst: TorchMojoTensor, src: TorchMojoTensor) -> None:
+def _copy_strided_enqueue(dst: TorchMojoTensor, src: TorchMojoTensor):
     """Queue the strided copy as an external call (tensor_holder is always
     loaded, so the item is always launch-ready; it only holds FIFO order).
     The queue holds raw pointers, so both tensors are handed over as the
@@ -1039,7 +1035,7 @@ def _copy_strided_enqueue(dst: TorchMojoTensor, src: TorchMojoTensor) -> None:
     _cq.external_call(holder.CopyStrided, args, keepalive=(dst, src))
 
 
-def _copy_strided_into(dst: TorchMojoTensor, src: TorchMojoTensor) -> None:
+def _copy_strided_into(dst: TorchMojoTensor, src: TorchMojoTensor):
     """dst[coords] = src[coords]; same shape and dtype, any strides.
 
     The shared materialize/copy primitive: powers .contiguous(), copy_ into

--- a/torch_mojo_backend/mojo_device/torch_mojo_tensor.py
+++ b/torch_mojo_backend/mojo_device/torch_mojo_tensor.py
@@ -69,17 +69,24 @@ def _holder_mod() -> _TensorHolderModule:
     return holder
 
 
+class _ReadyEvent(Protocol):
+    """The one thing the pending-transfer queues ask of a recorded event
+    (`max.driver.DeviceEvent`; tests inject stand-ins)."""
+
+    def is_ready(self) -> bool: ...
+
+
 # GPU H2D copies consume a MAX-owned pinned staging allocation asynchronously.
 # Keep that transfer owner alive until an event recorded behind its DMA
 # completes. This mirrors the lifetime tracking performed by CUDA's pinned
 # memory allocator without depending on torch-cuda.
-_PENDING_H2D: dict[max.driver.Device, deque] = {}
+_PENDING_H2D: dict[max.driver.Device, deque[tuple[_ReadyEvent, object]]] = {}
 _PENDING_H2D_LOCK = threading.Lock()
 
 # A non-blocking D2H returns a CPU tensor that aliases a MAX-owned pinned host
 # allocation. DLPack ties that owner to the returned tensor, while this queue
 # also retains it until the DMA event completes if the tensor dies early.
-_PENDING_D2H: dict[max.driver.Device, deque] = {}
+_PENDING_D2H: dict[max.driver.Device, deque[tuple[_ReadyEvent, object]]] = {}
 _PENDING_D2H_LOCK = threading.Lock()
 
 # A stream/event failure is already a fatal device condition, but raw-pointer
@@ -301,7 +308,9 @@ def _device_of(tensor: MojoTensorLike) -> max.driver.Device:
     return cast(max.driver.Device, tensor._device)
 
 
-def _dispatch_entry(func: torch._ops.OpOverload, args: tuple, kwargs: dict) -> object:
+def _dispatch_entry(
+    func: torch._ops.OpOverload, args: tuple[object, ...], kwargs: dict[str, object]
+) -> object:
     """``deferred_compile.dispatch``, resolved on first use.
 
     ``deferred_compile`` imports the call queue this module feeds, so it
@@ -311,7 +320,7 @@ def _dispatch_entry(func: torch._ops.OpOverload, args: tuple, kwargs: dict) -> o
     trick as ``output_specs._alloc``).
     """
     global _dispatch_entry
-    from . import deferred_compile
+    from torch_mojo_backend.mojo_device import deferred_compile
 
     # Same nominal-vs-structural self-rebind quirk as _ctx_ptr above, even
     # though both sides print identically.
@@ -480,8 +489,8 @@ class TorchMojoTensor(torch.Tensor):
         cls,
         func: torch._ops.OpOverload,
         types: Sequence[type],
-        args: tuple = (),
-        kwargs: dict | None = None,
+        args: tuple[object, ...] = (),
+        kwargs: dict[str, object] | None = None,
     ) -> object:
         """Redispatch wrapper operations to the existing Mojo backend kernels."""
         # Give higher-priority wrappers such as FakeTensor and
@@ -639,7 +648,7 @@ class TorchMojoTensor(torch.Tensor):
         consuming it, matching PyTorch's asynchronous accelerator-to-CPU
         contract. Blocking and CPU-device copies are ready on return.
         """
-        from . import deferred_compile
+        from torch_mojo_backend.mojo_device import deferred_compile
 
         src = self if self._is_contiguous else self._materialize_contiguous()
         # Reading device bytes is a host read: every queued launch must have
@@ -713,7 +722,7 @@ class TorchMojoTensor(torch.Tensor):
         """
         from torch_mojo_backend.mojo_device import dlpack
 
-        from . import deferred_compile
+        from torch_mojo_backend.mojo_device import deferred_compile
 
         src = self._contig()
         deferred_compile.drain()

--- a/torch_mojo_backend/testing.py
+++ b/torch_mojo_backend/testing.py
@@ -43,7 +43,7 @@ class CallChecker:
     fast path (eager) — no per-test bookkeeping needed.
     """
 
-    def __init__(self) -> None:
+    def __init__(self):
         self._functions_to_check: tuple[CountedCallable, ...] | None = None
         self._counts_before_starting_to_check: list[int] | None = None
 
@@ -108,7 +108,7 @@ class CallChecker:
                 twins.append(counter)
         return twins
 
-    def register(self, *funcs: Callable[..., object]) -> None:
+    def register(self, *funcs: Callable[..., object]):
         """Register the functions expected to run.
 
         `funcs` are typed `Callable` (each caller's own precise signature,
@@ -131,7 +131,7 @@ class CallChecker:
             f.call_count for f in self._functions_to_check
         ]
 
-    def check_was_called(self) -> None:
+    def check_was_called(self):
         if (
             self._functions_to_check is None
             or self._counts_before_starting_to_check is None
@@ -164,7 +164,7 @@ def check_functions_are_equivalent(
     fn_compiled: Callable[..., torch.Tensor | Sequence[torch.Tensor]] | None = None,
     rtol: float | None = None,
     atol: float | None = None,
-) -> None:
+):
     fn_compiled = fn_compiled or torch.compile(backend=mojo_backend)(fn)
     if device is not None:
         inputs = [input_tensor.to(device) for input_tensor in inputs]
@@ -209,7 +209,7 @@ def check_outputs(
     *,
     rtol: float | None = None,
     atol: float | None = None,
-) -> None:
+):
     # We compare to eager cpu execution
     # We first check if the function has a device argument
     has_device_arg = "device" in inspect.signature(fn).parameters

--- a/torch_mojo_backend/testing.py
+++ b/torch_mojo_backend/testing.py
@@ -1,6 +1,6 @@
 import contextlib
 import inspect
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass
 from typing import cast
 
@@ -48,7 +48,7 @@ class CallChecker:
         self._counts_before_starting_to_check: list[int] | None = None
 
     @staticmethod
-    def _fast_twins(func: Callable) -> list[CountedCallable]:
+    def _fast_twins(func: Callable[..., object]) -> list[CountedCallable]:
         """The aten_fast counterparts of an aten_functions twin.
 
         Matches `fast_<name>` and its variants `fast_<name>_<suffix>` (e.g.
@@ -73,7 +73,7 @@ class CallChecker:
         return twins
 
     @staticmethod
-    def _eager_twins(func: Callable) -> list[CountedCallable]:
+    def _eager_twins(func: Callable[..., object]) -> list[CountedCallable]:
         """The instrumented mojo registration(s) whose op matches an
         aten_functions twin. Covers ops implemented as custom / out-variant
         registrations (empty_like, mean.out, normal_, ...) that don't route
@@ -108,7 +108,7 @@ class CallChecker:
                 twins.append(counter)
         return twins
 
-    def register(self, *funcs: Callable) -> None:
+    def register(self, *funcs: Callable[..., object]) -> None:
         """Register the functions expected to run.
 
         `funcs` are typed `Callable` (each caller's own precise signature,
@@ -151,11 +151,17 @@ class CallChecker:
             )
 
 
+def _as_tensor_list(
+    outputs: torch.Tensor | Sequence[torch.Tensor],
+) -> list[torch.Tensor]:
+    return [outputs] if isinstance(outputs, torch.Tensor) else list(outputs)
+
+
 def check_functions_are_equivalent(
-    fn: Callable,
+    fn: Callable[..., torch.Tensor | Sequence[torch.Tensor]],
     device: str | None,
     inputs: list[torch.Tensor],
-    fn_compiled: Callable | None = None,
+    fn_compiled: Callable[..., torch.Tensor | Sequence[torch.Tensor]] | None = None,
     rtol: float | None = None,
     atol: float | None = None,
 ) -> None:
@@ -168,13 +174,11 @@ def check_functions_are_equivalent(
     output_compiled = fn_compiled(*inputs)
     output_original = fn(*inputs)
 
-    assert type(output_original) == type(output_compiled)
+    assert type(output_original) is type(output_compiled)
 
-    if isinstance(output_original, torch.Tensor):
-        output_original = [output_original]
-        output_compiled = [output_compiled]
-
-    for i, (original, compiled) in enumerate(zip(output_original, output_compiled)):
+    for i, (original, compiled) in enumerate(
+        zip(_as_tensor_list(output_original), _as_tensor_list(output_compiled))
+    ):
         assert original.shape == compiled.shape, f"Issue with output {i}"
         assert original.device == compiled.device, f"Issue with output {i}"
         assert original.dtype == compiled.dtype, f"Issue with output {i}"
@@ -199,7 +203,7 @@ def to_device(tensors: list[torch.Tensor], device: str) -> list[torch.Tensor]:
 
 
 def check_outputs(
-    fn: Callable,
+    fn: Callable[..., torch.Tensor | Sequence[torch.Tensor]],
     conf: Conf,
     inputs: list[torch.Tensor],
     *,
@@ -227,13 +231,8 @@ def check_outputs(
         else:
             outputs_conf = fn_to_run(*inputs_on_device)
 
-    # Now we compare outputs
-    if isinstance(outputs_eager_cpu, torch.Tensor):
-        outputs_eager_cpu = [outputs_eager_cpu]
-        outputs_conf = [outputs_conf]
-
     for i, (output_eager_cpu, output_conf) in enumerate(
-        zip(outputs_eager_cpu, outputs_conf)
+        zip(_as_tensor_list(outputs_eager_cpu), _as_tensor_list(outputs_conf))
     ):
         expected_device = torch.device(conf.device)
         if not (output_conf.device == expected_device):

--- a/torch_mojo_backend/torch_compile_backend/compiler.py
+++ b/torch_mojo_backend/torch_compile_backend/compiler.py
@@ -63,7 +63,7 @@ def global_max_objects() -> GlobalMaxObjects:
     return _global_max_objects
 
 
-def gather_stats_on_graph(gm: torch.fx.GraphModule) -> None:
+def gather_stats_on_graph(gm: torch.fx.GraphModule):
     # count the number of times we see each function.
     # print and sort alphabetically.
     function_counts: dict[str, int] = {}
@@ -79,10 +79,10 @@ def gather_stats_on_graph(gm: torch.fx.GraphModule) -> None:
 
 
 class TensorsBook:
-    def __init__(self) -> None:
+    def __init__(self):
         self.tensors: dict[str, Any] = {}
 
-    def __setitem__(self, name: str, tensor: object) -> None:
+    def __setitem__(self, name: str, tensor: object):
         self.tensors[name] = tensor
 
     def convert_to_max(self, something: object) -> object:
@@ -155,7 +155,7 @@ class _GraphFactory:
         self,
         replace_inputs: dict[str, torch.Tensor] = {},
         force_device: DeviceRef | None = None,
-    ) -> None:
+    ):
         """Creates the MAX graph according to the input fx graph.
 
         Create a new instance for each new graph to be created.
@@ -184,7 +184,7 @@ class _GraphFactory:
         self.replace_inputs = replace_inputs
         self.force_device = force_device
 
-    def initialize_graph(self) -> None:
+    def initialize_graph(self):
         if self.graph is not None:
             raise RuntimeError("Graph has already been initialized.")
 
@@ -214,7 +214,7 @@ class _GraphFactory:
         # torch_device_to_max_device also handles the eager "mojo" device.
         return torch_device_to_max_device(tensor.device)
 
-    def handle_placeholder(self, node: torch.fx.Node) -> None:
+    def handle_placeholder(self, node: torch.fx.Node):
         if node.name in self.replace_inputs:
             # We short-circuit this input and use a constant instead.
             # We still have to place it in the graph inputs list because
@@ -253,7 +253,7 @@ class _GraphFactory:
             )
             self.names_to_input_idx[node.name] = len(self.graph_inputs) - 1
 
-    def handle_call_function(self, node_idx: int, node: torch.fx.Node) -> None:
+    def handle_call_function(self, node_idx: int, node: torch.fx.Node):
         func_args = [self.tensor_book.convert_to_max(x) for x in node.args]
         func_kwargs = {
             k: self.tensor_book.convert_to_max(v) for k, v in node.kwargs.items()
@@ -310,7 +310,7 @@ class _GraphFactory:
 
         self.tensor_book[node.name] = func_output
 
-    def handle_get_attr(self, node: torch.fx.Node) -> None:
+    def handle_get_attr(self, node: torch.fx.Node):
         owning_module = node.graph.owning_module
         assert owning_module is not None
         assert isinstance(node.target, str)
@@ -484,7 +484,7 @@ class BaseMaxCompiler:
         gm: torch.fx.GraphModule,
         example_inputs: list[object],
         mode: str | None = None,
-    ) -> None:
+    ):
         self.gm = gm
         self.mojo_outputs = _graph_uses_mojo_device(gm, example_inputs)
         if profiling_enabled():
@@ -576,7 +576,7 @@ class BaseMaxCompiler:
 _buffer_cache: "dict[int, tuple[max.driver.Buffer, int, weakref.finalize[[int], torch.Tensor]]]" = {}
 
 
-def _evict_buffer(tensor_id: int, /) -> None:
+def _evict_buffer(tensor_id: int, /):
     _buffer_cache.pop(tensor_id, None)
 
 
@@ -618,7 +618,7 @@ def boxed_func(
 
 
 class mojo_backend:
-    def __init__(self, gm: torch.fx.GraphModule, example_inputs: list[object]) -> None:
+    def __init__(self, gm: torch.fx.GraphModule, example_inputs: list[object]):
         self.func_to_execute = aot_autograd(
             fw_compiler=boxed_func, decompositions=DECOMPOSITION_TABLE
         )(gm, example_inputs)

--- a/torch_mojo_backend/torch_compile_backend/compiler.py
+++ b/torch_mojo_backend/torch_compile_backend/compiler.py
@@ -1,6 +1,7 @@
 import time
 import traceback
 import weakref
+import datetime as dt
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
@@ -29,15 +30,12 @@ from torch_mojo_backend.torch_compile_backend.utils import (
     get_fully_qualified_name,
 )
 
-from ..aten_functions import MAPPING_TORCH_ATEN_TO_MOJO
-from .utils import get_accelerators
+from torch_mojo_backend.aten_functions import MAPPING_TORCH_ATEN_TO_MOJO
+from torch_mojo_backend.torch_compile_backend.utils import get_accelerators
 
 
 class MojoCompilerError(Exception):
     pass
-
-
-import datetime as dt
 
 
 @dataclass
@@ -385,10 +383,7 @@ class _GraphFactory:
                 output_tensors.append(converted)
         # Store the none indices for runtime handling
         self.graph.output(
-            *cast(
-                "list[max.graph.value.Value | max.graph.value.TensorValueLike]",
-                output_tensors,
-            )
+            *cast("list[max.graph.value.TensorValueLike]", output_tensors)
         )
         self.graph.__exit__(None, None, None)
         self._graph_open = False
@@ -577,10 +572,11 @@ class BaseMaxCompiler:
 # (catches storage reallocation, e.g. `param.data = ...`), evicted when the
 # tensor dies. Buffers alias the tensor memory, so in-place updates
 # (optimizer steps) are seen without invalidation.
-_buffer_cache: dict[int, tuple[max.driver.Buffer, int, weakref.finalize]] = {}
+# Quoted: `weakref.finalize` is not subscriptable at runtime.
+_buffer_cache: "dict[int, tuple[max.driver.Buffer, int, weakref.finalize[[int], torch.Tensor]]]" = {}
 
 
-def _evict_buffer(tensor_id: int) -> None:
+def _evict_buffer(tensor_id: int, /) -> None:
     _buffer_cache.pop(tensor_id, None)
 
 

--- a/torch_mojo_backend/torch_compile_backend/debug.py
+++ b/torch_mojo_backend/torch_compile_backend/debug.py
@@ -24,14 +24,14 @@ output_directory = Path("/tmp/.torch_mojo_backend_debug")
 output_directory_max = output_directory / "max"
 
 
-def set_print_options(session: engine.InferenceSession) -> None:
+def set_print_options(session: engine.InferenceSession):
     output_directory_max.mkdir(parents=True, exist_ok=True)
     session.set_debug_print_options(
         "BINARY_MAX_CHECKPOINT", output_directory=output_directory_max
     )
 
 
-def add_prints(node_idx: int, func_name: str, func_output: object) -> None:
+def add_prints(node_idx: int, func_name: str, func_output: object):
     if not debug_graph():
         return
     outputs: Sequence[TensorValue]
@@ -125,7 +125,7 @@ def make_debug_function(
     return new_function
 
 
-def debug_graph_if_required(gm: torch.fx.GraphModule, args: tuple[object, ...]) -> None:
+def debug_graph_if_required(gm: torch.fx.GraphModule, args: tuple[object, ...]):
     if not debug_graph():
         return
 

--- a/torch_mojo_backend/torch_compile_backend/utils.py
+++ b/torch_mojo_backend/torch_compile_backend/utils.py
@@ -1,5 +1,5 @@
 import warnings
-from collections.abc import Callable
+from collections.abc import Callable, Mapping, Sequence
 
 import torch
 from max.driver import CPU, Accelerator, Device, accelerator_count
@@ -19,7 +19,7 @@ def get_accelerators() -> list[Device]:
     return result
 
 
-def get_fully_qualified_name(func: Callable | str) -> str:
+def get_fully_qualified_name(func: Callable[..., object] | str) -> str:
     if isinstance(func, str):
         return f"torch.Tensor.{func}"
     result = ""
@@ -36,7 +36,10 @@ def get_fully_qualified_name(func: Callable | str) -> str:
 
 
 def get_error_message(
-    node: torch.fx.Node, node_idx: int, func_args: list | tuple, func_kwargs: dict
+    node: torch.fx.Node,
+    node_idx: int,
+    func_args: Sequence[object],
+    func_kwargs: Mapping[str, object],
 ) -> str:
     if node.stack_trace is None:
         stack_trace = "No stack trace available, likely because this node is the result of a decomposition."


### PR DESCRIPTION
Adds the requested lint/type-checker rules to `pyproject.toml`:

```toml
[tool.ruff.lint]
extend-select = ["UP", "ANN", "TID252"]   # was select = ["F", "UP", "ANN"]

[tool.ruff.lint.flake8-annotations]
suppress-none-returning = true

[tool.ruff.lint.flake8-tidy-imports]
ban-relative-imports = "all"

[tool.ruff.format]
line-ending = "lf"
skip-magic-trailing-comma = true

[tool.ty.rules]
missing-type-argument = "error"
```

`extend-select` keeps ruff's default rule set (E4, E7, E9, F) on. `UP` and `ANN` stay listed since they are not defaults. One addition beyond the request: `TID252` is in `extend-select`, because `ban-relative-imports` is only a setting for that rule and does nothing until the rule is selected.

What the new rules flagged, and how it was fixed:

- **64 relative imports** rewritten as absolute (`from .support import` → `from torch_mojo_backend.mojo_device.aten_ops.support import`, `from .conftest` → `from tests.conftest`).
- **24 default-E findings**: imports moved to the top of `aten_fast.py`, `compiler.py` and `gemma3.py`; `conftest.py` (env vars must precede the imports) and the streams re-exports at the bottom of `torch_mojo_device_module.py` keep a `noqa: E402`; two `type(a) == type(b)` → `is`; two `l` loop variables renamed; one `not x in` → `not in`.
- **126 `missing-type-argument`**: every bare `tuple`/`Callable`/`dict`/`list`/`deque`/`ContextVar`/`DataLoader`/`weakref.finalize` gets its real type arguments. No `Any`; `object` only where the value really is arbitrary (forwarded aten `*args`, the op registry). Two small runtime-visible edits fell out of that: `_evict_buffer` is positional-only so its `weakref.finalize` ParamSpec matches, and `_spec_matmul_out_shape` tests `0 in a._shape` instead of `a._numel == 0` (equivalent) so it can take any `MojoTensorLike`.

**Second commit: no more `-> None`.** With `suppress-none-returning` on, the 417 `-> None` annotations carried no information, so they are gone (ty infers the return from the body; `ty check` still passes). Three functions that returned the None result of a redispatch or a wrapped torch call now just call it, so ruff needs no annotation from them either. `tests/test_no_none_return_annotations.py` scans the Python sources and fails CI on any `) -> None:` (it runs in the existing `not mojo_device` matrix leg), and AGENTS.md states the rule.

Checks: `ruff check`, `ruff format --check` and `ty check` all pass on the whole repo. On an H100 node: `tests/test_compiler.py`, `tests/models/test_mnist.py`, `tests/test_mojo_device.py`, `tests/test_mojo_device_runtime.py` show the same result set as pristine main on the same node: 8 failures, all pre-existing environmental ones (the ptxas 12.8 `aten::linear`/`mm` gap and the four timing-based non-blocking-transfer tests), 168 passed, plus collection of the large test files and `benchmarks/test_coverage.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AbxaDeRuA7yywYEUuZV72
