### PR TITLE
Use dynamic shared memory for the >48 KiB GEMM routes; drop the ptxas probe

### DIFF
--- a/docs/kernel_call_queue.md
+++ b/docs/kernel_call_queue.md
@@ -113,14 +113,16 @@ definition mapping and is surfaced directly. There is no widening, dtype
 escalation, fallback build, or launch-time retry.
 
 One toolchain limit shapes the kernels rather than the build identity. ptxas
-caps a kernel's *static* shared memory at 48 KiB before CUDA 13 and fails the
-whole `.so` on the first kernel over the line, so every route needing more than
-that — the wgmma/TMA GEMM kernels, flash attention, the tf32 and fp32 cores —
-stages its tiles in dynamic (`extern`) shared memory, sized per launch by
+caps a kernel's *static* shared memory at 48 KiB (every target through CUDA
+12.8; portable targets such as `sm_90` still in 13.x, only `sm_90a`-style
+architecture-specific targets are exempt) and fails the whole `.so` on the
+first kernel over the line, so every route needing more than that — the
+wgmma/TMA GEMM kernels, flash attention, the tf32 and fp32 cores — stages its
+tiles in dynamic (`extern`) shared memory, sized per launch by
 `shared_mem_bytes` and opted into with
 `FuncAttribute.MAX_DYNAMIC_SHARED_SIZE_BYTES`. That window has never been
-capped that way, so those kernels assemble under any ptxas and nothing has to
-be probed or gated.
+capped that way, so those kernels assemble under any ptxas and any target, and
+nothing has to be probed or gated.
 
 Builds are protected by a per-identity file lock (`flock`) and written to a
 temporary file before an atomic rename. Concurrent requests for one identity,

--- a/docs/kernel_call_queue.md
+++ b/docs/kernel_call_queue.md
@@ -112,6 +112,16 @@ it. An unsupported dtype or flag reported by Mojo indicates a bug in Python's
 definition mapping and is surfaced directly. There is no widening, dtype
 escalation, fallback build, or launch-time retry.
 
+One toolchain limit shapes the kernels rather than the build identity. ptxas
+caps a kernel's *static* shared memory at 48 KiB before CUDA 13 and fails the
+whole `.so` on the first kernel over the line, so every route needing more than
+that — the wgmma/TMA GEMM kernels, flash attention, the tf32 and fp32 cores —
+stages its tiles in dynamic (`extern`) shared memory, sized per launch by
+`shared_mem_bytes` and opted into with
+`FuncAttribute.MAX_DYNAMIC_SHARED_SIZE_BYTES`. That window has never been
+capped that way, so those kernels assemble under any ptxas and nothing has to
+be probed or gated.
+
 Builds are protected by a per-identity file lock (`flock`) and written to a
 temporary file before an atomic rename. Concurrent requests for one identity,
 in this process or another, compile it once, and an interrupted compiler

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -6470,6 +6470,37 @@ def test_bf16_module_is_available_for_lazy_import():
     assert aten_fast._Gemm16MatmulExtension.MOJO_FILE.name == "gemm16_matmul_ops.mojo"
 
 
+def test_big_smem_gemm_routes_stage_in_dynamic_shared_memory():
+    """ptxas caps a kernel's *static* `.shared` at 48 KiB before CUDA 13 and
+    fails the whole `mojo build` on the first kernel over the line, so every
+    GEMM route needing more carves `external_memory` and opts in per launch
+    with MAX_DYNAMIC_SHARED_SIZE_BYTES."""
+    from torch_mojo_backend import eager_kernels
+
+    for relative in (
+        "gemm16_matmul_ops/gemm16_nn_v4_kernels.mojo",
+        "gemm16_matmul_ops/gemm16_bmm_v5_kernels.mojo",
+        "matmul_ops/tn_f32_gemm_core.mojo",
+    ):
+        source = (eager_kernels._PACKAGE_DIR / relative).read_text()
+        assert "external_memory[" in source, relative
+
+    for relative in (
+        "gemm16_matmul_ops/gemm16_nn_v4_kernels.mojo",
+        "gemm16_matmul_ops/gemm16_bmm_v5_kernels.mojo",
+        "matmul_ops/tn_f32_gemm_kernels.mojo",
+    ):
+        source = (eager_kernels._PACKAGE_DIR / relative).read_text()
+        assert "MAX_DYNAMIC_SHARED_SIZE_BYTES" in source, relative
+
+    # Both 128x128 fp32 TN cores are picked on shape alone: nothing routes
+    # around them to keep a build's shared-memory footprint down.
+    tn = (
+        eager_kernels._PACKAGE_DIR / "matmul_ops/tn_f32_gemm_kernels.mojo"
+    ).read_text()
+    assert "use_t128 = m >= 96 and n >= 96" in tn
+
+
 def test_bf16_v3_source_dependency_and_kernel_contract():
     """The lazy bridge includes v3 while v2 remains its explicit fallback."""
     from torch_mojo_backend.eager_kernels import aten_fast

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -6471,10 +6471,11 @@ def test_bf16_module_is_available_for_lazy_import():
 
 
 def test_big_smem_gemm_routes_stage_in_dynamic_shared_memory():
