### PR TITLE
Remove dead code found by vulture

### DIFF
--- a/benchmarks/bench_lib/check.py
+++ b/benchmarks/bench_lib/check.py
@@ -130,12 +130,9 @@ BENCH_NOTES_KEY: pytest.StashKey[list[str]] = pytest.StashKey()
 class Bench:
     """Measures one case, checks it against the baseline, stages updates."""
 
-    def __init__(
-        self, request: pytest.FixtureRequest, hw: Hardware, mojo: torch.device
-    ):
+    def __init__(self, request: pytest.FixtureRequest, hw: Hardware):
         self._request = request
         self._hw = hw
-        self._mojo = mojo
 
     def run(
         self, ref_fn: Callable[[], object], our_fn: Callable[[], object], flops: float

--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -103,10 +103,8 @@ def deterministic_operands():
 
 
 @pytest.fixture
-def bench(
-    request: pytest.FixtureRequest, hw: Hardware, mojo_device: torch.device
-) -> Bench:
-    return Bench(request, hw, mojo_device)
+def bench(request: pytest.FixtureRequest, hw: Hardware) -> Bench:
+    return Bench(request, hw)
 
 
 def pytest_terminal_summary(

--- a/torch_mojo_backend/distributed/nccl.py
+++ b/torch_mojo_backend/distributed/nccl.py
@@ -146,7 +146,6 @@ def _declare(lib: ctypes.CDLL):
     ]
     lib.ncclCommDestroy.argtypes = [ctypes.c_void_p]
     lib.ncclCommAbort.argtypes = [ctypes.c_void_p]
-    lib.ncclCommGetAsyncError.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_int)]
     lib.ncclCommUserRank.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_int)]
     lib.ncclCommCount.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_int)]
     for name, extra in [
@@ -287,16 +286,6 @@ class NcclComm:
             self._ccl._lib.ncclCommAbort(ctypes.c_void_p(self._handle))
             self._aborted = True
             self._handle = 0
-
-    def async_error(self) -> int:
-        err = ctypes.c_int(0)
-        self._ccl._check(
-            "ncclCommGetAsyncError",
-            self._ccl._lib.ncclCommGetAsyncError(
-                ctypes.c_void_p(self._handle), ctypes.byref(err)
-            ),
-        )
-        return err.value
 
     def all_reduce(
         self, send_ptr: int, recv_ptr: int, count: int, dtype: int, op: int, stream: int

--- a/torch_mojo_backend/distributed/process_group.py
+++ b/torch_mojo_backend/distributed/process_group.py
@@ -195,7 +195,6 @@ class MojoProcessGroup(dist.ProcessGroup):
         # this too; the C++-side store stays null and we keep it here instead.
         super().__init__(rank, world_size)  # ty: ignore[missing-argument, invalid-argument-type]
         self._store = store
-        self._timeout = timeout
         self._group_name = ""
         # Communicators keyed by mojo device index, created lazily at the
         # first device collective (a collective, blocking rendezvous — every


### PR DESCRIPTION
## Summary

A vulture 2.16 pass over the package, tests, benchmarks and scripts, with every hit checked by hand. Four items were real:

- `torch_mojo_backend/distributed/nccl.py`: `Comm.async_error` and its `ncclCommGetAsyncError` ctypes prototype had no caller.
- `torch_mojo_backend/distributed/process_group.py`: `self._timeout` was assigned in the constructor and never read. The timeout still reaches the CPU gloo group through the constructor argument.
- `benchmarks/bench_lib/check.py` + `benchmarks/conftest.py`: `Bench` stored the mojo device and never read it. All 14 benchmark test files request the `mojo_device` fixture themselves, so device registration still happens before any measurement.

## Kept on purpose

- `getBackendName`, `getGroupName`, `setGroupName` on `MojoProcessGroup` look unused from Python, but torch's `PyProcessGroup.hpp` trampoline forwards the C++ virtuals to those Python names, so `pg.name()` and friends land there.
- `SDPA_CAUSAL_NONE` mirrors the Mojo `CAUSAL_NONE = 0` regime alongside the three used ones.
- `bench_lib.baselines.rebuild()` is a documented maintenance entry point named in three error messages.
- Everything else vulture reports is name-based dispatch: `@map_to` aten implementations, `_register_fast(...)` strings, pytest hooks and autouse fixtures, the torch device-module protocol, pydantic validators, ctypes struct fields.

## Checks

`ruff check`, `ruff format --check`, and `ty check` pass. `benchmarks/test_coverage.py` passes. `tests/test_distributed.py` skips on this machine (no GPU), so the nccl and process-group deletions are verified by import and by inspection only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yfCEsnquoGy4FQqZSWeNu
