### PR TITLE
Call the PrivateUse1 kernel directly instead of redispatching through C++

### DIFF
--- a/tests/test_direct_dispatch.py
+++ b/tests/test_direct_dispatch.py
@@ -1,0 +1,283 @@
+"""The direct-impl table `__torch_dispatch__` uses instead of redispatching.
+
+`deferred_compile._direct` calls the PrivateUse1 callable straight out of
+`deferred_compile.DIRECT_IMPLS` rather than re-entering the C++ dispatcher.
+That is only sound if a library kernel and `__torch_dispatch__` hand an impl
+the same `(args, kwargs)`, so the probe library below registers one kernel per
+argument shape most likely to diverge -- a defaulted keyword-only scalar, an
+optional dtype, an `int[]?`, an `out=` overload, a TensorList -- and records
+what it receives on each path.
+"""
+
+import contextlib
+
+import pytest
+import torch
+
+from torch_mojo_backend import register_mojo_devices
+from torch_mojo_backend.mojo_device import deferred_compile
+from torch_mojo_backend.mojo_device.mojo_device_aten_ops import (
+    EAGER_CALL_COUNTERS,
+    _aten_ops_registry,
+)
+from torch_mojo_backend.mojo_device.register import _resolve_overload
+
+pytestmark = pytest.mark.xdist_group(name="group1")
+
+
+@pytest.fixture(autouse=True)
+def setup_mojo_device():
+    register_mojo_devices()
+
+
+def test_registered_ops_resolve_into_the_direct_table():
+    names = [name for name, _ in _aten_ops_registry]
+    unresolved = [name for name in names if _resolve_overload(name) is None]
+    # A name may only miss the table because this torch build has no such
+    # overload (`aten::empty_strided.memory_format` today). It keeps its
+    # library registration and goes on redispatching through C++.
+    for name in unresolved:
+        packet_name, _, overload = name.removeprefix("aten::").partition(".")
+        packet = getattr(torch.ops.aten, packet_name, None)
+        assert packet is None or (overload or "default") not in packet.overloads()
+    assert len(deferred_compile.DIRECT_IMPLS) == len(set(names)) - len(unresolved)
+
+
+def test_table_holds_the_call_counted_callable():
+    """`CallChecker` observes ops through EAGER_CALL_COUNTERS, so the table has
+    to hold the wrapper that increments them, not the bare impl."""
+    counted = EAGER_CALL_COUNTERS["aten::add.Tensor"]
+    before = counted.call_count
+    x = torch.ones(4, device="mojo")
+    (x + x).cpu()
+    assert counted.call_count > before
+    table_entry = deferred_compile.DIRECT_IMPLS[torch.ops.aten.add.Tensor]
+    assert getattr(table_entry, "__wrapped__", None) is counted
+
+
+@contextlib.contextmanager
+def _table_disabled(overload: torch._ops.OpOverload):
+    """Force `overload` back onto the C++ redispatch path."""
+    entry = deferred_compile.DIRECT_IMPLS.pop(overload, None)
+    try:
+        yield
+    finally:
+        if entry is not None:
+            deferred_compile.DIRECT_IMPLS[overload] = entry
+
+
+# ---------------------------------------------------------------------------
+# Argument-convention probe
+# ---------------------------------------------------------------------------
+
+_PROBE_SCHEMAS = (
+    "probe_alpha(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor",
+    "probe_dtype(Tensor self, *, ScalarType? dtype=None, bool non_blocking=False)"
+    " -> Tensor",
+    "probe_dims(Tensor self, int[1]? dim=None, bool keepdim=False, *,"
+    " ScalarType? dtype=None) -> Tensor",
+    "probe_out(Tensor self, Scalar other, *, Tensor(a!) out) -> Tensor(a!)",
+    "probe_list(Tensor[] self, Scalar other) -> ()",
+)
+
+
+@pytest.fixture(scope="module")
+def probe():
+    """A private library whose PrivateUse1 kernels only record their call.
+
+    Yields `(ops_namespace, seen, kernels)`; `kernels[name]` is the very
+    callable the library holds, so putting it in DIRECT_IMPLS reproduces what
+    `register_mojo_devices` does for the aten ops.
+    """
+    library = torch.library.Library("torch_mojo_probe", "DEF")
+    seen = []
+    kernels = {}
+
+    def make(name):
+        def kernel(*args, **kwargs):
+            seen.append((args, dict(kwargs)))
+            if name == "probe_list":
+                return None
+            if name == "probe_out":
+                return kwargs["out"]
+            return args[0]
+
+        return kernel
+
+    for schema in _PROBE_SCHEMAS:
+        library.define(schema)
+        name = schema.split("(")[0]
+        kernels[name] = make(name)
+        library.impl(name, kernels[name], "PrivateUse1")
+    try:
+        yield torch.ops.torch_mojo_probe, seen, kernels
+    finally:
+        library._destroy()
+
+
+def _both_paths(probe, name, call):
+    """Run `call()` once through the C++ redispatch and once through the
+    table, returning the `(args, kwargs)` the kernel saw each time."""
+    ops, seen, kernels = probe
+    overload = getattr(ops, name).default
+    seen.clear()
+    with _table_disabled(overload):
+        call()
+        assert len(seen) == 1, f"{name} never reached its PrivateUse1 kernel"
+        through_cpp = seen.pop()
+    deferred_compile.DIRECT_IMPLS[overload] = kernels[name]
+    try:
+        call()
+        assert len(seen) == 1
+        direct = seen.pop()
+    finally:
+        deferred_compile.DIRECT_IMPLS.pop(overload, None)
+    return through_cpp, direct
+
+
+def _same(left, right):
+    """Structural equality that compares tensors by identity."""
+    if isinstance(left, torch.Tensor) or isinstance(right, torch.Tensor):
+        return left is right
+    if isinstance(left, tuple | list) and isinstance(right, tuple | list):
+        return type(left) is type(right) and all(
+            _same(a, b) for a, b in zip(left, right, strict=True)
+        )
+    if isinstance(left, dict) and isinstance(right, dict):
+        return left.keys() == right.keys() and all(
+            _same(left[k], right[k]) for k in left
+        )
+    return type(left) is type(right) and left == right
+
+
+def _probe_alpha_given(ops):
+    tensor = torch.ones(4, device="mojo")
+    return lambda: ops.probe_alpha(tensor, tensor, alpha=2)
+
+
+def _probe_alpha_defaulted(ops):
+    tensor = torch.ones(4, device="mojo")
+    return lambda: ops.probe_alpha(tensor, tensor)
+
+
+def _probe_dtype_given(ops):
+    tensor = torch.ones(4, device="mojo")
+    return lambda: ops.probe_dtype(tensor, dtype=torch.float16)
+
+
+def _probe_dtype_defaulted(ops):
+    tensor = torch.ones(4, device="mojo")
+    return lambda: ops.probe_dtype(tensor)
+
+
+def _probe_dims_positional(ops):
+    tensor = torch.ones(4, device="mojo")
+    return lambda: ops.probe_dims(tensor, [0], True)
+
+
+def _probe_dims_keyword(ops):
+    tensor = torch.ones(4, device="mojo")
+    return lambda: ops.probe_dims(tensor, dim=[0], keepdim=True)
+
+
+def _probe_dims_defaulted(ops):
+    tensor = torch.ones(4, device="mojo")
+    return lambda: ops.probe_dims(tensor)
+
+
+def _probe_out(ops):
+    tensor = torch.ones(4, device="mojo")
+    out = torch.empty(4, device="mojo")
+    return lambda: ops.probe_out(tensor, 3, out=out)
+
+
+def _probe_list(ops):
+    tensor = torch.ones(4, device="mojo")
+    return lambda: ops.probe_list([tensor, tensor], 2.5)
+
+
+@pytest.mark.parametrize(
+    "name,build",
+    [
+        # A keyword-only Scalar, passed and left defaulted.
+        ("probe_alpha", _probe_alpha_given),
+        ("probe_alpha", _probe_alpha_defaulted),
+        # Optional ScalarType, passed and left defaulted.
+        ("probe_dtype", _probe_dtype_given),
+        ("probe_dtype", _probe_dtype_defaulted),
+        # int[1]? plus a positional bool, spelled three ways.
+        ("probe_dims", _probe_dims_positional),
+        ("probe_dims", _probe_dims_keyword),
+        ("probe_dims", _probe_dims_defaulted),
+        # out= overload.
+        ("probe_out", _probe_out),
+        # TensorList.
+        ("probe_list", _probe_list),
+    ],
+)
+def test_both_paths_see_the_same_arguments(probe, name, build):
+    ops, _, _ = probe
+    through_cpp, direct = _both_paths(probe, name, build(ops))
+    assert _same(through_cpp, direct), f"{name}: {through_cpp} != {direct}"
+
+
+# ---------------------------------------------------------------------------
+# Real aten ops: same result either way.
+# ---------------------------------------------------------------------------
+
+
+def _add_alpha(device):
+    a = torch.arange(6.0, device=device).reshape(2, 3)
+    return torch.ops.aten.add.Tensor(a, a, alpha=3)
+
+
+def _to_copy(device):
+    a = torch.arange(6.0, device=device)
+    return torch.ops.aten._to_copy.default(a, dtype=torch.float16)
+
+
+def _sum_keepdim(device):
+    a = torch.arange(6.0, device=device).reshape(2, 3)
+    return torch.ops.aten.sum.dim_IntList(a, [1], True)
+
+
+def _addcmul_out(device):
+    a = torch.arange(6.0, device=device)
+    out = torch.empty(6, device=device)
+    return torch.ops.aten.addcmul.out(a, a, a, value=2, out=out)
+
+
+def _foreach_mul_(device):
+    tensors = [torch.arange(4.0, device=device), torch.arange(3.0, device=device)]
+    torch.ops.aten._foreach_mul_.Scalar(tensors, 2.5)
+    return tensors
+
+
+@pytest.mark.parametrize(
+    "overload,run",
+    [
+        (torch.ops.aten.add.Tensor, _add_alpha),
+        (torch.ops.aten._to_copy.default, _to_copy),
+        (torch.ops.aten.sum.dim_IntList, _sum_keepdim),
+        (torch.ops.aten.addcmul.out, _addcmul_out),
+        (torch.ops.aten._foreach_mul_.Scalar, _foreach_mul_),
+    ],
+)
+def test_real_ops_agree_on_both_paths(overload, run):
+    def to_cpu(value):
+        if isinstance(value, list):
+            return [t.cpu() for t in value]
+        return value.cpu()
+
+    direct = to_cpu(run("mojo"))
+    with _table_disabled(overload):
+        assert overload not in deferred_compile.DIRECT_IMPLS
+        redispatched = to_cpu(run("mojo"))
+    expected = to_cpu(run("cpu"))
+    if isinstance(expected, list):
+        for a, b, c in zip(direct, redispatched, expected, strict=True):
+            torch.testing.assert_close(a, c)
+            torch.testing.assert_close(b, c)
+    else:
+        torch.testing.assert_close(direct, expected)
+        torch.testing.assert_close(redispatched, expected)

