### PR TITLE
Complete collective futures at enqueue time; fence the default stream lazily

### DIFF
--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -65,16 +65,12 @@ before anything touches CUDA or enumerates MAX devices.
 
 - **A comm stream overlaps compute.** Collectives run on a dedicated side
   device stream per device (`mojo_device/device_streams.py`): it waits for
-  the default stream so every producer kernel comes first, the collective
-  is enqueued, and the Work's future completes from a watcher thread once
-  the collective's end event fires on the device. DDP keeps enqueuing
-  backward compute while bucket allreduces fly; the end-of-backward
-  `future.wait()` blocks only for the un-overlappable tail. Every tensor a
-  collective touches is fenced with `device_streams.record_use` (the
-  backend's `record_stream` analog): its eventual stream-ordered free is
-  ordered after the collective on the device, because MAX does not fence
-  frees across streams by itself (measured; see the memory note in
-  `mojo_device/device_streams.py`).
+  the default stream so every producer kernel comes first, then the
+  collective is enqueued. Every tensor a collective touches is fenced with
+  `device_streams.record_use` (the backend's `record_stream` analog): its
+  eventual stream-ordered free is ordered after the collective on the
+  device, because MAX does not fence frees across streams by itself
+  (measured; see the memory note in `mojo_device/device_streams.py`).
   `TORCH_MOJO_BACKEND_COMM_STREAM=0` pins collectives to the default stream
   instead (simplest ordering, zero overlap) — also the automatic path for
   collectives needing default-stream copies after the NCCL call. Both paths
@@ -82,10 +78,30 @@ before anything touches CUDA or enumerates MAX devices.
   a stream (`docs/kernel_call_queue.md`). One contract carried over from
   stock torch: `wait()` an async collective before reading its result —
   including before exporting it through DLPack.
-- **Work objects** wrap completed `torch.futures.Future`s (no `devices=` —
-  the PrivateUse1 device guard is a stub, and a device-typed future would
-  do out-of-bounds bookkeeping for index ≥ 1). `wait()` is a host no-op by
-  design; device ordering comes from the stream.
+- **Work objects** wrap already-completed `torch.futures.Future`s (no
+  `devices=` — the PrivateUse1 device guard is a stub, and a device-typed
+  future would do out-of-bounds bookkeeping for index ≥ 1), so `wait()` is
+  a host no-op in both paths.
+- **The default stream is ordered after the comm stream lazily**, at the
+  first op that touches a buffer a collective read or wrote
+  (`mojo_device/comm_fence.py`): the collective records those buffers as
+  pending, and a hook in front of every eager op makes the default stream
+  wait on the comm stream when it sees one. Host reads no op mediates —
+  `torch.mojo.synchronize()`, a default-stream `synchronize()`/`query()`,
+  DLPack export, the D2H copy — fence the same way. This is what lets the
+  host run ahead: DDP's reducer never blocks on a bucket's future, so it
+  keeps enqueuing while allreduces fly, and the fence lands in
+  `finalize_backward` where it first reads a reduced bucket — after every
+  backward kernel is already enqueued, so overlap is unchanged. Blocking
+  the host on those futures instead cost ~2 ms of a 96 ms step, spent
+  launching the bucket→grad copies, `clip_grad_norm_` and the optimizer
+  against an idle GPU: nanoGPT 124M on 32 H100s (4 nodes, bf16, batch
+  32×1024 per rank) went 10.89 → 11.10 M tok/s when it stopped doing so
+  (paired A/B/B/A runs, medians of the 10-step windows), closing most of
+  the gap to stock CUDA torch's 11.16. Stock `ProcessGroupNCCL` gets there with a
+  device-typed future whose `wait()` makes the current stream wait; that
+  needs a C++ DeviceGuardImpl for PrivateUse1 which torch does not provide
+  and this backend cannot ship.
 - **The Python PG replaces the whole process group** (torch ≥ 2.10 behavior),
   so torch cannot compose `cpu:gloo` alongside it; the internal gloo handles
   CPU tensors instead, and `_device_types` stays empty, which routes object

--- a/tests/comm_fence_overhead.py
+++ b/tests/comm_fence_overhead.py
@@ -1,0 +1,69 @@
+"""torchrun-free worker for test_distributed.py's per-op overhead check.
+
+Prints two numbers:
+
+* ``us_per_op`` — one tiny eager op end to end, with or (``--no-hook``)
+  without the comm-fence wrapper `register_mojo_devices()` installs in front
+  of every op. A whole process per leg, because op registration happens once
+  per process. At ~20 us of eager dispatch per op the wrapper is under the
+  run-to-run noise here, hence the second number.
+* ``wrapper_us`` — the wrapper frame in isolation, against a callable that
+  does nothing. This is the cost the hook actually adds.
+"""
+
+import sys
+import time
+
+import torch
+
+
+def _time_add(x: torch.Tensor, y: torch.Tensor, iterations: int) -> float:
+    from torch_mojo_backend.mojo_device import torch_mojo_device_module
+
+    start = time.perf_counter()
+    for _ in range(iterations):
+        torch.add(x, y)
+    torch_mojo_device_module.synchronize()
+    return (time.perf_counter() - start) / iterations * 1e6
+
+
+def _time_wrapper_frame(x: torch.Tensor) -> float:
+    from torch_mojo_backend.mojo_device.register import _fence_pending_collectives
+
+    def target(a: object, b: object) -> object:
+        return a
+
+    wrapped = _fence_pending_collectives(target)
+    iterations = 200000
+    start = time.perf_counter()
+    for _ in range(iterations):
+        target(x, x)
+    raw = time.perf_counter() - start
+    start = time.perf_counter()
+    for _ in range(iterations):
+        wrapped(x, x)
+    hooked = time.perf_counter() - start
+    return (hooked - raw) / iterations * 1e6
+
+
+def main():
+    from torch_mojo_backend.mojo_device import register
+
+    if "--no-hook" in sys.argv:
+        # The wrapper is applied by register_mojo_devices()'s install loop
+        # through this global, so the identity gives the same process minus
+        # the hook and nothing else.
+        register._fence_pending_collectives = lambda func: func  # ty: ignore[invalid-assignment]
+    register.register_mojo_devices()
+
+    x = torch.ones(16, device="mojo")
+    y = torch.ones(16, device="mojo")
+    _time_add(x, y, 2000)  # warm the kernel cache and the dispatch caches
+    # Min of three: this is a host-cost measurement, so the fastest run is
+    # the one least polluted by whatever else the machine was doing.
+    print(f"us_per_op={min(_time_add(x, y, 10000) for _ in range(3)):.4f}")
+    print(f"wrapper_us={min(_time_wrapper_frame(x) for _ in range(3)):.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/ddp_worker.py
+++ b/tests/ddp_worker.py
@@ -160,6 +160,59 @@ def run_ddp_parity(failures: list[str]):
     dist.barrier()
 
 
+def run_lazy_fence(failures: list[str]):
+    """The comm-stream collective's result is fenced onto the default stream
+    lazily, at its first consumer (mojo_device/comm_fence.py).
+
+    256 MB per collective on purpose: the fence is only under test while the
+    allreduce is still running when the host reaches the consumer a few
+    microseconds later. A few-KB collective would have finished either way
+    and every assertion below would pass with no fence at all.
+
+    Measured against a build with ``comm_fence.mark_pending`` disarmed, (c)
+    is the check that catches the missing fence — (a) and (b) allocate a
+    256 MB destination first, which is usually long enough for the collective
+    to land anyway. They stay because they are the contract users write
+    against; (c) is the one with teeth.
+    """
+    rank = dist.get_rank()
+    world = dist.get_world_size()
+    expected = float(world * (world + 1) // 2)
+    numel = 64 * 1024 * 1024
+
+    # (a) host read straight after the collective.
+    a = torch.full((numel,), float(rank + 1), device="mojo")
+    dist.all_reduce(a)
+    _check(failures, "lazy_fence.host_read", bool((a.cpu() == expected).all()))
+    del a
+
+    # (b) device consumer of the result, read back through it.
+    b = torch.full((numel,), float(rank + 1), device="mojo")
+    dist.all_reduce(b)
+    doubled = b + b
+    _check(
+        failures,
+        "lazy_fence.device_consumer",
+        bool((doubled.cpu() == 2 * expected).all()),
+    )
+    del b, doubled
+
+    # (c) write into a VIEW of the reduced buffer. Unfenced, the fill lands
+    # first and the collective's output overwrites it.
+    c = torch.full((numel,), float(rank + 1), device="mojo")
+    dist.all_reduce(c)
+    c.narrow(0, 0, 1024).fill_(-7.0)
+    out = c.cpu()
+    _check(
+        failures,
+        "lazy_fence.view_write",
+        bool((out[:1024] == -7.0).all()) and bool((out[1024:] == expected).all()),
+    )
+    del c, out
+
+    dist.barrier()
+
+
 def main():
     mode = sys.argv[1]
     from torch_mojo_backend import register_mojo_devices
@@ -171,6 +224,8 @@ def main():
         run_collectives(failures)
     elif mode == "ddp_parity":
         run_ddp_parity(failures)
+    elif mode == "lazy_fence":
+        run_lazy_fence(failures)
     else:
         raise ValueError(f"unknown mode {mode}")
     dist.destroy_process_group()

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -19,6 +19,7 @@ import torch.distributed as dist
 from torch_mojo_backend import get_accelerators, register_mojo_devices
 
 _WORKER = Path(__file__).parent / "ddp_worker.py"
+_OVERHEAD_WORKER = Path(__file__).parent / "comm_fence_overhead.py"
 
 
 def _gpu_count() -> int:
@@ -97,8 +98,53 @@ def _run_torchrun(nproc: int, mode: str, extra_env: dict[str, str] | None = None
 
 
 @pytest.mark.parametrize("comm_stream", ["1", "0"], ids=["side-stream", "same-stream"])
-@pytest.mark.parametrize("mode", ["collectives", "ddp_parity"])
+@pytest.mark.parametrize("mode", ["collectives", "ddp_parity", "lazy_fence"])
 def test_two_rank_nccl(mode: str, comm_stream: str):
     if _gpu_count() < 2:
         pytest.skip("needs at least 2 GPUs")
     _run_torchrun(2, mode, {"TORCH_MOJO_BACKEND_COMM_STREAM": comm_stream})
+
+
+def _measure_overhead_microseconds(no_hook: bool) -> dict[str, float]:
+    result = subprocess.run(
+        [sys.executable, str(_OVERHEAD_WORKER)] + (["--no-hook"] if no_hook else []),
+        # os.environ, not the inherited environment: the Mojo runtime setenv()s
+        # PYTHONEXECUTABLE=/usr/bin/python3 at the C level once a kernel
+        # extension loads, which breaks a child launched with sys.executable.
+        env=dict(os.environ),
+        capture_output=True,
+        text=True,
+        timeout=900,
+        cwd=Path(__file__).parent.parent,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"overhead worker failed (rc={result.returncode})\n"
+            f"stdout:\n{result.stdout[-4000:]}\nstderr:\n{result.stderr[-4000:]}"
+        )
+    return {
+        key: float(value)
+        for key, _, value in (
+            line.partition("=") for line in result.stdout.splitlines()
+        )
+        if value
+    }
+
+
+def test_comm_fence_hook_per_op_overhead():
+    """What the per-op comm-fence hook costs when no collective is pending.
+
+    One subprocess per leg: the hook is installed once, at registration.
+    """
+    if _gpu_count() < 1:
+        pytest.skip("needs a GPU")
+    with_hook = _measure_overhead_microseconds(no_hook=False)
+    without_hook = _measure_overhead_microseconds(no_hook=True)
+    print(
+        f"\ncomm-fence hook: {with_hook['us_per_op']:.3f} us/op with, "
+        f"{without_hook['us_per_op']:.3f} us/op without "
+        f"({with_hook['us_per_op'] - without_hook['us_per_op']:+.3f} us/op); "
+        f"wrapper frame alone {with_hook['wrapper_us']:.3f} us"
+    )
+    assert with_hook["us_per_op"] - without_hook["us_per_op"] < 5.0
+    assert with_hook["wrapper_us"] < 5.0

--- a/torch_mojo_backend/distributed/process_group.py
+++ b/torch_mojo_backend/distributed/process_group.py
@@ -13,12 +13,9 @@ Design (see docs/distributed.md for the full story):
 - NCCL collectives run on a dedicated comm stream (a side stream,
   ``mojo_device/device_streams.py``) for compute/communication overlap: it
   waits for the default stream first (so producers are ordered before the
-  collective), the collective is enqueued, and a watcher thread completes
-  the Work's future once the end event fires. DDP's Reducer therefore keeps
-  enqueuing backward compute on the default stream while bucket allreduces
-  fly on the comm stream, and its end-of-backward ``future.wait()`` blocks
-  only for the un-overlappable tail. Every tensor a collective touches is
-  fenced via ``device_streams.record_use`` (see that module's docstring).
+  collective) and the collective is enqueued. Every tensor a collective
+  touches is fenced via ``device_streams.record_use`` (see that module's
+  docstring) and recorded as pending in ``mojo_device/comm_fence.py``.
   ``TORCH_MOJO_BACKEND_COMM_STREAM=0`` falls back to the default stream
   itself (ordering free, zero overlap) — also the automatic path for
   collectives needing default-stream copies AFTER the collective
@@ -27,12 +24,24 @@ Design (see docs/distributed.md for the full story):
   first (rule 1 in device_streams.py).
 
 - Work objects wrap an already-completed ``torch.futures.Future`` holding the
-  output tensors. Never pass ``devices=`` to that Future: with a device list
-  it routes through the stub PythonDeviceGuard whose ``deviceCount() == 1``
-  and performs an out-of-bounds write for device indices >= 1. A plain CPU
-  future does zero device bookkeeping, which is exactly right here because
-  stream order already guarantees device-side completion for any consumer on
-  the same stream. ``wait()`` on it is a host-side no-op by design.
+  output tensors, on both paths, so ``wait()`` is a host-side no-op. Never
+  pass ``devices=`` to that Future: with a device list it routes through the
+  stub PythonDeviceGuard whose ``deviceCount() == 1`` and performs an
+  out-of-bounds write for device indices >= 1.
+
+  Completing at enqueue time rather than when the collective's end event
+  fires is what keeps the host free, and it is the whole point of
+  ``comm_fence``. Stock ``ProcessGroupNCCL`` does the same and pays for it
+  with a device-typed future whose ``wait()`` makes the *current stream*
+  wait — a C++ DeviceGuardImpl this backend cannot ship. Instead the device
+  ordering is inserted lazily: the first default-stream op touching a
+  collective's buffer makes the default stream wait on the comm stream.
+  For DDP that lands in ``finalize_backward``, where the Reducer first reads
+  a reduced bucket — after every backward kernel is already enqueued — so
+  overlap is unchanged while the host runs ahead into the bucket→grad
+  copies, ``clip_grad_norm_`` and the optimizer step. Blocking the host on
+  the future instead cost ~2 ms/step of exposed GPU idle: nanoGPT 124M on
+  32 H100s went 10.89 -> 11.10 M tok/s when it stopped doing so.
 
 - The DDP Reducer calls ``allreduce`` through the C++ trampoline and then
   ``Work.get_future()`` (default_comm_hooks.cpp) — both supported by
@@ -46,17 +55,15 @@ One process drives exactly one GPU (torchrun layout). Set
 
 import datetime
 import os
-import queue
 import sys
 import threading
-import time
 import traceback
 from collections.abc import Callable
 from typing import cast
 
 import torch
 import torch.distributed as dist
-from max.driver import Device, DeviceEvent
+from max.driver import Device
 from torch._C._distributed_c10d import (
     AllgatherOptions,
     AllreduceCoalescedOptions,
@@ -74,7 +81,7 @@ from torch._C._distributed_c10d import (
 from torch.distributed import PrefixStore, Store, Work
 
 from torch_mojo_backend.distributed import nccl
-from torch_mojo_backend.mojo_device import torch_mojo_device_module
+from torch_mojo_backend.mojo_device import comm_fence, torch_mojo_device_module
 from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
 
 _NCCL_DTYPE_OF: dict[torch.dtype, int] = {
@@ -161,74 +168,6 @@ def _loud(fn: Callable[..., Work]) -> Callable[..., Work]:
     return wrapper
 
 
-_CompletionJob = tuple[
-    DeviceEvent, torch.futures.Future[list[torch.Tensor]], list[torch.Tensor]
-]
-
-
-class _CommCompletionWorker:
-    """Completes collective futures once their device-side end event fires.
-
-    One daemon thread per process group; jobs resolve FIFO because events on
-    one stream complete in enqueue order. Polls ``is_ready`` (short spin,
-    then 200 µs sleeps) instead of a blocking wait so ``abort()`` can
-    unstick the thread when a communicator dies mid-collective.
-    """
-
-    def __init__(self):
-        self._jobs: queue.SimpleQueue[_CompletionJob | None] = queue.SimpleQueue()
-        self._thread: threading.Thread | None = None
-        self._lock = threading.Lock()
-        self.aborted = False
-
-    def submit(
-        self,
-        event: DeviceEvent,
-        future: torch.futures.Future[list[torch.Tensor]],
-        result: list[torch.Tensor],
-    ):
-        with self._lock:
-            if self._thread is None:
-                self._thread = threading.Thread(
-                    target=self._run, name="mojo-comm-completion", daemon=True
-                )
-                self._thread.start()
-        self._jobs.put((event, future, result))
-
-    def shutdown(self):
-        with self._lock:
-            thread = self._thread
-            self._thread = None
-        if thread is not None:
-            self._jobs.put(None)
-            thread.join(timeout=30)
-
-    def _run(self):
-        while True:
-            job = self._jobs.get()
-            if job is None:
-                return
-            event, future, result = job
-            try:
-                spin_until = time.monotonic() + 0.001
-                while not event.is_ready():
-                    if self.aborted:
-                        raise RuntimeError(
-                            "communicator aborted while a collective was in flight"
-                        )
-                    if time.monotonic() > spin_until:
-                        time.sleep(0.0002)
-                future.set_result(result)
-            except Exception as e:
-                try:
-                    future.set_exception(e)  # ty: ignore[invalid-argument-type] -- the stub types it as the result type
-                except Exception:
-                    pass
-                traceback.print_exc()
-            finally:
-                del event, future, result
-
-
 class MojoProcessGroup(dist.ProcessGroup):
     """NCCL-backed process group for ``mojo`` tensors, gloo for CPU tensors."""
 
@@ -260,7 +199,6 @@ class MojoProcessGroup(dist.ProcessGroup):
         self._comm_stream_enabled = (
             os.environ.get("TORCH_MOJO_BACKEND_COMM_STREAM", "1") != "0"
         )
-        self._completion = _CommCompletionWorker()
         # Private CPU backend: torch will not compose gloo around a Python PG
         # (see module docstring), so CPU tensors are our job too.
         # The stub declares the collectives on ProcessGroup only; the gloo
@@ -289,21 +227,31 @@ class MojoProcessGroup(dist.ProcessGroup):
         self._group_name = name
 
     def shutdown(self):
-        # Let in-flight comm-stream collectives complete before tearing down
-        # the communicators they run on.
-        self._completion.shutdown()
+        # Nothing waits for a comm-stream collective any more (see
+        # _stream_work), so drain them here before the communicators they
+        # run on are destroyed.
+        self._quiesce_comm_streams()
         for comm in self._comms.values():
             comm.destroy()
         self._comms.clear()
 
     def abort(self):
-        # Flag first so the completion worker errors out its pending futures
-        # instead of waiting forever on events an aborted comm never fires.
-        self._completion.aborted = True
+        # An aborted communicator never finishes its work: drop the pending
+        # fences rather than let a later op wait on the comm stream forever.
+        for index in self._max_devices:
+            comm_fence.discard(index)
         for comm in self._comms.values():
             comm.abort()
         self._comms.clear()
-        self._completion.shutdown()
+
+    def _quiesce_comm_streams(self):
+        """Complete every in-flight comm-stream collective, fences included."""
+        for index, max_device in self._max_devices.items():
+            if self._comm_stream_enabled:
+                from torch_mojo_backend.mojo_device.device_streams import get_stream
+
+                get_stream(max_device, "nccl").synchronize()
+            comm_fence.discard(index)
 
     def _ensure_device_current(self, ordinal: int):
         # NCCL resolves the target GPU from the thread-current CUDA context,
@@ -353,13 +301,13 @@ class MojoProcessGroup(dist.ProcessGroup):
         then runs the same ``enqueue`` on the default stream. Eligibility is
         the caller's job: only collectives needing NO default-stream work
         after the NCCL call (no copy-back into non-contiguous outputs) may
-        come here, because nothing makes the default stream wait for the
-        comm stream; completion is signaled host-side through the Work's
-        future instead.
+        come here, because the default stream is ordered after the comm
+        stream lazily, at the first consumer, not here.
 
-        ``fenced`` lists every tensor the collective reads or writes,
+        ``fenced`` lists every tensor the collective reads or writes. Each is
         recorded against the comm stream (``device_streams.record_use``) so
-        each one's free is ordered after this collective.
+        its free is ordered after this collective, and marked pending in
+        ``comm_fence`` so its first default-stream use is too.
         """
         if not self._comm_stream_enabled:
             return None
@@ -372,11 +320,10 @@ class MojoProcessGroup(dist.ProcessGroup):
         for tensor in fenced:
             assert isinstance(tensor, TorchMojoTensor)
             record_use(tensor._holder, comm_stream)
-        future = torch.futures.Future[
-            list[torch.Tensor]
-        ]()  # no devices= — see module docstring
-        self._completion.submit(comm_stream.record_event(), future, result)
-        return _create_work_from_future(future)
+        comm_fence.mark_pending(
+            index, comm_stream, cast(tuple[TorchMojoTensor, ...], fenced)
+        )
+        return _completed_work(result)
 
     def _fence_default(self, index: int):
         """Drain, and order the default stream after the comm stream.
@@ -385,12 +332,15 @@ class MojoProcessGroup(dist.ProcessGroup):
         issue order. When comm-stream and default-stream collectives mix,
         this fence keeps device execution order equal to issue order. (The
         reverse direction is ``wait_default_stream`` in ``_stream_work``.)
+        Unconditional, unlike ``comm_fence``: a comm-stream collective no
+        consumer has touched yet is still pending on the device.
         """
         self._drained()
         if self._comm_stream_enabled and index in self._max_devices:
             from torch_mojo_backend.mojo_device.device_streams import get_stream
 
             get_stream(self._max_devices[index], "nccl").make_default_stream_wait()
+            comm_fence.discard(index)
 
     def _init_comm(self, index: int, ordinal: int) -> nccl.NcclComm:
         key = f"nccl-uid-{self._comm_seq}"
@@ -987,11 +937,7 @@ class MojoProcessGroup(dist.ProcessGroup):
         # collectives on the comm stream.
         if self._comms:
             torch_mojo_device_module.synchronize()
-            if self._comm_stream_enabled:
-                from torch_mojo_backend.mojo_device.device_streams import get_stream
-
-                for max_device in self._max_devices.values():
-                    get_stream(max_device, "nccl").synchronize()
+            self._quiesce_comm_streams()
         return self._gloo.barrier(opts)
 
     def _one_per_rank(self, tensors: list[torch.Tensor]):

--- a/torch_mojo_backend/mojo_device/comm_fence.py
+++ b/torch_mojo_backend/mojo_device/comm_fence.py
@@ -1,0 +1,137 @@
+"""Lazy default-stream fencing for collectives that ran on the comm stream.
+
+A collective enqueued on the "nccl" side stream completes its Work future at
+enqueue time, so ``wait()`` never blocks the host (see
+``distributed/process_group.py`` for why that matters). The device ordering
+that future no longer carries is carried by the tensors instead: every buffer
+a collective reads or writes is recorded here as *pending*, and the first
+default-stream consumer of one makes the default stream wait on the comm
+stream before it runs. A stream is FIFO, so that single wait orders the
+default stream after every collective enqueued so far — hence a per-buffer
+record but a per-device fence.
+
+Buffers are keyed by ``id(tensor._holder)``: views share their base's holder,
+so a write into a bucket view fences on the whole bucket. Identity keys can
+be recycled after a free, which can only add a fence, never drop one.
+
+``PENDING`` is the fast path — empty means no collective is in flight, the
+only state the per-op hook in ``register.py`` has to distinguish. That hook
+captures the dict by reference, so it is mutated in place, never rebound.
+"""
+
+import threading
+
+from torch_mojo_backend.mojo_device import device_streams
+from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
+
+PENDING: dict[int, int] = {}  # id(holder) -> mojo device index
+_COMM_STREAMS: dict[int, device_streams.Stream] = {}
+# Collectives are issued from the autograd thread while the main thread runs
+# the optimizer; the truthiness poll on the hot path stays lock-free.
+# Reentrant, and every fence below idempotent, because the fence drains the
+# kernel-call queue while holding it and a launch may fence again.
+_LOCK = threading.RLock()
+
+
+# A record only leaves PENDING when something consumes its buffer, so a
+# program that collectives onto fresh tensors and never reads them would grow
+# it without bound. Fence at this many (DDP reuses one buffer per bucket and
+# sits around 75) rather than carry a leak.
+_MAX_PENDING = 4096
+
+
+def mark_pending(
+    index: int, stream: device_streams.Stream, tensors: tuple[TorchMojoTensor, ...]
+):
+    """Record every buffer a collective just enqueued on `stream` touches."""
+    with _LOCK:
+        _COMM_STREAMS[index] = stream
+        if len(PENDING) >= _MAX_PENDING:
+            fence_all()  # reentrant lock
+        for tensor in tensors:
+            PENDING[id(tensor._holder)] = index
+
+
+def _keys_locked(index: int) -> list[int]:
+    return [key for key, value in PENDING.items() if value == index]
+
+
+def _fence_locked(index: int):
+    keys = _keys_locked(index)
+    stream = _COMM_STREAMS.get(index)
+    if not keys or stream is None:
+        return
+    # Queued launches were issued before this fence and must stay before it
+    # on the default stream (rule 1 in device_streams.py).
+    from torch_mojo_backend.mojo_device import deferred_compile
+
+    deferred_compile.drain()
+    stream.make_default_stream_wait()
+    for key in keys:  # only once the wait is on the stream
+        PENDING.pop(key, None)
+
+
+def fence_device(index: int):
+    """Order the default stream after every collective pending on `index`."""
+    if not PENDING:
+        return
+    with _LOCK:
+        _fence_locked(index)
+
+
+def fence_all():
+    """``fence_device`` for every device with a collective in flight."""
+    if not PENDING:
+        return
+    with _LOCK:
+        for index in sorted(set(PENDING.values())):
+            _fence_locked(index)
+
+
+def fence_tensor(tensor: TorchMojoTensor):
+    """Fence before a host read of `tensor` that no eager op mediates."""
+    if not PENDING:
+        return
+    index = PENDING.get(id(tensor._holder))
+    if index is not None:
+        fence_device(index)
+
+
+def discard(index: int):
+    """Forget `index`'s pending buffers without fencing — for callers that
+    already ordered or completed the comm stream themselves."""
+    if not PENDING:
+        return
+    with _LOCK:
+        for key in _keys_locked(index):
+            PENDING.pop(key, None)
+
+
+def _pending_index(value: object) -> int | None:
+    if isinstance(value, TorchMojoTensor):
+        return PENDING.get(id(value._holder))
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            if isinstance(item, TorchMojoTensor):
+                index = PENDING.get(id(item._holder))
+                if index is not None:
+                    return index
+    return None
+
+
+def fence_pending_args(args: tuple[object, ...], kwargs: dict[str, object]):
+    """Fence if any argument of an eager op reads or writes a pending buffer.
+
+    Reached only while ``PENDING`` is non-empty. Lists are scanned one level
+    deep, which is where the foreach and concat ops keep their tensors.
+    """
+    for value in args:
+        index = _pending_index(value)
+        if index is not None:
+            fence_device(index)
+            return
+    for value in kwargs.values():
+        index = _pending_index(value)
+        if index is not None:
+            fence_device(index)
+            return

--- a/torch_mojo_backend/mojo_device/register.py
+++ b/torch_mojo_backend/mojo_device/register.py
@@ -5,10 +5,32 @@ from typing import TypeVar
 
 import torch
 
+from torch_mojo_backend.mojo_device import comm_fence
 from torch_mojo_backend.mojo_device.mojo_device_aten_ops import _aten_ops_registry
 
 _T = TypeVar("_T")
 _registered = False
+
+
+def _fence_pending_collectives(func: Callable[..., object]) -> Callable[..., object]:
+    """Order this op after any collective still in flight on the comm stream.
+
+    Wrapped around every eager op at registration time — the one choke point
+    where a default-stream consumer of a collective's buffer can be caught
+    (see mojo_device/comm_fence.py). While nothing is pending, which is every
+    op of a non-distributed run, the cost is this frame plus a dict
+    truthiness test.
+    """
+    pending = comm_fence.PENDING  # by reference: comm_fence mutates in place
+    fence_pending_args = comm_fence.fence_pending_args
+
+    @wraps(func)
+    def with_comm_fence(*args: object, **kwargs: object) -> object:
+        if pending:
+            fence_pending_args(args, kwargs)
+        return func(*args, **kwargs)
+
+    return with_comm_fence
 
 
 def _install_torch_accelerator_synchronize(torch_mojo_device_module: ModuleType):
@@ -412,7 +434,7 @@ def register_mojo_devices():
 
     # Register all collected aten operations
     for op_name, func in _aten_ops_registry:
-        torch.library.impl(op_name, "privateuseone")(func)
+        torch.library.impl(op_name, "privateuseone")(_fence_pending_collectives(func))
 
     from torch_mojo_backend.mojo_device.mojo_device_autograd import (
         register_autograd_ops,

--- a/torch_mojo_backend/mojo_device/streams.py
+++ b/torch_mojo_backend/mojo_device/streams.py
@@ -215,10 +215,24 @@ class Stream(torch._C.Stream):
         return self._device_stream.handle
 
     def query(self) -> bool:
+        self._fence_pending_comm_work()
         return self._device_stream.query()
 
     def synchronize(self):
+        self._fence_pending_comm_work()
         self._device_stream.synchronize()
+
+    def _fence_pending_comm_work(self):
+        """Both observations above answer "is my work done?" for this stream.
+
+        On the default stream that has to include a collective still in
+        flight on the comm stream, which is ordered onto it lazily
+        (mojo_device/comm_fence.py) — so fence before observing, once.
+        """
+        if self._device_stream.is_default:
+            from torch_mojo_backend.mojo_device import comm_fence
+
+            comm_fence.fence_device(self._index)
 
     def wait_event(self, event: Event):
         event.wait(self)

--- a/torch_mojo_backend/mojo_device/torch_mojo_device_module.py
+++ b/torch_mojo_backend/mojo_device/torch_mojo_device_module.py
@@ -192,9 +192,12 @@ def synchronize(device: "int | str | torch.device | None" = None):
     """Public: wait for work and release completed asynchronous transfer
     owners. Pending kernel launches count as work, so the queue drains
     first — a caller of ``torch.mojo.synchronize()`` is entitled to assume
-    every op it issued has actually run on the device."""
-    from torch_mojo_backend.mojo_device import deferred_compile
+    every op it issued has actually run on the device. So does a collective
+    still flying on the comm stream, which only the default stream is waited
+    on here: fence it onto that stream first (mojo_device/comm_fence.py)."""
+    from torch_mojo_backend.mojo_device import comm_fence, deferred_compile
 
+    comm_fence.fence_all()
     deferred_compile.drain()
     _device_synchronize(device)
 

--- a/torch_mojo_backend/mojo_device/torch_mojo_tensor.py
+++ b/torch_mojo_backend/mojo_device/torch_mojo_tensor.py
@@ -644,8 +644,12 @@ class TorchMojoTensor(torch.Tensor):
         consuming it, matching PyTorch's asynchronous accelerator-to-CPU
         contract. Blocking and CPU-device copies are ready on return.
         """
-        from torch_mojo_backend.mojo_device import deferred_compile
+        from torch_mojo_backend.mojo_device import comm_fence, deferred_compile
 
+        # A collective that wrote these bytes may still be flying on the comm
+        # stream; the default stream this transfer rides is ordered after it
+        # lazily (mojo_device/comm_fence.py), and this is a first use.
+        comm_fence.fence_tensor(self)
         src = self if self._is_contiguous else self._materialize_contiguous()
         # Reading device bytes is a host read: every queued launch must have
         # executed before the transfer is enqueued -- INCLUDING the strided
@@ -716,8 +720,9 @@ class TorchMojoTensor(torch.Tensor):
         not see a buffer whose producing launches -- including the copy a
         strided export just queued -- are still waiting on a compile.
         """
-        from torch_mojo_backend.mojo_device import deferred_compile, dlpack
+        from torch_mojo_backend.mojo_device import comm_fence, deferred_compile, dlpack
 
+        comm_fence.fence_tensor(self)  # same reason as _to_cpu_tensor's
         src = self._contig()
         deferred_compile.drain()
         return dlpack.make_capsule(

--- a/torch_mojo_backend/torch_compile_backend/compiler.py
+++ b/torch_mojo_backend/torch_compile_backend/compiler.py
@@ -24,6 +24,7 @@ from torch_mojo_backend.aten_functions import (
     torch_device_to_max_device,
 )
 from torch_mojo_backend.flags import profiling_enabled, verbose_enabled
+from torch_mojo_backend.mojo_device import comm_fence
 from torch_mojo_backend.torch_compile_backend import debug
 from torch_mojo_backend.torch_compile_backend.utils import (
     get_accelerators,
@@ -528,6 +529,10 @@ class BaseMaxCompiler:
         # Detach tensors to avoid gradient tracking issues with DLpack
         if profiling_enabled():
             start_inference_time = time.time_ns()
+        if comm_fence.PENDING:
+            # The graph reads its inputs' device memory straight from MAX, so
+            # the per-op hook in register.py never sees them; fence here.
+            comm_fence.fence_pending_args(args, {})
         input_tensors = [
             _cached_buffer_for(x) for x in args if isinstance(x, torch.Tensor)
         ]


### PR DESCRIPTION
Collectives on the comm stream now complete their `Work` future at enqueue time, and the default stream is ordered after the comm stream lazily, the first time an eager op touches a tensor a collective read or wrote. `wait()` never blocks the host in either path; device ordering comes from the stream, as in stock `ProcessGroupNCCL`.

### Why

On 4 nodes × 8 H100 (nanoGPT 124M, bf16, DDP, batch 32×1024 per rank) main trained at 10.9 M tok/s against 11.16 M for stock torch, while a single GPU with no DDP was at parity (86.0 vs 87.2 ms/step). The difference was DDP integration: the comm-stream path completed each bucket's future from a watcher thread only once the collective's end event fired, so the reducer's `getFuture()->wait()` at the end of backward blocked the host until the last all-reduce finished. Stock marks the future complete at enqueue and makes `wait()` a stream wait, so its host runs ahead and has the bucket→grad copies, `clip_grad_norm_`, the optimizer and the next batch already enqueued when the GPU finishes reducing. Ours started launching them into an idle GPU — the reducer alone issues ~75 `copy_` kernels, tens of µs of host time each.

Stock's mechanism needs a C++ `DeviceGuardImpl` for PrivateUse1 that torch does not provide yet, so this does it in Python:

- `_stream_work` records the tensors it touched as *pending* (`mojo_device/comm_fence.py`, keyed by holder so views of a DDP bucket are covered) and returns a completed future. The `_CommCompletionWorker` thread is gone.
- Every eager op is wrapped once, at the single install loop in `register.py`: while nothing is pending the wrapper is one dict-truthiness test (measured 54 ns/op; 21.27 vs 21.42 µs/op on a 16-element `add`, i.e. below noise); when an argument is pending, the default stream waits on the comm stream once (FIFO, so that covers every collective enqueued so far) and the pending set for that device is cleared. Host reads that bypass eager ops fence too: `_to_cpu_tensor`, `__dlpack__`, `synchronize()`, the default stream's `query()`/`synchronize()`, and compiled graphs at entry.
- Overlap is unchanged: the fence lands where the reducer first touches the reduced buckets, after all backward compute is enqueued.

### Measured (32×H100, 100 steps, per 10-step window, ABBA paired in one job)

| batch 32 | windows (k tok/s) | median |
|---|---|---|
| main | 10937 10956 10940 10932 10947 10932 10863 10928 10889 | 10932 |
| this PR | 10956 11164 11118 11166 11147 11121 11087 11063 11112 | 11118 |
| this PR | 11075 11036 11129 11044 11091 11085 11059 11094 11108 | 11085 |
| main | 10846 10951 10896 10480 10712 10605 10869 10579 10852 | 10846 |

10.89 → 11.10 M tok/s (+2.0%, ~1.85 ms/step recovered); stock torch on the same nodes: 11.16. At batch 12 the medians move 6.82 → 7.15 but the within-leg spread is ±20%, so that is not a result; the remaining small-batch gap to stock (9.6–9.7) is something else and is not addressed here.

### Validation

- 2 GPUs: `tests/test_distributed.py` + `tests/test_mojo_streams.py` 21 passed, including DDP-vs-single-process step parity at the existing tolerance, and a new `lazy_fence` mode that all-reduces 256 MB and then reads via `.cpu()`, consumes on device, and writes into a `narrow()` view of the reduced buffer. Disarming `mark_pending` makes the view-write check fail, so the test has teeth.
- 1 GPU: `test_mojo_device.py` (87 passed / 10 skipped / 2 xfailed / 2 xpassed, identical to main), `test_compile_mojo_device.py` 44 passed, `test_compiler.py` 36 passed / 31 skipped, `test_mojo_autocast.py` 3, `test_autograd_memory_lifetime.py` 1, `test_dlpack.py` + `test_call_queue.py` 50 passed with one failure that fails identically on main (`test_consumed_capsule_survives_dlpack_module_reload`, a cluster `PYTHONEXECUTABLE` issue).
- ruff, ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AbxaDeRuA7yywYEUuZV72
