### PR TITLE
Compare conv2d fp32 conformance against a float64 anchor

### DIFF
--- a/conformance/test_opinfo.py
+++ b/conformance/test_opinfo.py
@@ -46,6 +46,8 @@ from torch.testing._internal.common_methods_invocations import op_db
 from torch.testing._internal.common_utils import TestCase, run_tests
 from torch.testing._internal.opinfo.core import OpInfo, SampleInput
 
+from torch_mojo_backend.testing import assert_close_fp64_anchored
+
 # The dtypes worth exercising on an accelerator backend.  Deliberately not the
 # full OpInfo set: float64 is absent on some GPUs we target and complex is not
 # implemented at all, so including them would report a backend-wide gap once
@@ -275,6 +277,22 @@ def _cross_device_comparison_skip_reason(op: OpInfo, dtype: torch.dtype) -> str 
     return None
 
 
+# Nodes compared through `assert_close_fp64_anchored` instead of the default
+# bar: fp32 reductions whose result depends on summation order, so two correct
+# kernels differ by more than rtol 1.3e-6 / atol 1e-5 on a few elements, and
+# WHICH elements depends on the CPU's SIMD width (this node passed or failed
+# on GitHub's runners depending on the machine drawn). torch's own fp32
+# conv2d lands up to 4.6e-5 from the float64 answer on these very samples.
+# Kept to the nodes that have shown it; not a general policy.
+_FP64_ANCHORED: frozenset[tuple[str, torch.dtype]] = frozenset(
+    {("nn_functional_conv2d", torch.float32)}
+)
+
+
+def _to_float64(sample: SampleInput) -> SampleInput:
+    return sample.transform(lambda t: t.double() if t.is_floating_point() else t)
+
+
 class TestOpInfoConformance(TestCase):
     """One test per (operator, dtype), driven entirely by OpInfo metadata."""
 
@@ -323,9 +341,22 @@ class TestOpInfoConformance(TestCase):
             moved = _to_device(sample, device, placement)
             actual = op(moved.input, *moved.args, **moved.kwargs)
             expected = op(sample.input, *sample.args, **sample.kwargs)
-            # assertEqual carries the OpInfo precisionOverride for this dtype
-            # when the operator declares one; otherwise assert_close defaults.
-            self.assertEqual(_to_cpu(actual), expected, exact_dtype=True)
+            if (
+                (op.formatted_name, dtype) in _FP64_ANCHORED
+                and isinstance(actual, torch.Tensor)
+                and isinstance(expected, torch.Tensor)
+            ):
+                exact = _to_float64(sample)
+                reference = op(exact.input, *exact.args, **exact.kwargs)
+                assert isinstance(reference, torch.Tensor)
+                cpu_actual = _to_cpu(actual)
+                assert isinstance(cpu_actual, torch.Tensor)
+                assert_close_fp64_anchored(cpu_actual, expected, reference)
+            else:
+                # assertEqual carries the OpInfo precisionOverride for this
+                # dtype when the operator declares one; otherwise assert_close
+                # defaults.
+                self.assertEqual(_to_cpu(actual), expected, exact_dtype=True)
             checked += 1
         if checked == 0:
             self.skipTest("OpInfo produced no sample inputs for this dtype")

--- a/tests/test_assert_close_fp64_anchored.py
+++ b/tests/test_assert_close_fp64_anchored.py
@@ -1,0 +1,57 @@
+"""Host-only pins for `assert_close_fp64_anchored`."""
+
+import pytest
+import torch
+
+from torch_mojo_backend.testing import assert_close_fp64_anchored
+
+# Small magnitudes, so atol (1e-5) rather than rtol sets the default bar.
+_REFERENCE = torch.linspace(-1.0, 1.0, 64, dtype=torch.float64).reshape(8, 8)
+
+
+def _rounded_with_noise(noise: float) -> torch.Tensor:
+    """torch's-result stand-in: the exact answer rounded to fp32 plus one
+    element perturbed by `noise` (fp32 summation-order error)."""
+    out = _REFERENCE.float()
+    out[3, 3] += noise
+    return out
+
+
+def test_identical_results_pass():
+    torch_result = _rounded_with_noise(2e-5)
+    assert_close_fp64_anchored(torch_result.clone(), torch_result, _REFERENCE)
+
+
+def test_error_comparable_to_torchs_passes_beyond_the_default_bar():
+    torch_result = _rounded_with_noise(2e-5)
+    ours = _REFERENCE.float()
+    ours[5, 1] -= 3e-5  # > atol 1e-5, < 2x torch's own 2e-5 miss
+    with pytest.raises(AssertionError):
+        torch.testing.assert_close(ours, torch_result)
+    assert_close_fp64_anchored(ours, torch_result, _REFERENCE)
+
+
+def test_error_far_beyond_torchs_fails():
+    torch_result = _rounded_with_noise(2e-5)
+    ours = _REFERENCE.float()
+    ours[5, 1] -= 5e-4
+    with pytest.raises(AssertionError, match="1 / 64 elements"):
+        assert_close_fp64_anchored(ours, torch_result, _REFERENCE)
+
+
+def test_where_torch_is_exact_the_default_bar_is_the_floor():
+    torch_result = _REFERENCE.float()  # exact, up to fp32 rounding
+    ours = torch_result.clone()
+    ours[0, 0] += 5e-6  # inside atol 1e-5
+    assert_close_fp64_anchored(ours, torch_result, _REFERENCE)
+    ours[0, 0] += 5e-5  # outside it, and torch itself is (nearly) exact
+    with pytest.raises(AssertionError):
+        assert_close_fp64_anchored(ours, torch_result, _REFERENCE)
+
+
+def test_dtype_and_shape_must_match():
+    torch_result = _REFERENCE.float()
+    with pytest.raises(AssertionError):
+        assert_close_fp64_anchored(torch_result.double(), torch_result, _REFERENCE)
+    with pytest.raises(AssertionError):
+        assert_close_fp64_anchored(torch_result.flatten(), torch_result, _REFERENCE)