--- a/torch_mojo_backend/mojo_device/deferred_compile.py
+++ b/torch_mojo_backend/mojo_device/deferred_compile.py
@@ -60,8 +60,9 @@ _DEVICE_LOCK = call_queue._LOCK
 #
 # `__torch_dispatch__` already unboxed this call's arguments, so redispatching
 # through `func(*args, **kwargs)` re-enters the C++ dispatcher only to box and
-# unbox them again for the very same Python callable -- ~5.7 us/op, and eager
-# nanoGPT issues ~2200 ops a step. A dict hit calls that callable straight.
+# unbox them again for the very same Python callable -- ~8 us per dispatch,
+# and an eager nanoGPT step makes ~760 of them (6 ms of a 37 ms host budget
+# at batch 12). A dict hit calls that callable straight.
 #
 # The fallthrough below is what the table cannot cover: CompositeImplicit ops
 # that decompose in C++, and anything with no PrivateUse1 registration.

--- a/torch_mojo_backend/mojo_device/deferred_compile.py
+++ b/torch_mojo_backend/mojo_device/deferred_compile.py
@@ -9,7 +9,9 @@ compiled units are still building — those wait in the kernel-call queue
 kernel compilation. This layer contributes exactly three things:
 
 - pump the call queue at every dispatch entry (launch the ready prefix);