-    """ptxas caps a kernel's *static* `.shared` at 48 KiB before CUDA 13 and
-    fails the whole `mojo build` on the first kernel over the line, so every
-    GEMM route needing more carves `external_memory` and opts in per launch
-    with MAX_DYNAMIC_SHARED_SIZE_BYTES."""
+    """ptxas caps a kernel's *static* `.shared` at 48 KiB (every target
+    through CUDA 12.8, portable targets still in 13.x) and fails the whole
+    `mojo build` on the first kernel over the line, so every GEMM route
+    needing more carves `external_memory` and opts in per launch with
+    MAX_DYNAMIC_SHARED_SIZE_BYTES."""
     from torch_mojo_backend import eager_kernels
 
     for relative in (

--- a/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_bmm_v5_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_bmm_v5_kernels.mojo
@@ -41,6 +41,7 @@ kernel (never atomics).
 The operand dtype is bfloat16 or float16 via _GEMM16_DT, same as the family.
 """
 
+from std.collections import OptionalReg
 from std.gpu import (
     MAX_THREADS_PER_BLOCK_METADATA,
     block_dim,
@@ -48,10 +49,19 @@ from std.gpu import (
     grid_dim,
     thread_idx,
 )
-from max.gpu.host import DeviceAttribute, DeviceBuffer, DeviceContext
+from max.gpu.host import (
+    DeviceAttribute,
+    DeviceBuffer,
+    DeviceContext,
+    FuncAttribute,
+)
 from max.gpu.host.nvidia.tma import TensorMapSwizzle, create_tma_descriptor
 from std.gpu.intrinsics import warpgroup_reg_alloc, warpgroup_reg_dealloc
-from max.gpu.memory import fence_async_view_proxy, fence_mbarrier_init
+from max.gpu.memory import (
+    external_memory,
+    fence_async_view_proxy,
+    fence_mbarrier_init,
+)
 from std.memory import AddressSpace
 from max.gpu.sync import barrier, named_barrier
 from max.gpu.primitives import (
@@ -60,6 +70,7 @@ from max.gpu.primitives import (
     cluster_sync_relaxed,
 )
 from std.memory import stack_allocation
+from std.sys import size_of
 from std.sys.info import _has_sm_9x, _is_sm_9x
 from std.utils.index import Index, IndexList
 from std.utils.static_tuple import StaticTuple
@@ -79,9 +90,131 @@ comptime _B5_DT = _GEMM16_DT
 comptime _B5_F32 = DType.float32
 comptime _B5_PTR = UnsafePointer[Scalar[_B5_DT], MutAnyOrigin]
 comptime _B5_F32_PTR = UnsafePointer[Scalar[_B5_F32], MutAnyOrigin]
+comptime _B5_SMEM = UnsafePointer[
+    Scalar[_B5_DT], MutAnyOrigin, address_space=AddressSpace.SHARED
+]
 comptime _B5_BK = 64
 comptime _B5_GROUP = 4
 comptime _B5_SWIZZLE = TensorMapSwizzle.SWIZZLE_128B
+
+# ---------------------------------------------------------------------------
+# Where the operand pipelines live.
+#
+# Both bodies below stage their operand pipeline (and, with the TMA-store
+# epilogue, the C tile) in shared memory: 32 KiB to 208 KiB of it depending on
+# the instantiation, and all but the two smallest exceed the 49152 bytes ptxas
+# allows a kernel in *static* `.shared` on sm_90 before CUDA 13 -- where it
+# fails the whole `mojo build`, not just the offending kernel.  Those carve one
+# `external_memory` slab into their three tiles instead; the dynamic window
+# has never been subject to the cap (it is opted into per launch with
+# MAX_DYNAMIC_SHARED_SIZE_BYTES, the scheme eager_flash_attention uses).
+#
+# The instantiations that FIT stay static, because the dynamic window is not
+# free: its base sits past the static mbarriers rounded up to the 1024-byte
+# alignment below, so converting a kernel that fits costs it ~1 KiB and can
+# cost the smallest one a resident CTA.  `_b5_dynamic_smem` decides from the
+# instantiation's own byte count, so the split is geometry, not a toolchain
+# question.
+#
+# The mbarriers stay static either way: 16-48 bytes, and keeping them out of
+# the carve keeps the dynamic size a simple function of the tile geometry.
+# The scalar-C instantiations reserve 1 KiB for the dummy C tile ptxas
+# dead-eliminates, because a carve that dropped it would hand the epilogue a
+# pointer into the B pipeline if anyone ever un-gated it; no converted config
+# loses a resident CTA to that 1 KiB.
+#
+# The carve is aligned to 1024 bytes, NOT to the 128 the TMA instructions
+# themselves ask for, and that is load-bearing rather than cautious.  128B
+# swizzling repeats over an atom of 8 rows x 128 bytes = 1024 bytes.  The TMA
+# loads survive any 128-byte base because the writer (TMA) and the reader (the
+# wgmma descriptor) both derive the swizzle from the same shared address, so a
+# shifted base shifts both alike.  The TMA-store epilogue does not: it stages C
+# by hand at `((lcol // 8) ^ (row % 8))`, an XOR on the tile-RELATIVE row, and
+# the store's hardware de-swizzle is an XOR on the ADDRESS.  Those agree only
+# when the tile starts on an atom boundary.  A 128-byte-aligned carve was built
+# and measured: the mainloop stayed exact (the scalar-C epilogue passed every
+# case) while every TMA-store case came back scrambled.  The static path's
+# `alignment=1024` on the C tile is that same requirement, and each tile offset
+# below is a whole number of atoms, so aligning the base carries it to all
+# three.
+# ---------------------------------------------------------------------------
+
+
+# The sm_90 static `.shared` ceiling ptxas enforces before CUDA 13, and the
+# mbarrier allowance to charge against it: the persistent body declares two
+# arrays of `stages` 8-byte barriers (48 B at its deepest pipeline), the tiny
+# body one (24 B).  Charging every instantiation the larger figure keeps the
+# fit test independent of which body is asking.
+comptime _B5_STATIC_SHARED_CAP = 49152
+comptime _B5_MBAR_ALLOWANCE = 48
+
+
+@always_inline
+def _b5_tile_bytes[stages: Int, bm: Int, bn: Int, tma_store: Bool]() -> Int:
+    """Shared bytes the A/B pipeline and the C staging tile occupy.
+
+    The scalar-C epilogue never reads its C tile, and ptxas drops the dead
+    allocation, so it contributes nothing here -- which is what makes this
+    agree with the measured static `.shared` of every instantiation.
+    """
+    return (
+        stages * (bm + bn) * _B5_BK + (bm * bn if tma_store else 0)
+    ) * size_of[_B5_DT]()
+
+
+@always_inline
+def _b5_dynamic_smem[stages: Int, bm: Int, bn: Int, tma_store: Bool]() -> Bool:
+    """Whether this instantiation stages its tiles in the DYNAMIC window.
+
+    True for everything that would not fit in static `.shared` -- every
+    instantiation but `tiny_m64n64` (40976 B) and `tiny_m64n64_scalar_c`
+    (32784 B).
+    """
+    return (
+        _b5_tile_bytes[stages, bm, bn, tma_store]() + _B5_MBAR_ALLOWANCE
+        > _B5_STATIC_SHARED_CAP
+    )
+
+
+@always_inline
+def _b5_smem_bytes[stages: Int, bm: Int, bn: Int, tma_store: Bool]() -> Int:
+    """Bytes of dynamic shared memory one CTA of this instantiation needs.
+
+    A + B pipeline slabs plus the C staging tile, in that order -- the order
+    the kernel carves them.  Zero for an instantiation that stages statically:
+    the dynamic window is unused then and the launch must not reserve any of
+    it.
+    """
+    # The C tile's offset inside the carve has to keep the 1024-byte swizzle
+    # atom the hand-written epilogue assumes (see the header comment); every
+    # (stages, bm, bn) the ladder instantiates satisfies it, and this says so
+    # to the next one that does not.
+    comptime assert (
+        stages * (bm + bn) * _B5_BK * size_of[_B5_DT]()
+    ) % 1024 == 0, "v5 BMM: C staging tile must start on a 128B-swizzle atom"
+    comptime if not _b5_dynamic_smem[stages, bm, bn, tma_store]():
+        return 0
+    return (
+        stages * (bm + bn) * _B5_BK + (bm * bn if tma_store else 512)
+    ) * size_of[_B5_DT]()
+
+
+@always_inline
+def _b5_smem_arg[bytes: Int]() -> OptionalReg[Int]:
+    """`shared_mem_bytes` for a launch, absent when nothing is dynamic."""
+    comptime if bytes == 0:
+        return OptionalReg[Int](None)
+    return OptionalReg[Int](bytes)
+
+
+@always_inline
+def _b5_smem_attr[bytes: Int]() -> OptionalReg[FuncAttribute]:
+    """The >48 KiB dynamic-shared opt-in, absent when nothing is dynamic."""
+    comptime if bytes == 0:
+        return OptionalReg[FuncAttribute](None)
+    return OptionalReg[FuncAttribute](
+        FuncAttribute.MAX_DYNAMIC_SHARED_SIZE_BYTES(UInt32(bytes))
+    )
 
 
 @always_inline
@@ -156,20 +289,6 @@ def _b5_bmm_nn_persistent_ws[
         ]()
         comptime A_PIPE_LAYOUT = Layout.row_major(stages, bm * _B5_BK)
         comptime B_PIPE_LAYOUT = Layout.row_major(stages, bn * _B5_BK)
-        var a_pipeline = LayoutTensor[
-            _B5_DT,
-            A_PIPE_LAYOUT,
-            MutAnyOrigin,
-            address_space=AddressSpace.SHARED,
-            alignment=128,
-        ].stack_allocation()
-        var b_pipeline = LayoutTensor[
-            _B5_DT,
-            B_PIPE_LAYOUT,
-            MutAnyOrigin,
-            address_space=AddressSpace.SHARED,
-            alignment=128,
-        ].stack_allocation()
         # C staging tile for the TMA-store epilogue (swizzled 128B rows of
         # 64 elements, bn // 64 chunks).  A dummy allocation for the scalar
         # epilogue: staging + a coalesced cooperative flush was tried there
@@ -177,13 +296,54 @@ def _b5_bmm_nn_persistent_ws[
         # flush sits on the consumer's critical path while the direct
         # stores' 82% sector waste is absorbed by L2 (89% hit, DRAM 7%).
         comptime C_SMEM_ELEMS = bm * bn if tma_store else 512
-        var c_smem = LayoutTensor[
-            _B5_DT,
-            Layout.row_major(1, C_SMEM_ELEMS),
-            MutAnyOrigin,
-            address_space=AddressSpace.SHARED,
-            alignment=1024,
-        ].stack_allocation()
+        # A/B pipeline + C tile: static if it fits, else one extern slab
+        # carved in that order (see the header comment).
+        var a_smem: _B5_SMEM
+        var b_smem: _B5_SMEM
+        var c_smem: _B5_SMEM
+        comptime if not _b5_dynamic_smem[stages, bm, bn, tma_store]():
+            a_smem = (
+                LayoutTensor[
+                    _B5_DT,
+                    A_PIPE_LAYOUT,
+                    MutAnyOrigin,
+                    address_space=AddressSpace.SHARED,
+                    alignment=128,
+                ]
+                .stack_allocation()
+                .ptr
+            )
+            b_smem = (
+                LayoutTensor[
+                    _B5_DT,
+                    B_PIPE_LAYOUT,
+                    MutAnyOrigin,
+                    address_space=AddressSpace.SHARED,
+                    alignment=128,
+                ]
+                .stack_allocation()
+                .ptr
+            )
+            c_smem = (
+                LayoutTensor[
+                    _B5_DT,
+                    Layout.row_major(1, C_SMEM_ELEMS),
+                    MutAnyOrigin,
+                    address_space=AddressSpace.SHARED,
+                    alignment=1024,
+                ]
+                .stack_allocation()
+                .ptr
+            )
+        else:
+            var smem_base = external_memory[
+                Scalar[_B5_DT],
+                address_space=AddressSpace.SHARED,
+                alignment=1024,
+            ]().as_unsafe_any_origin()
+            a_smem = smem_base
+            b_smem = smem_base + stages * bm * _B5_BK
+            c_smem = b_smem + stages * bn * _B5_BK
         var full_barriers = stack_allocation[
             stages,
             SharedMemBarrier,
@@ -266,7 +426,7 @@ def _b5_bmm_nn_persistent_ws[
                             MutAnyOrigin,
                             address_space=AddressSpace.SHARED,
                             alignment=128,
-                        ](a_pipeline.ptr + stage * bm * _B5_BK)
+                        ](a_smem + stage * bm * _B5_BK)
                         var k0 = t * _B5_BK
                         a_tma.async_copy_3d(
                             a_tile, full_barriers[stage], (k0, m0, ab)
@@ -283,11 +443,7 @@ def _b5_bmm_nn_persistent_ws[
                                 MutAnyOrigin,
                                 address_space=AddressSpace.SHARED,
                                 alignment=128,
-                            ](
-                                b_pipeline.ptr
-                                + stage * bn * _B5_BK
-                                + cc * 64 * _B5_BK
-                            )
+                            ](b_smem + stage * bn * _B5_BK + cc * 64 * _B5_BK)
                             comptime if cluster_m > 1:
                                 b_tma.async_multicast_load_3d(
                                     b_chunk,
@@ -356,14 +512,14 @@ def _b5_bmm_nn_persistent_ws[
                         MutAnyOrigin,
                         address_space=AddressSpace.SHARED,
                         alignment=128,
-                    ](a_pipeline.ptr + stage * bm * _B5_BK)
+                    ](a_smem + stage * bm * _B5_BK)
                     var b_tile = LayoutTensor[
                         _B5_DT,
                         B_LAYOUT,
                         MutAnyOrigin,
                         address_space=AddressSpace.SHARED,
                         alignment=128,
-                    ](b_pipeline.ptr + stage * bn * _B5_BK)
+                    ](b_smem + stage * bn * _B5_BK)
                     warpgroup_fence(accum)
                     wgmma.arrive()
                     wgmma.wgmma[consumers](
@@ -412,7 +568,7 @@ def _b5_bmm_nn_persistent_ws[
                             + ((lcol // 8) ^ (row % 8)) * 8
                             + lcol % 8
                         )
-                        c_smem.ptr.store[alignment=4](elem, pair)
+                        c_smem.store[alignment=4](elem, pair)
                     fence_async_view_proxy()
                     named_barrier[NCONS](1)
                     if warp_group_idx == 1 and warp_group_thread_idx == 0:
@@ -423,7 +579,7 @@ def _b5_bmm_nn_persistent_ws[
                                 MutAnyOrigin,
                                 address_space=AddressSpace.SHARED,
                                 alignment=128,
-                            ](c_smem.ptr + chunk * bm * 64)
+                            ](c_smem + chunk * bm * 64)
                             c_tma.async_store_3d(
                                 c_chunk, (n0 + chunk * 64, m0, bidx)
                             )
@@ -519,28 +675,55 @@ def _b5_bmm_nn_tiny[
         comptime B_CHUNK_LAYOUT = tile_layout_mn_major[
             _B5_DT, 64, _B5_BK, _B5_SWIZZLE
         ]()
-        var a_pipeline = LayoutTensor[
-            _B5_DT,
-            Layout.row_major(stages, bm * _B5_BK),
-            MutAnyOrigin,
-            address_space=AddressSpace.SHARED,
-            alignment=128,
-        ].stack_allocation()
-        var b_pipeline = LayoutTensor[
-            _B5_DT,
-            Layout.row_major(stages, bn * _B5_BK),
-            MutAnyOrigin,
-            address_space=AddressSpace.SHARED,
-            alignment=128,
-        ].stack_allocation()
         comptime C_SMEM_ELEMS = bm * bn if tma_store else 512
-        var c_smem = LayoutTensor[
-            _B5_DT,
-            Layout.row_major(1, C_SMEM_ELEMS),
-            MutAnyOrigin,
-            address_space=AddressSpace.SHARED,
-            alignment=1024,
-        ].stack_allocation()
+        # A/B pipeline + C tile: static if it fits, else one extern slab
+        # carved in that order (see the header comment).
+        var a_smem: _B5_SMEM
+        var b_smem: _B5_SMEM
+        var c_smem: _B5_SMEM
+        comptime if not _b5_dynamic_smem[stages, bm, bn, tma_store]():
+            a_smem = (
+                LayoutTensor[
+                    _B5_DT,
+                    Layout.row_major(stages, bm * _B5_BK),
+                    MutAnyOrigin,
+                    address_space=AddressSpace.SHARED,
+                    alignment=128,
+                ]
+                .stack_allocation()
+                .ptr
+            )
+            b_smem = (
+                LayoutTensor[
+                    _B5_DT,
+                    Layout.row_major(stages, bn * _B5_BK),
+                    MutAnyOrigin,
+                    address_space=AddressSpace.SHARED,
+                    alignment=128,
+                ]
+                .stack_allocation()
+                .ptr
+            )
+            c_smem = (
+                LayoutTensor[
+                    _B5_DT,
+                    Layout.row_major(1, C_SMEM_ELEMS),
+                    MutAnyOrigin,
+                    address_space=AddressSpace.SHARED,
+                    alignment=1024,
+                ]
+                .stack_allocation()
+                .ptr
+            )
+        else:
+            var smem_base = external_memory[
+                Scalar[_B5_DT],
+                address_space=AddressSpace.SHARED,
+                alignment=1024,
+            ]().as_unsafe_any_origin()
+            a_smem = smem_base
+            b_smem = smem_base + stages * bm * _B5_BK
+            c_smem = b_smem + stages * bn * _B5_BK
         var full_barriers = stack_allocation[
             stages,
             SharedMemBarrier,
@@ -584,7 +767,7 @@ def _b5_bmm_nn_tiny[
                 MutAnyOrigin,
                 address_space=AddressSpace.SHARED,
                 alignment=128,
-            ](a_pipeline.ptr + stage * bm * _B5_BK)
+            ](a_smem + stage * bm * _B5_BK)
             a_tma.async_copy_3d(a_tile, full_barriers[stage], (k0, m0, ab))
             comptime for cc in range(B_CHUNKS):
                 var b_chunk = LayoutTensor[
@@ -593,7 +776,7 @@ def _b5_bmm_nn_tiny[
                     MutAnyOrigin,
                     address_space=AddressSpace.SHARED,
                     alignment=128,
-                ](b_pipeline.ptr + stage * bn * _B5_BK + cc * 64 * _B5_BK)
+                ](b_smem + stage * bn * _B5_BK + cc * 64 * _B5_BK)
                 b_tma.async_copy_3d(
                     b_chunk, full_barriers[stage], (n0 + cc * 64, k0, bb)
                 )
@@ -631,14 +814,14 @@ def _b5_bmm_nn_tiny[
                 MutAnyOrigin,
                 address_space=AddressSpace.SHARED,
                 alignment=128,
-            ](a_pipeline.ptr + stage * bm * _B5_BK)
+            ](a_smem + stage * bm * _B5_BK)
             var b_tile = LayoutTensor[
                 _B5_DT,
                 B_LAYOUT,
                 MutAnyOrigin,
                 address_space=AddressSpace.SHARED,
                 alignment=128,
-            ](b_pipeline.ptr + stage * bn * _B5_BK)
+            ](b_smem + stage * bn * _B5_BK)
             warpgroup_fence(accum)
             wgmma.arrive()
             wgmma.wgmma[1](a_tile, b_tile, accum, 0)
@@ -676,7 +859,7 @@ def _b5_bmm_nn_tiny[
                     + ((lcol // 8) ^ (row % 8)) * 8
                     + lcol % 8
                 )
-                c_smem.ptr.store[alignment=4](elem, pair)
+                c_smem.store[alignment=4](elem, pair)
             fence_async_view_proxy()
             barrier()
             if thread_idx.x == 0:
@@ -687,7 +870,7 @@ def _b5_bmm_nn_tiny[
                         MutAnyOrigin,
                         address_space=AddressSpace.SHARED,
                         alignment=128,
-                    ](c_smem.ptr + chunk * bm * 64)
+                    ](c_smem + chunk * bm * 64)
                     c_tma.async_store_3d(c_chunk, (n0 + chunk * 64, m0, bidx))
                 c_tma.commit_group()
                 c_tma.wait_group[0]()
@@ -778,6 +961,8 @@ def _b5_enqueue_tiny[
     var macro_rows = (m + bm - 1) // bm
     var blocks_n = (n + bn - 1) // bn
     var total_works = batch_count * macro_rows * blocks_n
+    # Both absent for an instantiation that stages statically.
+    comptime SMEM = _b5_smem_bytes[stages, bm, bn, tma_store]()
     ctx.enqueue_function[_b5_bmm_nn_tiny[stages, bn, tma_store]](
         a_tma,
         b_tma,
@@ -792,6 +977,8 @@ def _b5_enqueue_tiny[
         Int64(0 if b_bs == 0 else 1),
         grid_dim=(total_works,),
         block_dim=(128,),
+        shared_mem_bytes=_b5_smem_arg[SMEM](),
+        func_attribute=_b5_smem_attr[SMEM](),
     )
 
 
@@ -878,6 +1065,8 @@ def _b5_enqueue_batched[
     # SM overlap them instead.
     var num_clusters = min(occ * (sm_count // cluster_m), total_works)
     var grid_x = num_clusters * cluster_m
+    # Both absent for an instantiation that stages statically.
+    comptime SMEM = _b5_smem_bytes[stages, bm, bn, tma_store]()
     ctx.enqueue_function[
         _b5_bmm_nn_persistent_ws[
             stages, cluster_m, bm, bn, consumers, tma_store
@@ -896,6 +1085,8 @@ def _b5_enqueue_batched[
         Int64(0 if b_bs == 0 else 1),
         grid_dim=(grid_x,),
         block_dim=(128 * (consumers + 1),),
+        shared_mem_bytes=_b5_smem_arg[SMEM](),
+        func_attribute=_b5_smem_attr[SMEM](),
     )
 
 

--- a/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_nn_v4_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_nn_v4_kernels.mojo
@@ -48,10 +48,19 @@ from max.gpu.compute.mma import (
     wgmma_fence_aligned,
     wgmma_wait_group_sync,
 )
-from max.gpu.host import DeviceAttribute, DeviceBuffer, DeviceContext
+from max.gpu.host import (
+    DeviceAttribute,
+    DeviceBuffer,
+    DeviceContext,
+    FuncAttribute,
+)
 from max.gpu.host.nvidia.tma import TensorMapSwizzle, create_tma_descriptor
 from std.gpu.intrinsics import warpgroup_reg_alloc, warpgroup_reg_dealloc
-from max.gpu.memory import fence_async_view_proxy, fence_mbarrier_init
+from max.gpu.memory import (
+    external_memory,
+    fence_async_view_proxy,
+    fence_mbarrier_init,
+)
 from std.memory import AddressSpace
 from max.gpu.sync import named_barrier
 from max.gpu.primitives import (
@@ -60,6 +69,7 @@ from max.gpu.primitives import (
     cluster_sync_relaxed,
 )
 from std.memory import stack_allocation
+from std.sys import size_of
 from std.sys.info import _has_sm_9x, _is_sm_9x
 from std.utils.index import Index, IndexList
 from std.utils.static_tuple import StaticTuple
@@ -97,6 +107,93 @@ comptime _V4_PROD_BM = 128
 comptime _V4_PROD_BN = 256
 comptime _V4_PROD_CONSUMERS = 2
 comptime _V4_PROD_TMA_STORE = True
+
+
+# ============================================================================
+# Operand/staging tiles: one dynamic (extern) shared slab per CTA.
+#
+# Every tile the v4 bodies stage -- the A and B operand pipelines and the C
+# tile of the TMA-store epilogues -- runs from 72 KiB to 208 KiB per CTA, past
+# the 49152-byte cap ptxas puts on a kernel's *static* `.shared` before CUDA
+# 13, and ptxas fails the whole `mojo build` on the first kernel over the line
+# rather than the one kernel.  Dynamic shared memory is not capped that way:
+# it is opted into per function with MAX_DYNAMIC_SHARED_SIZE_BYTES and sized
+# by the launch's `shared_mem_bytes`, which is how eager_flash_attention fits
+# its own ~200 KiB slabs (fa4_fwd_kernel.mojo / fa4_fwd_launch.mojo).
+#
+# The mbarriers stay static: tens of bytes, and keeping them out of the carve
+# keeps the slab size a plain function of the tile geometry.  The carve is
+# entirely compile-time, so every CTA of a cluster still sees each tile at one
+# shared offset -- what TMA multicast into a peer CTA and `arrive_cluster`
+# require.
+#
+# The slab base is aligned to the largest alignment any tile asks for (the C
+# staging tile's 1024) so that one `external_memory` declaration serves every
+# call site; every offset passed below is a multiple of its tile's own
+# alignment.  The padding this costs (at most 1 KiB, ptxas rounding the
+# barriers up to the slab's alignment) leaves the biggest of these kernels at
+# 214016 bytes, inside sm_90's 232448-byte per-block maximum and still one CTA
+# per SM.
+comptime _V4_DYN_SMEM_ALIGN = 1024
+
+
+@always_inline
+def _v4_dyn_smem_tile[
+    layout: Layout, align: Int, offset: Int
+]() -> LayoutTensor[
+    _V4_DT,
+    layout,
+    MutAnyOrigin,
+    address_space=AddressSpace.SHARED,
+    alignment=align,
+]:
+    """One shared tile of `layout`, `offset` elements into the CTA's slab."""
+    # A tile lands on `align` only when its byte offset is a multiple of it --
+    # the slab base already carries `_V4_DYN_SMEM_ALIGN`.  For a 1024-aligned
+    # tile that IS the 128B-swizzle atom (8 rows x 128 B): an epilogue that
+    # stages C by hand at a tile-RELATIVE row and lets the TMA store
+    # de-swizzle by ADDRESS agrees with itself only on an atom boundary, and a
+    # 128-byte-aligned carve was measured to scramble every TMA-store case
+    # while leaving the mainloop exact (see the same finding recorded in
+    # gemm16_bmm_v5_kernels.mojo).  Every carve in this family satisfies this
+    # today; the assert is what catches the geometry that would not, instead
+    # of a silently wrong result.
+    comptime assert (
+        offset * size_of[Scalar[_V4_DT]]()
+    ) % align == 0, "dynamic smem carve offset is not aligned like the tile"
+    return LayoutTensor[
+        _V4_DT,
+        layout,
+        MutAnyOrigin,
+        address_space=AddressSpace.SHARED,
+        alignment=align,
+    ](
+        (
+            external_memory[
+                Scalar[_V4_DT],
+                address_space=AddressSpace.SHARED,
+                alignment=_V4_DYN_SMEM_ALIGN,
+            ]()
+            + offset
+        ).as_unsafe_any_origin()
+    )
+
+
+# Shared bytes one persistent CTA carves out of its slab: both operand
+# pipelines plus the C staging tile, in the order `_v4_nn_persistent_ws`
+# carves them.  The kernel asserts at compile time that this equals the end
+# of its own last carving, so the launch size and the carve cannot drift.
+@always_inline
+def _v4_persistent_smem_bytes[
+    stages: Int, bm: Int, bn: Int, tma_store: Bool
+]() -> Int:
+    return (stages * (bm + bn) * _V4_BK + (bm * bn if tma_store else 512)) * 2
+
+
+@always_inline
+def _v4_dyn_smem_attr[dyn_bytes: Int]() -> FuncAttribute:
+    """The opt-in above sm_90's 48 KiB default dynamic-shared allowance."""
+    return FuncAttribute.MAX_DYNAMIC_SHARED_SIZE_BYTES(UInt32(dyn_bytes))
 
 
 # One (64 x BN x BK) slab of WGMMA work per consumer warp group through the
@@ -292,30 +389,25 @@ def _v4_nn_persistent_ws[
         ]()
         comptime A_PIPE_LAYOUT = Layout.row_major(stages, bm * _V4_BK)
         comptime B_PIPE_LAYOUT = Layout.row_major(stages, bn * _V4_BK)
-        var a_pipeline = LayoutTensor[
-            _V4_DT,
-            A_PIPE_LAYOUT,
-            MutAnyOrigin,
-            address_space=AddressSpace.SHARED,
-            alignment=128,
-        ].stack_allocation()
-        var b_pipeline = LayoutTensor[
-            _V4_DT,
-            B_PIPE_LAYOUT,
-            MutAnyOrigin,
-            address_space=AddressSpace.SHARED,
-            alignment=128,
-        ].stack_allocation()
+        # Three carvings of one extern slab -- see `_v4_dyn_smem_tile`.
+        var a_pipeline = _v4_dyn_smem_tile[A_PIPE_LAYOUT, 128, 0]()
+        var b_pipeline = _v4_dyn_smem_tile[
+            B_PIPE_LAYOUT, 128, stages * bm * _V4_BK
+        ]()
         # C staging tile for the TMA-store epilogue (swizzled 128B rows of
         # 64 elements, bn // 64 chunks).  A dummy allocation when disabled.
         comptime C_SMEM_ELEMS = bm * bn if tma_store else 512
-        var c_smem = LayoutTensor[
-            _V4_DT,
-            Layout.row_major(1, C_SMEM_ELEMS),
-            MutAnyOrigin,
-            address_space=AddressSpace.SHARED,
-            alignment=1024,
-        ].stack_allocation()
+        comptime C_SMEM_OFFSET = stages * (bm + bn) * _V4_BK
+        var c_smem = _v4_dyn_smem_tile[
+            Layout.row_major(1, C_SMEM_ELEMS), 1024, C_SMEM_OFFSET
+        ]()
+        # The C tile is the last carving, so its end IS the slab size the
+        # launch must ask for; keeping the two in step is not left to a
+        # comment.
+        comptime assert (
+            _v4_persistent_smem_bytes[stages, bm, bn, tma_store]()
+            == (C_SMEM_OFFSET + C_SMEM_ELEMS) * 2
+        ), "persistent-body smem carve and launch size disagree"
         var full_barriers = stack_allocation[
             stages,
             SharedMemBarrier,
@@ -693,6 +785,7 @@ def _v4_enqueue_nn_persistent[
     var total_works = macro_rows * blocks_n
     var num_clusters = min(sm_count // cluster_m, total_works)
     var grid_x = num_clusters * cluster_m
+    comptime DYN_SMEM = _v4_persistent_smem_bytes[stages, bm, bn, tma_store]()
     ctx.enqueue_function[
         _v4_nn_persistent_ws[
             stages,
@@ -715,6 +808,8 @@ def _v4_enqueue_nn_persistent[
         Int64(k),
         grid_dim=(grid_x,),
         block_dim=(128 * (consumers + 1),),
+        shared_mem_bytes=DYN_SMEM,
+        func_attribute=_v4_dyn_smem_attr[DYN_SMEM](),
     )
 
 

--- a/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_nt_v4_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_nt_v4_kernels.mojo
@@ -63,6 +63,10 @@ from layout.tensor_core_async import (
 )
 from layout.tma_async import SharedMemBarrier, TMATensorTile
 from gemm16_dtype import _GEMM16_DT, _GEMM16_TAG
+from gemm16_nn_v4_kernels import (
+    _v4_dyn_smem_attr,
+    _v4_dyn_smem_tile,
+)
 
 comptime _V4_DT = _GEMM16_DT
 comptime _V4_F32 = DType.float32
@@ -95,6 +99,18 @@ def _v4_b_layout[bn: Int]() -> Layout:
 
 def _v4_b_half_layout[bn: Int]() -> Layout:
     return tile_layout_k_major[_V4_DT, bn // _V4_CLUSTER, _V4_BK, _V4_SWIZZLE]()
+
+
+# Shared bytes one persistent NT CTA carves out of its slab: both operand
+# pipelines plus the two consumer warp groups' C staging slices, in the order
+# the kernel carves them.  The kernel asserts at compile time that this
+# equals the end of its own last carving, so the launch size and the carve
+# cannot drift.
+@always_inline
+def _v4c_nt_smem_bytes[bn: Int, stages: Int]() -> Int:
+    return (
+        stages * (_V4_BM + bn) * _V4_BK + _V4_CONSUMERS * _V4_WG_ROWS * bn
+    ) * 2
 
 
 @always_inline
@@ -225,30 +241,33 @@ def _v4c_nt_persistent[
     comptime CFRAG = 64 * bn // 128
     comptime TMA_BYTES = (_V4_BM + bn) * _V4_BK * 2
     comptime if _is_sm_9x():
-        var a_pipeline = LayoutTensor[
-            _V4_DT,
-            Layout.row_major(stages, _V4_BM * _V4_BK),
-            MutAnyOrigin,
-            address_space=AddressSpace.SHARED,
-            alignment=128,
-        ].stack_allocation()
-        var b_pipeline = LayoutTensor[
-            _V4_DT,
+        # Three carvings of one extern slab -- see `_v4_dyn_smem_tile`
+        # (gemm16_nn_v4_kernels.mojo).
+        var a_pipeline = _v4_dyn_smem_tile[
+            Layout.row_major(stages, _V4_BM * _V4_BK), 128, 0
+        ]()
+        var b_pipeline = _v4_dyn_smem_tile[
             Layout.row_major(stages, bn * _V4_BK),
-            MutAnyOrigin,
-            address_space=AddressSpace.SHARED,
-            alignment=128,
-        ].stack_allocation()
+            128,
+            stages * _V4_BM * _V4_BK,
+        ]()
         # One 64 x bn bf16 staging slice per consumer warp group, arranged
         # as consecutive 64x64 boxes in the canonical 128B-swizzled TMA
         # layout expected by the C descriptor.
-        var c_staging = LayoutTensor[
-            _V4_DT,
+        comptime C_STAGING_ELEMS = _V4_CONSUMERS * _V4_WG_ROWS * bn
+        comptime C_STAGING_OFFSET = stages * (_V4_BM + bn) * _V4_BK
+        var c_staging = _v4_dyn_smem_tile[
             Layout.row_major(_V4_CONSUMERS, _V4_WG_ROWS * bn),
-            MutAnyOrigin,
-            address_space=AddressSpace.SHARED,
-            alignment=128,
-        ].stack_allocation()
+            128,
+            C_STAGING_OFFSET,
+        ]()
+        # The staging tile is the last carving, so its end IS the slab size
+        # the launch must ask for; keeping the two in step is not left to a
+        # comment.
+        comptime assert (
+            _v4c_nt_smem_bytes[bn, stages]()
+            == (C_STAGING_OFFSET + C_STAGING_ELEMS) * 2
+        ), "NT persistent smem carve and launch size disagree"
         var full_barriers = stack_allocation[
             stages,
             SharedMemBarrier,
@@ -573,6 +592,7 @@ def _v4c_enqueue_nt_persistent[
     var c_tma = TMATensorTile[
         _V4_DT, 2, Index(_V4_WG_ROWS, bn), Index(_V4_WG_ROWS, _V4_C_BOX_N)
     ](c_desc)
+    comptime DYN_SMEM = _v4c_nt_smem_bytes[bn, stages]()
     ctx.enqueue_function[
         _v4c_nt_persistent[bn, stages, raster_h, defer_release]
     ](
@@ -584,6 +604,8 @@ def _v4c_enqueue_nt_persistent[
         Int64(k),
         grid_dim=(grid_x,),
         block_dim=(_V4_THREADS,),
+        shared_mem_bytes=DYN_SMEM,
+        func_attribute=_v4_dyn_smem_attr[DYN_SMEM](),
     )
 
 

--- a/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_tn_v4_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_tn_v4_kernels.mojo
@@ -53,6 +53,8 @@ from layout.tensor_core_async import tile_layout_k_major, tile_layout_mn_major
 from layout.tma_async import SharedMemBarrier, TMATensorTile
 
 from gemm16_nn_v4_kernels import (
+    _v4_dyn_smem_attr,
+    _v4_dyn_smem_tile,
     _v4_mma_tile,
     maybe_enqueue_gemm16_tn_v4_persistent,
 )
@@ -96,6 +98,15 @@ def _v4_b_smem_layout[BN: Int, KMAJ_B: Bool]() -> Layout:
     comptime if KMAJ_B:
         return tile_layout_k_major[_V4_DT, BN, _V4_BK, _V4_SWIZZLE]()
     return tile_layout_mn_major[_V4_DT, BN, _V4_BK, _V4_SWIZZLE]()
+
+
+# Shared bytes one `_v4_tn_ws_body` CTA carves out of its slab: the two
+# operand pipelines, in the order the body carves them.  The body asserts at
+# compile time that this equals the end of its own last carving, so the
+# launch size and the carve cannot drift.
+@always_inline
+def _v4_ws_smem_bytes[STAGES: Int, BM: Int, BN: Int]() -> Int:
+    return STAGES * (BM + BN) * _V4_BK * 2
 
 
 # ============================================================================
@@ -144,20 +155,18 @@ def _v4_tn_ws_body[
         comptime A_PIPE_LAYOUT = Layout.row_major(STAGES, BM * _V4_BK)
         comptime B_PIPE_LAYOUT = Layout.row_major(STAGES, BN * _V4_BK)
 
-        var a_pipeline = LayoutTensor[
-            _V4_DT,
-            A_PIPE_LAYOUT,
-            MutAnyOrigin,
-            address_space=AddressSpace.SHARED,
-            alignment=128,
-        ].stack_allocation()
-        var b_pipeline = LayoutTensor[
-            _V4_DT,
-            B_PIPE_LAYOUT,
-            MutAnyOrigin,
-            address_space=AddressSpace.SHARED,
-            alignment=128,
-        ].stack_allocation()
+        # Two carvings of one extern slab -- see `_v4_dyn_smem_tile`
+        # (gemm16_nn_v4_kernels.mojo).
+        comptime B_PIPE_OFFSET = STAGES * BM * _V4_BK
+        var a_pipeline = _v4_dyn_smem_tile[A_PIPE_LAYOUT, 128, 0]()
+        var b_pipeline = _v4_dyn_smem_tile[B_PIPE_LAYOUT, 128, B_PIPE_OFFSET]()
+        # The B pipeline is the last carving, so its end IS the slab size the
+        # launch must ask for; keeping the two in step is not left to a
+        # comment.
+        comptime assert (
+            _v4_ws_smem_bytes[STAGES, BM, BN]()
+            == (B_PIPE_OFFSET + STAGES * BN * _V4_BK) * 2
+        ), "TN warp-specialized smem carve and launch size disagree"
         var full_barriers = stack_allocation[
             STAGES,
             SharedMemBarrier,
@@ -708,6 +717,7 @@ def _v4_enqueue_splitk_m128n256[
     var count = m * n
     var ws = ctx.enqueue_create_buffer[DType.float32](splits * count)
     var ws_ptr = ws.unsafe_ptr().as_unsafe_any_origin()
+    comptime DYN_SMEM = _v4_ws_smem_bytes[4, _V4_BM, 256]()
     comptime if COL_A and not KMAJ_B:
         ctx.enqueue_function[_v4_tn_splitk_m128n256_s4](
             _v4_make_a_tma(a, m, k, ctx),
@@ -719,6 +729,8 @@ def _v4_enqueue_splitk_m128n256[
             Int64(chunk_tiles),
             grid_dim=(grid_x, splits),
             block_dim=(_V4_THREADS,),
+            shared_mem_bytes=DYN_SMEM,
+            func_attribute=_v4_dyn_smem_attr[DYN_SMEM](),
         )
     elif not COL_A and KMAJ_B:
         ctx.enqueue_function[_v4_nt_splitk_m128n256_s4](
@@ -731,6 +743,8 @@ def _v4_enqueue_splitk_m128n256[
             Int64(chunk_tiles),
             grid_dim=(grid_x, splits),
             block_dim=(_V4_THREADS,),
+            shared_mem_bytes=DYN_SMEM,
+            func_attribute=_v4_dyn_smem_attr[DYN_SMEM](),
         )
     elif not COL_A and not KMAJ_B:
         ctx.enqueue_function[_v4_nn_splitk_m128n256_s4](
@@ -743,6 +757,8 @@ def _v4_enqueue_splitk_m128n256[
             Int64(chunk_tiles),
             grid_dim=(grid_x, splits),
             block_dim=(_V4_THREADS,),
+            shared_mem_bytes=DYN_SMEM,
+            func_attribute=_v4_dyn_smem_attr[DYN_SMEM](),
         )
     else:
         ctx.enqueue_function[_v4_tt_splitk_m128n256_s4](
@@ -755,6 +771,8 @@ def _v4_enqueue_splitk_m128n256[
             Int64(chunk_tiles),
             grid_dim=(grid_x, splits),
             block_dim=(_V4_THREADS,),
+            shared_mem_bytes=DYN_SMEM,
+            func_attribute=_v4_dyn_smem_attr[DYN_SMEM](),
         )
     ctx.enqueue_function[_v4_tn_splitk_reduce](
         output,
@@ -794,6 +812,8 @@ def _v4_enqueue_direct_m128n192(
     var b_tma = TMATensorTile[_V4_DT, 2, Index(_V4_BK, 192), Index(_V4_BK, 64)](
         b_desc
     )
+    comptime DYN_SMEM_S3 = _v4_ws_smem_bytes[3, _V4_BM, 192]()
+    comptime DYN_SMEM_S4 = _v4_ws_smem_bytes[4, _V4_BM, 192]()
     if multi_wave:
         ctx.enqueue_function[_v4_tn_direct_m128n192_s3g16](
             a_tma,
@@ -804,6 +824,8 @@ def _v4_enqueue_direct_m128n192(
             Int64(k),
             grid_dim=(grid_x,),
             block_dim=(_V4_THREADS,),
+            shared_mem_bytes=DYN_SMEM_S3,
+            func_attribute=_v4_dyn_smem_attr[DYN_SMEM_S3](),
         )
     else:
         ctx.enqueue_function[_v4_tn_direct_m128n192_s4](
@@ -815,6 +837,8 @@ def _v4_enqueue_direct_m128n192(
             Int64(k),
             grid_dim=(grid_x,),
             block_dim=(_V4_THREADS,),
+            shared_mem_bytes=DYN_SMEM_S4,
+            func_attribute=_v4_dyn_smem_attr[DYN_SMEM_S4](),
         )
 
 
@@ -828,6 +852,7 @@ def _v4_enqueue_tt_direct_m128n64(
     grid_x: Int,
     ctx: DeviceContext,
 ) raises:
+    comptime DYN_SMEM = _v4_ws_smem_bytes[4, _V4_BM, 64]()
     ctx.enqueue_function[_v4_tt_direct_m128n64_s4](
         _v4_make_a_tma(a, m, k, ctx),
         _v4_make_b_kmaj_tma[64](b, n, k, ctx),
@@ -837,6 +862,8 @@ def _v4_enqueue_tt_direct_m128n64(
         Int64(k),
         grid_dim=(grid_x,),
         block_dim=(_V4_THREADS,),
+        shared_mem_bytes=DYN_SMEM,
+        func_attribute=_v4_dyn_smem_attr[DYN_SMEM](),
     )
 
 
@@ -850,6 +877,7 @@ def _v4_enqueue_tt_direct_m64n128(
     grid_x: Int,
     ctx: DeviceContext,
 ) raises:
+    comptime DYN_SMEM = _v4_ws_smem_bytes[3, 64, 128]()
     ctx.enqueue_function[_v4_tt_direct_m64n128_s3](
         _v4_make_a_tma[64](a, m, k, ctx),
         _v4_make_b_kmaj_tma[128](b, n, k, ctx),
@@ -859,6 +887,8 @@ def _v4_enqueue_tt_direct_m64n128(
         Int64(k),
         grid_dim=(grid_x,),
         block_dim=(256,),
+        shared_mem_bytes=DYN_SMEM,
+        func_attribute=_v4_dyn_smem_attr[DYN_SMEM](),
     )
 
 

--- a/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_v3_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_v3_kernels.mojo
@@ -44,9 +44,14 @@ from gemm16_kernels import (
     enqueue_gemm16_gemm as _enqueue_accepted_bf16_gemm,
 )
 from gemm16_bmm_v5_kernels import try_enqueue_bmm16_nn_batched
-from gemm16_nn_v4_kernels import maybe_enqueue_gemm16_nn_v4
+from gemm16_nn_v4_kernels import (
+    _v4_dyn_smem_attr,
+    _v4_dyn_smem_tile,
+    maybe_enqueue_gemm16_nn_v4,
+)
 from gemm16_nt_v4_kernels import maybe_enqueue_gemm16_nt_v4
 from gemm16_tn_v4_kernels import (
+    _v4_ws_smem_bytes,
     try_enqueue_gemm16_gemm_splitk_rm_v4,
     try_enqueue_gemm16_gemm_tn_v4,
     try_enqueue_gemm16_gemm_tt_v4,
@@ -218,6 +223,26 @@ comptime _V3_TN_SMALL_B_PIPE_LAYOUT = Layout.row_major(
 )
 
 
+# ============================================================================
+# Where the operand pipelines live.
+#
+# Each of the five warp-specialized kernels below stages one A and one B
+# pipeline in shared memory: 72 KiB for the 64x128 tiles, 144 KiB for the
+# 128x256 ones, so both come from the dynamic (`extern`) shared window, as the
+# whole gemm16 family does -- see the design comment above `_v4_dyn_smem_tile`
+# in gemm16_nn_v4_kernels.mojo.
+#
+# These kernels have no C staging tile -- the epilogue writes accumulator
+# registers straight to global, so nothing here re-derives a swizzle from a
+# tile-relative row the way a TMA-store epilogue does -- and the carve is
+# therefore A pipeline then B pipeline and nothing else, which is the layout
+# `_v4_ws_smem_bytes` already sizes for the identically-shaped v4 TN bodies.
+# Every kernel asserts at compile time that its own last carving ends where
+# that size says it should.  The mbarriers stay static: two arrays of three
+# 8-byte barriers, 48 bytes.
+# ============================================================================
+
+
 @__llvm_arg_metadata(a_tma, `nvvm.grid_constant`)
 @__llvm_arg_metadata(b_tma, `nvvm.grid_constant`)
 @__llvm_metadata(
@@ -238,20 +263,20 @@ def _v3_nn_ws_m128n256_tma_s3(
     var n = Int(n_arg)
     var k = Int(k_arg)
     comptime if _is_sm_9x():
-        var a_pipeline = LayoutTensor[
-            _V3_DT,
-            _V3_NN_A_PIPE_LAYOUT,
-            MutAnyOrigin,
-            address_space=AddressSpace.SHARED,
-            alignment=128,
-        ].stack_allocation()
-        var b_pipeline = LayoutTensor[
-            _V3_DT,
-            _V3_NN_B_PIPE_LAYOUT,
-            MutAnyOrigin,
-            address_space=AddressSpace.SHARED,
-            alignment=128,
-        ].stack_allocation()
+        # Two carvings of one extern slab -- see `_v4_dyn_smem_tile`
+        # (gemm16_nn_v4_kernels.mojo).
+        comptime B_PIPE_OFFSET = _V3_NN_STAGES * _V3_NN_BM * _V3_NN_BK
+        var a_pipeline = _v4_dyn_smem_tile[_V3_NN_A_PIPE_LAYOUT, 128, 0]()
+        var b_pipeline = _v4_dyn_smem_tile[
+            _V3_NN_B_PIPE_LAYOUT, 128, B_PIPE_OFFSET
+        ]()
+        # The B pipeline is the last carving, so its end IS the slab size the
+        # launch must ask for; keeping the two in step is not left to a
+        # comment.
+        comptime assert (
+            _v4_ws_smem_bytes[_V3_NN_STAGES, _V3_NN_BM, _V3_NN_BN]()
+            == (B_PIPE_OFFSET + _V3_NN_STAGES * _V3_NN_BN * _V3_NN_BK) * 2
+        ), "v3 NN 128x256 smem carve and launch size disagree"
         var full_barriers = stack_allocation[
             _V3_NN_STAGES,
             SharedMemBarrier,
@@ -423,6 +448,7 @@ def _v3_enqueue_nn_ws_m128n256_tma_s3(
     )
     var a_tma = _V3_NN_A_TMA(a_desc)
     var b_tma = _V3_NN_B_TMA(b_desc)
+    comptime DYN_SMEM = _v4_ws_smem_bytes[_V3_NN_STAGES, _V3_NN_BM, _V3_NN_BN]()
     ctx.enqueue_function[_v3_nn_ws_m128n256_tma_s3](
         a_tma,
         b_tma,
@@ -432,6 +458,8 @@ def _v3_enqueue_nn_ws_m128n256_tma_s3(
         Int64(k),
         grid_dim=(grid_x,),
         block_dim=(_V3_NN_THREADS,),
+        shared_mem_bytes=DYN_SMEM,
+        func_attribute=_v4_dyn_smem_attr[DYN_SMEM](),
     )
 
 
@@ -457,20 +485,28 @@ def _v3_nn_ws_m64n128_tma_s3(
     var n = Int(n_arg)
     var k = Int(k_arg)
     comptime if _is_sm_9x():
-        var a_pipeline = LayoutTensor[
-            _V3_DT,
-            _V3_NN_SMALL_A_PIPE_LAYOUT,
-            MutAnyOrigin,
-            address_space=AddressSpace.SHARED,
-            alignment=128,
-        ].stack_allocation()
-        var b_pipeline = LayoutTensor[
-            _V3_DT,
-            _V3_NN_SMALL_B_PIPE_LAYOUT,
-            MutAnyOrigin,
-            address_space=AddressSpace.SHARED,
-            alignment=128,
-        ].stack_allocation()
+        # Two carvings of one extern slab -- see `_v4_dyn_smem_tile`
+        # (gemm16_nn_v4_kernels.mojo).
+        comptime B_PIPE_OFFSET = (
+            _V3_NN_SMALL_STAGES * _V3_NN_SMALL_BM * _V3_NN_SMALL_BK
+        )
+        var a_pipeline = _v4_dyn_smem_tile[_V3_NN_SMALL_A_PIPE_LAYOUT, 128, 0]()
+        var b_pipeline = _v4_dyn_smem_tile[
+            _V3_NN_SMALL_B_PIPE_LAYOUT, 128, B_PIPE_OFFSET
+        ]()
+        # The B pipeline is the last carving, so its end IS the slab size the
+        # launch must ask for; keeping the two in step is not left to a
+        # comment.
+        comptime assert (
+            _v4_ws_smem_bytes[
+                _V3_NN_SMALL_STAGES, _V3_NN_SMALL_BM, _V3_NN_SMALL_BN
+            ]()
+            == (
+                B_PIPE_OFFSET
+                + _V3_NN_SMALL_STAGES * _V3_NN_SMALL_BN * _V3_NN_SMALL_BK
+            )
+            * 2
+        ), "v3 NN 64x128 smem carve and launch size disagree"
         var full_barriers = stack_allocation[
             _V3_NN_SMALL_STAGES,
             SharedMemBarrier,
@@ -647,6 +683,9 @@ def _v3_enqueue_nn_ws_m64n128_tma_s3(
     )
     var a_tma = _V3_NN_SMALL_A_TMA(a_desc)
     var b_tma = _V3_NN_SMALL_B_TMA(b_desc)
+    comptime DYN_SMEM = _v4_ws_smem_bytes[
+        _V3_NN_SMALL_STAGES, _V3_NN_SMALL_BM, _V3_NN_SMALL_BN
+    ]()
     ctx.enqueue_function[_v3_nn_ws_m64n128_tma_s3](
         a_tma,
         b_tma,
@@ -656,6 +695,8 @@ def _v3_enqueue_nn_ws_m64n128_tma_s3(
         Int64(k),
         grid_dim=(grid_x,),
         block_dim=(_V3_NN_SMALL_THREADS,),
+        shared_mem_bytes=DYN_SMEM,
+        func_attribute=_v4_dyn_smem_attr[DYN_SMEM](),
     )
 
 
@@ -679,20 +720,20 @@ def _v3_nt_ws_m128n256_tma_s3(
     var n = Int(n_arg)
     var k = Int(k_arg)
     comptime if _is_sm_9x():
-        var a_pipeline = LayoutTensor[
-            _V3_DT,
-            _V3_NT_A_PIPE_LAYOUT,
-            MutAnyOrigin,
-            address_space=AddressSpace.SHARED,
-            alignment=128,
-        ].stack_allocation()
-        var b_pipeline = LayoutTensor[
-            _V3_DT,
-            _V3_NT_B_PIPE_LAYOUT,
-            MutAnyOrigin,
-            address_space=AddressSpace.SHARED,
-            alignment=128,
-        ].stack_allocation()
+        # Two carvings of one extern slab -- see `_v4_dyn_smem_tile`
+        # (gemm16_nn_v4_kernels.mojo).
+        comptime B_PIPE_OFFSET = _V3_NT_STAGES * _V3_NT_BM * _V3_NT_BK
+        var a_pipeline = _v4_dyn_smem_tile[_V3_NT_A_PIPE_LAYOUT, 128, 0]()
+        var b_pipeline = _v4_dyn_smem_tile[
+            _V3_NT_B_PIPE_LAYOUT, 128, B_PIPE_OFFSET
+        ]()
+        # The B pipeline is the last carving, so its end IS the slab size the
+        # launch must ask for; keeping the two in step is not left to a
+        # comment.
+        comptime assert (
+            _v4_ws_smem_bytes[_V3_NT_STAGES, _V3_NT_BM, _V3_NT_BN]()
+            == (B_PIPE_OFFSET + _V3_NT_STAGES * _V3_NT_BN * _V3_NT_BK) * 2
+        ), "v3 NT 128x256 smem carve and launch size disagree"
         var full_barriers = stack_allocation[
             _V3_NT_STAGES,
             SharedMemBarrier,
@@ -862,6 +903,7 @@ def _v3_enqueue_nt_ws_m128n256_tma_s3(
     )
     var a_tma = _V3_NT_A_TMA(a_desc)
     var b_tma = _V3_B_K_TMA(b_desc)
+    comptime DYN_SMEM = _v4_ws_smem_bytes[_V3_NT_STAGES, _V3_NT_BM, _V3_NT_BN]()
     ctx.enqueue_function[_v3_nt_ws_m128n256_tma_s3](
         a_tma,
         b_tma,
@@ -871,6 +913,8 @@ def _v3_enqueue_nt_ws_m128n256_tma_s3(
         Int64(k),
         grid_dim=(grid_x,),
         block_dim=(_V3_NT_THREADS,),
+        shared_mem_bytes=DYN_SMEM,
+        func_attribute=_v4_dyn_smem_attr[DYN_SMEM](),
     )
 
 
@@ -896,20 +940,28 @@ def _v3_tn_ws_m64n128_tma_col_a_s3(
     var n = Int(n_arg)
     var k = Int(k_arg)
     comptime if _is_sm_9x():
-        var a_pipeline = LayoutTensor[
-            _V3_DT,
-            _V3_TN_SMALL_A_PIPE_LAYOUT,
-            MutAnyOrigin,
-            address_space=AddressSpace.SHARED,
-            alignment=128,
-        ].stack_allocation()
-        var b_pipeline = LayoutTensor[
-            _V3_DT,
-            _V3_TN_SMALL_B_PIPE_LAYOUT,
-            MutAnyOrigin,
-            address_space=AddressSpace.SHARED,
-            alignment=128,
-        ].stack_allocation()
+        # Two carvings of one extern slab -- see `_v4_dyn_smem_tile`
+        # (gemm16_nn_v4_kernels.mojo).
+        comptime B_PIPE_OFFSET = (
+            _V3_TN_SMALL_STAGES * _V3_TN_SMALL_BM * _V3_TN_SMALL_BK
+        )
+        var a_pipeline = _v4_dyn_smem_tile[_V3_TN_SMALL_A_PIPE_LAYOUT, 128, 0]()
+        var b_pipeline = _v4_dyn_smem_tile[
+            _V3_TN_SMALL_B_PIPE_LAYOUT, 128, B_PIPE_OFFSET
+        ]()
+        # The B pipeline is the last carving, so its end IS the slab size the
+        # launch must ask for; keeping the two in step is not left to a
+        # comment.
+        comptime assert (
+            _v4_ws_smem_bytes[
+                _V3_TN_SMALL_STAGES, _V3_TN_SMALL_BM, _V3_TN_SMALL_BN
+            ]()
+            == (
+                B_PIPE_OFFSET
+                + _V3_TN_SMALL_STAGES * _V3_TN_SMALL_BN * _V3_TN_SMALL_BK
+            )
+            * 2
+        ), "v3 TN 64x128 smem carve and launch size disagree"
         var full_barriers = stack_allocation[
             _V3_TN_SMALL_STAGES,
             SharedMemBarrier,
@@ -1115,6 +1167,9 @@ def _v3_enqueue_tn_ws_m64n128_tma_col_a_s3(
     )
     var a_tma = _V3_TN_SMALL_A_TMA(a_desc)
     var b_tma = _V3_TN_SMALL_B_TMA(b_desc)
+    comptime DYN_SMEM = _v4_ws_smem_bytes[
+        _V3_TN_SMALL_STAGES, _V3_TN_SMALL_BM, _V3_TN_SMALL_BN
+    ]()
     ctx.enqueue_function[_v3_tn_ws_m64n128_tma_col_a_s3](
         a_tma,
         b_tma,
@@ -1124,6 +1179,8 @@ def _v3_enqueue_tn_ws_m64n128_tma_col_a_s3(
         Int64(k),
         grid_dim=(grid_x,),
         block_dim=(_V3_TN_SMALL_THREADS,),
+        shared_mem_bytes=DYN_SMEM,
+        func_attribute=_v4_dyn_smem_attr[DYN_SMEM](),
     )
 
 
@@ -1153,20 +1210,21 @@ def _v3_tn_ws_m128n256_tma_col_a_s3(
         # directly into an MN-major shared layout, which is exactly the
         # column-major A representation accepted by SM90 WGMMA.  This avoids
         # the explicit shared-memory transpose used by the fallback TN path.
-        var a_pipeline = LayoutTensor[
-            _V3_DT,
-            _V3_TN_WS_A_PIPE_LAYOUT,
-            MutAnyOrigin,
-            address_space=AddressSpace.SHARED,
-            alignment=128,
-        ].stack_allocation()
-        var b_pipeline = LayoutTensor[
-            _V3_DT,
-            _V3_TN_WS_B_PIPE_LAYOUT,
-            MutAnyOrigin,
-            address_space=AddressSpace.SHARED,
-            alignment=128,
-        ].stack_allocation()
+        # Two carvings of one extern slab -- see `_v4_dyn_smem_tile`
+        # (gemm16_nn_v4_kernels.mojo).
+        comptime B_PIPE_OFFSET = _V3_TN_WS_STAGES * _V3_TN_WS_BM * _V3_TN_WS_BK
+        var a_pipeline = _v4_dyn_smem_tile[_V3_TN_WS_A_PIPE_LAYOUT, 128, 0]()
+        var b_pipeline = _v4_dyn_smem_tile[
+            _V3_TN_WS_B_PIPE_LAYOUT, 128, B_PIPE_OFFSET
+        ]()
+        # The B pipeline is the last carving, so its end IS the slab size the
+        # launch must ask for; keeping the two in step is not left to a
+        # comment.
+        comptime assert (
+            _v4_ws_smem_bytes[_V3_TN_WS_STAGES, _V3_TN_WS_BM, _V3_TN_WS_BN]()
+            == (B_PIPE_OFFSET + _V3_TN_WS_STAGES * _V3_TN_WS_BN * _V3_TN_WS_BK)
+            * 2
+        ), "v3 TN 128x256 smem carve and launch size disagree"
         var full_barriers = stack_allocation[
             _V3_TN_WS_STAGES,
             SharedMemBarrier,
@@ -1373,6 +1431,9 @@ def _v3_enqueue_tn_ws_m128n256_tma_col_a_s3(
     )
     var a_tma = _V3_TN_WS_A_TMA(a_desc)
     var b_tma = _V3_TN_WS_B_TMA(b_desc)
+    comptime DYN_SMEM = _v4_ws_smem_bytes[
+        _V3_TN_WS_STAGES, _V3_TN_WS_BM, _V3_TN_WS_BN
+    ]()
     ctx.enqueue_function[_v3_tn_ws_m128n256_tma_col_a_s3](
         a_tma,
         b_tma,
@@ -1382,6 +1443,8 @@ def _v3_enqueue_tn_ws_m128n256_tma_col_a_s3(
         Int64(k),
         grid_dim=(grid_x,),
         block_dim=(_V3_TN_WS_THREADS,),
+        shared_mem_bytes=DYN_SMEM,
+        func_attribute=_v4_dyn_smem_attr[DYN_SMEM](),
     )
 
 

--- a/torch_mojo_backend/eager_kernels/matmul_ops/tn_f32_gemm_core.mojo
+++ b/torch_mojo_backend/eager_kernels/matmul_ops/tn_f32_gemm_core.mojo
@@ -75,12 +75,27 @@ from max.gpu.memory import (
     async_copy,
     async_copy_commit_group,
     async_copy_wait_group,
+    external_memory,
 )
 from std.memory import AddressSpace
 from max.gpu.sync import named_barrier
 from std.math import ceildiv
-from std.memory import stack_allocation
 from std.utils.static_tuple import StaticTuple
+
+
+# Bytes of *shared* memory each core carves out of its dynamic slab, as a
+# function of its own tile parameters. Read by the launch wrappers in
+# tn_f32_gemm_kernels.mojo to size the `MAX_DYNAMIC_SHARED_SIZE_BYTES` opt-in:
+# one source of a number that must agree on both sides of a launch, rather
+# than two formulas that could drift.
+@always_inline
+def _tn_core_smem_bytes[BM: Int, BN: Int, BK: Int, STAGES: Int]() -> Int:
+    return (STAGES * BM * BK + STAGES * BK * BN) * 4
+
+
+@always_inline
+def _tn_split_smem_bytes[BM: Int, BN: Int, BK: Int, STAGES: Int]() -> Int:
+    return 2 * STAGES * BK * (BM + BN) * 4
 
 
 @__llvm_metadata(
@@ -164,12 +179,23 @@ def _tn_core_kernel[
     var tr = lane // LC
     var tc = lane % LC
 
-    var a_smem = stack_allocation[
-        STAGES * BM * BK, F32, address_space=AddressSpace.SHARED
+    # ---- shared-memory staging ----
+    # The 128x128 instantiation stages 65536 B, past the 49152 B ptxas allows
+    # a kernel in *static* `.shared` before CUDA 13 (and it fails the whole
+    # `mojo build`, not just this kernel), so both instantiations carve the
+    # dynamic window instead, like FA4's `external_memory` base
+    # (fa4_fwd_kernel.mojo): one alignment=16 allocation split at a comptime
+    # offset (STAGES * BM * BK floats) so B's slab keeps the 16B-aligned
+    # source cp.async needs, which the assert below is what actually holds a
+    # future (STAGES, BM) to.
+    comptime assert (
+        STAGES * BM * BK * 4
+    ) % 16 == 0, "B slab offset breaks the 16B alignment cp.async needs"
+    var smem_base = external_memory[
+        Scalar[F32], address_space=AddressSpace.SHARED, alignment=16
     ]()
-    var b_smem = stack_allocation[
-        STAGES * BK * BN, F32, address_space=AddressSpace.SHARED
-    ]()
+    var a_smem = smem_base
+    var b_smem = smem_base + STAGES * BM * BK
 
     # Fragment base columns within a smem row.
     var am0 = wr * WM + tr * TM
@@ -471,8 +497,18 @@ def _tn_split_kernel[
     comptime EX_CHUNK = min((TM * QN) // 2, GROUP_F // (TG * 4))
     comptime EX_ROUNDS = (TM * QN + EX_CHUNK - 1) // EX_CHUNK
     comptime assert EX_CHUNK >= 1
-    var smem = stack_allocation[
-        2 * GROUP_F, F32, address_space=AddressSpace.SHARED
+    # Carved from the dynamic window -- see _tn_core_kernel's comment. This
+    # kernel is only ever instantiated at BM=BN=128 (comptime assert above),
+    # so `smem` is 65536 B at STAGES=2 and 131072 B at STAGES=4. Every
+    # downstream offset (`a_smem`, `b_smem`, `ex_smem`) is a comptime multiple
+    # of BK * BM (or BN) = 2048 floats = 8192 B, so the carve stays
+    # 16B-aligned -- the assert below is what holds a future
+    # (STAGES, BK, BM, BN) to that rather than a comment.
+    comptime assert (GROUP_F * 4) % 16 == 0 and (
+        STAGES * BK * BM * 4
+    ) % 16 == 0, "smem carve breaks the 16B alignment cp.async needs"
+    var smem = external_memory[
+        Scalar[F32], address_space=AddressSpace.SHARED, alignment=16
     ]()
     var a_smem = smem + gid * GROUP_F
     var b_smem = a_smem + STAGES * BK * BM

--- a/torch_mojo_backend/eager_kernels/matmul_ops/tn_f32_gemm_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/matmul_ops/tn_f32_gemm_kernels.mojo
@@ -51,16 +51,28 @@
 # ===----------------------------------------------------------------------=== #
 
 from max.gpu.sync import barrier
+from std.builtin.device_passable import DevicePassable
+from std.ffi import _get_global_or_null, external_call
 from std.gpu import block_idx, thread_idx
-from max.gpu.host import DeviceAttribute, DeviceBuffer, DeviceContext
+from max.gpu.host import (
+    DeviceAttribute,
+    DeviceBuffer,
+    DeviceContext,
+    FuncAttribute,
+)
 from std.memory import AddressSpace
 from std.math import ceildiv
-from std.memory import stack_allocation
+from std.memory import alloc, stack_allocation
 from std.sys.info import _has_sm_9x
 
 from gemm_splitk_common import TARGET_BLOCKS, _ksplit_reduce_kernel
 from op_utils import _enqueue_cached, _make_ptr
-from tn_f32_gemm_core import _tn_core_kernel, _tn_split_kernel
+from tn_f32_gemm_core import (
+    _tn_core_kernel,
+    _tn_core_smem_bytes,
+    _tn_split_kernel,
+    _tn_split_smem_bytes,
+)
 
 
 # Split-K workspace cap. 32 MB never binds for the tiny-MN deep-K regime it
@@ -145,6 +157,69 @@ def _tn_ksplit_reduce_wide_kernel(
 
 
 @always_inline
+def _enqueue_cached_smem3d[
+    declared_arg_types: TypeList[Trait=AnyType, ...],
+    //,
+    func: def(* args: * declared_arg_types) thin -> None,
+    *Ts: DevicePassable,
+](
+    ctx: DeviceContext,
+    key: String,
+    gx: Int,
+    gy: Int,
+    gz: Int,
+    threads: Int,
+    smem_bytes: Int,
+    *args: *Ts,
+) raises:
+    """`op_utils._enqueue_cached`, 3D grid, with a
+    `MAX_DYNAMIC_SHARED_SIZE_BYTES` opt-in baked into the cached
+    `DeviceFunction` -- the 3D-grid twin of
+    `softmax_backward_ops.softmax_backward_kernels._enqueue_cached_smem`
+    (kept local rather than shared: that helper is keyed for a caller
+    serving many different `smem_bytes` per process, which the TN cores
+    never do -- `smem_bytes` is a comptime constant of `func` here, so one
+    process only ever asks this helper for one value per `key`).
+
+    The `_tn_core_kernel`/`_tn_split_kernel` it launches stage their tiles
+    from `external_memory` (tn_f32_gemm_core.mojo), sized here by
+    `smem_bytes`.
+    """
+    var name = String(t"TMB_KERNEL_{key}_{ctx.id()}")
+    comptime FuncT = type_of(ctx.compile_function[func]())
+
+    if global_ptr := _get_global_or_null(name):
+        var fptr = global_ptr.value().bitcast[FuncT]()
+        ctx.enqueue_function(
+            fptr[],
+            *args,
+            grid_dim=(gx, gy, gz),
+            block_dim=(threads,),
+            shared_mem_bytes=smem_bytes,
+        )
+        return
+
+    var compiled = ctx.compile_function[func](
+        func_attribute=FuncAttribute.MAX_DYNAMIC_SHARED_SIZE_BYTES(
+            UInt32(smem_bytes)
+        )
+    )
+    var fptr = alloc[FuncT](1)
+    fptr.init_pointee_move(compiled^)
+    external_call["KGEN_CompilerRT_InsertGlobal", NoneType](
+        StringSlice(name),
+        fptr.bitcast[NoneType](),
+    )
+    ctx.enqueue_function(
+        fptr[],
+        *args,
+        grid_dim=(gx, gy, gz),
+        block_dim=(threads,),
+        shared_mem_bytes=smem_bytes,
+    )
+
+
+@always_inline
 def _tn_core_launch[
     BM: Int,
     BN: Int,
@@ -178,6 +253,10 @@ def _tn_core_launch[
     a[(kt+kk)*m + bm+cm] — coalesced along m, no transpose, no copy.
     """
     comptime THREADS = (BM // WM) * (BN // WN) * 32
+    # Both instantiations stage from the dynamic shared window, sized here and
+    # in the kernel from the one formula (`_tn_core_smem_bytes`, see
+    # tn_f32_gemm_core.mojo).
+    comptime SMEM_BYTES = _tn_core_smem_bytes[BM, BN, BK, STAGES]()
     var c = _make_ptr[DType.float32](c_addr).as_unsafe_any_origin()
     var a = (
         _make_ptr[DType.float32](a_addr).as_unsafe_any_origin().as_immutable()
@@ -187,7 +266,7 @@ def _tn_core_launch[
     )
 
     if va4 and vb4:
-        _enqueue_cached[
+        _enqueue_cached_smem3d[
             _tn_core_kernel[BM, BN, BK, WM, WN, LR, 4, 4, STAGES, MINB, PUMP]
         ](
             ctx,
@@ -196,6 +275,7 @@ def _tn_core_launch[
             gy,
             gz,
             THREADS,
+            SMEM_BYTES,
             c,
             a,
             b,
@@ -205,7 +285,7 @@ def _tn_core_launch[
             Int64(ksplits),
         )
     elif va4:
-        _enqueue_cached[
+        _enqueue_cached_smem3d[
             _tn_core_kernel[BM, BN, BK, WM, WN, LR, 4, 1, STAGES, MINB, PUMP]
         ](
             ctx,
@@ -214,6 +294,7 @@ def _tn_core_launch[
             gy,
             gz,
             THREADS,
+            SMEM_BYTES,
             c,
             a,
             b,
@@ -223,7 +304,7 @@ def _tn_core_launch[
             Int64(ksplits),
         )
     elif vb4:
-        _enqueue_cached[
+        _enqueue_cached_smem3d[
             _tn_core_kernel[BM, BN, BK, WM, WN, LR, 1, 4, STAGES, MINB, PUMP]
         ](
             ctx,
@@ -232,6 +313,7 @@ def _tn_core_launch[
             gy,
             gz,
             THREADS,
+            SMEM_BYTES,
             c,
             a,
             b,
@@ -241,7 +323,7 @@ def _tn_core_launch[
             Int64(ksplits),
         )
     else:
-        _enqueue_cached[
+        _enqueue_cached_smem3d[
             _tn_core_kernel[BM, BN, BK, WM, WN, LR, 1, 1, STAGES, MINB, PUMP]
         ](
             ctx,
@@ -250,6 +332,7 @@ def _tn_core_launch[
             gy,
             gz,
             THREADS,
+            SMEM_BYTES,
             c,
             a,
             b,
@@ -285,6 +368,9 @@ def _tn_split_launch[
 ) raises:
     """Launch the warp-group split core (256 threads) with VEC_A/VEC_B
     picked by the caller's alignment gates."""
+    # Only ever instantiated at BM=BN=128, so its 65536-131072 B slab comes
+    # from the dynamic shared window -- see tn_f32_gemm_core.mojo.
+    comptime SMEM_BYTES = _tn_split_smem_bytes[BM, BN, BK, STAGES]()
     var c = _make_ptr[DType.float32](c_addr).as_unsafe_any_origin()
     var a = (
         _make_ptr[DType.float32](a_addr).as_unsafe_any_origin().as_immutable()
@@ -294,13 +380,16 @@ def _tn_split_launch[
     )
 
     if va4 and vb4:
-        _enqueue_cached[_tn_split_kernel[BM, BN, BK, 4, 4, STAGES, LR, SERP]](
+        _enqueue_cached_smem3d[
+            _tn_split_kernel[BM, BN, BK, 4, 4, STAGES, LR, SERP]
+        ](
             ctx,
             String(t"tn_s_{BM}x{BN}x{BK}_v44_s{STAGES}_l{LR}_z{SERP}"),
             gx,
             gy,
             gz,
             256,
+            SMEM_BYTES,
             c,
             a,
             b,
@@ -310,13 +399,16 @@ def _tn_split_launch[
             Int64(ksplits),
         )
     elif va4:
-        _enqueue_cached[_tn_split_kernel[BM, BN, BK, 4, 1, STAGES, LR, SERP]](
+        _enqueue_cached_smem3d[
+            _tn_split_kernel[BM, BN, BK, 4, 1, STAGES, LR, SERP]
+        ](
             ctx,
             String(t"tn_s_{BM}x{BN}x{BK}_v41_s{STAGES}_l{LR}_z{SERP}"),
             gx,
             gy,
             gz,
             256,
+            SMEM_BYTES,
             c,
             a,
             b,
@@ -326,13 +418,16 @@ def _tn_split_launch[
             Int64(ksplits),
         )
     elif vb4:
-        _enqueue_cached[_tn_split_kernel[BM, BN, BK, 1, 4, STAGES, LR, SERP]](
+        _enqueue_cached_smem3d[
+            _tn_split_kernel[BM, BN, BK, 1, 4, STAGES, LR, SERP]
+        ](
             ctx,
             String(t"tn_s_{BM}x{BN}x{BK}_v14_s{STAGES}_l{LR}_z{SERP}"),
             gx,
             gy,
             gz,
             256,
+            SMEM_BYTES,
             c,
             a,
             b,
@@ -342,13 +437,16 @@ def _tn_split_launch[
             Int64(ksplits),
         )
     else:
-        _enqueue_cached[_tn_split_kernel[BM, BN, BK, 1, 1, STAGES, LR, SERP]](
+        _enqueue_cached_smem3d[
+            _tn_split_kernel[BM, BN, BK, 1, 1, STAGES, LR, SERP]
+        ](
             ctx,
             String(t"tn_s_{BM}x{BN}x{BK}_v11_s{STAGES}_l{LR}_z{SERP}"),
             gx,
             gy,
             gz,
             256,
+            SMEM_BYTES,
             c,
             a,
             b,


### PR DESCRIPTION
Every GEMM route that stages more than 48 KiB of shared memory now carves it from the dynamic window (`external_memory` + `FuncAttribute.MAX_DYNAMIC_SHARED_SIZE_BYTES`, the pattern FA4, the tf32 cores and the softmax-backward kernels already use) instead of `stack_allocation`. There is no ptxas probe, no on-disk verdict cache, no `PTXAS_BIG_SMEM` define and no `TORCH_MOJO_BACKEND_PTXAS_BIG_SMEM` override: nothing is left in the loader that depends on which assembler MAX shells out to.

**Supersedes #429 and #432.** Those two kept the static allocation on ptxas 13 so device code there stayed byte-identical, and paid for it with a `mojo build` probe at first use. The measurement below is why that was not needed.

### Why static was ever a problem

ptxas rejects a kernel whose *static* `.shared` exceeds 48 KiB, and one such kernel fails the whole `.so`. Measured against hand-written PTX with the 12.8 and 13.0 assemblers in the venv: 12.8 refuses it for every target; 13.0 still refuses it for portable targets (`sm_90`, `sm_80`, `sm_86`) and accepts it only for architecture-specific ones (`sm_90a`, `sm_100a`), up to the card's real maximum (227 KiB on Hopper). It is a portability rule, not a hardware limit: NVIDIA documents that anything past 48 KiB per block must be dynamic and opted into per function. The dynamic window has never been capped that way, so these kernels assemble under any ptxas and any target.

### Performance on ptxas 13.3 (the bundled compiler)

H100 PCIe (nvidia-perf), `benchmarks/test_gemm.py` cases that hit the converted kernels: bf16 `mm` and `bmm` on every shape and layout plus fp32 TN `mm`, 59 cases. Core clock pinned at 1395 MHz, CUPTI device time, ABBA over two legs per variant. Values are our kernel's device time, dynamic relative to static:

| | median | mean | min | max |
|---|---|---|---|---|
| this branch vs #432's static path (2 legs each) | +0.10% | +0.25% | −6.7% | +8.0% |
| same-variant repeatability (median) | 0.5% | | | |

The extremes are cases whose measurement is bimodal (12–40% scatter between two runs of the *same* variant); every case with under 2% scatter is within noise except the bf16 **NT** `mm` route, which is repeatably slower with dynamic shared memory: +4.2% on 4096³, +3.1% on 2048×8192×2048, +1.9% on 8192×2048×2048, +5.3% on 768×50304×49152 in the #432 A/B. Register, stack and local usage are identical in every kernel pair (`cuobjdump -res-usage`), so it is not pressure; the SASS differs only in shared-memory address arithmetic (~160 of 1260 instructions in the NT persistent kernels). Under the suite's 8% band and the 10% acceptance bar; noted as a follow-up lead on `gemm16_nt_v4_kernels.mojo`. The fp32 TN cores, including the 64×64 core that fitted in static and was converted anyway, are within 1%.

### Correctness on ptxas 12.8 (the regime that used to fail)

SLURM H100 node with `MODULAR_NVPTX_COMPILER_PATH=/usr/local/cuda/bin/ptxas` (12.8): both matmul extension families build (they used to fail with `uses too much shared data`), `tests/test_eager_kernels.py -k "matmul or gemm or mm or linear"` 294 passed / 12 skipped, the matmul slice of `tests/test_aten_functions.py` 22 passed, `tests/test_eager_kernel_loader.py` 19 passed, plus bf16 4096³ and fp32 TN `mm` checked against torch CPU.

### What stays static

Only the v5 BMM tiny 64×64 body (40976 B with the TMA-store epilogue, 32784 B with the scalar one). `_b5_dynamic_smem` decides from the instantiation's byte count, so the split is geometry, not a toolchain question. Every dynamic carve keeps the 1024-byte alignment the 128B TMA swizzle atom needs, held by a comptime assert in `_v4_dyn_smem_tile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AbxaDeRuA7yywYEUuZV72