--- a/torch_mojo_backend/testing.py
+++ b/torch_mojo_backend/testing.py
@@ -185,6 +185,59 @@ def check_functions_are_equivalent(
         torch.testing.assert_close(original, compiled, rtol=rtol, atol=atol)
 
 
+# torch.testing.assert_close's default (rtol, atol) per floating dtype.
+_DEFAULT_TOLERANCES: dict[torch.dtype, tuple[float, float]] = {
+    torch.float16: (1e-3, 1e-5),
+    torch.bfloat16: (1.6e-2, 1e-5),
+    torch.float32: (1.3e-6, 1e-5),
+    torch.float64: (1e-7, 1e-7),
+}
+
+
+def assert_close_fp64_anchored(
+    actual: torch.Tensor,
+    expected: torch.Tensor,
+    reference: torch.Tensor,
+    *,
+    slack: float = 2.0,
+):
+    """`actual` must sit as close to the float64 `reference` as `expected`
+    (torch's own result in the working dtype) does, within a factor `slack`.
+
+    For fp32 reductions torch's default bar (rtol 1.3e-6, atol 1e-5) is
+    tighter than torch's own rounding error against the exact answer, so
+    two correct implementations that merely sum in a different order fail
+    it on some elements, depending on the CPU's SIMD width. This bar asks
+    the question the default one means to: is the kernel as accurate as
+    torch's? The default tolerance stays as a floor, so where torch is exact
+    the check is the ordinary one.
+    """
+    assert actual.shape == expected.shape, (actual.shape, expected.shape)
+    assert actual.dtype == expected.dtype, (actual.dtype, expected.dtype)
+    assert reference.dtype == torch.float64, reference.dtype
+    rtol, atol = _DEFAULT_TOLERANCES[expected.dtype]
+    actual, expected = actual.cpu(), expected.cpu()
+    if not torch.isfinite(reference).all():
+        torch.testing.assert_close(
+            actual, expected, rtol=rtol, atol=atol, equal_nan=True
+        )
+        return
+    error = (actual.double() - reference).abs()
+    torch_error = (expected.double() - reference).abs()
+    allowed = torch.clamp(atol + rtol * reference.abs(), min=slack * torch_error.max())
+    bad = error > allowed
+    if bad.any():
+        worst = int(error.flatten().argmax())
+        raise AssertionError(
+            f"{int(bad.sum())} / {bad.numel()} elements further from the float64 "
+            f"reference than {slack}x torch's own worst error "
+            f"({float(torch_error.max()):.3g}) and outside rtol={rtol}, atol={atol}. "
+            f"Worst: actual {float(actual.flatten()[worst])!r}, torch "
+            f"{float(expected.flatten()[worst])!r}, reference "
+            f"{float(reference.flatten()[worst])!r} at flat index {worst}."
+        )
+
+
 @dataclass
 class Conf:
     device: str


### PR DESCRIPTION
The one node still red on main after #438: `test_matches_cpu_nn_functional_conv2d_mojo_float32`.

**What fails.** One element of 256 sits 1.3e-5 from torch's result against the fp32 default bar (rtol 1.3e-6, atol 1e-5). It passed or failed on GitHub's runners depending on the machine drawn, while six consecutive runs on one cluster node all pass, so it is fp32 summation order following the CPU's SIMD width, not a kernel bug. The bar is tighter than torch's own accuracy: measured on these very OpInfo samples, torch's fp32 conv2d lands up to 4.6e-5 from the float64 answer.

**The fix.** `torch_mojo_backend.testing.assert_close_fp64_anchored(actual, expected, reference)` asks the question the default bar means to ask: `actual` must be as close to the float64 `reference` as torch's own fp32 result is, within a factor of 2, with the default tolerance kept as a floor so the check stays the ordinary one where torch is exact. Integer and bool outputs are untouched (the helper is only reached for floating results).

**Scope, deliberately narrow.** The conformance harness routes exactly one node through it, listed in `_FP64_ANCHORED` in `conformance/test_opinfo.py` with the evidence next to it. Every other node keeps `assertEqual` at OpInfo's tolerance, and nothing in `tests/` changes its comparison. `tests/test_assert_close_fp64_anchored.py` pins the helper's semantics (comparable-to-torch error passes beyond the default bar, far-beyond fails, default bar is the floor where torch is exact).

**Verification.** ruff, format and ty pass. On a GPU-less SLURM node (the CI environment): the node passes, the other conv2d dtypes still xfail as declared, and the pin tests pass. On an H100 the fp32 node passes too (bf16/fp16 conv2d fail there with the cluster's known ptxas 12.8 "no GPU accelerator available at compile time" gap, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AbxaDeRuA7yywYEUuZV72