-- drain it before device work that would bypass the queue (see below).
+- drain it before device work that would bypass the queue (see below);
+- call the op's PrivateUse1 kernel out of ``DIRECT_IMPLS`` rather than let
+  ``func(...)`` walk the C++ dispatcher back to that same callable.
 
 Buffer retention is not this layer's job: every queued item carries the
 tensors its raw pointers name (queue rule 3), stated explicitly at each
@@ -37,6 +39,8 @@ plain tracker update unless the queue recently launched from another
 thread (then it synchronizes once and clears).
 """
 
+from collections.abc import Callable
+
 import torch
 from torch.utils._pytree import tree_flatten
 
@@ -50,12 +54,36 @@ from torch_mojo_backend.eager_kernels import call_queue
 _DEVICE_LOCK = call_queue._LOCK
 
 
+# Every op registered for PrivateUse1, keyed by its OpOverload and holding
+# the exact callable `torch.library.impl` was handed. Filled at device
+# registration (mojo_device/register.py); empty until then.
+#
+# `__torch_dispatch__` already unboxed this call's arguments, so redispatching
+# through `func(*args, **kwargs)` re-enters the C++ dispatcher only to box and
+# unbox them again for the very same Python callable -- ~5.7 us/op, and eager
+# nanoGPT issues ~2200 ops a step. A dict hit calls that callable straight.
+#
+# The fallthrough below is what the table cannot cover: CompositeImplicit ops
+# that decompose in C++, and anything with no PrivateUse1 registration.
+#
+# Consequence for implementations: with no `_DisableTorchDispatch` around
+# them, a torch op an impl runs on a mojo tensor re-enters
+# `__torch_dispatch__` instead of dropping straight to the backend kernel.
+# That is correct (and pumps the queue), but an impl for op X must never call
+# op X on a mojo tensor. Impls that need the backend kernel without the round
+# trip use `.redispatch(<keyset>, ...)`, as the foreach and addr fallbacks do.
+DIRECT_IMPLS: dict[torch._ops.OpOverload, Callable[..., object]] = {}
+
+
 def _direct(
     func: torch._ops.OpOverload, args: tuple[object, ...], kwargs: dict[str, object]
 ) -> object:
     """Execute one aten op through the PrivateUse1 kernels."""
+    impl = DIRECT_IMPLS.get(func)
     with _DEVICE_LOCK:
         call_queue.order_direct_launch()
+        if impl is not None:
+            return impl(*args, **kwargs)
         with torch._C._DisableTorchDispatch():
             return func(*args, **kwargs)
 

--- a/torch_mojo_backend/mojo_device/register.py
+++ b/torch_mojo_backend/mojo_device/register.py
@@ -5,7 +5,7 @@ from typing import TypeVar
 
 import torch
 
-from torch_mojo_backend.mojo_device import comm_fence
+from torch_mojo_backend.mojo_device import comm_fence, deferred_compile
 from torch_mojo_backend.mojo_device.mojo_device_aten_ops import _aten_ops_registry
 
 _T = TypeVar("_T")
@@ -31,6 +31,21 @@ def _fence_pending_collectives(func: Callable[..., object]) -> Callable[..., obj
         return func(*args, **kwargs)
 
     return with_comm_fence
+
+
+def _resolve_overload(op_name: str) -> torch._ops.OpOverload | None:
+    """``"aten::add.Tensor"`` -> ``torch.ops.aten.add.Tensor``; a name with no
+    overload suffix takes ``.default``. ``None`` when this torch build has no
+    such operator, in which case only the library registration is installed
+    and the op keeps redispatching through C++.
+    """
+    namespace, _, rest = op_name.partition("::")
+    packet_name, _, overload_name = rest.partition(".")
+    try:
+        packet = getattr(getattr(torch.ops, namespace), packet_name)
+        return getattr(packet, overload_name or "default")
+    except AttributeError:
+        return None
 
 
 def _install_torch_accelerator_synchronize(torch_mojo_device_module: ModuleType):
@@ -432,9 +447,17 @@ def register_mojo_devices():
             # doesn't include our subclass by construction.
             supported_types.append(TorchMojoTensor)  # ty: ignore[invalid-argument-type]
 
-    # Register all collected aten operations
+    # Register all collected aten operations. The library registration is what
+    # a call reaching the backend key from C++ finds -- factories such as
+    # `torch.empty(device="mojo")` have no wrapper argument and never pass
+    # through `__torch_dispatch__`. The table beside it is the shortcut for
+    # calls that did (see deferred_compile.DIRECT_IMPLS).
     for op_name, func in _aten_ops_registry:
-        torch.library.impl(op_name, "privateuseone")(_fence_pending_collectives(func))
+        wrapped = _fence_pending_collectives(func)
+        torch.library.impl(op_name, "privateuseone")(wrapped)
+        overload = _resolve_overload(op_name)
+        if overload is not None:
+            deferred_compile.DIRECT_IMPLS[overload] = wrapped
 
     from torch_mojo_backend.mojo_device.mojo_device_autograd import (
         register_autograd_ops,


### PR DESCRIPTION
`TorchMojoTensor.__torch_dispatch__` already has the op's arguments unboxed in Python, yet `deferred_compile._direct` called `func(*args, **kwargs)` again under `_DisableTorchDispatch`, walking the C++ dispatcher back to the very Python kernel we registered with `torch.library`, boxing and unboxing the arguments a second time. This keeps a table from `OpOverload` to that same wrapped callable, filled in the install loop in `register.py`, and `_direct` calls it directly; ops not in the table (CompositeImplicit ops that decompose in C++, anything unregistered) take the old path. The `torch.library` registration stays because factories such as `torch.empty(device="mojo")` have no wrapper argument and reach the backend key without passing `__torch_dispatch__`.

218 of 219 registered ops resolve into the table; `aten::empty_strided.memory_format` has no such overload in this torch and keeps the C++ path.

**Stacked on #441** — review the last two commits.

### Measured (H100, SM clock pinned, ABBA base/new/new/base in one allocation)

| config | metric | before | after |
|---|---|---|---|
| 1 GPU, batch 12 | host time to issue a step | 37.4 ms | 31.0 ms |
| 1 GPU, batch 12 | wall per step | 37.5 ms | 36.7 ms |
| 1 GPU, batch 32 | wall per step | 85.5 ms | 85.5 ms (GPU-bound) |
| 8-GPU DDP, batch 12 | wall per step | 50.7 ms | 45.2 ms |
| 4 nodes × 8, batch 12 | median tok/s | 7.4 M | 8.0 M |
| 4 nodes × 8, batch 32 | median tok/s | 11.2 M | 11.2 M |

The C++ round trip costs ~8 µs and an eager nanoGPT step makes ~760 real dispatches (torch.profiler's 2164 aten records per step double-counted every op through the redispatch; the count drops to 1403 with this change), so the 6.3 ms recovered is the whole of it. The saving is invisible to cProfile — Python own time is unchanged — because it was dispatcher and boxing time in C++.

### Why nothing else had to change

Both `__torch_dispatch__` and a library kernel receive positional args in schema order and only the explicitly passed keyword-only args. `tests/test_direct_dispatch.py` proves it rather than assumes it: a probe library records `(args, kwargs)` on both paths for nine kwarg patterns (keyword-only Scalar passed and defaulted, `ScalarType?`, `int[1]?` with a positional bool, an `out=` overload, a `Tensor[]`) and they are identical, and five real ops agree on both paths. The test also asserts the table holds the call-counted callable the test suite's `call_checker` relies on. Without `_DisableTorchDispatch`, a torch op an impl runs on a mojo tensor re-enters `__torch_dispatch__` instead of dropping to the kernel; the audit found no such site (the `.transpose`/`.view` hits in `aten_fast.py` are comments; nested backend calls in `aten_ops/` already use `.redispatch(<keyset>, ...)`), and the autocast cast path is above `__torch_dispatch__` and stays differentiable.

### Validation

Serial, 1 GPU: `test_mojo_device` 87 passed / 10 skipped / 2 xfailed / 2 xpassed, `test_eager_kernels` 1762 passed, `test_compile_mojo_device` 44, `test_call_queue` 50, `test_mojo_streams` 11, `test_mojo_autocast` 3, `test_autograd_memory_lifetime` 1, new `test_direct_dispatch` 16; `test_dlpack` has the one known cluster failure; `test_aten_functions` 29 failed / 578 passed, the failing set byte-identical to the base branch's (35 failed there): `searchsorted`/`bucketize` kernels from a `__mojocache__` built with no GPU visible, plus MAX compile-backend failures, none in this change's path. 2 GPUs: `test_distributed` 10 passed. ruff and ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AbxaDeRuA7yywYEUuZV72
