### PR TITLE
Require module-scope imports (ruff PLC0415) and sweep the lazy ones

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,19 @@ Always use uv to run commands to ensure the correct environment is activated. Ne
 - **Code Quality**: Uses Ruff for linting/formatting with Python 3.11+ target and
   pyupgrade rules, plus flake8-annotations (`ANN`) to require type hints; Astral's
   `ty` (`uv run ty check`) statically checks those hints — see "Type hints" below
+- **Imports** live at module scope (`PLC0415`). An import that genuinely
+  cannot — a real cycle, a `sys.path`/env ordering, an optional dependency —
+  stays where it is with `# noqa: PLC0415 -- <why>`, and the reason must be
+  a checked fact. Verify a suspected cycle by hoisting the import and
+  re-importing the module in a fresh interpreter; most "cycles" are not one.
+  Importing `aten_fast` is not an exception: it loads no Mojo extension
+  (measured: nothing lands in `sys.modules`, 0.02 s), because a kernel is
+  built and dlopened by the first *call* into its descriptor. The one
+  import-time side effect in the kernel layer is reading
+  `eager_kernels.tensor_holder`, whose module `__getattr__` builds and
+  dlopens that extension there and then. Watch for late binding: code and
+  tests that monkeypatch `module.function` need the *module* imported at the
+  top, not the function.
 - **Monkeypatching**: every runtime patch of a torch (or other third-party)
   module or class lives in `torch_mojo_backend/monkeypatching.py`, one
   function per patch with a docstring saying what upstream lacks, so each can

--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -29,6 +29,8 @@ from _pytest.terminal import TerminalReporter
 from bench_lib.check import BENCH_NOTES_KEY, Bench, bench_key, update_mode
 from bench_lib.hw import Hardware, detect
 
+from torch_mojo_backend import register_mojo_devices
+
 # Set to a path to make collection write every benchmark node's baseline
 # key there, one per line, and measure nothing.  test_coverage.py drives
 # this to reconcile the recorded baselines against the suite: the keys come
@@ -86,8 +88,6 @@ def hw() -> Hardware:
 
 @pytest.fixture(scope="session")
 def mojo_device(hw: Hardware) -> torch.device:
-    from torch_mojo_backend import register_mojo_devices
-
     register_mojo_devices()
     return torch.device("mojo")
 

--- a/benchmarks/test_coverage.py
+++ b/benchmarks/test_coverage.py
@@ -37,7 +37,6 @@ from bench_lib import baselines
 # `environment.root = ["benchmarks"]` in [tool.ty], mirroring the sys.path
 # insert -- left for a repo-wide config change rather than a local workaround.)
 from conftest import KEY_DUMP_ENV  # ty: ignore[unresolved-import]
-
 from torch_mojo_backend.mojo_device import mojo_device_aten_ops as reg
 
 BENCH_DIR = Path(__file__).resolve().parent

--- a/benchmarks/test_coverage.py
+++ b/benchmarks/test_coverage.py
@@ -38,6 +38,8 @@ from bench_lib import baselines
 # insert -- left for a repo-wide config change rather than a local workaround.)
 from conftest import KEY_DUMP_ENV  # ty: ignore[unresolved-import]
 
+from torch_mojo_backend.mojo_device import mojo_device_aten_ops as reg
+
 BENCH_DIR = Path(__file__).resolve().parent
 
 FAMILY_MODULES = (
@@ -160,8 +162,6 @@ SKIPPED_OPS: dict[str, str] = {
 
 
 def test_every_registered_op_is_classified():
-    from torch_mojo_backend.mojo_device import mojo_device_aten_ops as reg
-
     registered = {name for name, _ in reg._aten_ops_registry}
     covered: dict[str, str] = {}
     skipped: dict[str, str] = dict(SKIPPED_OPS)

--- a/conformance/regenerate_known_unsupported.py
+++ b/conformance/regenerate_known_unsupported.py
@@ -47,7 +47,10 @@ from types import ModuleType
 from typing import Any
 
 import pytest
+import torch
 from _pytest.runner import CallInfo
+
+import torch_mojo_backend
 
 _RECORD_DIR_ENV = "CONFORMANCE_UNSUPPORTED_RECORD_DIR"
 _HERE = Path(__file__).resolve().parent
@@ -165,10 +168,8 @@ def _import_suite() -> ModuleType:
     """The conformance test module, imported the way its conftest does."""
     os.environ.setdefault("PYTORCH_TESTING_DEVICE_FOR_CUSTOM", "privateuse1")
     sys.path.insert(0, str(_HERE))
-    import torch_mojo_backend
-
     torch_mojo_backend.register_mojo_devices()
-    import test_opinfo
+    import test_opinfo  # noqa: PLC0415 -- importable only via the sys.path insert above
 
     return test_opinfo
 
@@ -180,8 +181,6 @@ def _device_token() -> str:
     not after "privateuse1" -- "mojo" for us -- so it is read from torch rather
     than spelled out here.
     """
-    import torch
-
     return str(torch._C._get_privateuse1_backend_name())
 
 
@@ -192,9 +191,10 @@ def _node_index(suite: ModuleType) -> dict[str, tuple[str, str, str]]:
     nothing has to be parsed back out of a node name whose operator token
     itself contains underscores.
     """
-    import known_unsupported
-    import torch
-    from torch.testing._internal.common_methods_invocations import op_db
+    import known_unsupported  # noqa: PLC0415 -- importable only via _import_suite's sys.path insert
+    from torch.testing._internal.common_methods_invocations import (  # noqa: PLC0415 -- pulls in common_device_type, which must not load before PYTORCH_TESTING_DEVICE_FOR_CUSTOM is set (conformance/conftest.py)
+        op_db,
+    )
 
     device = _device_token()
     index: dict[str, tuple[str, str, str]] = {}
@@ -356,7 +356,7 @@ def main() -> int:
         raise SystemExit("--no-run needs --records DIR from an earlier run")
 
     suite = _import_suite()
-    import known_unsupported
+    import known_unsupported  # noqa: PLC0415 -- importable only via _import_suite's sys.path insert
 
     accelerator = known_unsupported.accelerator_key()
     if args.write and accelerator != known_unsupported.BASE_ACCELERATOR:

--- a/current_bench/bench_gemm.py
+++ b/current_bench/bench_gemm.py
@@ -393,7 +393,10 @@ def main():
 
     register_mojo_devices()
     max_device = list(get_accelerators())[0]
-    from torch_mojo_backend.eager_kernels import _ctx_ptr, tensor_holder  # noqa: PLC0415 -- reading `tensor_holder` runs eager_kernels' module __getattr__, which builds (cold cache) and dlopens the extension
+    from torch_mojo_backend.eager_kernels import (  # noqa: PLC0415 -- reading `tensor_holder` runs eager_kernels' module __getattr__, which builds (cold cache) and dlopens the extension
+        _ctx_ptr,
+        tensor_holder,
+    )
 
     def mojo_synchronize():
         tensor_holder.synchronize(_ctx_ptr(max_device))

--- a/current_bench/bench_gemm.py
+++ b/current_bench/bench_gemm.py
@@ -393,7 +393,7 @@ def main():
 
     register_mojo_devices()
     max_device = list(get_accelerators())[0]
-    from torch_mojo_backend.eager_kernels import _ctx_ptr, tensor_holder
+    from torch_mojo_backend.eager_kernels import _ctx_ptr, tensor_holder  # noqa: PLC0415 -- reading `tensor_holder` runs eager_kernels' module __getattr__, which builds (cold cache) and dlopens the extension
 
     def mojo_synchronize():
         tensor_holder.synchronize(_ctx_ptr(max_device))

--- a/current_bench/bench_gpt2_504.py
+++ b/current_bench/bench_gpt2_504.py
@@ -13,6 +13,7 @@ import sys
 import time
 
 import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from torch_mojo_backend import register_mojo_devices
 
@@ -25,8 +26,6 @@ ITERS = 3
 
 
 def main():
-    from transformers import AutoModelForCausalLM, AutoTokenizer
-
     tok = AutoTokenizer.from_pretrained("gpt2")
     model = AutoModelForCausalLM.from_pretrained("gpt2").eval()
     ids = tok(PROMPT, return_tensors="pt").input_ids

--- a/current_bench/bench_gpt2_batch.py
+++ b/current_bench/bench_gpt2_batch.py
@@ -13,6 +13,7 @@ import sys
 import time
 
 import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from torch_mojo_backend import register_mojo_devices
 
@@ -27,8 +28,6 @@ ITERS = 3
 
 
 def main():
-    from transformers import AutoModelForCausalLM, AutoTokenizer
-
     tok = AutoTokenizer.from_pretrained("gpt2")
     model = AutoModelForCausalLM.from_pretrained("gpt2").eval().to(DEVICE)
     ids = tok(PROMPT, return_tensors="pt").input_ids

--- a/current_bench/bench_gpt2_compile.py
+++ b/current_bench/bench_gpt2_compile.py
@@ -22,6 +22,7 @@ import sys
 import time
 
 import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
 
 DEVICE = sys.argv[1]
 MODE = sys.argv[2]
@@ -38,8 +39,6 @@ if DEVICE == "mojo" or MODE.startswith("compile-max"):
 
 
 def main():
-    from transformers import AutoModelForCausalLM, AutoTokenizer
-
     tok = AutoTokenizer.from_pretrained("gpt2")
     model_kwargs = {}
     if MODE == "compile-max-eager-attn":

--- a/current_bench/bench_mfma_configs.py
+++ b/current_bench/bench_mfma_configs.py
@@ -133,7 +133,10 @@ def main():
     register_mojo_devices()
     device = list(get_accelerators())[0]
 
-    from torch_mojo_backend.eager_kernels import _ctx_ptr, tensor_holder  # noqa: PLC0415 -- reading `tensor_holder` runs eager_kernels' module __getattr__, which builds (cold cache) and dlopens the extension
+    from torch_mojo_backend.eager_kernels import (  # noqa: PLC0415 -- reading `tensor_holder` runs eager_kernels' module __getattr__, which builds (cold cache) and dlopens the extension
+        _ctx_ptr,
+        tensor_holder,
+    )
 
     ctx = _ctx_ptr(device)
     tuning = load_tuning_extension()

--- a/current_bench/bench_mfma_configs.py
+++ b/current_bench/bench_mfma_configs.py
@@ -11,8 +11,17 @@ from pathlib import Path
 from types import ModuleType
 
 import torch
+from max.dtype import DType
 
 from torch_mojo_backend import get_accelerators, register_mojo_devices
+from torch_mojo_backend.eager_kernels import (
+    _build_extension,
+    _load_extension,
+    _resolve_mojo_file,
+    _variant_module_name,
+)
+from torch_mojo_backend.eager_kernels.matmul_ops import MatmulExtension
+from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
 
 CONFIGS = {
     0: "bm32_bn64_wm16_wn32_bk32",
@@ -70,14 +79,6 @@ def load_tuning_extension() -> ModuleType:
     those two and none of the production kernels.  Building it here keeps this
     tuning harness off the dispatch path it is meant to measure.
     """
-    from torch_mojo_backend.eager_kernels import (
-        _build_extension,
-        _load_extension,
-        _resolve_mojo_file,
-        _variant_module_name,
-    )
-    from torch_mojo_backend.eager_kernels.matmul_ops import MatmulExtension
-
     source = _resolve_mojo_file(MatmulExtension.MOJO_FILE)
     return _load_extension(
         _variant_module_name(source, None), _build_extension(source, None)
@@ -131,10 +132,8 @@ def main():
 
     register_mojo_devices()
     device = list(get_accelerators())[0]
-    from max.dtype import DType
 
-    from torch_mojo_backend.eager_kernels import _ctx_ptr, tensor_holder
-    from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
+    from torch_mojo_backend.eager_kernels import _ctx_ptr, tensor_holder  # noqa: PLC0415 -- reading `tensor_holder` runs eager_kernels' module __getattr__, which builds (cold cache) and dlopens the extension
 
     ctx = _ctx_ptr(device)
     tuning = load_tuning_extension()

--- a/current_bench/bench_mojo.py
+++ b/current_bench/bench_mojo.py
@@ -11,6 +11,12 @@ import sys
 import time
 
 import torch
+from transformers import (
+    AutoModel,
+    AutoModelForCausalLM,
+    AutoModelForImageClassification,
+    AutoTokenizer,
+)
 
 from torch_mojo_backend import register_mojo_devices
 
@@ -44,15 +50,11 @@ def _bench_one(model, inputs, device):
 
 
 def _load_resnet():
-    from transformers import AutoModelForImageClassification
-
     m = AutoModelForImageClassification.from_pretrained("microsoft/resnet-18")
     return m, {"pixel_values": torch.randn(1, 3, 224, 224)}
 
 
 def _load_bert():
-    from transformers import AutoModel, AutoTokenizer
-
     tok = AutoTokenizer.from_pretrained("bert-base-uncased")
     m = AutoModel.from_pretrained("bert-base-uncased")
     return m, dict(
@@ -61,8 +63,6 @@ def _load_bert():
 
 
 def _load_gpt2():
-    from transformers import AutoModelForCausalLM, AutoTokenizer
-
     tok = AutoTokenizer.from_pretrained("gpt2")
     m = AutoModelForCausalLM.from_pretrained("gpt2")
     return m, dict(tok("The quick brown fox jumps over", return_tensors="pt"))

--- a/current_bench/bench_nanogpt_train.py
+++ b/current_bench/bench_nanogpt_train.py
@@ -57,7 +57,10 @@ def import_nanogpt(nanogpt_path: Path) -> tuple[type, type]:
         )
     if str(nanogpt_path) not in sys.path:
         sys.path.insert(0, str(nanogpt_path))
-    from model import GPT, GPTConfig  # noqa: PLC0415 -- nanoGPT, reachable only via the sys.path insert above
+    from model import (  # noqa: PLC0415 -- nanoGPT, reachable only via the sys.path insert above
+        GPT,
+        GPTConfig,
+    )
 
     return GPTConfig, GPT
 

--- a/current_bench/bench_nanogpt_train.py
+++ b/current_bench/bench_nanogpt_train.py
@@ -30,6 +30,8 @@ from pathlib import Path
 
 import torch
 
+from torch_mojo_backend import register_mojo_devices
+
 DEFAULT_NANOGPT_PATH = Path("/root/nanoGPT")
 
 # nanoGPT train.py defaults for the 124M single-GPU run.
@@ -55,7 +57,7 @@ def import_nanogpt(nanogpt_path: Path) -> tuple[type, type]:
         )
     if str(nanogpt_path) not in sys.path:
         sys.path.insert(0, str(nanogpt_path))
-    from model import GPT, GPTConfig
+    from model import GPT, GPTConfig  # noqa: PLC0415 -- nanoGPT, reachable only via the sys.path insert above
 
     return GPTConfig, GPT
 
@@ -202,8 +204,6 @@ def parse_args() -> argparse.Namespace:
 def main():
     args = parse_args()
     if args.device.startswith("mojo"):
-        from torch_mojo_backend import register_mojo_devices
-
         register_mojo_devices()
 
     dtype = DTYPES[args.dtype]

--- a/current_bench/profile_gpt2_generate_aten.py
+++ b/current_bench/profile_gpt2_generate_aten.py
@@ -333,7 +333,10 @@ def main():
             raise RuntimeError(f"Expected MAX accelerator 0 to be a GPU: {max_device}")
 
         def synchronize():
-            from torch_mojo_backend.eager_kernels import _ctx_ptr, tensor_holder  # noqa: PLC0415 -- reading `tensor_holder` runs eager_kernels' module __getattr__, which builds (cold cache) and dlopens the extension
+            from torch_mojo_backend.eager_kernels import (  # noqa: PLC0415 -- reading `tensor_holder` runs eager_kernels' module __getattr__, which builds (cold cache) and dlopens the extension
+                _ctx_ptr,
+                tensor_holder,
+            )
 
             tensor_holder.synchronize(_ctx_ptr(max_device))
 

--- a/current_bench/profile_gpt2_generate_aten.py
+++ b/current_bench/profile_gpt2_generate_aten.py
@@ -23,8 +23,12 @@ import time
 from pathlib import Path
 
 import torch
+import transformers
 from tabulate import tabulate
 from torch.profiler import ProfilerActivity, profile
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from torch_mojo_backend import get_accelerators, register_mojo_devices
 
 PROMPT = "Here is how quantum computing works: "
 
@@ -323,15 +327,13 @@ def main():
         execution_device = "cuda"
         synchronize = torch.cuda.synchronize
     else:
-        from torch_mojo_backend import get_accelerators, register_mojo_devices
-
         register_mojo_devices()
         max_device = list(get_accelerators())[0]
         if "gpu" not in str(max_device).lower():
             raise RuntimeError(f"Expected MAX accelerator 0 to be a GPU: {max_device}")
 
         def synchronize():
-            from torch_mojo_backend.eager_kernels import _ctx_ptr, tensor_holder
+            from torch_mojo_backend.eager_kernels import _ctx_ptr, tensor_holder  # noqa: PLC0415 -- reading `tensor_holder` runs eager_kernels' module __getattr__, which builds (cold cache) and dlopens the extension
 
             tensor_holder.synchronize(_ctx_ptr(max_device))
 
@@ -342,9 +344,6 @@ def main():
     dtype = {"bf16": torch.bfloat16, "fp16": torch.float16, "fp32": torch.float32}[
         args.dtype
     ]
-
-    import transformers
-    from transformers import AutoModelForCausalLM, AutoTokenizer
 
     print(
         "Environment: "

--- a/current_bench/profile_nanogpt_train_aten.py
+++ b/current_bench/profile_nanogpt_train_aten.py
@@ -38,8 +38,6 @@ import torch
 from tabulate import tabulate
 from torch.profiler import ProfilerActivity, profile
 
-from torch_mojo_backend import get_accelerators, register_mojo_devices
-
 from current_bench.bench_nanogpt_train import (
     DEFAULT_NANOGPT_PATH,
     DTYPES,
@@ -51,6 +49,7 @@ from current_bench.bench_nanogpt_train import (
     make_synchronize,
     training_step,
 )
+from torch_mojo_backend import get_accelerators, register_mojo_devices
 
 
 def self_gpu_us(event: object) -> float:

--- a/current_bench/profile_nanogpt_train_aten.py
+++ b/current_bench/profile_nanogpt_train_aten.py
@@ -38,6 +38,8 @@ import torch
 from tabulate import tabulate
 from torch.profiler import ProfilerActivity, profile
 
+from torch_mojo_backend import get_accelerators, register_mojo_devices
+
 from current_bench.bench_nanogpt_train import (
     DEFAULT_NANOGPT_PATH,
     DTYPES,
@@ -333,8 +335,6 @@ def main():
     if args.device == "cuda":
         execution_backend = f"PyTorch {vendor}"
     else:
-        from torch_mojo_backend import get_accelerators, register_mojo_devices
-
         register_mojo_devices()
         max_device = list(get_accelerators())[0]
         if "gpu" not in str(max_device).lower():

--- a/current_bench/run_hf_mojo.py
+++ b/current_bench/run_hf_mojo.py
@@ -12,6 +12,13 @@ import sys
 import traceback
 
 import torch
+from transformers import (
+    AutoModel,
+    AutoModelForCausalLM,
+    AutoModelForImageClassification,
+    AutoModelForSequenceClassification,
+    AutoTokenizer,
+)
 
 from torch_mojo_backend import register_mojo_devices
 
@@ -52,8 +59,6 @@ def _compare(model, inputs, extract):
 
 
 def run_bert():
-    from transformers import AutoModel, AutoTokenizer
-
     name = "bert-base-uncased"
     tok = AutoTokenizer.from_pretrained(name)
     model = AutoModel.from_pretrained(name)
@@ -62,8 +67,6 @@ def run_bert():
 
 
 def run_gpt2():
-    from transformers import AutoModelForCausalLM, AutoTokenizer
-
     name = "gpt2"
     tok = AutoTokenizer.from_pretrained(name)
     model = AutoModelForCausalLM.from_pretrained(name)
@@ -72,8 +75,6 @@ def run_gpt2():
 
 
 def run_distilbert():
-    from transformers import AutoModelForSequenceClassification, AutoTokenizer
-
     name = "distilbert-base-uncased-finetuned-sst-2-english"
     tok = AutoTokenizer.from_pretrained(name)
     model = AutoModelForSequenceClassification.from_pretrained(name)
@@ -82,8 +83,6 @@ def run_distilbert():
 
 
 def run_vit():
-    from transformers import AutoModelForImageClassification
-
     name = "google/vit-base-patch16-224"
     model = AutoModelForImageClassification.from_pretrained(name)
     inputs = {"pixel_values": torch.randn(1, 3, 224, 224)}
@@ -91,8 +90,6 @@ def run_vit():
 
 
 def run_resnet():
-    from transformers import AutoModelForImageClassification
-
     name = "microsoft/resnet-18"
     model = AutoModelForImageClassification.from_pretrained(name)
     inputs = {"pixel_values": torch.randn(1, 3, 224, 224)}

--- a/demo_scripts/gpt2.py
+++ b/demo_scripts/gpt2.py
@@ -6,6 +6,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch._dynamo import mark_dynamic
+from transformers import GPT2LMHeadModel
 
 from torch_mojo_backend import get_accelerators, mojo_backend
 
@@ -156,8 +157,6 @@ class GPT2(nn.Module):
         assert model_type in {"gpt2", "gpt2-medium", "gpt2-large", "gpt2-xl"}
         override_args = override_args or {}
         assert all(k == "dropout" for k in override_args)
-
-        from transformers import GPT2LMHeadModel
 
         print(f"loading weights from pretrained gpt: {model_type}")
 
@@ -316,7 +315,7 @@ class Tokenizer(Protocol):
 
 def load_tokenizer() -> Tokenizer:
     try:
-        import tiktoken
+        import tiktoken  # noqa: PLC0415 -- optional: the except branch below is a working fallback
 
         enc = tiktoken.get_encoding("gpt2")
         return enc

--- a/demo_scripts/nanogpt_ddp.py
+++ b/demo_scripts/nanogpt_ddp.py
@@ -98,7 +98,9 @@ def main():
     device = args.device
 
     if device == "mojo":
-        from torch_mojo_backend import register_mojo_devices  # noqa: PLC0415 -- optional, like the import at the top: --device cuda must run in a stock-torch venv
+        from torch_mojo_backend import (  # noqa: PLC0415 -- optional, like the import at the top: --device cuda must run in a stock-torch venv
+            register_mojo_devices,
+        )
 
         register_mojo_devices()
         backend = "mojo"
@@ -117,7 +119,9 @@ def main():
     # rank-offset seed for on-device randomness (dropout).
     torch.manual_seed(args.seed)
     if device == "mojo":
-        from torch_mojo_backend.mojo_device import torch_mojo_device_module  # noqa: PLC0415 -- same optional import as above
+        from torch_mojo_backend.mojo_device import (  # noqa: PLC0415 -- same optional import as above
+            torch_mojo_device_module,
+        )
 
         torch_mojo_device_module.manual_seed_all(args.seed + rank)
     else:

--- a/demo_scripts/nanogpt_ddp.py
+++ b/demo_scripts/nanogpt_ddp.py
@@ -98,7 +98,7 @@ def main():
     device = args.device
 
     if device == "mojo":
-        from torch_mojo_backend import register_mojo_devices
+        from torch_mojo_backend import register_mojo_devices  # noqa: PLC0415 -- optional, like the import at the top: --device cuda must run in a stock-torch venv
 
         register_mojo_devices()
         backend = "mojo"
@@ -117,14 +117,14 @@ def main():
     # rank-offset seed for on-device randomness (dropout).
     torch.manual_seed(args.seed)
     if device == "mojo":
-        from torch_mojo_backend.mojo_device import torch_mojo_device_module
+        from torch_mojo_backend.mojo_device import torch_mojo_device_module  # noqa: PLC0415 -- same optional import as above
 
         torch_mojo_device_module.manual_seed_all(args.seed + rank)
     else:
         torch.cuda.manual_seed_all(args.seed + rank)
 
     sys.path.insert(0, str(args.nanogpt_path))
-    from model import (  # ty: ignore[unresolved-import] -- nanoGPT, from --nanogpt-path
+    from model import (  # ty: ignore[unresolved-import] -- nanoGPT, from --nanogpt-path  # noqa: PLC0415 -- reachable only via the sys.path insert above
         GPT,
         GPTConfig,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ extend-select = [
     "UP",  # pyupgrade
     "ANN", # flake8-annotations: every function needs type hints (ty then checks them)
     "TID252", # relative imports (banned below)
+    "PLC0415", # imports at the top of the file (lazy ones need a noqa saying why)
 ]
 
 [tool.ruff.lint.isort]

--- a/scripts/compare_kernel_asm.py
+++ b/scripts/compare_kernel_asm.py
@@ -73,13 +73,13 @@ import shutil
 import subprocess
 import sys
 import textwrap
-
-import max as max_package
 import threading
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
+
+import max as max_package
 
 DEFAULT_KERNEL_DIR = Path("torch_mojo_backend/eager_kernels")
 SIDECAR_SUFFIXES = (".ptx", ".amdgcn", ".ll")

--- a/scripts/compare_kernel_asm.py
+++ b/scripts/compare_kernel_asm.py
@@ -73,6 +73,8 @@ import shutil
 import subprocess
 import sys
 import textwrap
+
+import max as max_package
 import threading
 import uuid
 from concurrent.futures import ThreadPoolExecutor
@@ -152,7 +154,6 @@ def mojo_cli() -> Path:
     candidates = []
     if sys.executable:  # None/'' in embedded interpreters
         candidates.append(Path(sys.executable).parent / "mojo")
-    import max as max_package
 
     for base in list(getattr(max_package, "__path__", ())):
         candidates.extend(parent / "bin" / "mojo" for parent in Path(base).parents)

--- a/tests/comm_fence_overhead.py
+++ b/tests/comm_fence_overhead.py
@@ -16,10 +16,11 @@ import time
 
 import torch
 
+from torch_mojo_backend.mojo_device import register, torch_mojo_device_module
+from torch_mojo_backend.mojo_device.register import _fence_pending_collectives
+
 
 def _time_add(x: torch.Tensor, y: torch.Tensor, iterations: int) -> float:
-    from torch_mojo_backend.mojo_device import torch_mojo_device_module
-
     start = time.perf_counter()
     for _ in range(iterations):
         torch.add(x, y)
@@ -28,8 +29,6 @@ def _time_add(x: torch.Tensor, y: torch.Tensor, iterations: int) -> float:
 
 
 def _time_wrapper_frame(x: torch.Tensor) -> float:
-    from torch_mojo_backend.mojo_device.register import _fence_pending_collectives
-
     def target(a: object, b: object) -> object:
         return a
 
@@ -47,8 +46,6 @@ def _time_wrapper_frame(x: torch.Tensor) -> float:
 
 
 def main():
-    from torch_mojo_backend.mojo_device import register
-
     if "--no-hook" in sys.argv:
         # The wrapper is applied by register_mojo_devices()'s install loop
         # through this global, so the identity gives the same process minus

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,11 @@ from max.dtype import DType
 from mojo.paths import _build_mojo_source_package
 
 from torch_mojo_backend import get_accelerators, register_mojo_devices
+from torch_mojo_backend.mojo_device.torch_mojo_tensor import (
+    TorchMojoTensor,
+    _row_major_strides,
+    _torch_dtype_of,
+)
 from torch_mojo_backend.testing import CallChecker, Conf
 from torch_mojo_backend.torch_compile_backend import compiler
 
@@ -127,11 +132,6 @@ def fake_mojo_tensor() -> Callable[..., torch.Tensor]:
     exercised on a machine with no GPU. The pointer is never dereferenced:
     such tests replace the native `call` entry point.
     """
-    from torch_mojo_backend.mojo_device.torch_mojo_tensor import (
-        TorchMojoTensor,
-        _row_major_strides,
-        _torch_dtype_of,
-    )
 
     def make(
         device: Device,

--- a/tests/ddp_worker.py
+++ b/tests/ddp_worker.py
@@ -20,6 +20,8 @@ import torch
 import torch.distributed as dist
 from torch.nn.parallel import DistributedDataParallel as DDP
 
+from torch_mojo_backend import register_mojo_devices
+
 
 class ElemwiseNet(torch.nn.Module):
     """Matmul-free so it runs even where GEMM routes are unavailable."""
@@ -215,7 +217,6 @@ def run_lazy_fence(failures: list[str]):
 
 def main():
     mode = sys.argv[1]
-    from torch_mojo_backend import register_mojo_devices
 
     register_mojo_devices()
     dist.init_process_group(backend="mojo", timeout=datetime.timedelta(seconds=300))

--- a/tests/test_aten_functions.py
+++ b/tests/test_aten_functions.py
@@ -13,6 +13,8 @@ from torch._dynamo.exc import BackendCompilerFailed
 from torch.ops import aten  # ty: ignore[unresolved-import]
 
 from torch_mojo_backend import aten_functions, mojo_backend, register_mojo_devices
+from torch_mojo_backend.eager_kernels import aten_fast
+from torch_mojo_backend.mojo_device.mojo_device_aten_ops import EAGER_CALL_COUNTERS
 from torch_mojo_backend.testing import (
     CallChecker,
     Conf,
@@ -374,8 +376,6 @@ def test_native_batch_norm_legit_no_training_2d_input(device: str):
 
 def test_aten_native_batch_norm_inference(conf: Conf, call_checker: CallChecker):
     """Test aten.native_batch_norm in inference mode (training=False)."""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     call_checker.register(
         aten_functions.aten_native_batch_norm, aten_fast.fast_aten_native_batch_norm
     )
@@ -419,8 +419,6 @@ def test_aten_native_layer_norm_basic(
     conf: Conf, dtype: torch.dtype, call_checker: CallChecker
 ):
     """Test aten.native_layer_norm returns (output, mean, rstd)"""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     call_checker.register(
         aten_functions.aten_native_layer_norm, aten_fast.fast_aten_native_layer_norm
     )
@@ -466,8 +464,6 @@ def test_aten_native_layer_norm_different_eps(
     conf: Conf, eps: float, call_checker: CallChecker
 ):
     """Test aten.native_layer_norm with different epsilon values"""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     call_checker.register(
         aten_functions.aten_native_layer_norm, aten_fast.fast_aten_native_layer_norm
     )
@@ -1848,8 +1844,6 @@ def test_aten_addr_basic(conf: Conf, dtype: torch.dtype, call_checker: CallCheck
     and ..._bfloat16. beta/alpha values below match the failing OpInfo
     sample exactly.
     """
-    from torch_mojo_backend.mojo_device.mojo_device_aten_ops import EAGER_CALL_COUNTERS
-
     call_checker.register(EAGER_CALL_COUNTERS["aten::addr"])
 
     def fn(self, vec1, vec2):
@@ -1867,8 +1861,6 @@ def test_aten_addr_default_beta_alpha(
     conf: Conf, dtype: torch.dtype, call_checker: CallChecker
 ):
     """aten.addr with default beta=alpha=1 (self + outer(vec1, vec2))."""
-    from torch_mojo_backend.mojo_device.mojo_device_aten_ops import EAGER_CALL_COUNTERS
-
     call_checker.register(EAGER_CALL_COUNTERS["aten::addr"])
 
     def fn(self, vec1, vec2):
@@ -1884,8 +1876,6 @@ def test_aten_addr_default_beta_alpha(
 def test_aten_addr_beta_zero(conf: Conf, call_checker: CallChecker):
     """beta=0 must ignore `self` entirely, including nan/inf in it (matches
     ATen's own addr contract, see aten/src/ATen/native/LinearAlgebra.cpp)."""
-    from torch_mojo_backend.mojo_device.mojo_device_aten_ops import EAGER_CALL_COUNTERS
-
     call_checker.register(EAGER_CALL_COUNTERS["aten::addr"])
 
     def fn(self, vec1, vec2):
@@ -1903,8 +1893,6 @@ def test_aten_addr_self_broadcast(conf: Conf, call_checker: CallChecker):
     shape (here: 0-d): the fast path's own right-alignment handles this
     directly (see `fast_aten_addr`), so this still goes through the fused
     kernel, not the composite fallback -- verified via call_checker."""
-    from torch_mojo_backend.mojo_device.mojo_device_aten_ops import EAGER_CALL_COUNTERS
-
     call_checker.register(EAGER_CALL_COUNTERS["aten::addr"])
 
     def fn(self, vec1, vec2):
@@ -3993,8 +3981,6 @@ def test_fill_scalar_basic(
     call_checker: CallChecker,
 ):
     """Test basic fill.Scalar functionality with different dtypes, shapes, and values"""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     call_checker.register(
         aten_functions.aten_fill_scalar, aten_fast.fast_aten_fill_scalar
     )
@@ -4019,8 +4005,6 @@ def test_fill_scalar_integer_dtypes(
     call_checker: CallChecker,
 ):
     """Test fill.Scalar functionality with integer dtypes"""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     call_checker.register(
         aten_functions.aten_fill_scalar, aten_fast.fast_aten_fill_scalar
     )
@@ -4037,8 +4021,6 @@ def test_fill_scalar_integer_dtypes(
 @pytest.mark.parametrize("value", [-5, 100])
 def test_fill_scalar_integer_values(conf: Conf, value: int, call_checker: CallChecker):
     """Test fill.Scalar with integer values"""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     call_checker.register(
         aten_functions.aten_fill_scalar, aten_fast.fast_aten_fill_scalar
     )
@@ -4054,8 +4036,6 @@ def test_fill_scalar_integer_values(conf: Conf, value: int, call_checker: CallCh
 
 def test_fill_scalar_single_element(conf: Conf, call_checker: CallChecker):
     """Test fill.Scalar with single element tensor"""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     call_checker.register(
         aten_functions.aten_fill_scalar, aten_fast.fast_aten_fill_scalar
     )
@@ -4083,8 +4063,6 @@ def test_fill_scalar_zero_dim(conf: Conf):
 
 def test_fill__scalar_inplace(conf: Conf, call_checker: CallChecker):
     """Test fill_.Scalar fills tensor in-place"""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     call_checker.register(
         aten_functions.aten_fill__scalar, aten_fast.fast_aten_fill__scalar
     )
@@ -4290,8 +4268,6 @@ def test_aten_erf_basic(conf: Conf, dtype: torch.dtype):
 
 
 def test_aten__unsafe_view(conf: Conf, call_checker: CallChecker):
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     call_checker.register(
         aten_functions.aten__unsafe_view, aten_fast.fast_aten__unsafe_view
     )
@@ -4307,8 +4283,6 @@ def test_aten__unsafe_view(conf: Conf, call_checker: CallChecker):
 def test_aten__unsafe_view_dtypes(
     conf: Conf, dtype: torch.dtype, call_checker: CallChecker
 ):
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     call_checker.register(
         aten_functions.aten__unsafe_view, aten_fast.fast_aten__unsafe_view
     )

--- a/tests/test_call_queue.py
+++ b/tests/test_call_queue.py
@@ -21,15 +21,17 @@ import weakref
 from collections import deque
 from collections.abc import Iterator
 from pathlib import Path
+from types import SimpleNamespace
 from typing import cast
 
 import pytest
 import torch
 
+import torch_mojo_backend
 from torch_mojo_backend import TorchMojoTensor, eager_kernels, get_accelerators
 from torch_mojo_backend.eager_kernels import aten_fast, call_queue
 from torch_mojo_backend.eager_kernels.output_specs import _TensorOutputSpec
-from torch_mojo_backend.mojo_device import torch_mojo_device_module
+from torch_mojo_backend.mojo_device import torch_mojo_device_module, torch_mojo_tensor
 
 
 @pytest.fixture(autouse=True)
@@ -438,10 +440,6 @@ def test_failed_allocation_drains_synchronizes_and_retries_once(
     the queue (releasing what its items retain), synchronizes the device so
     the stream-ordered frees land, and retries exactly once. Non-OOM errors
     and a second failure propagate untouched."""
-    from types import SimpleNamespace
-
-    from torch_mojo_backend.mojo_device import torch_mojo_tensor
-
     synced: list[bool] = []
     device = SimpleNamespace(
         default_stream=SimpleNamespace(synchronize=lambda: synced.append(True))
@@ -503,7 +501,6 @@ def test_budget_is_computed_from_free_device_memory(
     """Without the env override, the bound adapts to the device: half the
     smallest free-VRAM figure across the accelerators, floored at 1 GiB,
     falling back to 8 GiB when nothing can report memory statistics."""
-    import torch_mojo_backend
 
     class _FakeAccelerator:
         def __init__(self, free: int):

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -17,6 +17,8 @@ import torch
 import torch.distributed as dist
 
 from torch_mojo_backend import get_accelerators, register_mojo_devices
+from torch_mojo_backend.distributed import nccl
+from torch_mojo_backend.distributed.process_group import _nccl_dtype, _nccl_red_op
 
 _WORKER = Path(__file__).parent / "ddp_worker.py"
 _OVERHEAD_WORKER = Path(__file__).parent / "comm_fence_overhead.py"
@@ -33,9 +35,6 @@ def test_backend_name_registered():
 
 
 def test_nccl_dtype_and_op_maps():
-    from torch_mojo_backend.distributed import nccl
-    from torch_mojo_backend.distributed.process_group import _nccl_dtype, _nccl_red_op
-
     assert _nccl_dtype(torch.bfloat16) == nccl.NCCL_BFLOAT16 == 9
     assert _nccl_dtype(torch.float32) == nccl.NCCL_FLOAT32 == 7
     assert _nccl_dtype(torch.int64) == nccl.NCCL_INT64 == 4

--- a/tests/test_eager_kernel_loader.py
+++ b/tests/test_eager_kernel_loader.py
@@ -4,14 +4,17 @@ import inspect
 import subprocess
 from collections import deque
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from types import ModuleType
 from typing import Protocol, cast
 
 import pytest
+from max.driver import CPU
+from max.dtype import DType
 
 from torch_mojo_backend import eager_kernels
+from torch_mojo_backend.eager_kernels import aten_fast
 
 
 class _NativeCallModule(Protocol):
@@ -465,13 +468,6 @@ def test_spec_descriptor_canonical_defines_match_make_defines():
     """The memoized canonical defines must stay field-for-field equal to the
     literal ``make_defines`` dicts: the define-gate scanner reads the dicts,
     the hot path uses the memo, and the two must never drift."""
-    from dataclasses import dataclass, field
-
-    from max.driver import CPU
-    from max.dtype import DType
-
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     cpu = CPU()
 
     @dataclass

--- a/tests/test_eager_kernels.py
+++ b/tests/test_eager_kernels.py
@@ -13,7 +13,15 @@ import torch
 from max.driver import CPU
 from torch.testing._internal.common_methods_invocations import op_db
 
-from torch_mojo_backend import TorchMojoTensor, get_accelerators, register_mojo_devices
+from torch_mojo_backend import (
+    TorchMojoTensor,
+    eager_kernels,
+    get_accelerators,
+    register_mojo_devices,
+)
+from torch_mojo_backend.eager_flash_attention import load_fa4_ops
+from torch_mojo_backend.eager_kernels import _ctx_ptr, aten_fast
+from torch_mojo_backend.mojo_device.mojo_device_aten_ops import EAGER_CALL_COUNTERS
 
 pytestmark = pytest.mark.xdist_group(name="group1")
 
@@ -64,8 +72,6 @@ def _spy_defined_native_calls(
     monkeypatch: pytest.MonkeyPatch, targets: set[tuple[str, str]]
 ) -> dict[tuple[str, str], list[tuple[tuple[object, ...], dict[str, object]]]]:
     """Observe descriptor calls at the stable one-function native ABI."""
-    from torch_mojo_backend import eager_kernels
-
     calls = {target: [] for target in targets}
     original_load = eager_kernels.MOJO_EXTENSION_LOADER.load_canonical
 
@@ -97,8 +103,6 @@ def _replace_defined_native_calls(
     replacements: dict[tuple[str, str], Callable[..., object]],
 ):
     """Replace selected constant `call` entry points without compiling them."""
-    from torch_mojo_backend import eager_kernels
-
     original_load = eager_kernels.MOJO_EXTENSION_LOADER.load_canonical
 
     def load_canonical(
@@ -1398,8 +1402,6 @@ def test_fast_native_layer_norm_fp32_gpu_optional_affine_without_fill(
     mojo_gpu, monkeypatch, has_weight, has_bias, input_shape, normalized_shape, eps
 ):
     """The direct GPU ABI handles optional affine tensors without stand-ins."""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     generator = torch.Generator().manual_seed(20260720)
     numel = math.prod(input_shape)
     cols = math.prod(normalized_shape)
@@ -1451,8 +1453,6 @@ def test_fast_native_layer_norm_gpu_prologue_runs_without_a_gpu(
     runs the same prologue with no device at all, so the whole matrix is
     checked everywhere the suite runs.
     """
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     device = SimpleNamespace(label="gpu")
     next_ptr = iter(range(300, 400))
 
@@ -2130,9 +2130,6 @@ def test_fast_native_layer_norm_backward_output_masks(
 def test_fast_native_layer_norm_backward_rejects_metadata_before_materializing(
     mojo_gpu, monkeypatch, invalid
 ):
-    from torch_mojo_backend.eager_kernels import aten_fast
-    from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
-
     rows, cols = 3, 4
     # Keep every kernel input noncontiguous so an accidental materialization
     # after incomplete validation is observable.
@@ -2178,8 +2175,6 @@ def test_fast_native_layer_norm_backward_rejects_metadata_before_materializing(
 
 
 def test_fast_native_layer_norm_backward_empty_rows(mojo_gpu):
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     cols = 65
     input = torch.empty(0, cols).to(mojo_gpu)
     grad_output = torch.empty_like(input)
@@ -2205,8 +2200,6 @@ def test_fast_native_layer_norm_backward_empty_rows(mojo_gpu):
 
 @pytest.mark.parametrize("affine", [False, True])
 def test_fast_layer_norm_training_backward(mojo_gpu, affine):
-    from torch_mojo_backend.mojo_device.mojo_device_aten_ops import EAGER_CALL_COUNTERS
-
     generator = torch.Generator().manual_seed(20260718)
     shape = (2, 16, 384)
     input = torch.randn(shape, generator=generator)
@@ -2393,8 +2386,6 @@ def test_fast_layer_norm_backward_allows_mutated_forward_output(mojo_gpu):
 
 
 def test_fast_native_layer_norm_rejects_wrong_affine_shape(mojo_gpu, monkeypatch):
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     input = torch.randn(2, 2, 3).to(mojo_gpu)
     wrong_shape_same_numel = torch.randn(6).to(mojo_gpu)
     bias = torch.randn(2, 3).to(mojo_gpu)
@@ -2508,8 +2499,6 @@ def _decode_philox_rng_state(state: torch.Tensor) -> tuple[int, int]:
 
 
 def test_fast_native_dropout_reserves_exact_full_width_interval(mojo_gpu, monkeypatch):
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     calls = []
     _replace_defined_native_calls(
         monkeypatch,
@@ -2546,8 +2535,6 @@ def test_fast_native_dropout_reserves_exact_full_width_interval(mojo_gpu, monkey
 def test_fast_native_dropout_reservation_wrap_does_not_mutate_state(
     mojo_gpu, monkeypatch
 ):
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     calls = []
     _replace_defined_native_calls(
         monkeypatch,
@@ -2572,9 +2559,6 @@ def test_fast_native_dropout_reservation_wrap_does_not_mutate_state(
 def test_fast_native_dropout_invalid_probability_does_not_touch_rng_or_input(
     mojo_gpu, monkeypatch, p
 ):
-    from torch_mojo_backend.eager_kernels import aten_fast
-    from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
-
     input = torch.randn(3, 8).to(mojo_gpu)[:, ::2]
     _torch_mojo().manual_seed_all(20260718)
     before = _torch_mojo().get_rng_state(input.device)
@@ -2603,8 +2587,6 @@ def test_fast_native_dropout_backward_multiplication_semantics(mojo_gpu):
 
 
 def test_fast_native_dropout_training_backward_and_saved_mask(mojo_gpu):
-    from torch_mojo_backend.mojo_device.mojo_device_aten_ops import EAGER_CALL_COUNTERS
-
     generator = torch.Generator().manual_seed(20260718)
     input = torch.randn(3, 17, generator=generator).to(mojo_gpu).requires_grad_()
     grad_output = torch.randn(3, 17, generator=generator)
@@ -3047,8 +3029,6 @@ def test_fast_l2_norm_out_and_mul_inplace_alias(mojo_gpu):
 
 
 def _eager_registration_snapshot(op_name):
-    from torch_mojo_backend.mojo_device.mojo_device_aten_ops import EAGER_CALL_COUNTERS
-
     assert op_name in EAGER_CALL_COUNTERS, f"missing eager registration for {op_name}"
     counter = EAGER_CALL_COUNTERS[op_name]
     return counter, counter.call_count
@@ -3855,8 +3835,6 @@ def test_fast_embedding_dense_backward_strided_temporary_lifetime(
     mojo_gpu, monkeypatch
 ):
     """Internal contiguous copies may die once their launches are enqueued."""
-    from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
-
     num_weights = 13
     padding_idx = 5
     indices_storage = torch.tensor(
@@ -3897,8 +3875,6 @@ def test_fast_embedding_dense_backward_strided_temporary_lifetime(
 
 def test_fast_embedding_dense_backward_host_bridge_abi(mojo_gpu, monkeypatch):
     """The host forwards nine runtime arguments and the tensor's own context."""
-    from torch_mojo_backend.eager_kernels import _ctx_ptr, aten_fast
-
     grad_storage = torch.arange(2 * 3 * 5 + 3, dtype=torch.float32).to(mojo_gpu)
     index_storage = torch.tensor([99, 99, 1, 2, 1, 4, 2, 7], dtype=torch.int64).to(
         mojo_gpu
@@ -4085,7 +4061,7 @@ def test_fast_gelu_forward_bf16_direct_runtime_layout(
     mojo_gpu, monkeypatch, approximate, storage_offset, shape
 ):
     """The direct BF16 bridge covers aligned and two-byte-offset tails."""
-    from torch_mojo_backend.eager_kernels.aten_fast import _ctx_ptr
+    _ctx_ptr = aten_fast._ctx_ptr
 
     elements = math.prod(shape)
     backing = torch.linspace(-8.0, 8.0, elements + storage_offset, dtype=torch.bfloat16)
@@ -4321,8 +4297,6 @@ def test_fast_gelu_forward_invalid_mode_rejects_before_materialization(
     mojo_gpu, monkeypatch
 ):
     """Invalid metadata is rejected before tensor or output work begins."""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     input = torch.randn(17, dtype=torch.bfloat16).to(mojo_gpu)
 
     def reject_work(*_args, **_kwargs):
@@ -4460,9 +4434,6 @@ def test_fast_gelu_backward_rejects_mixed_dtype_before_materialization(
     mojo_h100, monkeypatch
 ):
     """A mismatched dtype must return NOT_HANDLED without touching storage."""
-    from torch_mojo_backend.eager_kernels import aten_fast
-    from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
-
     input = torch.randn(17, dtype=torch.bfloat16).to(mojo_h100)
     grad_output = torch.randn(17, dtype=torch.float32).to(mojo_h100)
 
@@ -5073,11 +5044,9 @@ def test_fast_argreduce_strided_axis(mojo_gpu: str, shape: tuple[int, ...], dim:
 def test_fast_argreduce_strided_direct_gate_matches_the_kernel_regime(mojo_gpu: str):
     """The Python gate and the Mojo kernel must agree about which layouts go
     in place: a queued launch cannot fall back."""
-    from torch_mojo_backend.eager_kernels.aten_fast import (
-        _ARG_DIRECT_MIN_INNER,
-        _arg_strided_direct_ok,
-        _t,
-    )
+    _ARG_DIRECT_MIN_INNER = aten_fast._ARG_DIRECT_MIN_INNER
+    _arg_strided_direct_ok = aten_fast._arg_strided_direct_ok
+    _t = aten_fast._t
 
     contiguous = _t(torch.randn(8, _ARG_DIRECT_MIN_INNER).to(mojo_gpu))
     assert contiguous is not None
@@ -6085,8 +6054,6 @@ def test_fast_cross_entropy_training_uses_direct_nll_kernel(
 
 
 def test_fast_nll_loss_autograd_uses_saved_tensor_hooks(mojo_gpu):
-    from torch_mojo_backend.mojo_device.mojo_device_aten_ops import EAGER_CALL_COUNTERS
-
     log_probs = torch.log_softmax(torch.randn(7, 11), dim=-1)
     target = torch.arange(7, dtype=torch.int64) % 11
     grad_output = torch.randn(())
@@ -6224,8 +6191,6 @@ def test_fast_linear_single_token(mojo_device, dtype):
 
 @pytest.mark.parametrize("with_bias", [False, True])
 def test_fast_linear_training_backward(mojo_gpu, with_bias):
-    from torch_mojo_backend.mojo_device.mojo_device_aten_ops import EAGER_CALL_COUNTERS
-
     generator = torch.Generator().manual_seed(20260718)
     x = torch.randn(2, 16, 32, generator=generator)
     weight = torch.randn(64, 32, generator=generator)
@@ -6279,8 +6244,6 @@ def test_fast_linear_training_backward(mojo_gpu, with_bias):
 def test_fast_linear_native_backward_honors_output_mask_helper_calls(
     mojo_h100, monkeypatch, requires_grad, expected_mm_calls, expected_sum_calls
 ):
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     mm_calls = 0
     sum_calls = 0
     original_mm = aten_fast.fast_aten_mm
@@ -6459,14 +6422,10 @@ def test_fast_addmm_gpt2_batch32(mojo_gpu, in_features, out_features):
 
 
 def test_tf32_module_is_available_for_lazy_import():
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     assert aten_fast._Tf32MatmulExtension.MOJO_FILE.name == "tf32_matmul_ops.mojo"
 
 
 def test_bf16_module_is_available_for_lazy_import():
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     assert aten_fast._Gemm16MatmulExtension.MOJO_FILE.name == "gemm16_matmul_ops.mojo"
 
 
@@ -6476,8 +6435,6 @@ def test_big_smem_gemm_routes_stage_in_dynamic_shared_memory():
     `mojo build` on the first kernel over the line, so every GEMM route
     needing more carves `external_memory` and opts in per launch with
     MAX_DYNAMIC_SHARED_SIZE_BYTES."""
-    from torch_mojo_backend import eager_kernels
-
     for relative in (
         "gemm16_matmul_ops/gemm16_nn_v4_kernels.mojo",
         "gemm16_matmul_ops/gemm16_bmm_v5_kernels.mojo",
@@ -6504,8 +6461,6 @@ def test_big_smem_gemm_routes_stage_in_dynamic_shared_memory():
 
 def test_bf16_v3_source_dependency_and_kernel_contract():
     """The lazy bridge includes v3 while v2 remains its explicit fallback."""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     assert [path.name for path in aten_fast._GEMM16_SOURCE_PATHS] == [
         "gemm16_matmul_ops.mojo",
         "gemm16_v3_kernels.mojo",
@@ -6583,9 +6538,6 @@ def test_bf16_unavailable_bridge_falls_back_before_allocation(
     monkeypatch, operation, failure_mode
 ):
     """Missing sources skip early; a compiler failure is memoized and raised."""
-    from torch_mojo_backend import eager_kernels
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     device = SimpleNamespace(label="gpu", api="cuda", architecture_name="sm_90a")
 
     def tensor(shape):
@@ -6650,8 +6602,6 @@ def test_bf16_unavailable_bridge_falls_back_before_allocation(
 
 def test_bf16_matmul_family_precedes_tf32_and_tensorspec(monkeypatch):
     """Every eligible public entry point gives BF16 the first opportunity."""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     lhs, rhs, bias, weight = (
         _opaque_tensor(),
         _opaque_tensor(),
@@ -6704,8 +6654,6 @@ def test_gemm16_alignment_favors_split_helper(monkeypatch):
     """The cheap pre-check gemm16's bias split relies on: every v3/v4
     tensor-core route needs m, n, and k each a multiple of 64, so a shape
     missing that can never benefit from splitting the mm from the bias."""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     monkeypatch.setattr(aten_fast, "_t", lambda value: value)
 
     def tensor(shape):
@@ -6737,7 +6685,6 @@ def test_addmm_skips_split_for_misaligned_shapes(monkeypatch):
     with no benefit.  Regression guard for the ~5us-per-launch tax that
     turned this exact shape's f16 addmm from an already-good <1.0x ratio
     into a 1.25-1.65x regression before this gate existed."""
-    from torch_mojo_backend.eager_kernels import aten_fast
 
     def tensor(shape):
         return SimpleNamespace(_shape=tuple(shape))
@@ -6765,7 +6712,6 @@ def test_addmm_tries_split_for_aligned_shapes(monkeypatch):
     """A 64-aligned addmm shape (unlike S5) does try the bias-free mm plus
     a separate add first, since it could plausibly reach a fast gemm16
     route -- see _gemm16_alignment_favors_split."""
-    from torch_mojo_backend.eager_kernels import aten_fast
 
     def tensor(shape):
         return SimpleNamespace(_shape=tuple(shape))
@@ -6798,9 +6744,6 @@ def test_tf32_unavailable_bridge_falls_back_before_allocation(
     monkeypatch, operation, failure_mode
 ):
     """Missing sources skip early; a compiler failure is memoized and raised."""
-    from torch_mojo_backend import eager_kernels
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     device = SimpleNamespace(label="gpu", api="cuda", architecture_name="sm_90a")
 
     def tensor(shape):
@@ -6866,8 +6809,6 @@ def test_tf32_unavailable_bridge_falls_back_before_allocation(
 
 def test_tf32_matmul_family_prefers_opt_in_routes(monkeypatch):
     """Eligible public matmul calls return before the TensorSpec fallback."""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     lhs, rhs, bias, weight = (
         _opaque_tensor(),
         _opaque_tensor(),
@@ -6919,9 +6860,6 @@ def test_tf32_matmul_family_highest_retains_tensorspec_fallback(monkeypatch):
     _gemm16_alignment_favors_split -- does inspect operand shapes via `_t`
     even here; that's a deliberate, cheap `isinstance` check, not the
     expensive TF32-extension import this test actually guards.)"""
-    from torch_mojo_backend import eager_kernels
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     lhs, rhs, bias, input, weight = (_opaque_tensor() for _ in range(5))
     fallback = object()
     spec_calls = []
@@ -6965,10 +6903,6 @@ def test_tf32_matmul_family_highest_retains_tensorspec_fallback(monkeypatch):
 def test_matmul_spec_device_oom_is_not_disguised_as_unsupported(
     monkeypatch, fake_mojo_tensor
 ):
-    from torch_mojo_backend import eager_kernels
-    from torch_mojo_backend.eager_kernels import aten_fast
-    from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
-
     device = CPU()
 
     def fake_tensor(shape: tuple[int, ...]) -> TorchMojoTensor:
@@ -7006,8 +6940,6 @@ def test_matmul_spec_device_oom_is_not_disguised_as_unsupported(
 
 
 def test_tf32_addmm_scalars_retain_existing_not_handled_contract(monkeypatch):
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     calls = []
     monkeypatch.setattr(
         aten_fast, "_try_gemm16_mm", lambda *args, **kwargs: calls.append("gemm16")
@@ -7029,8 +6961,6 @@ def test_tf32_addmm_scalars_retain_existing_not_handled_contract(monkeypatch):
 
 
 def test_tf32_linear_flattens_contiguous_gpt_input_as_zero_copy_view(monkeypatch):
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     input, weight, bias = _opaque_tensor(), _opaque_tensor(), _opaque_tensor()
     holder = object()
     input_metadata = SimpleNamespace(
@@ -7071,8 +7001,6 @@ def test_tf32_linear_flattens_contiguous_gpt_input_as_zero_copy_view(monkeypatch
 
 
 def test_tf32_linear_noncontiguous_batch_retains_tensorspec_path(monkeypatch):
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     input, weight = _opaque_tensor(), _opaque_tensor()
     input_metadata = SimpleNamespace(_shape=(2, 3, 8), _is_contiguous=False)
     weight_metadata = SimpleNamespace(_shape=(11, 8))
@@ -7102,8 +7030,6 @@ def test_sdpa_forward_tf32_bmm_routing_preserves_raw_fallback(
     monkeypatch, tf32_available, dropout_p
 ):
     """Both SDPA BMMs route the effective probabilities in every dropout mode."""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     device = SimpleNamespace(label="gpu")
     next_ptr = iter(range(100, 200))
 
@@ -7241,8 +7167,6 @@ def test_bf16_gemm_host_bridge_layouts_offsets_context_and_highest(
     monkeypatch, lhs_transposed, rhs_transposed, transpose_b
 ):
     """BF16 preserves dense views and is independent of FP32 policy."""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     device = SimpleNamespace(id=7, label="gpu", api="cuda", architecture_name="sm_90a")
     m, n, k = 6, 7, 5
 
@@ -7354,8 +7278,6 @@ def test_bf16_gemm_host_bridge_layouts_offsets_context_and_highest(
 
 def test_bf16_gemm_no_bias_uses_ignored_output_pointer(monkeypatch):
     """The 11-argument ABI always receives a valid fourth pointer."""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     device = SimpleNamespace(label="gpu", api="cuda", architecture_name="sm_90a")
 
     def tensor(shape, ptr):
@@ -7418,8 +7340,6 @@ def test_gemm16_float16_mm_matches_fp32_reference_on_every_layout(
     FP32, so a 333-deep contraction stays near 1e-3 relative.  A kernel that
     accumulated in float16 instead would miss it by an order of magnitude.
     """
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     m, n, k = 357, 789, 333  # awkward on purpose: exercises the edge tiles
     a, b = _gemm16_operands(layout, m, n, k, torch.float16, mojo_h100)
 
@@ -7443,8 +7363,6 @@ def test_gemm16_float16_every_entry_point_launches_the_bridge(
     mojo_h100: torch.device, monkeypatch: pytest.MonkeyPatch, op: str
 ):
     """mm / addmm / linear / bmm all route float16 through the same bridge."""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     m, n, k, batch = 64, 96, 128, 3
     calls = _spy_defined_native_calls(
         monkeypatch,
@@ -7494,8 +7412,6 @@ def test_gemm16_float16_and_bfloat16_are_separate_specializations(
     Mixing the two dtypes in one call must decline rather than reinterpret the
     operand bits, which have different exponent widths.
     """
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     calls = _spy_defined_native_calls(
         monkeypatch, {("gemm16_matmul_ops.mojo", "Gemm16")}
     )
@@ -7513,8 +7429,6 @@ def test_gemm16_float16_and_bfloat16_are_separate_specializations(
 
 def test_gemm16_float16_linear_backward_matches_fp32_reference(mojo_h100: torch.device):
     """linear_backward's dgrad/wgrad pair is the NN and TN route in float16."""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     rows, in_features, out_features = 128, 192, 96
 
     def half(*shape: int) -> torch.Tensor:
@@ -7577,8 +7491,6 @@ def test_gemm16_float16_linear_backward_matches_fp32_reference(mojo_h100: torch.
 def test_bf16_gemm_rejects_invalid_metadata_before_resolve_or_allocation(
     monkeypatch, invalid_case
 ):
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     h100 = SimpleNamespace(id=0, label="gpu", api="cuda", architecture_name="sm_90a")
     other = SimpleNamespace(id=1, label="gpu", api="cuda", architecture_name="sm_90a")
 
@@ -7658,8 +7570,6 @@ def test_bf16_gemm_rejects_invalid_metadata_before_resolve_or_allocation(
 
 
 def test_bf16_linear_flattens_contiguous_gpt_input_without_precision_query(monkeypatch):
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     input, weight, bias = _opaque_tensor(), _opaque_tensor(), _opaque_tensor()
     holder = object()
     input_metadata = SimpleNamespace(
@@ -7718,8 +7628,6 @@ def test_bf16_linear_flattens_contiguous_gpt_input_without_precision_query(monke
 def test_bf16_bmm_host_bridge_padded_layouts_offsets_and_logical_transpose(
     monkeypatch, lhs_transposed, rhs_transposed, transpose_b
 ):
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     device = SimpleNamespace(id=9, label="gpu", api="cuda", architecture_name="sm_90a")
     batch, m, n, k = 3, 7, 5, 9
 
@@ -7832,8 +7740,6 @@ def test_bf16_bmm_host_bridge_padded_layouts_offsets_and_logical_transpose(
 def test_bf16_bmm_rejects_invalid_metadata_before_resolve_or_allocation(
     monkeypatch, invalid_case
 ):
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     h100 = SimpleNamespace(label="gpu", api="cuda", architecture_name="sm_90a")
 
     def tensor(shape, *, device=h100, dtype=aten_fast.DType.bfloat16, strides=None):
@@ -7889,8 +7795,6 @@ def test_bf16_bmm_rejects_invalid_metadata_before_resolve_or_allocation(
 @pytest.mark.parametrize("operation", ["gemm", "bmm"])
 def test_bf16_bridge_error_propagates_without_retry(monkeypatch, operation):
     """A failed enqueue must not allocate or invoke the bridge a second time."""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     device = SimpleNamespace(label="gpu", api="cuda", architecture_name="sm_90a")
 
     def tensor(shape, ptr):
@@ -7934,8 +7838,6 @@ def test_bf16_bridge_error_propagates_without_retry(monkeypatch, operation):
 def test_bf16_helpers_reject_cross_device_before_resolve_or_allocation(
     monkeypatch, invalid_case
 ):
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     devices = [
         SimpleNamespace(
             id=device_id, label="gpu", api="cuda", architecture_name="sm_90a"
@@ -7987,8 +7889,6 @@ def test_tf32_helpers_route_each_fake_device_context_and_reject_cross_device(
     monkeypatch,
 ):
     """Context selection is operand-local and never falls back to device zero."""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     devices = [
         SimpleNamespace(
             id=device_id, label="gpu", api="cuda", architecture_name="sm_90a"
@@ -8090,8 +7990,6 @@ def test_tf32_gemm_host_bridge_layouts(
     mojo_h100, monkeypatch, lhs_transposed, rhs_transposed, transpose_b
 ):
     """The host helper preserves dense views and passes physical layouts."""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     m, n, k = 6, 7, 5
 
     def dense_view(shape, transposed):
@@ -8138,8 +8036,6 @@ def test_tf32_gemm_host_bridge_layouts(
 
 def test_tf32_gemm_host_bridge_strict_fp32_never_launches(mojo_gpu, monkeypatch):
     """The ``highest`` policy must retain the strict-FP32 SIMT path."""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     calls = []
     _replace_defined_native_calls(
         monkeypatch,
@@ -8164,8 +8060,6 @@ def test_tf32_gemm_host_bridge_strict_fp32_never_launches(mojo_gpu, monkeypatch)
 def test_tf32_gemm_host_bridge_no_bias_uses_ignored_output_pointer(
     mojo_h100, monkeypatch
 ):
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     calls = []
     _replace_defined_native_calls(
         monkeypatch,
@@ -8188,8 +8082,6 @@ def test_tf32_gemm_host_bridge_no_bias_uses_ignored_output_pointer(
 
 def test_tf32_gemm_rejects_non_mojo_bias_before_operand_inspection(monkeypatch):
     """A supplied CPU bias cannot be silently reinterpreted as no bias."""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     lhs = _opaque_tensor()
     rhs = _opaque_tensor()
     cpu_bias = torch.randn(7)
@@ -8231,8 +8123,6 @@ def test_tf32_gemm_rejects_non_mojo_bias_before_operand_inspection(monkeypatch):
 def test_tf32_gemm_host_bridge_rejects_before_allocation(
     mojo_h100, monkeypatch, invalid_case
 ):
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     calls = []
     _replace_defined_native_calls(
         monkeypatch,
@@ -8292,8 +8182,6 @@ def test_tf32_bmm_host_bridge_strided_dense_layouts(
     mojo_h100, monkeypatch, lhs_transposed, rhs_transposed, transpose_b
 ):
     """The dormant BMM bridge preserves offsets, batch gaps, and layouts."""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     batch, m, n, k = 3, 7, 5, 9
 
     def dense_batched_view(shape, transposed, gap, offset):
@@ -8338,8 +8226,6 @@ def test_tf32_bmm_host_bridge_strided_dense_layouts(
 
 
 def test_tf32_bmm_host_bridge_strict_fp32_never_launches(mojo_gpu, monkeypatch):
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     calls = []
     _replace_defined_native_calls(
         monkeypatch,
@@ -8368,8 +8254,6 @@ def test_tf32_bmm_host_bridge_strict_fp32_never_launches(mojo_gpu, monkeypatch):
 def test_tf32_bmm_host_bridge_rejects_unsupported_inputs(
     mojo_h100, monkeypatch, invalid_case
 ):
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     calls = []
     _replace_defined_native_calls(
         monkeypatch,
@@ -8416,8 +8300,6 @@ def test_tf32_bmm_host_bridge_rejects_unsupported_inputs(
 
 def _require_real_bf16_gemm_sources():
     """Skip before lazy import while an optional BF16 source is absent."""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     missing = [
         path.name for path in aten_fast._GEMM16_SOURCE_PATHS if not path.is_file()
     ]
@@ -8427,8 +8309,6 @@ def _require_real_bf16_gemm_sources():
 
 def _bf16_dense_matrix_pair(generator, shape, transposed, offset, mojo_h100):
     """Create matching stored-BF16 CPU/Mojo views with a pointer offset."""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     rows, cols = shape
     storage = torch.randn(offset + rows * cols + 4, generator=generator).to(
         torch.bfloat16
@@ -8449,8 +8329,6 @@ def _bf16_dense_batched_pair(
     non-contiguous (non-packed) batch stride rather than ``rows * cols``.
     ``dtype`` defaults to bfloat16; pass ``torch.float16`` for the other
     16-bit route."""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     batch, rows, cols = shape
     matrix_elements = rows * cols
     batch_stride = matrix_elements + gap
@@ -8506,7 +8384,6 @@ def test_bf16_real_v3_aligned_dynamic_gemm_routes(
 ):
     """Production v3 routes match one-round FP32 references."""
     _require_real_bf16_gemm_sources()
-    from torch_mojo_backend.eager_kernels import aten_fast
 
     generator = torch.Generator().manual_seed(20260719)
     lhs, mojo_lhs = _bf16_dense_matrix_pair(
@@ -8558,7 +8435,6 @@ def test_bf16_real_tn_wgrad_tiny_m_huge_n_half_tile_n_regime(mojo_h100, monkeypa
     harness and benchmarks.
     """
     _require_real_bf16_gemm_sources()
-    from torch_mojo_backend.eager_kernels import aten_fast
 
     m, n, k = 768, 4224, 1024
     generator = torch.Generator().manual_seed(20260810)
@@ -8611,7 +8487,6 @@ def test_bf16_real_tn_wgrad_ragged_n_persistent_route(mojo_h100, monkeypatch, m,
     timings live in the perf harness and benchmarks.
     """
     _require_real_bf16_gemm_sources()
-    from torch_mojo_backend.eager_kernels import aten_fast
 
     generator = torch.Generator().manual_seed(20260811)
     lhs, mojo_lhs = _bf16_dense_matrix_pair(generator, (m, k), True, 0, mojo_h100)
@@ -8665,7 +8540,6 @@ def test_bf16_real_nn_dgrad_ragged_n_persistent_route(mojo_h100, monkeypatch, m,
     Correctness only; timings live in the perf harness and benchmarks.
     """
     _require_real_bf16_gemm_sources()
-    from torch_mojo_backend.eager_kernels import aten_fast
 
     generator = torch.Generator().manual_seed(20260812)
     lhs, mojo_lhs = _bf16_dense_matrix_pair(generator, (m, k), False, 0, mojo_h100)
@@ -8695,7 +8569,6 @@ def test_bf16_real_gemm_extension_handles_tails_offsets_and_all_layouts(
 ):
     """Real BF16 GEMM matches an FP32-accumulate, one-BF16-round oracle."""
     _require_real_bf16_gemm_sources()
-    from torch_mojo_backend.eager_kernels import aten_fast
 
     generator = torch.Generator().manual_seed(20260719)
     m, n, k = 33, 65, 31
@@ -8770,7 +8643,6 @@ def test_addmm_bias_broadcast_shapes_stay_correct(
     is_gemm16_dtype = dtype in (torch.bfloat16, torch.float16)
     if is_gemm16_dtype:
         _require_real_bf16_gemm_sources()
-    from torch_mojo_backend.eager_kernels import aten_fast
 
     # 64-aligned in every dim: _gemm16_alignment_favors_split must consider
     # this shape worth splitting into a bias-free mm plus a separate add.
@@ -8821,7 +8693,6 @@ def test_linear_bias_broadcast_shapes_use_gemm16_fast_path(
     """F.linear's bias broadcasts the same way addmm's does; every shape
     stays on the gemm16 fast path -- see _try_gemm16_linear."""
     _require_real_bf16_gemm_sources()
-    from torch_mojo_backend.eager_kernels import aten_fast
 
     # 64-aligned in every dim: _gemm16_alignment_favors_split must consider
     # this shape worth splitting into a bias-free mm plus a separate add.
@@ -8856,7 +8727,6 @@ def test_bf16_real_bmm_extension_handles_all_layouts_offsets_and_padded_batches(
 ):
     """Real BF16 BMM covers physical layouts and a logical RHS transpose."""
     _require_real_bf16_gemm_sources()
-    from torch_mojo_backend.eager_kernels import aten_fast
 
     generator = torch.Generator().manual_seed(20260719)
     batch, m, n, k = 3, 7, 5, 9
@@ -8917,7 +8787,6 @@ def test_bf16_real_bmm_batched_tn_wgmma_route(
     correctness at wgmma-triggering scale, batch > 1, non-contiguous
     (padded, not back-to-back) batch strides, and both 16-bit dtypes."""
     _require_real_bf16_gemm_sources()
-    from torch_mojo_backend.eager_kernels import aten_fast
 
     lhs_transposed = layout[0] == "T"
     rhs_transposed = layout[1] == "T"
@@ -8962,8 +8831,6 @@ def test_tf32_dense_batched_layout_accepts_broadcast_stride_zero():
     the batch stride passed through unchanged, for both physical layouts.
     Genuine overlap (a stride strictly between 0 and matrix_elements) is
     still rejected -- only exact broadcast is a first-class case."""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     h100 = SimpleNamespace(label="gpu", api="cuda", architecture_name="sm_90a")
 
     def tensor(shape, strides):
@@ -9024,7 +8891,6 @@ def test_bf16_real_bmm_batched_nn_v5_route(
     k forces. Shapes mirror the reconciled harness table (see the PR body
     for the measured ratios vs cuBLAS)."""
     _require_real_bf16_gemm_sources()
-    from torch_mojo_backend.eager_kernels import aten_fast
 
     generator = torch.Generator().manual_seed(20260816)
     lhs, mojo_lhs = _bf16_dense_batched_pair(
@@ -9065,7 +8931,6 @@ def test_bf16_real_bmm_batched_nn_v5_broadcast_a(
     for `fast_aten_bmm` (see that function's docstring; conv itself reaches
     the bridge through its own call site, not this classifier)."""
     _require_real_bf16_gemm_sources()
-    from torch_mojo_backend.eager_kernels import aten_fast
 
     generator = torch.Generator().manual_seed(20260816)
     a2d = torch.randn(m, k, generator=generator).to(dtype)
@@ -9102,7 +8967,6 @@ def test_bf16_real_bmm_batched_nn_v5_declines_on_misaligned_base_pointer(
     fall back to a still-correct route (the pre-wgmma accepted BMM kernel),
     not corrupt output or raise."""
     _require_real_bf16_gemm_sources()
-    from torch_mojo_backend.eager_kernels import aten_fast
 
     generator = torch.Generator().manual_seed(20260816)
     batch, m, n, k = 2, 64, 128, 64
@@ -9129,7 +8993,6 @@ def test_bf16_real_linear_forward_backward_uses_three_gemm_routes(
 ):
     """Linear forward, input-grad, and weight-grad all use real BF16 GEMM."""
     _require_real_bf16_gemm_sources()
-    from torch_mojo_backend.eager_kernels import aten_fast
 
     generator = torch.Generator().manual_seed(20260719)
     input = torch.randn(2, 5, 73, generator=generator).to(torch.bfloat16)
@@ -9207,8 +9070,6 @@ def _f32_transposed_dense_pair(
     (1, m) over a row-major (k, m) buffer — with a storage offset (offset 1
     makes the base pointer 16B-misaligned, forcing the 4-byte staging
     variants)."""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     storage = torch.randn(offset + m * k + 4, generator=generator)
     host = torch.as_strided(storage, (m, k), (1, m), offset)
     device_storage = storage.to(device)
@@ -9359,8 +9220,6 @@ def test_f32_tn_route_linear_weight_gradient(mojo_h100: str):
 
 def _tf32_dense_matrix_pair(generator, shape, transposed, offset, mojo_h100):
     """Create matching CPU/Mojo dense views with a nonzero storage offset."""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     rows, cols = shape
     storage = torch.randn(offset + rows * cols + 4, generator=generator)
     strides = (1, rows) if transposed else (cols, 1)
@@ -9373,8 +9232,6 @@ def _tf32_dense_matrix_pair(generator, shape, transposed, offset, mojo_h100):
 
 def _tf32_dense_batched_pair(generator, shape, transposed, gap, offset, mojo_h100):
     """Create dense per-matrix views separated by padding on both devices."""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     batch, rows, cols = shape
     matrix_elements = rows * cols
     batch_stride = matrix_elements + gap
@@ -9401,8 +9258,6 @@ def test_tf32_real_gemm_extension_handles_tails_offsets_and_layouts(
     mojo_h100, monkeypatch, operation, lhs_transposed, rhs_transposed
 ):
     """The lazily loaded extension, not SIMT fallback, computes real GEMMs."""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     generator = torch.Generator().manual_seed(20260719)
     m, n, k = 33, 65, 31
     lhs, mojo_lhs = _tf32_dense_matrix_pair(
@@ -9443,8 +9298,6 @@ def test_tf32_real_bmm_extension_handles_layouts_offsets_and_padded_batches(
     mojo_h100, monkeypatch, lhs_transposed, rhs_transposed, transpose_b
 ):
     """Real BMM covers every physical layout and the logical RHS transpose."""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     generator = torch.Generator().manual_seed(20260719)
     batch, m, n, k = 3, 7, 5, 9
     lhs, mojo_lhs = _tf32_dense_batched_pair(
@@ -9477,8 +9330,6 @@ def test_tf32_real_bmm_extension_handles_layouts_offsets_and_padded_batches(
 
 def test_tf32_real_linear_forward_backward_uses_gemm_extension(mojo_h100, monkeypatch):
     """Linear forward, input-grad, and weight-grad all use the real TF32 GEMM."""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     generator = torch.Generator().manual_seed(20260719)
     input = torch.randn(2, 5, 73, generator=generator)
     weight = torch.randn(67, 73, generator=generator)
@@ -9667,9 +9518,6 @@ def test_fa4_causal_gapped_qkv_forward_backward(
     not one kernel with a runtime dimension -- both get their own cached
     launch here.
     """
-    from torch_mojo_backend.eager_flash_attention import load_fa4_ops
-    from torch_mojo_backend.mojo_device.mojo_device_aten_ops import EAGER_CALL_COUNTERS
-
     module = load_fa4_ops()
     calls = {"forward": 0, "backward": 0}
     suffix = _FA4_DTYPE_SUFFIX[dtype]
@@ -9846,8 +9694,6 @@ def test_fa4_bhsd_native_forward_backward_matches_reference(
     BHSD-native TMA path (no BTHD gather-copy materialization) across every
     BM=192 tail-residue class reachable under seqlen % 128 == 0, for both
     the d64 and d128 tile configs."""
-    from torch_mojo_backend.eager_flash_attention import load_fa4_ops
-
     module = load_fa4_ops()
     suffix = _FA4_DTYPE_SUFFIX[dtype]
     bhsd_name = f"flash_attention_fwd_{suffix}_d{head_dim}_causal_bhsd"
@@ -9945,8 +9791,7 @@ def test_fa4_bhsd_d64_direct_partial_tail_block(mojo_h100, batch, heads, seqlen,
     SDPA/flash-op eligibility gate (see test_aten_functions.py for that
     coverage) or the forward's own allocation/dtype/layout plumbing.
     """
-    from torch_mojo_backend.eager_flash_attention import load_fa4_ops
-    from torch_mojo_backend.eager_kernels.aten_fast import _ctx_ptr
+    _ctx_ptr = aten_fast._ctx_ptr
 
     module = load_fa4_ops()
     suffix = _FA4_DTYPE_SUFFIX[dtype]
@@ -10033,8 +9878,6 @@ def test_fa4_sdpa_odd_seqlen_forward_matches_reference(
     the math decomposition would also produce) and that its output matches
     a CPU fp32 reference.
     """
-    from torch_mojo_backend.eager_flash_attention import load_fa4_ops
-
     module = load_fa4_ops()
     suffix = _FA4_DTYPE_SUFFIX[dtype]
     bhsd_name = f"flash_attention_fwd_{suffix}_d{head_dim}_causal_bhsd"
@@ -10142,8 +9985,6 @@ def test_fa4_sdpa_odd_seqlen_requires_grad_uses_decomposition(
     ``_ScaledDotProductAttentionAutograd`` Function instead -- which still
     produces correct gradients, proven here against a CPU fp32 reference.
     """
-    from torch_mojo_backend.eager_flash_attention import load_fa4_ops
-
     module = load_fa4_ops()
     suffix = _FA4_DTYPE_SUFFIX[dtype]
     watched_names = {
@@ -10218,8 +10059,6 @@ def test_fa4_bhsd_gate_rejects_misaligned_offset_view(mojo_h100, monkeypatch, he
     BTHD-materialize-and-copy path. Still produces correct output. A 2-byte
     (one bf16 element) offset breaks 16-byte alignment independently of
     head_dim, so this is exercised at both tile configs."""
-    from torch_mojo_backend.eager_flash_attention import load_fa4_ops
-
     module = load_fa4_ops()
     calls = {"bhsd": 0, "dense": 0}
     bhsd_name = f"flash_attention_fwd_bf16_d{head_dim}_causal_bhsd"
@@ -10378,9 +10217,6 @@ def test_fast_sdpa_partial_gradients_save_and_compute_only_dependencies(
     contract is pinned by
     ``test_fused_flash_attention_partial_gradients_match_reference``.
     """
-    from torch_mojo_backend.eager_kernels import aten_fast
-    from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
-
     monkeypatch.setattr(aten_fast, "_fused_fa_inputs", lambda *a, **k: None)
 
     generator = torch.Generator().manual_seed(20260718)
@@ -10505,8 +10341,6 @@ def test_fused_flash_attention_partial_gradients_match_reference(mojo_gpu, requi
     if list(get_accelerators())[0].architecture_name != "gfx942":
         pytest.skip("the fused flash-attention kernels target gfx942")
 
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     generator = torch.Generator().manual_seed(20260718)
     batch, heads, query_length, key_length, head_dim = 2, 2, 5, 7, 3
     host_inputs = [
@@ -10563,8 +10397,6 @@ def test_fast_sdpa_saved_tensor_hooks_own_saved_allocations(mojo_gpu, monkeypatc
     here; the same ownership property is asserted for that path's own,
     different saved set by the test below.
     """
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     monkeypatch.setattr(aten_fast, "_fused_fa_inputs", lambda *a, **k: None)
 
     generator = torch.Generator().manual_seed(20260718)
@@ -10634,8 +10466,6 @@ def test_fused_flash_attention_saved_tensor_hooks_own_saved_allocations(mojo_gpu
     """
     if list(get_accelerators())[0].architecture_name != "gfx942":
         pytest.skip("the fused flash-attention kernels target gfx942")
-
-    from torch_mojo_backend.eager_kernels import aten_fast
 
     generator = torch.Generator().manual_seed(20260718)
     batch, heads, query_length, key_length, head_dim = 1, 2, 5, 7, 4
@@ -10735,8 +10565,6 @@ def test_fast_sdpa_saved_tensor_hook_rejects_holderless_mojo_result(mojo_gpu):
 
 def test_sdpa_fused_backward_host_bridge_abi(mojo_gpu, monkeypatch):
     """The host helper forwards offset pointers and flattened runtime shape."""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     shape = (2, 3, 5)
     elements = 30
     probs_storage = torch.randn(elements + 2).to(mojo_gpu)
@@ -10775,8 +10603,6 @@ def test_sdpa_fused_backward_host_bridge_abi(mojo_gpu, monkeypatch):
 
 def test_sdpa_fused_backward_materializes_strided_operands(mojo_gpu, monkeypatch):
     """The raw bridge sees dense temporary pointers, never strided metadata."""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     shape = (2, 3, 5)
     probabilities = torch.randn(shape).to(mojo_gpu).transpose(1, 2)
     grad = torch.randn(shape).to(mojo_gpu).transpose(1, 2)
@@ -10815,8 +10641,6 @@ def test_sdpa_fused_backward_materializes_strided_operands(mojo_gpu, monkeypatch
 
 
 def test_sdpa_fused_backward_no_mask_ignores_dropout_scale(mojo_gpu, monkeypatch):
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     calls = []
     _replace_defined_native_calls(
         monkeypatch,
@@ -10839,8 +10663,6 @@ def test_sdpa_fused_backward_no_mask_ignores_dropout_scale(mojo_gpu, monkeypatch
 
 
 def test_sdpa_fused_backward_empty_skips_bridge(mojo_gpu, monkeypatch):
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     calls = []
     _replace_defined_native_calls(
         monkeypatch,
@@ -10878,8 +10700,6 @@ def test_sdpa_fused_backward_empty_skips_bridge(mojo_gpu, monkeypatch):
 def test_sdpa_fused_backward_validates_before_materializing(
     mojo_gpu, monkeypatch, invalid
 ):
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     probabilities = torch.randn(2, 3).to(mojo_gpu)
     grad = torch.randn(2, 3).to(mojo_gpu)
     mask = torch.ones(2, 3, dtype=torch.bool).to(mojo_gpu)
@@ -10921,8 +10741,6 @@ def test_fast_sdpa_dropout_matches_captured_mask_reference(
     mojo_gpu, monkeypatch, is_causal
 ):
     """Dropout belongs after softmax and before both value-gradient BMMs."""
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     generator = torch.Generator().manual_seed(20260718)
     batch, heads, length, head_dim = 2, 3, 7, 4
     shape = (batch, heads, length, head_dim)

--- a/tests/test_eager_optimizer_ops.py
+++ b/tests/test_eager_optimizer_ops.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 
 from torch_mojo_backend import TorchMojoTensor
+from torch_mojo_backend.mojo_device.mojo_device_aten_ops import EAGER_CALL_COUNTERS
 from torch_mojo_backend.testing import CallChecker
 
 pytestmark = pytest.mark.xdist_group(name="group1")
@@ -11,8 +12,6 @@ pytestmark = pytest.mark.xdist_group(name="group1")
 
 def _watch_eager_op(call_checker: CallChecker, op_name: str):
     """Require the exact PrivateUse1 registration, not a decomposition twin."""
-    from torch_mojo_backend.mojo_device.mojo_device_aten_ops import EAGER_CALL_COUNTERS
-
     call_checker.register(EAGER_CALL_COUNTERS[op_name])
 
 
@@ -394,8 +393,6 @@ def test_fused_adamw_optimizer_two_groups_matches_cpu(
         eps=1e-8,
         fused=True,
     )
-
-    from torch_mojo_backend.mojo_device.mojo_device_aten_ops import EAGER_CALL_COUNTERS
 
     fused_counter = EAGER_CALL_COUNTERS["aten::_fused_adamw_"]
     calls_before = fused_counter.call_count

--- a/tests/test_fa4_host_wiring.py
+++ b/tests/test_fa4_host_wiring.py
@@ -8,6 +8,7 @@ from typing import cast
 import pytest
 import torch
 
+import torch_mojo_backend.eager_flash_attention as package
 from torch_mojo_backend.eager_kernels import aten_fast
 from torch_mojo_backend.mojo_device import mojo_device_autograd as autograd
 from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
@@ -58,8 +59,6 @@ def _mt(tensor: SimpleNamespace | None) -> TorchMojoTensor:
 def test_fa4_rejects_ineligible_regimes_before_loading_or_device_work(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    import torch_mojo_backend.eager_flash_attention as package
-
     monkeypatch.setattr(aten_fast, "_t", lambda tensor: tensor)
 
     def forbidden(*_args, **_kwargs):
@@ -101,8 +100,6 @@ def test_fa4_rejects_ineligible_regimes_before_loading_or_device_work(
 def test_fa4_forward_bridge_uses_dynamic_bthd_allocations(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    import torch_mojo_backend.eager_flash_attention as package
-
     device = _device()
     # A fixed 3-tuple (not a list/tuple(generator)) so *public below unpacks
     # to a fixed arity instead of tuple[SimpleNamespace, ...].
@@ -194,8 +191,6 @@ def test_fa4_forward_bridge_selects_f16_kernel_symbol_and_allocation(
     Mirrors ``test_fa4_forward_bridge_uses_dynamic_bthd_allocations`` above,
     only with f16 inputs: the bf16 bridge symbol must not be touched.
     """
-    import torch_mojo_backend.eager_flash_attention as package
-
     device = _device()
     # A fixed 3-tuple (not a list/tuple(generator)) so *public below unpacks
     # to a fixed arity instead of tuple[SimpleNamespace, ...].
@@ -349,8 +344,6 @@ def test_fa4_strided_layout_contract_is_strict():
 def test_fa4_canonical_fused_qkv_uses_zero_copy_strided_forward_bridge(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    import torch_mojo_backend.eager_flash_attention as package
-
     device = _device()
     batch, heads, seqlen, head_dim = 2, 12, 256, 64
     token_stride = 3 * heads * head_dim
@@ -459,8 +452,6 @@ def test_fa4_offset_view_public_layout_copies_and_uses_contiguous_fallback(
     the BHSD-native path requires 16-byte alignment and a misaligned base
     pointer violates that even though the tensor is otherwise eligible.
     """
-    import torch_mojo_backend.eager_flash_attention as package
-
     device = _device()
     # +2 bytes (one bf16/f16 element) off a 16-byte-aligned address: still
     # fully contiguous, but ptr % 16 != 0.
@@ -541,8 +532,6 @@ def test_fa4_forward_bridge_uses_bhsd_native_path_for_aligned_contiguous_public_
     aligned skips BTHD materialization entirely: no transpose, no copy, and
     the output is allocated directly in the (B, H, S, D) layout and
     returned as-is."""
-    import torch_mojo_backend.eager_flash_attention as package
-
     device = _device()
     # A fixed 3-tuple (not tuple(generator)) so *public below unpacks to a
     # fixed arity instead of tuple[SimpleNamespace, ...].
@@ -889,8 +878,6 @@ def test_fa4_saved_variable_recompute_rederives_natives_independently(
 def test_fa4_combined_backward_bridge_allocates_exact_scratch(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    import torch_mojo_backend.eager_flash_attention as package
-
     device = _device()
     q_native, k_native, v_native = [
         _tensor(name, shape=(2, 384, 4, 64), device=device, ptr=ptr)
@@ -990,8 +977,6 @@ def test_fa4_combined_backward_bridge_allocates_exact_scratch(
 def test_fa4_canonical_fused_qkv_uses_strided_backward_bridge(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    import torch_mojo_backend.eager_flash_attention as package
-
     device = _device()
     batch, seqlen, heads, head_dim = 2, 256, 12, 64
     token_stride = 3 * heads * head_dim

--- a/tests/test_mojo_device.py
+++ b/tests/test_mojo_device.py
@@ -11,12 +11,17 @@ from typing import cast
 import max.driver
 import pytest
 import torch
+from torch.optim.optimizer import _default_to_fused_or_foreach
 
 from torch_mojo_backend import TorchMojoTensor, mojo_backend, register_mojo_devices
+from torch_mojo_backend.eager_kernels import aten_fast
 from torch_mojo_backend.mojo_device import (
+    cuda_peer,
+    dlpack,
     torch_mojo_device_module,
     torch_mojo_tensor as mojo_tensor_module,
 )
+from torch_mojo_backend.torch_compile_backend import utils
 from torch_mojo_backend.mojo_device.torch_mojo_device_module import (
     _reserve_philox_state,
 )
@@ -388,8 +393,6 @@ def test_non_blocking_d2h_survives_destination_destruction(mojo_device):
     if max_device.label != "gpu":
         pytest.skip("requires a MAX GPU")
 
-    from torch_mojo_backend.mojo_device import dlpack
-
     a = torch.randn(4096, 4096).to(mojo_device)
     b = torch.randn(4096, 4096).to(mojo_device)
     source = torch.arange(1 << 20, dtype=torch.float32).to(mojo_device)
@@ -419,8 +422,6 @@ def test_non_blocking_d2h_adoption_failure_synchronizes(mojo_device, monkeypatch
     max_device = find_equivalent_max_device(torch.device(mojo_device))
     if max_device.label != "gpu":
         pytest.skip("requires a MAX GPU")
-
-    from torch_mojo_backend.mojo_device import dlpack
 
     source = torch.arange(1 << 20, dtype=torch.float32).to(mojo_device)
 
@@ -756,8 +757,6 @@ def test_module_to_mojo_preserves_tied_parameters(mojo_device):
 
 
 def test_mojo_parameters_enable_foreach_optimizer_selection(mojo_device):
-    from torch.optim.optimizer import _default_to_fused_or_foreach
-
     parameter = torch.nn.Parameter(torch.ones(8)).to(mojo_device)
     fused, foreach = _default_to_fused_or_foreach([parameter], differentiable=False)
 
@@ -889,9 +888,6 @@ def test_mojo_clip_grad_norm_matches_cpu(mojo_gpu_available, foreach):
 
 
 def test_metal_fast_add_gate_is_decided_once(monkeypatch):
-    from torch_mojo_backend.eager_kernels import aten_fast
-    from torch_mojo_backend.torch_compile_backend import utils
-
     aten_fast._has_metal_accelerator.cache_clear()
     monkeypatch.setattr(
         utils,
@@ -1185,8 +1181,6 @@ def test_same_gpu_transfer_skips_the_host(mojo_gpu):
     measured 375 ms bounced against 0.64 ms on device, so an order of
     magnitude is a wide margin around that.
     """
-    import time
-
     big = torch.randn(1 << 26, device="cuda")  # 256 MB
     big.to(mojo_gpu)
     torch_mojo_device_module.synchronize()
@@ -1215,8 +1209,6 @@ def test_pointer_ordinal_identifies_the_owning_gpu(mojo_gpu):
     `cuda:0` by ordinal would assume both runtimes enumerate alike.  Asking the
     driver who owns each allocation is a fact rather than an assumption.
     """
-    from torch_mojo_backend.mojo_device import cuda_peer
-
     on_mojo = torch.zeros(8, device=mojo_gpu)
     assert isinstance(on_mojo, TorchMojoTensor)
     torch_mojo_device_module.synchronize()

--- a/tests/test_mojo_device.py
+++ b/tests/test_mojo_device.py
@@ -21,7 +21,6 @@ from torch_mojo_backend.mojo_device import (
     torch_mojo_device_module,
     torch_mojo_tensor as mojo_tensor_module,
 )
-from torch_mojo_backend.torch_compile_backend import utils
 from torch_mojo_backend.mojo_device.torch_mojo_device_module import (
     _reserve_philox_state,
 )
@@ -30,6 +29,7 @@ from torch_mojo_backend.mojo_device.torch_mojo_tensor import (
     find_equivalent_max_device,
     get_ordered_accelerators,
 )
+from torch_mojo_backend.torch_compile_backend import utils
 
 pytestmark = pytest.mark.xdist_group(name="group1")
 

--- a/tests/test_mojo_streams.py
+++ b/tests/test_mojo_streams.py
@@ -3,11 +3,25 @@ underlying device streams / free fence (mojo_device/device_streams.py)."""
 
 import pytest
 import torch
+from torch.utils._mode_utils import no_dispatch
 
 from torch_mojo_backend import register_mojo_devices
-from torch_mojo_backend.mojo_device import torch_mojo_device_module as torch_mojo
+from torch_mojo_backend.mojo_device import (
+    deferred_compile,
+    torch_mojo_device_module as torch_mojo,
+)
+from torch_mojo_backend.mojo_device.device_streams import (
+    default_stream,
+    default_stream_ctx_ptr,
+    get_stream,
+    record_use,
+)
 from torch_mojo_backend.mojo_device.streams import Stream as MojoStream
-from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
+from torch_mojo_backend.mojo_device.torch_mojo_tensor import (
+    TorchMojoTensor,
+    _holder_mod,
+    find_equivalent_max_device,
+)
 
 
 def _mt(tensor: torch.Tensor) -> TorchMojoTensor:
@@ -78,7 +92,6 @@ def test_documented_device_agnostic_pattern(mojo_gpu: str):
 def test_wait_stream_orders_real_work(mojo_gpu: str):
     x = torch.randn(2048, 2048, device=mojo_gpu)
     y = (x * 1.5 + 0.25).tanh()
-    from torch_mojo_backend.mojo_device import deferred_compile
 
     deferred_compile.drain()
     side = torch.Stream(device=mojo_gpu)
@@ -144,8 +157,6 @@ def test_record_stream_accepts_mojo_streams(mojo_gpu: str):
 
 def test_record_stream_under_no_dispatch(mojo_gpu: str):
     """record_stream must work under no_dispatch(), as torch.distributed calls it."""
-    from torch.utils._mode_utils import no_dispatch
-
     tensor = torch.ones(64, device=mojo_gpu)
     side = torch_mojo.Stream()
     with no_dispatch():
@@ -155,15 +166,6 @@ def test_record_stream_under_no_dispatch(mojo_gpu: str):
 
 def test_side_stream_is_distinct_from_default(mojo_gpu: str):
     """A side stream is a real second stream, not an alias of the default."""
-    from torch_mojo_backend.mojo_device.device_streams import (
-        default_stream,
-        default_stream_ctx_ptr,
-        get_stream,
-    )
-    from torch_mojo_backend.mojo_device.torch_mojo_tensor import (
-        find_equivalent_max_device,
-    )
-
     device = find_equivalent_max_device(torch.device("mojo", 0))
     owner_ctx = default_stream_ctx_ptr(device)
     assert device.default_stream._device_context_ptr() == owner_ctx
@@ -178,13 +180,6 @@ def test_side_stream_is_distinct_from_default(mojo_gpu: str):
 
 def test_record_use_fences_free_against_side_stream_reader(mojo_gpu: str):
     """record_use fences a free so a side-stream reader can't race pool reuse."""
-    from torch_mojo_backend.mojo_device import deferred_compile
-    from torch_mojo_backend.mojo_device.device_streams import get_stream, record_use
-    from torch_mojo_backend.mojo_device.torch_mojo_tensor import (
-        _holder_mod,
-        find_equivalent_max_device,
-    )
-
     device = find_equivalent_max_device(torch.device("mojo", 0))
     stream = get_stream(device, "lifetime-test")
     n = 8 * 1024 * 1024

--- a/tests/test_out_variant_resize.py
+++ b/tests/test_out_variant_resize.py
@@ -4,14 +4,14 @@ import pytest
 import torch
 
 from torch_mojo_backend import TorchMojoTensor
+from torch_mojo_backend.eager_kernels.aten_fast import _spec_of
+from torch_mojo_backend.mojo_device.mojo_device_aten_ops import EAGER_CALL_COUNTERS
 from torch_mojo_backend.testing import CallChecker
 
 pytestmark = pytest.mark.xdist_group(name="group1")
 
 
 def _watch_eager_op(call_checker: CallChecker, op_name: str):
-    from torch_mojo_backend.mojo_device.mojo_device_aten_ops import EAGER_CALL_COUNTERS
-
     call_checker.register(EAGER_CALL_COUNTERS[op_name])
 
 
@@ -45,8 +45,6 @@ def test_resized_out_invalidates_cached_tensor_spec(
 ):
     """A spec operation after resize must use the new pointer and shape."""
     _watch_eager_op(call_checker, "aten::mul.out")
-    from torch_mojo_backend.eager_kernels.aten_fast import _spec_of
-
     out = torch.empty((), dtype=torch.float32, device=mojo_gpu)
     assert isinstance(out, TorchMojoTensor)
     _spec_of(out)

--- a/tests/test_sdpa_host_wiring.py
+++ b/tests/test_sdpa_host_wiring.py
@@ -4,6 +4,7 @@ from typing import cast
 import pytest
 
 from torch_mojo_backend import eager_kernels
+from torch_mojo_backend.eager_kernels import aten_fast
 from torch_mojo_backend.mojo_device import mojo_device_autograd as autograd
 from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
 
@@ -66,16 +67,12 @@ def _query_gradient_context(has_dropout: bool) -> SimpleNamespace:
 
 
 def test_sdpa_backward_bridge_is_lazy_registered():
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     assert aten_fast._SdpaBackwardExtension.MOJO_FILE.name == "sdpa_backward_ops.mojo"
 
 
 def test_missing_sdpa_kernel_module_returns_not_handled_before_device_work(
     monkeypatch: pytest.MonkeyPatch, tmp_path
 ):
-    from torch_mojo_backend.eager_kernels import aten_fast
-
     device = object()
     probabilities = SimpleNamespace(
         _dtype=aten_fast.DType.float32, _device=device, _shape=(2, 3)

--- a/torch_mojo_backend/distributed/__init__.py
+++ b/torch_mojo_backend/distributed/__init__.py
@@ -19,7 +19,9 @@ __all__ = ["register_distributed_backend", "use_local_rank_gpu"]
 
 
 def use_local_rank_gpu():
-    from torch_mojo_backend.distributed.process_group import use_local_rank_gpu as impl
+    from torch_mojo_backend.distributed.process_group import (  # noqa: PLC0415 -- process_group needs torch._C._distributed_c10d, absent from torch builds without distributed
+        use_local_rank_gpu as impl,
+    )
 
     impl()
 
@@ -30,7 +32,9 @@ def register_distributed_backend():
         return
     if "mojo" in torch.distributed.Backend.backend_list:
         return
-    from torch_mojo_backend.distributed.process_group import create_mojo_process_group
+    from torch_mojo_backend.distributed.process_group import (  # noqa: PLC0415 -- same as above; the is_available() guard right before is what makes it optional
+        create_mojo_process_group,
+    )
 
     torch.distributed.Backend.register_backend(
         "mojo", create_mojo_process_group, devices=["mojo"]

--- a/torch_mojo_backend/distributed/nccl.py
+++ b/torch_mojo_backend/distributed/nccl.py
@@ -71,7 +71,7 @@ def _candidate_libnccl_paths() -> list[str]:
         return [override]
     candidates = []
     try:
-        import nvidia.nccl
+        import nvidia.nccl  # noqa: PLC0415 -- optional: the wheel may not be installed
 
         # nvidia.nccl is a namespace package: no __file__, only __path__.
         for package_dir in nvidia.nccl.__path__:

--- a/torch_mojo_backend/distributed/process_group.py
+++ b/torch_mojo_backend/distributed/process_group.py
@@ -81,8 +81,17 @@ from torch._C._distributed_c10d import (
 from torch.distributed import PrefixStore, Store, Work
 
 from torch_mojo_backend.distributed import nccl
-from torch_mojo_backend.mojo_device import comm_fence, torch_mojo_device_module
-from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
+from torch_mojo_backend.mojo_device import (
+    comm_fence,
+    cuda_peer,
+    deferred_compile,
+    torch_mojo_device_module,
+)
+from torch_mojo_backend.mojo_device.device_streams import get_stream, record_use
+from torch_mojo_backend.mojo_device.torch_mojo_tensor import (
+    TorchMojoTensor,
+    find_equivalent_max_device,
+)
 
 _NCCL_DTYPE_OF: dict[torch.dtype, int] = {
     torch.int8: nccl.NCCL_INT8,
@@ -248,8 +257,6 @@ class MojoProcessGroup(dist.ProcessGroup):
         """Complete every in-flight comm-stream collective, fences included."""
         for index, max_device in self._max_devices.items():
             if self._comm_stream_enabled:
-                from torch_mojo_backend.mojo_device.device_streams import get_stream
-
                 get_stream(max_device, "nccl").synchronize()
             comm_fence.discard(index)
 
@@ -263,11 +270,6 @@ class MojoProcessGroup(dist.ProcessGroup):
 
     def _device_state(self, tensor: torch.Tensor) -> tuple[nccl.NcclComm, int, int]:
         """(communicator, default-stream CUstream, device index) for a tensor."""
-        from torch_mojo_backend.mojo_device import cuda_peer
-        from torch_mojo_backend.mojo_device.torch_mojo_tensor import (
-            find_equivalent_max_device,
-        )
-
         index = tensor.device.index
         if index is None:
             index = torch_mojo_device_module.current_device()
@@ -311,8 +313,6 @@ class MojoProcessGroup(dist.ProcessGroup):
         """
         if not self._comm_stream_enabled:
             return None
-        from torch_mojo_backend.mojo_device.device_streams import get_stream, record_use
-
         comm_stream = get_stream(self._max_devices[index], "nccl")
         self._drained()  # producers must be ON the stream before we fence it
         comm_stream.wait_default_stream()
@@ -337,8 +337,6 @@ class MojoProcessGroup(dist.ProcessGroup):
         """
         self._drained()
         if self._comm_stream_enabled and index in self._max_devices:
-            from torch_mojo_backend.mojo_device.device_streams import get_stream
-
             get_stream(self._max_devices[index], "nccl").make_default_stream_wait()
             comm_fence.discard(index)
 
@@ -356,8 +354,6 @@ class MojoProcessGroup(dist.ProcessGroup):
 
     def _drained(self):
         """Launch every queued mojo kernel so the stream sees all producers."""
-        from torch_mojo_backend.mojo_device import deferred_compile
-
         deferred_compile.drain()
 
     def _dense(self, tensor: torch.Tensor) -> torch.Tensor:

--- a/torch_mojo_backend/eager_kernels/__init__.py
+++ b/torch_mojo_backend/eager_kernels/__init__.py
@@ -858,7 +858,9 @@ def _bootstrap_allocate_single_output(spec: object) -> object:
     declared `Callable[[object], object]` type.
     """
     global _allocate_single_output
-    from torch_mojo_backend.eager_kernels.output_specs import _allocate_output_spec  # noqa: PLC0415 -- the cycle this docstring describes
+    from torch_mojo_backend.eager_kernels.output_specs import (  # noqa: PLC0415 -- the cycle this docstring describes
+        _allocate_output_spec,
+    )
 
     _allocate_single_output = cast("Callable[[object], object]", _allocate_output_spec)
     return _allocate_single_output(spec)

--- a/torch_mojo_backend/eager_kernels/__init__.py
+++ b/torch_mojo_backend/eager_kernels/__init__.py
@@ -45,6 +45,7 @@ import json
 import os
 import platform
 import re
+import shutil
 import subprocess
 import sys
 import threading
@@ -56,6 +57,7 @@ from pathlib import Path
 from types import ModuleType
 from typing import IO, ClassVar, Generic, NoReturn, TypeVar, cast
 
+import max as _max_pkg
 from max import driver
 from max.dtype import DType
 
@@ -78,8 +80,6 @@ def _find_mojo() -> Path:
     candidates: list[Path] = []
     if sys.executable:  # None/'' in embedded interpreters and workers
         candidates.append(Path(sys.executable).parent / "mojo")
-    import max as _max_pkg
-
     for base in list(getattr(_max_pkg, "__path__", ())) or (
         [_max_pkg.__file__] if getattr(_max_pkg, "__file__", None) else []
     ):
@@ -88,8 +88,6 @@ def _find_mojo() -> Path:
         if cand.is_file():
             _MOJO_EXE_CACHE.append(cand)
             return cand
-    import shutil
-
     which = shutil.which("mojo")
     if which is not None:
         _MOJO_EXE_CACHE.append(Path(which))
@@ -860,7 +858,7 @@ def _bootstrap_allocate_single_output(spec: object) -> object:
     declared `Callable[[object], object]` type.
     """
     global _allocate_single_output
-    from torch_mojo_backend.eager_kernels.output_specs import _allocate_output_spec
+    from torch_mojo_backend.eager_kernels.output_specs import _allocate_output_spec  # noqa: PLC0415 -- the cycle this docstring describes
 
     _allocate_single_output = cast("Callable[[object], object]", _allocate_output_spec)
     return _allocate_single_output(spec)

--- a/torch_mojo_backend/eager_kernels/aten_fast.py
+++ b/torch_mojo_backend/eager_kernels/aten_fast.py
@@ -32,8 +32,9 @@ import torch
 from max.driver import Device
 from max.dtype import DType
 from max.experimental.torch import max_dtype_to_torch
+from max.experimental.torch.torch import torch_dtype_to_max
 
-from torch_mojo_backend import eager_kernels, is_running_tests
+from torch_mojo_backend import eager_flash_attention, eager_kernels, is_running_tests
 from torch_mojo_backend.eager_kernels import _ctx_ptr, call_queue as _call_queue
 from torch_mojo_backend.eager_kernels.activation_backward_ops import (
     ActivationBackwardExtension as _ActivationBackwardExtension,
@@ -109,6 +110,7 @@ from torch_mojo_backend.mojo_device.torch_mojo_tensor import (
     _resize_payload,
     _row_major_strides,
 )
+from torch_mojo_backend.torch_compile_backend import utils as _compile_utils
 from torch_mojo_backend.types import CountedCallable
 
 _VariantFlag = bool | int | str
@@ -2625,9 +2627,7 @@ def _scaled_operand(
 def _has_metal_accelerator() -> bool:
     """Decided on the first `add`, then a cache hit: CUDA and ROCm never
     evaluate the Metal conditions, and a process that never adds never asks."""
-    from torch_mojo_backend.torch_compile_backend.utils import get_accelerators
-
-    return any(device.api == "metal" for device in get_accelerators())
+    return any(device.api == "metal" for device in _compile_utils.get_accelerators())
 
 
 def fast_aten_add(
@@ -5910,8 +5910,6 @@ def _torch_dtype_to_max(dtype: object) -> DType | None:
     # `object`: the autograd doubles-based tests probe this with non-dtypes.
     if not isinstance(dtype, torch.dtype):
         return None
-    from max.experimental.torch.torch import torch_dtype_to_max
-
     try:
         return torch_dtype_to_max(dtype)
     except (KeyError, ValueError):
@@ -7727,9 +7725,7 @@ def fast_fa4_16bit_d64_causal_forward(
     if inputs is None:
         return NOT_HANDLED
 
-    from torch_mojo_backend.eager_flash_attention import load_fa4_ops
-
-    fa4_ops = load_fa4_ops()
+    fa4_ops = eager_flash_attention.load_fa4_ops()
     assert isinstance(inputs, tuple)
     q, k, v = inputs
     qkv_dtype = q._dtype
@@ -7840,9 +7836,7 @@ def fast_fa4_16bit_d64_causal_backward(
 ) -> tuple[TorchMojoTensor, TorchMojoTensor, TorchMojoTensor] | _NotHandled:
     """Enqueue FA4 preprocess/main/convert and return public BHTD grads
     (bf16 or f16, matching Q/K/V's shared dtype)."""
-    from torch_mojo_backend.eager_flash_attention import load_fa4_ops
-
-    fa4_ops = load_fa4_ops()
+    fa4_ops = eager_flash_attention.load_fa4_ops()
     batch, seqlen, heads, head_dim = q_native._shape
     qkv_dtype = q_native._dtype
     prepared = _fa4_prepare_qkv_bridge(q_native, k_native, v_native)
@@ -10154,8 +10148,6 @@ def _instrument_call_counts():
     """Give every fast op a test-only call counter, mirroring what
     `aten_functions.map_to` does, so `CallChecker` can assert that an op
     was handled by either implementation."""
-    import functools
-
     for name, func in list(globals().items()):
         if not name.startswith("fast_aten"):
             continue

--- a/torch_mojo_backend/eager_kernels/call_queue.py
+++ b/torch_mojo_backend/eager_kernels/call_queue.py
@@ -60,6 +60,7 @@ from types import ModuleType
 from typing import Protocol, runtime_checkable
 
 from torch_mojo_backend.is_running_tests import IS_RUNNING_TESTS
+from torch_mojo_backend.mojo_device import torch_mojo_device_module as _dm
 
 
 @runtime_checkable
@@ -164,7 +165,7 @@ def _free_device_memory() -> int | None:
     or None when no accelerator can report one (CPU-only hosts, backends
     without memory statistics)."""
     try:
-        from torch_mojo_backend import get_accelerators
+        from torch_mojo_backend import get_accelerators  # noqa: PLC0415 -- cycle: the package __init__ reaches this module
 
         frees = [device.stats["free_memory"] for device in get_accelerators()]
     except Exception:
@@ -245,8 +246,6 @@ def _translate(exc: BaseException) -> BaseException:
 
 def _device_only_synchronize():
     """The device barrier that never drains: safe inside the launch path."""
-    from torch_mojo_backend.mojo_device import torch_mojo_device_module as _dm
-
     _dm._device_synchronize()
 
 

--- a/torch_mojo_backend/eager_kernels/call_queue.py
+++ b/torch_mojo_backend/eager_kernels/call_queue.py
@@ -165,7 +165,9 @@ def _free_device_memory() -> int | None:
     or None when no accelerator can report one (CPU-only hosts, backends
     without memory statistics)."""
     try:
-        from torch_mojo_backend import get_accelerators  # noqa: PLC0415 -- cycle: the package __init__ reaches this module
+        from torch_mojo_backend import (  # noqa: PLC0415 -- cycle: the package __init__ reaches this module
+            get_accelerators,
+        )
 
         frees = [device.stats["free_memory"] for device in get_accelerators()]
     except Exception:

--- a/torch_mojo_backend/eager_kernels/output_specs.py
+++ b/torch_mojo_backend/eager_kernels/output_specs.py
@@ -55,7 +55,9 @@ def _bootstrap_alloc(
     so this rebind type-checks against its declared `_AllocFn` type.
     """
     global _alloc
-    from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor  # noqa: PLC0415 -- the cycle this docstring describes
+    from torch_mojo_backend.mojo_device.torch_mojo_tensor import (  # noqa: PLC0415 -- the cycle this docstring describes
+        TorchMojoTensor,
+    )
 
     _alloc = cast(_AllocFn, TorchMojoTensor._alloc)
     return _alloc(shape, dtype, device)

--- a/torch_mojo_backend/eager_kernels/output_specs.py
+++ b/torch_mojo_backend/eager_kernels/output_specs.py
@@ -55,7 +55,7 @@ def _bootstrap_alloc(
     so this rebind type-checks against its declared `_AllocFn` type.
     """
     global _alloc
-    from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
+    from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor  # noqa: PLC0415 -- the cycle this docstring describes
 
     _alloc = cast(_AllocFn, TorchMojoTensor._alloc)
     return _alloc(shape, dtype, device)

--- a/torch_mojo_backend/mojo_device/aten_ops/support.py
+++ b/torch_mojo_backend/mojo_device/aten_ops/support.py
@@ -1,7 +1,7 @@
 """Shared plumbing for the eager aten implementations in this package.
 
-Everything the implementation modules have in common lives here — the lazily
-imported `aten_fast` handle, the actionable `NotImplementedError`, the
+Everything the implementation modules have in common lives here — the
+`aten_fast` handle, the actionable `NotImplementedError`, the
 strided/broadcasting copy that every `out=` variant ends with — so no
 implementation module ever has to import another one.
 """
@@ -12,7 +12,9 @@ from typing import NoReturn
 
 import torch
 from max.dtype import DType
+from max.experimental.torch import max_dtype_to_torch
 
+from torch_mojo_backend.eager_kernels import aten_fast
 from torch_mojo_backend.mojo_device.torch_mojo_tensor import (
     TorchMojoTensor,
     _resize_payload,
@@ -25,26 +27,13 @@ _COMPOSITE_EXPLICIT_AUTOGRAD = torch._C.DispatchKeySet(
 )
 
 
-_aten_fast_module = None
-
-
 def _fast() -> ModuleType:
-    """The aten_fast module.
-
-    Imported lazily: the first import triggers the (cached) Mojo kernel
-    compilation, which pure torch.compile workloads should never pay for.
-    """
-    global _aten_fast_module
-    if _aten_fast_module is None:
-        from torch_mojo_backend.eager_kernels import aten_fast
-
-        _aten_fast_module = aten_fast
-    return _aten_fast_module
+    """The aten_fast module. Importing it loads no Mojo extension: a
+    kernel is built and dlopened by the first call into its descriptor."""
+    return aten_fast
 
 
 def max_dtype_to_torch_dtype(dtype: DType) -> torch.dtype:
-    from max.experimental.torch import max_dtype_to_torch
-
     return max_dtype_to_torch(dtype)
 
 

--- a/torch_mojo_backend/mojo_device/aten_ops/transfer.py
+++ b/torch_mojo_backend/mojo_device/aten_ops/transfer.py
@@ -6,7 +6,12 @@ import max.driver
 import torch
 from max.experimental.torch.torch import torch_dtype_to_max
 
-from torch_mojo_backend.mojo_device import cuda_peer, torch_mojo_device_module
+from torch_mojo_backend import eager_kernels
+from torch_mojo_backend.mojo_device import (
+    cuda_peer,
+    deferred_compile,
+    torch_mojo_device_module,
+)
 from torch_mojo_backend.mojo_device.aten_ops.support import (
     _copy_into_tensor,
     _fast,
@@ -65,9 +70,6 @@ def _upload_on_device(
         return True
     if not cuda_peer.same_physical_device(src.data_ptr(), dest_ptr):
         return False
-    from torch_mojo_backend import eager_kernels
-    from torch_mojo_backend.mojo_device import deferred_compile
-
     deferred_compile.drain()
     torch.cuda.synchronize()
     holder = cast(_TensorHolderModule, eager_kernels.tensor_holder)
@@ -120,8 +122,6 @@ def mojo_device__copy_from(
         cpu = cpu.contiguous()
         if dest._is_contiguous:
             if dest._numel > 0:
-                from torch_mojo_backend import eager_kernels
-
                 holder = cast(_TensorHolderModule, eager_kernels.tensor_holder)
                 transfer_owner = holder.copy_from_host(
                     eager_kernels._ctx_ptr(dest._device),

--- a/torch_mojo_backend/mojo_device/comm_fence.py
+++ b/torch_mojo_backend/mojo_device/comm_fence.py
@@ -21,7 +21,7 @@ captures the dict by reference, so it is mutated in place, never rebound.
 
 import threading
 
-from torch_mojo_backend.mojo_device import device_streams
+from torch_mojo_backend.mojo_device import deferred_compile, device_streams
 from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
 
 PENDING: dict[int, int] = {}  # id(holder) -> mojo device index
@@ -63,8 +63,6 @@ def _fence_locked(index: int):
         return
     # Queued launches were issued before this fence and must stay before it
     # on the default stream (rule 1 in device_streams.py).
-    from torch_mojo_backend.mojo_device import deferred_compile
-
     deferred_compile.drain()
     stream.make_default_stream_wait()
     for key in keys:  # only once the wait is on the stream

--- a/torch_mojo_backend/mojo_device/device_streams.py
+++ b/torch_mojo_backend/mojo_device/device_streams.py
@@ -22,13 +22,14 @@ from typing import TYPE_CHECKING, Protocol
 
 import max.driver
 
+from torch_mojo_backend import eager_kernels
+
 if TYPE_CHECKING:
     from torch_mojo_backend.mojo_device.torch_mojo_tensor import _TensorHolderModule
 
 
 def _holder_mod() -> "_TensorHolderModule":
-    # Lazy: importing this module must not trigger a Mojo kernel build.
-    from torch_mojo_backend.mojo_device.torch_mojo_tensor import (
+    from torch_mojo_backend.mojo_device.torch_mojo_tensor import (  # noqa: PLC0415 -- cycle: torch_mojo_tensor reaches this module (for `Stream`) before it defines this name
         _holder_mod as holder_mod,
     )
 
@@ -52,8 +53,6 @@ def default_stream_ctx_ptr(device: max.driver.Device) -> int:
     exactly the context pointer the kernel extensions allocate/free through,
     and a test asserts the two stay in sync.
     """
-    from torch_mojo_backend import eager_kernels
-
     return eager_kernels._ctx_ptr(device)
 
 

--- a/torch_mojo_backend/mojo_device/mojo_device_autograd.py
+++ b/torch_mojo_backend/mojo_device/mojo_device_autograd.py
@@ -14,6 +14,8 @@ from typing import Protocol, TypeVar, runtime_checkable
 
 import torch
 
+from torch_mojo_backend.eager_kernels import aten_fast as _aten_fast
+from torch_mojo_backend.mojo_device import deferred_compile
 from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
 
 # _require_handled passes its argument through unchanged, including the
@@ -24,9 +26,9 @@ _registered = False
 
 
 def _fast() -> ModuleType:
-    from torch_mojo_backend.eager_kernels import aten_fast
-
-    return aten_fast
+    """Indirection, not deferral: the host-contract tests swap the whole
+    module out through this function."""
+    return _aten_fast
 
 
 def _require_handled(result: _ResultT | None, operation: str) -> _ResultT:
@@ -665,8 +667,6 @@ def _scaled_dot_product_attention_autograd(
     # check above is metadata-only and safe on pending tensors. Buffers
     # these paths allocate afterwards are retained per queued item (queue
     # rule 3), so no extra bookkeeping is owed here.
-    from torch_mojo_backend.mojo_device import deferred_compile
-
     deferred_compile.drain()
     if not needs_backward:
         return _require_handled(

--- a/torch_mojo_backend/mojo_device/register.py
+++ b/torch_mojo_backend/mojo_device/register.py
@@ -2,9 +2,17 @@ from collections.abc import Callable
 from functools import wraps
 
 import torch
+from torch.utils.backend_registration import _setup_privateuseone_for_python_backend
 
-from torch_mojo_backend.mojo_device import comm_fence, deferred_compile
+from torch_mojo_backend.distributed import register_distributed_backend
+from torch_mojo_backend.mojo_device import (
+    comm_fence,
+    deferred_compile,
+    torch_mojo_device_module,
+)
 from torch_mojo_backend.mojo_device.mojo_device_aten_ops import _aten_ops_registry
+from torch_mojo_backend.mojo_device.mojo_device_autocast import register_autocast_ops
+from torch_mojo_backend.mojo_device.mojo_device_autograd import register_autograd_ops
 from torch_mojo_backend.monkeypatching import apply_torch_monkeypatches
 
 _registered = False
@@ -48,11 +56,6 @@ def _resolve_overload(op_name: str) -> torch._ops.OpOverload | None:
 
 def register_mojo_devices():
     """Enable the mojo device globally and register all aten ops"""
-    from torch.utils.backend_registration import _setup_privateuseone_for_python_backend
-
-    from torch_mojo_backend.mojo_device import torch_mojo_device_module
-
-    # since it's so recent we import it here.
     global _registered
     if _registered:
         # Already registered
@@ -82,20 +85,8 @@ def register_mojo_devices():
         if overload is not None:
             deferred_compile.DIRECT_IMPLS[overload] = wrapped
 
-    from torch_mojo_backend.mojo_device.mojo_device_autograd import (
-        register_autograd_ops,
-    )
-
     register_autograd_ops()
-
-    from torch_mojo_backend.mojo_device.mojo_device_autocast import (
-        register_autocast_ops,
-    )
-
     register_autocast_ops()
-
-    from torch_mojo_backend.distributed import register_distributed_backend
-
     register_distributed_backend()
 
     _registered = True

--- a/torch_mojo_backend/mojo_device/streams.py
+++ b/torch_mojo_backend/mojo_device/streams.py
@@ -48,7 +48,7 @@ _default_streams_lock = threading.Lock()
 
 
 def _current_device_index() -> int:
-    from torch_mojo_backend.mojo_device import torch_mojo_device_module
+    from torch_mojo_backend.mojo_device import torch_mojo_device_module  # noqa: PLC0415 -- cycle: torch_mojo_device_module imports this module (see the E402 note at its end)
 
     return torch_mojo_device_module.current_device()
 
@@ -65,7 +65,7 @@ def _resolve_index(device: _DeviceLike) -> int:
 
 
 def _max_device_of(index: int) -> max.driver.Device:
-    from torch_mojo_backend.mojo_device.torch_mojo_tensor import (
+    from torch_mojo_backend.mojo_device.torch_mojo_tensor import (  # noqa: PLC0415 -- same cycle, one module further: torch_mojo_tensor imports torch_mojo_device_module
         find_equivalent_max_device,
     )
 
@@ -230,7 +230,7 @@ class Stream(torch._C.Stream):
         (mojo_device/comm_fence.py) — so fence before observing, once.
         """
         if self._device_stream.is_default:
-            from torch_mojo_backend.mojo_device import comm_fence
+            from torch_mojo_backend.mojo_device import comm_fence  # noqa: PLC0415 -- same cycle: comm_fence imports torch_mojo_tensor
 
             comm_fence.fence_device(self._index)
 

--- a/torch_mojo_backend/mojo_device/streams.py
+++ b/torch_mojo_backend/mojo_device/streams.py
@@ -48,7 +48,9 @@ _default_streams_lock = threading.Lock()
 
 
 def _current_device_index() -> int:
-    from torch_mojo_backend.mojo_device import torch_mojo_device_module  # noqa: PLC0415 -- cycle: torch_mojo_device_module imports this module (see the E402 note at its end)
+    from torch_mojo_backend.mojo_device import (  # noqa: PLC0415 -- cycle: torch_mojo_device_module imports this module (see the E402 note at its end)
+        torch_mojo_device_module,
+    )
 
     return torch_mojo_device_module.current_device()
 
@@ -230,7 +232,9 @@ class Stream(torch._C.Stream):
         (mojo_device/comm_fence.py) — so fence before observing, once.
         """
         if self._device_stream.is_default:
-            from torch_mojo_backend.mojo_device import comm_fence  # noqa: PLC0415 -- same cycle: comm_fence imports torch_mojo_tensor
+            from torch_mojo_backend.mojo_device import (  # noqa: PLC0415 -- same cycle: comm_fence imports torch_mojo_tensor
+                comm_fence,
+            )
 
             comm_fence.fence_device(self._index)
 

--- a/torch_mojo_backend/mojo_device/torch_mojo_device_module.py
+++ b/torch_mojo_backend/mojo_device/torch_mojo_device_module.py
@@ -195,7 +195,10 @@ def synchronize(device: "int | str | torch.device | None" = None):
     every op it issued has actually run on the device. So does a collective
     still flying on the comm stream, which only the default stream is waited
     on here: fence it onto that stream first (mojo_device/comm_fence.py)."""
-    from torch_mojo_backend.mojo_device import comm_fence, deferred_compile  # noqa: PLC0415 -- same cycle, through comm_fence's import of torch_mojo_tensor
+    from torch_mojo_backend.mojo_device import (  # noqa: PLC0415 -- same cycle, through comm_fence's import of torch_mojo_tensor
+        comm_fence,
+        deferred_compile,
+    )
 
     comm_fence.fence_all()
     deferred_compile.drain()

--- a/torch_mojo_backend/mojo_device/torch_mojo_device_module.py
+++ b/torch_mojo_backend/mojo_device/torch_mojo_device_module.py
@@ -176,7 +176,7 @@ def _device_synchronize(device: "int | str | torch.device | None" = None):
     is nothing of theirs to wait for; only the *other* thread's issued work
     must land first, which is exactly a stream synchronize.
     """
-    from torch_mojo_backend.mojo_device.torch_mojo_tensor import (
+    from torch_mojo_backend.mojo_device.torch_mojo_tensor import (  # noqa: PLC0415 -- cycle: torch_mojo_tensor imports this module
         _release_synchronized_d2h_owners,
         _release_synchronized_h2d_sources,
         find_equivalent_max_device,
@@ -195,7 +195,7 @@ def synchronize(device: "int | str | torch.device | None" = None):
     every op it issued has actually run on the device. So does a collective
     still flying on the comm stream, which only the default stream is waited
     on here: fence it onto that stream first (mojo_device/comm_fence.py)."""
-    from torch_mojo_backend.mojo_device import comm_fence, deferred_compile
+    from torch_mojo_backend.mojo_device import comm_fence, deferred_compile  # noqa: PLC0415 -- same cycle, through comm_fence's import of torch_mojo_tensor
 
     comm_fence.fence_all()
     deferred_compile.drain()
@@ -218,7 +218,7 @@ def memory_stats(device: "int | str | torch.device | None" = None) -> dict[str, 
     ``torch.cuda.memory_stats`` on a CUDA build; callers that want a number
     for this device get honest ones here.
     """
-    from torch_mojo_backend.mojo_device.torch_mojo_tensor import (
+    from torch_mojo_backend.mojo_device.torch_mojo_tensor import (  # noqa: PLC0415 -- same cycle as _device_synchronize above
         find_equivalent_max_device,
     )
 

--- a/torch_mojo_backend/mojo_device/torch_mojo_tensor.py
+++ b/torch_mojo_backend/mojo_device/torch_mojo_tensor.py
@@ -615,7 +615,9 @@ class TorchMojoTensor(torch.Tensor):
         consuming it, matching PyTorch's asynchronous accelerator-to-CPU
         contract. Blocking and CPU-device copies are ready on return.
         """
-        from torch_mojo_backend.mojo_device import comm_fence  # noqa: PLC0415 -- cycle: comm_fence imports this module
+        from torch_mojo_backend.mojo_device import (  # noqa: PLC0415 -- cycle: comm_fence imports this module
+            comm_fence,
+        )
 
         # A collective that wrote these bytes may still be flying on the comm
         # stream; the default stream this transfer rides is ordered after it
@@ -689,7 +691,9 @@ class TorchMojoTensor(torch.Tensor):
         not see a buffer whose producing launches -- including the copy a
         strided export just queued -- are still waiting on a compile.
         """
-        from torch_mojo_backend.mojo_device import comm_fence  # noqa: PLC0415 -- cycle: comm_fence imports this module
+        from torch_mojo_backend.mojo_device import (  # noqa: PLC0415 -- cycle: comm_fence imports this module
+            comm_fence,
+        )
 
         comm_fence.fence_tensor(self)  # same reason as _to_cpu_tensor's
         src = self._contig()

--- a/torch_mojo_backend/mojo_device/torch_mojo_tensor.py
+++ b/torch_mojo_backend/mojo_device/torch_mojo_tensor.py
@@ -12,14 +12,22 @@ import torch
 from max.driver import CPU
 from max.dtype import DType
 from max.experimental.torch import max_dtype_to_torch
+from max.experimental.torch.torch import torch_dtype_to_max
 
 from torch_mojo_backend import eager_kernels
+from torch_mojo_backend.eager_kernels import _ctx_ptr, call_queue, is_device_oom
 from torch_mojo_backend.eager_kernels.data_movement_ops import DataMovementExtension
 from torch_mojo_backend.eager_kernels.output_specs import (
     _submit_prepared_into,
     _TensorOutputSpec,
 )
-from torch_mojo_backend.mojo_device import objc_autorelease, torch_mojo_device_module
+from torch_mojo_backend.mojo_device import (
+    deferred_compile,
+    dlpack,
+    objc_autorelease,
+    torch_mojo_device_module,
+)
+from torch_mojo_backend.mojo_device.deferred_compile import dispatch as _dispatch_entry
 
 
 class _MojoTensorHolder(Protocol):
@@ -160,19 +168,6 @@ class _HolderOwner:
             wait(owner_ctx, event)
 
 
-def _ctx_ptr(device: max.driver.Device) -> int:
-    # Rebinds this module-level name to the real (cached) implementation on
-    # first use, so the lazy import costs one call, not one per call.
-    global _ctx_ptr
-    from torch_mojo_backend.eager_kernels import _ctx_ptr as real_ctx_ptr
-
-    # Self-rebind via `global`: ty compares the two same-shaped `def`s
-    # nominally, not structurally, and treats reassigning a function to
-    # (what is, at runtime,) itself as unsound.
-    _ctx_ptr = real_ctx_ptr  # ty: ignore[invalid-assignment]
-    return real_ctx_ptr(device)
-
-
 def _retain_failed_transfer_owner(device: max.driver.Device, owner: object) -> object:
     token = object()
     with _FAILED_TRANSFER_OWNERS_LOCK:
@@ -304,26 +299,6 @@ def _device_of(tensor: MojoTensorLike) -> max.driver.Device:
     return cast(max.driver.Device, tensor._device)
 
 
-def _dispatch_entry(
-    func: torch._ops.OpOverload, args: tuple[object, ...], kwargs: dict[str, object]
-) -> object:
-    """``deferred_compile.dispatch``, resolved on first use.
-
-    ``deferred_compile`` imports the call queue this module feeds, so it
-    cannot be imported at module scope. Rebinding the global on the first
-    dispatch keeps that direction intact and leaves the steady state at one
-    plain global lookup instead of a per-op ``sys.modules`` hit (the same
-    trick as ``output_specs._alloc``).
-    """
-    global _dispatch_entry
-    from torch_mojo_backend.mojo_device import deferred_compile
-
-    # Same nominal-vs-structural self-rebind quirk as _ctx_ptr above, even
-    # though both sides print identically.
-    _dispatch_entry = deferred_compile.dispatch  # ty: ignore[invalid-assignment]
-    return _dispatch_entry(func, args, kwargs)
-
-
 @runtime_checkable
 class _SynchronizableStream(Protocol):
     def synchronize(self): ...
@@ -369,8 +344,6 @@ def _alloc_with_recovery(
     try:
         return holder_mod.alloc(ctx_ptr, nbytes)
     except Exception as exc:
-        from torch_mojo_backend.eager_kernels import call_queue, is_device_oom
-
         if not is_device_oom(exc):
             raise
         sys.stderr.write(
@@ -600,8 +573,6 @@ class TorchMojoTensor(torch.Tensor):
         non_blocking: bool = False,
     ) -> "TorchMojoTensor":
         """H2D: allocate and enqueue a copy from a CPU torch tensor."""
-        from max.experimental.torch.torch import torch_dtype_to_max
-
         t = cpu_tensor.detach()
         if t.device.type != "cpu":
             # alloc_from_host below dereferences data_ptr() as HOST memory, so
@@ -644,7 +615,7 @@ class TorchMojoTensor(torch.Tensor):
         consuming it, matching PyTorch's asynchronous accelerator-to-CPU
         contract. Blocking and CPU-device copies are ready on return.
         """
-        from torch_mojo_backend.mojo_device import comm_fence, deferred_compile
+        from torch_mojo_backend.mojo_device import comm_fence  # noqa: PLC0415 -- cycle: comm_fence imports this module
 
         # A collective that wrote these bytes may still be flying on the comm
         # stream; the default stream this transfer rides is ordered after it
@@ -676,8 +647,6 @@ class TorchMojoTensor(torch.Tensor):
         # remain alive until the non-owning DeviceBuffer copy has completed.
         _record_d2h_owner(src._device, (owner, src._holder))
         try:
-            from torch_mojo_backend.mojo_device import dlpack
-
             return torch.from_dlpack(
                 dlpack.make_capsule(owner, ptr, src._shape, src._dtype, CPU())
             )
@@ -720,7 +689,7 @@ class TorchMojoTensor(torch.Tensor):
         not see a buffer whose producing launches -- including the copy a
         strided export just queued -- are still waiting on a compile.
         """
-        from torch_mojo_backend.mojo_device import comm_fence, deferred_compile, dlpack
+        from torch_mojo_backend.mojo_device import comm_fence  # noqa: PLC0415 -- cycle: comm_fence imports this module
 
         comm_fence.fence_tensor(self)  # same reason as _to_cpu_tensor's
         src = self._contig()
@@ -730,8 +699,6 @@ class TorchMojoTensor(torch.Tensor):
         )
 
     def __dlpack_device__(self) -> tuple[int, int]:
-        from torch_mojo_backend.mojo_device import dlpack
-
         return dlpack.dlpack_device(self._device)
 
     def __coerce_same_metadata_as_tangent__(
@@ -1023,8 +990,6 @@ def _copy_strided_enqueue(dst: TorchMojoTensor, src: TorchMojoTensor):
     loaded, so the item is always launch-ready; it only holds FIFO order).
     The queue holds raw pointers, so both tensors are handed over as the
     item's keep-alive: their buffers must outlive the launch."""
-    from torch_mojo_backend.eager_kernels import call_queue as _cq
-
     holder = _holder_mod()
     args = (
         dst._ptr,
@@ -1035,7 +1000,7 @@ def _copy_strided_enqueue(dst: TorchMojoTensor, src: TorchMojoTensor):
         dst._itemsize,
         _ctx_ptr(dst._device),
     )
-    _cq.external_call(holder.CopyStrided, args, keepalive=(dst, src))
+    call_queue.external_call(holder.CopyStrided, args, keepalive=(dst, src))
 
 
 def _copy_strided_into(dst: TorchMojoTensor, src: TorchMojoTensor):
@@ -1044,9 +1009,7 @@ def _copy_strided_into(dst: TorchMojoTensor, src: TorchMojoTensor):
     The shared materialize/copy primitive: powers .contiguous(), copy_ into
     views, and expand materialization (src strides may contain 0s).
     """
-    from torch_mojo_backend.eager_kernels import call_queue as _cq
-
-    if _cq.enabled() and _cq.active():
+    if call_queue.enabled() and call_queue.active():
         # Hold FIFO position behind queued producers of src/dst.
         _copy_strided_enqueue(dst, src)
         return
@@ -1064,7 +1027,9 @@ def _copy_strided_into(dst: TorchMojoTensor, src: TorchMojoTensor):
 @functools.cache
 def get_ordered_accelerators() -> list[max.driver.Device]:
     """Get accelerators ordered with GPUs first, then CPU last"""
-    from torch_mojo_backend.torch_compile_backend.compiler import get_accelerators
+    from torch_mojo_backend.torch_compile_backend.compiler import (  # noqa: PLC0415 -- cycle: compiler imports comm_fence, which imports this module
+        get_accelerators,
+    )
 
     accelerators = list(get_accelerators())
 

--- a/torch_mojo_backend/monkeypatching.py
+++ b/torch_mojo_backend/monkeypatching.py
@@ -16,12 +16,23 @@ registration APIs (``torch.library.impl``, the PrivateUse1 backend module,
 ``mojo_device/register.py``.
 """
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping, Sequence
 from functools import wraps
 from types import ModuleType
 from typing import TypeVar
 
 import torch
+import torch._functorch._aot_autograd.runtime_wrappers as runtime_wrappers
+import torch._subclasses.fake_tensor as fake_tensor_module
+import torch.fx.experimental.proxy_tensor as proxy_tensor
+import torch.optim.optimizer as optimizer_module
+import torch.utils._foreach_utils as foreach_utils
+from torch._dynamo.variables.builder import VariableBuilder
+from torch._subclasses.fake_tensor import FakeTensor
+from torch._subclasses.functional_tensor import FunctionalTensor, FunctionalTensorMode
+
+from torch_mojo_backend.mojo_device import streams as mojo_streams
+from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
 
 _T = TypeVar("_T")
 
@@ -103,9 +114,7 @@ def _install_torch_accelerator_stream_api(torch_mojo_device_module: ModuleType):
 
     @wraps(original_set_stream)
     def set_stream(stream: torch.Stream):
-        from torch_mojo_backend.mojo_device.streams import Stream as MojoStream
-
-        if isinstance(stream, MojoStream):
+        if isinstance(stream, mojo_streams.Stream):
             torch_mojo_device_module.set_stream(stream)
         else:
             original_set_stream(stream)
@@ -131,8 +140,6 @@ def _install_torch_stream_event_dispatch():
     """
     if getattr(torch.Stream, "_torch_mojo_backend", False):
         return
-    from torch_mojo_backend.mojo_device import streams as mojo_streams
-
     original_stream = torch.Stream
     original_event = torch.Event
     construct_stream = _forwarding_constructor(original_stream)
@@ -191,11 +198,6 @@ def _declare_mojo_tensor_foreach_capable():
     optimizers. TorchMojoTensor is a transparent PrivateUse1 wrapper, so opt
     it into the same lists as DTensor and other supported tensor types.
     """
-    import torch.optim.optimizer as optimizer_module
-    import torch.utils._foreach_utils as foreach_utils
-
-    from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
-
     for supported_types in (
         optimizer_module._foreach_supported_types,
         foreach_utils._foreach_supported_types,
@@ -233,18 +235,6 @@ def _declare_mojo_tensor_as_plain_tensor():
       "unsupported operand type(s) for +: 'FunctionalTensor' and
       'TorchMojoTensor'".
     """
-    from collections.abc import Mapping, Sequence
-
-    import torch._functorch._aot_autograd.runtime_wrappers as runtime_wrappers
-    import torch._subclasses.fake_tensor as fake_tensor_module
-    import torch.fx.experimental.proxy_tensor as proxy_tensor
-    from torch._subclasses.functional_tensor import (
-        FunctionalTensor,
-        FunctionalTensorMode,
-    )
-
-    from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
-
     if TorchMojoTensor not in proxy_tensor.HANDLED_TYPES:
         # torch infers HANDLED_TYPES' type from its own fixed-length tuple
         # literal, so extending it by one element is always a "wrong length"
@@ -348,10 +338,6 @@ def _trace_mojo_tensor_as_a_plain_tensor_in_dynamo():
     ``wrap_tensor``. Add the mojo wrapper there. The table is memoized per
     ``config.trace_numpy`` value, so populate both.
     """
-    from torch._dynamo.variables.builder import VariableBuilder
-
-    from torch_mojo_backend.mojo_device.torch_mojo_tensor import TorchMojoTensor
-
     for trace_numpy in (False, True):
         table = VariableBuilder._type_dispatch_impl(trace_numpy)
         table[TorchMojoTensor] = VariableBuilder.wrap_tensor
@@ -376,8 +362,6 @@ def _keep_mojo_kernels_out_of_fake_tensor_construction():
     test has this same rough edge — see test_privateuseone_python_backend
     "prevent compile-time FakeTensor crashes".)
     """
-    from torch._subclasses.fake_tensor import FakeTensor
-
     exclude_privateuse1 = torch._C.DispatchKeySet(torch._C.DispatchKey.PrivateUse1)
     original_new = FakeTensor.__new__
 

--- a/torch_mojo_backend/testing.py
+++ b/torch_mojo_backend/testing.py
@@ -7,6 +7,8 @@ from typing import cast
 import torch
 
 from torch_mojo_backend import mojo_backend
+from torch_mojo_backend.eager_kernels import aten_fast
+from torch_mojo_backend.mojo_device.mojo_device_aten_ops import EAGER_CALL_COUNTERS
 from torch_mojo_backend.types import CountedCallable
 
 
@@ -25,7 +27,7 @@ def _xfail_if_unsupported(device: str) -> Iterator[None]:
         yield
     except NotImplementedError as exc:
         if str(device).startswith("mojo") and "mojo" in str(exc):
-            import pytest
+            import pytest  # noqa: PLC0415 -- pytest is a dev dependency; this module imports without it
 
             pytest.xfail(f"unsupported on mojo eager: {exc}")
         raise
@@ -59,10 +61,6 @@ class CallChecker:
         name = getattr(func, "__name__", "")
         if not name.startswith("aten"):
             return []
-        try:
-            from torch_mojo_backend.eager_kernels import aten_fast
-        except Exception:
-            return []
         base = f"fast_{name}"
         twins = []
         for attr in dir(aten_fast):
@@ -83,12 +81,6 @@ class CallChecker:
         if not name.startswith("aten_"):
             return []
         base = name[len("aten_") :]  # e.g. "empty_like", "mean_out", "_log_softmax"
-        try:
-            from torch_mojo_backend.mojo_device.mojo_device_aten_ops import (
-                EAGER_CALL_COUNTERS,
-            )
-        except Exception:
-            return []
         candidates = {f"aten::{base}"}
         if "_" in base:
             head, tail = base.rsplit("_", 1)

--- a/torch_mojo_backend/torch_compile_backend/compiler.py
+++ b/torch_mojo_backend/torch_compile_backend/compiler.py
@@ -16,6 +16,7 @@ from max import engine
 from max.experimental.torch.torch import torch_dtype_to_max
 from max.graph import DeviceRef, Graph, KernelLibrary, ops as max_ops
 from torch._dynamo.backends.common import aot_autograd
+from torch._subclasses.fake_tensor import unset_fake_temporarily
 
 from torch_mojo_backend.aten_functions import (
     CURRENT_FX_NODE,
@@ -25,6 +26,11 @@ from torch_mojo_backend.aten_functions import (
 )
 from torch_mojo_backend.flags import profiling_enabled, verbose_enabled
 from torch_mojo_backend.mojo_device import comm_fence
+from torch_mojo_backend.mojo_device.torch_mojo_tensor import (
+    TorchMojoTensor,
+    _row_major_strides,
+    find_equivalent_max_device,
+)
 from torch_mojo_backend.torch_compile_backend import debug
 from torch_mojo_backend.torch_compile_backend.utils import (
     get_accelerators,
@@ -320,8 +326,6 @@ class _GraphFactory:
             # function). Bake it into the MAX graph as a constant. The
             # compiler runs under AOTAutograd's fake mode, which must not
             # intercept the reads of the real constant.
-            from torch._subclasses.fake_tensor import unset_fake_temporarily
-
             device = self.get_max_device(attr_value)
             with unset_fake_temporarily():
                 host = attr_value.detach().cpu()
@@ -452,11 +456,6 @@ def _mojo_tensor_from_buffer(buffer: max.driver.Buffer) -> torch.Tensor:
     MAX buffers release their device memory when the last Python reference
     drops, exactly like the eager TensorHolder.
     """
-    from torch_mojo_backend.mojo_device.torch_mojo_tensor import (
-        TorchMojoTensor,
-        _row_major_strides,
-    )
-
     shape = tuple(buffer.shape)
     return TorchMojoTensor._make(
         buffer,
@@ -654,13 +653,6 @@ dummy_backend = aot_autograd(fw_compiler=dummy_compiler)
 #   which can take advantage of MAX's automatic kernel fusion.
 def fast_from_dlpack(t: torch.Tensor) -> max.driver.Buffer:
     if t.device.type == "cuda":
-        # Deferred: torch_mojo_tensor imports this module (get_ordered_accelerators
-        # -> compiler.get_accelerators), so importing it back at module scope
-        # would cycle.
-        from torch_mojo_backend.mojo_device.torch_mojo_tensor import (
-            find_equivalent_max_device,
-        )
-
         stream = torch.cuda.current_stream(t.device).cuda_stream
         # _from_dlpack wants a concrete driver Device, not the graph-building
         # DeviceRef torch_device_to_max_device returns.


### PR DESCRIPTION
Adds ruff's `import-outside-top-level` (`PLC0415`) to `extend-select` and sweeps every site it flagged on main: 277 function-level imports in 49 files, of which **248 move to module scope and 29 stay lazy**, each with `# noqa: PLC0415 -- <reason>` where the reason is a checked fact. AGENTS.md gets a bullet stating the rule and the three exceptions.

### What stays lazy, and why

| reason | count | where |
|---|---|---|
| real import cycle, verified by hoisting and re-importing in a fresh interpreter | 13 | `torch_mojo_tensor` ↔ `comm_fence`/`compiler`, `torch_mojo_device_module`, `streams`, `device_streams`, `output_specs` ↔ `eager_kernels/__init__`, `call_queue` → package `get_accelerators` |
| `sys.path` / env ordering | 6 | the conformance driver's suite imports (`common_device_type` must not load before `PYTORCH_TESTING_DEVICE_FOR_CUSTOM` is set), nanoGPT's `model` in two scripts |
| optional dependency | 7 | `nvidia.nccl`, `tiktoken`, `pytest` inside the shipped `testing.py`, `process_group` behind `torch.distributed.is_available()`, the mojo imports in `nanogpt_ddp.py` (its `--device cuda` runs in a stock venv) |
| verified import-time side effect | 3 | `eager_kernels.tensor_holder` in three `current_bench` scripts: reading that attribute runs the package's module `__getattr__`, which builds and dlopens the extension |

Nine suspected cycles turned out not to be cycles when probed and were moved.

### One belief corrected

Several comments said that importing `aten_fast` compiles the eager kernels, which is why tests and the dispatch helpers imported it lazily. Measured on a GPU node: importing it puts no native module in `sys.modules` and costs 0.02 s; a kernel is built and dlopened by the first *call* into its descriptor. Two test files already imported it at module scope, and pytest collection of the whole tree (6596 tests) prints no build line. So the 110 per-test imports in `tests/test_eager_kernels.py`, the accessor functions that fed them, and the lazy imports in `aten_ops/support.py::_fast`, `mojo_device_autograd::_fast` and `testing.py` are all hoisted, and the stale docstring in `support.py` is corrected. `import torch_mojo_backend.torch_compile_backend` still loads no native module.

### Late binding preserved

Eight host-wiring tests monkeypatch `eager_flash_attention.load_fa4_ops` and `torch_compile_backend.utils.get_accelerators`; `aten_fast` now imports those *modules* rather than the names so the patches keep taking effect. Every `monkeypatch.setattr` target in the suite was checked against the moved imports; those were the only two.

### Validation

ruff (with PLC0415) 0, ruff format clean, ty 0. Fresh-interpreter import of all 93 package modules on a GPU node: 0 failures. `pytest --collect-only` over tests, conformance and benchmarks: 6596 tests, no kernel build. Serial on 1 GPU: `test_eager_kernels` 1762 passed, `test_compile_mojo_device` 44, `test_mojo_device` 87 (10 skipped, 2 xfailed, 2 xpassed), `test_call_queue` 50, `test_eager_optimizer_ops` 52, `test_eager_kernel_loader` 19, `test_direct_dispatch` 16, `test_fa4_host_wiring` 16, `test_mojo_streams` 11, `test_sdpa_host_wiring` 8, `test_out_variant_resize` 5, `test_monkeypatching_is_centralized` 2, the touched `test_aten_functions` slice 58 passed / 1 xfailed; `test_distributed` 10 passed on 2 GPUs. The only failure is the pre-existing `test_dlpack.py::test_consumed_capsule_survives_dlpack_module_reload` on this cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AbxaDeRuA7yywYEUuZV72
