### PR TITLE
Fix every Mojo compiler warning (Mojo 1.0 deprecations)

### DIFF
--- a/current_bench/bench_mfma_direct.mojo
+++ b/current_bench/bench_mfma_direct.mojo
@@ -13,7 +13,7 @@ dimensions. Example:
 from std.builtin.sort import sort
 from std.collections import List, Optional
 from std.gpu import block_idx, grid_dim, thread_idx
-from std.gpu.host import DeviceContext, FuncAttribute
+from max.gpu.host import DeviceContext, FuncAttribute
 from std.math import ceildiv
 from std.time import perf_counter_ns
 from std.sys import get_defined_bool, get_defined_int
@@ -41,7 +41,7 @@ comptime THREADS = (BM // WM) * (BN // WN) * WARP_K * 64
 
 @__name("bench_mfma_fill_bf16")
 def _fill_bf16(
-    ptr: UnsafePointer[Scalar[DType.bfloat16], MutAnyOrigin],
+    ptr: Pointer[Scalar[DType.bfloat16], MutAnyOrigin],
     count: Int,
     value: Scalar[DType.bfloat16],
 ):
@@ -49,17 +49,17 @@ def _fill_bf16(
     var stride = Int(grid_dim.x) * 256 * 4
     while i < count:
         if i + 4 <= count:
-            ptr.store[width=4](i, SIMD[DType.bfloat16, 4](value))
+            ptr.unsafe_store[width=4](i, SIMD[DType.bfloat16, 4](value))
         else:
             for lane in range(4):
                 if i + lane < count:
-                    ptr[i + lane] = value
+                    ptr[unsafe_offset=i + lane] = value
         i += stride
 
 
 @always_inline
 def _enqueue_fill(
-    ptr: UnsafePointer[Scalar[DType.bfloat16], MutAnyOrigin],
+    ptr: Pointer[Scalar[DType.bfloat16], MutAnyOrigin],
     count: Int,
     value: Scalar[DType.bfloat16],
     ctx: DeviceContext,
@@ -120,24 +120,22 @@ def main() raises:
         var b = TileTensor[mut=False](b_buf, row_major(Coord(k, n)))
         var c = TileTensor[mut=True](c_buf, row_major(Coord(m, n)))
         var c_ptr = c_buf.unsafe_ptr().as_unsafe_any_origin()
-        var bias_ptr = (
-            bias_buf.unsafe_ptr().as_unsafe_any_origin().as_immutable()
-        )
+        var bias_ptr = bias_buf.unsafe_ptr().as_unsafe_any_origin().as_imm()
 
         @always_inline
         @parameter
         @__copy_capture(c_ptr, bias_ptr, n)
         def _bias_store[
-            value_dtype: DType, width: SIMDSize, *, alignment: Int = 1
+            value_dtype: DType, width: SIMDLength, *, alignment: Int = 1
         ](coords: IndexList[2], value: SIMD[value_dtype, width]):
             var row = Int(coords[0])
             var col = Int(coords[1])
             var off = row * n + col
             var result = (
                 value.cast[DType.float32]()
-                + bias_ptr.load[width=width](col).cast[DType.float32]()
+                + bias_ptr.unsafe_load[width=width](col).cast[DType.float32]()
             )
-            c_ptr.store[width=width, alignment=4](
+            c_ptr.unsafe_store[width=width, alignment=4](
                 off, result.cast[DType.bfloat16]()
             )
 

--- a/demo_scripts/dummy_mojo_kernels/dummy.mojo
+++ b/demo_scripts/dummy_mojo_kernels/dummy.mojo
@@ -26,16 +26,16 @@ struct Grayscale:
             ) -> SIMD[DType.float32, simd_width]:
                 return img_in.load[simd_width](idx).cast[DType.float32]()
 
-            row = Int(idx[0].value())
-            col = Int(idx[1].value())
+            var row = Int(idx[0].value())
+            var col = Int(idx[1].value())
 
             # Load RGB values
-            r = load(IndexList[3](row, col, 0))
-            g = load(IndexList[3](row, col, 1))
-            b = load(IndexList[3](row, col, 2))
+            var r = load(IndexList[3](row, col, 0))
+            var g = load(IndexList[3](row, col, 1))
+            var b = load(IndexList[3](row, col, 2))
 
             # Apply standard grayscale conversion formula
-            gray = 0.21 * r + 0.71 * g + 0.07 * b
+            var gray = 0.21 * r + 0.71 * g + 0.07 * b
             return min(gray, 255)
 
         foreach[color_to_grayscale, target=target, simd_width=1](img_out, ctx)

--- a/docs/strided_owning_tensors_design.md
+++ b/docs/strided_owning_tensors_design.md
@@ -249,7 +249,7 @@ struct OwnedTensor(Movable, Writable):
         print("OWNED_DEL ptr=", Int(self.buf.unsafe_ptr()), " nbytes=", self.nbytes)
 
     @staticmethod
-    def data_ptr(self_ptr: UnsafePointer[Self, MutAnyOrigin]) raises -> PythonObject:
+    def data_ptr(self_ptr: Pointer[Self, MutAnyOrigin]) raises -> PythonObject:
         return PythonObject(Int(self_ptr[].buf.unsafe_ptr()))
 
 

--- a/tests/dummy_mojo_kernels/dummy.mojo
+++ b/tests/dummy_mojo_kernels/dummy.mojo
@@ -26,16 +26,16 @@ struct Grayscale:
             ) -> SIMD[DType.float32, simd_width]:
                 return img_in.load[simd_width](idx).cast[DType.float32]()
 
-            row = Int(idx[0].value())
-            col = Int(idx[1].value())
+            var row = Int(idx[0].value())
+            var col = Int(idx[1].value())
 
             # Load RGB values
-            r = load(IndexList[3](row, col, 0))
-            g = load(IndexList[3](row, col, 1))
-            b = load(IndexList[3](row, col, 2))
+            var r = load(IndexList[3](row, col, 0))
+            var g = load(IndexList[3](row, col, 1))
+            var b = load(IndexList[3](row, col, 2))
 
             # Apply standard grayscale conversion formula
-            gray = 0.21 * r + 0.71 * g + 0.07 * b
+            var gray = 0.21 * r + 0.71 * g + 0.07 * b
             return min(gray, 255)
 
         foreach[color_to_grayscale, target=target, simd_width=1](img_out, ctx)
@@ -59,27 +59,27 @@ struct GrayscaleMulti:
         def color_to_grayscale[
             simd_width: Int
         ](idx: Coord) -> SIMD[DType.float32, simd_width]:
-            row = Int(idx[0].value())
-            col = Int(idx[1].value())
+            var row = Int(idx[0].value())
+            var col = Int(idx[1].value())
 
-            noise = noise_in.load[simd_width](IndexList[2](row, col)).cast[
+            var noise = noise_in.load[simd_width](IndexList[2](row, col)).cast[
                 DType.float32
             ]()
 
             # Load RGB values
-            r = (
+            var r = (
                 img_in.load[simd_width](IndexList[3](row, col, 0)).cast[
                     DType.float32
                 ]()
                 + noise
             )
-            g = (
+            var g = (
                 img_in.load[simd_width](IndexList[3](row, col, 1)).cast[
                     DType.float32
                 ]()
                 + noise
             )
-            b = (
+            var b = (
                 img_in.load[simd_width](IndexList[3](row, col, 2)).cast[
                     DType.float32
                 ]()
@@ -87,7 +87,7 @@ struct GrayscaleMulti:
             )
 
             # Apply standard grayscale conversion formula
-            gray = 0.21 * r + 0.71 * g + 0.07 * b
+            var gray = 0.21 * r + 0.71 * g + 0.07 * b
             red_out.store(IndexList[2](row, col), r)
             return min(gray, 255)
 

--- a/torch_mojo_backend/eager_flash_attention/fa4_bwd_kernel.mojo
+++ b/torch_mojo_backend/eager_flash_attention/fa4_bwd_kernel.mojo
@@ -136,11 +136,11 @@ def bwd_main_kernel[
     v_tma: TMATensorTile[dtype, 3, kv_tile_shape, kv_desc_shape],
     dk_tma: TMATensorTile[dtype, 3, st_tile_shape, st_desc_shape],
     dv_tma: TMATensorTile[dtype, 3, st_tile_shape, st_desc_shape],
-    lse_log2_ptr: UnsafePointer[Float32, ImmutAnyOrigin],
-    dpsum_ptr: UnsafePointer[Float32, ImmutAnyOrigin],
-    dq_accum_ptr: UnsafePointer[Float32, MutAnyOrigin],
-    dk_accum_ptr: UnsafePointer[Float32, MutAnyOrigin],
-    dv_accum_ptr: UnsafePointer[Float32, MutAnyOrigin],
+    lse_log2_ptr: Pointer[Float32, ImmutAnyOrigin],
+    dpsum_ptr: Pointer[Float32, ImmutAnyOrigin],
+    dq_accum_ptr: Pointer[Float32, MutAnyOrigin],
+    dk_accum_ptr: Pointer[Float32, MutAnyOrigin],
+    dv_accum_ptr: Pointer[Float32, MutAnyOrigin],
     seq_len_arg: Int64,
     softmax_scale: Float32,
 ):
@@ -209,12 +209,12 @@ def bwd_main_kernel[
         alignment=128,
     ]()
     var k_base = smem_base
-    var v_base = k_base + kv_tile_size
-    var ring_base = v_base + kv_tile_size
+    var v_base = k_base.unsafe_offset(kv_tile_size)
+    var ring_base = v_base.unsafe_offset(kv_tile_size)
     # sdS is double-buffered: stage m%2 is written at iter m and read
     # by the dQ GEMM; the pre-dQ barrier of iter m+1 proves dQ(m)
     # retired before either warpgroup rewrites stage m%2 at iter m+2.
-    var sds_base = ring_base + STAGES * q_slot_size
+    var sds_base = ring_base.unsafe_offset(STAGES * q_slot_size)
     # lse_log2/dpsum smem ring: 2 stages x BM f32 each, prefetched
     # one m-tile ahead (consumer threads issue the gmem loads; the
     # per-iter named barrier orders store->read across warpgroups).
@@ -222,8 +222,8 @@ def bwd_main_kernel[
     # BM-f32 buffer per Q/dO slot pair, filled by the producer warp
     # and published by the Q slot's full barrier (init(2): TMA
     # expect + producer arrive); recycled with the slot's empties.
-    var lse_smem = (sds_base + 2 * sds_size).bitcast[Float32]()
-    var dps_smem = lse_smem + (STAGES // 2) * BM
+    var lse_smem = (sds_base.unsafe_offset(2 * sds_size)).unsafe_bitcast[Float32]()
+    var dps_smem = lse_smem.unsafe_offset((STAGES // 2) * BM)
     # dQ mailbox (FA4): per MMA wg, the raw dQ^T c-frag dump
     # [chunk(BM/8)][tid(128)][4] f32 = 20 KiB; the producer's drain
     # warp cp.reduce.async.bulk's it into dq_accum. Named-barrier
@@ -233,7 +233,7 @@ def bwd_main_kernel[
         BM if D == 128 else BM // 2
     )  # 64 x (q cols per wg): 5120 at hdim128/BM=80, 4096 at hdim64
     comptime DRAIN_BAR: Int = 128 + 32
-    var dq_mail = dps_smem + (STAGES // 2) * BM
+    var dq_mail = dps_smem.unsafe_offset((STAGES // 2) * BM)
 
     var k_smem = LayoutTensor[
         dtype,
@@ -269,14 +269,14 @@ def bwd_main_kernel[
         alignment=8,
     ]()
     if thread_idx.x == 0:
-        mbar_k[0].init()
-        mbar_v[0].init()
+        mbar_k[unsafe_offset=0].init()
+        mbar_v[unsafe_offset=0].init()
         comptime for s in range(STAGES):
             # One expect-arrive per slot (producer lane 0); the
             # slot's 320-B lse/dps cp.async.bulk rides the same
             # barrier via expect_tx (FA4's design — no stager warp).
-            full[s].init(1)
-            empty[s].init(Int32(NWG * 128))
+            full[unsafe_offset=s].init(1)
+            empty[unsafe_offset=s].init(Int32(NWG * 128))
     barrier()
 
     # Sliding window (causal local, v1: dense, left % 128 == 0).
@@ -314,14 +314,14 @@ def bwd_main_kernel[
         # stays identical to dense. Every per-CTA scalar is
         # warp.broadcast-laundered (tid-widening hazard class, see
         # HANDOFF.md).
-        var tbl = dk_accum_ptr.bitcast[Int32]() + 8 * Int(block_idx.x)
-        n_block = Int(warp.broadcast(tbl[0]))
-        vl_q_base = Int(warp.broadcast(tbl[1]))
-        var vl_k_base: Int = Int(warp.broadcast(tbl[2]))
-        var vl_slk: Int = Int(warp.broadcast(tbl[4]))
-        num_m_blocks = Int(warp.broadcast(tbl[5]))
-        m_start = Int(warp.broadcast(tbl[6]))
-        vl_mpad_base = Int(warp.broadcast(tbl[7]))
+        var tbl = dk_accum_ptr.unsafe_bitcast[Int32]().unsafe_offset(8 * Int(block_idx.x))
+        n_block = Int(warp.broadcast(tbl[unsafe_offset=0]))
+        vl_q_base = Int(warp.broadcast(tbl[unsafe_offset=1]))
+        var vl_k_base: Int = Int(warp.broadcast(tbl[unsafe_offset=2]))
+        var vl_slk: Int = Int(warp.broadcast(tbl[unsafe_offset=4]))
+        num_m_blocks = Int(warp.broadcast(tbl[unsafe_offset=5]))
+        m_start = Int(warp.broadcast(tbl[unsafe_offset=6]))
+        vl_mpad_base = Int(warp.broadcast(tbl[unsafe_offset=7]))
         h_idx = Int(block_idx.y)
         comptime if gqa_ratio > 1:
             # pack-GQA (varlen): block_idx.y is the KV head; h_idx
@@ -342,7 +342,7 @@ def bwd_main_kernel[
             # slk - slq; host-asserted slq <= slk). The S^T mask
             # base for trip 0 — self-attn (offs == 0, m_start*BM ==
             # n*BN) reduces to 0, i.e. mask_d = it*BM as in dense.
-            var vl_slq: Int = Int(warp.broadcast(tbl[3]))
+            var vl_slq: Int = Int(warp.broadcast(tbl[unsafe_offset=3]))
             vl_mask_base = (
                 m_start * BM - n_block * BN + (vl_slk - vl_slq)
             )
@@ -388,13 +388,13 @@ def bwd_main_kernel[
         if thread_idx.x < 32:
             var lane: Int = Int(thread_idx.x)
             if lane == 0:
-                mbar_k[0].expect_bytes(Int32(BN * D * size_of[dtype]()))
+                mbar_k[unsafe_offset=0].expect_bytes(Int32(BN * D * size_of[dtype]()))
                 k_tma.async_copy_3d(
-                    k_smem, mbar_k[0], (0, h_idx // gqa_ratio, kv_row)
+                    k_smem, mbar_k[unsafe_offset=0], (0, h_idx // gqa_ratio, kv_row)
                 )
-                mbar_v[0].expect_bytes(Int32(BN * D * size_of[dtype]()))
+                mbar_v[unsafe_offset=0].expect_bytes(Int32(BN * D * size_of[dtype]()))
                 v_tma.async_copy_3d(
-                    v_smem, mbar_v[0], (0, h_idx // gqa_ratio, kv_row)
+                    v_smem, mbar_v[unsafe_offset=0], (0, h_idx // gqa_ratio, kv_row)
                 )
 
             var slot: Int = 0
@@ -439,7 +439,7 @@ def bwd_main_kernel[
                 # cp.async.bulk copies counted by the same
                 # expect_tx (FA4's design — the TMA/DMA engine does
                 # the staging; no warp touches gmem).
-                empty[slot].wait(phase)
+                empty[unsafe_offset=slot].wait(phase)
                 if lane == 0:
                     var q_st = LayoutTensor[
                         dtype,
@@ -447,12 +447,12 @@ def bwd_main_kernel[
                         MutAnyOrigin,
                         address_space=AddressSpace.SHARED,
                         alignment=128,
-                    ]((ring_base + slot * q_slot_size).as_unsafe_any_origin())
-                    full[slot].expect_bytes(
+                    ]((ring_base.unsafe_offset(slot * q_slot_size)).as_unsafe_any_origin())
+                    full[unsafe_offset=slot].expect_bytes(
                         Int32(BM * D * size_of[dtype]() + BM * 4)
                     )
                     q_tma.async_copy_3d(
-                        q_st, full[slot], (0, h_cur, q_row)
+                        q_st, full[unsafe_offset=slot], (0, h_cur, q_row)
                     )
                     inlined_assembly[
                         "cp.async.bulk.shared::cluster.global"
@@ -461,13 +461,13 @@ def bwd_main_kernel[
                         NoneType,
                         constraints="r,l,r,r",
                     ](
-                        Int32(Int(lse_smem + (slot // 2) * BM)),
+                        Int32(Int(lse_smem.unsafe_offset((slot // 2) * BM))),
                         Int64(lse_byte),
                         Int32(BM * 4),
-                        Int32(Int(full + slot)),
+                        Int32(Int(full.unsafe_offset(slot))),
                     )
 
-                empty[slot + 1].wait(phase)
+                empty[unsafe_offset=slot + 1].wait(phase)
                 if lane == 0:
                     var do_st = LayoutTensor[
                         dtype,
@@ -475,12 +475,12 @@ def bwd_main_kernel[
                         MutAnyOrigin,
                         address_space=AddressSpace.SHARED,
                         alignment=128,
-                    ]((ring_base + (slot + 1) * q_slot_size).as_unsafe_any_origin())
-                    full[slot + 1].expect_bytes(
+                    ]((ring_base.unsafe_offset((slot + 1) * q_slot_size)).as_unsafe_any_origin())
+                    full[unsafe_offset=slot + 1].expect_bytes(
                         Int32(BM * D * size_of[dtype]() + BM * 4)
                     )
                     do_tma.async_copy_3d(
-                        do_st, full[slot + 1], (0, h_cur, q_row)
+                        do_st, full[unsafe_offset=slot + 1], (0, h_cur, q_row)
                     )
                     inlined_assembly[
                         "cp.async.bulk.shared::cluster.global"
@@ -489,10 +489,10 @@ def bwd_main_kernel[
                         NoneType,
                         constraints="r,l,r,r",
                     ](
-                        Int32(Int(dps_smem + (slot // 2) * BM)),
+                        Int32(Int(dps_smem.unsafe_offset((slot // 2) * BM))),
                         Int64(dps_byte),
                         Int32(BM * 4),
-                        Int32(Int(full + slot + 1)),
+                        Int32(Int(full.unsafe_offset(slot + 1))),
                     )
 
                 q_row += BM
@@ -557,7 +557,7 @@ def bwd_main_kernel[
                             Int64(
                                 dq_byte_base + w * DQ_MAIL_F32 * 4
                             ),
-                            Int32(Int(dq_mail + w * DQ_MAIL_F32)),
+                            Int32(Int(dq_mail.unsafe_offset(w * DQ_MAIL_F32))),
                             Int32(DQ_MAIL_F32 * 4),
                         )
                     cp_async_bulk_commit_group()
@@ -577,7 +577,7 @@ def bwd_main_kernel[
     var wg: Int = wgid - 1
 
     comptime for s in range(STAGES):
-        _ = empty[s].arrive()
+        _ = empty[unsafe_offset=s].arrive()
 
     # ---- WGMMA operators.
     # S^T / dP^T: (BN x BM) = KV-tile · {Q,dO}-tile^T, M split by wg.
@@ -692,8 +692,8 @@ def bwd_main_kernel[
         ).cast[accum_type]()
 
     # ---- consumer state.
-    mbar_k[0].wait(UInt32(0))
-    mbar_v[0].wait(UInt32(0))
+    mbar_k[unsafe_offset=0].wait(UInt32(0))
+    mbar_v[unsafe_offset=0].wait(UInt32(0))
 
 
     var slot: Int = 0
@@ -711,28 +711,28 @@ def bwd_main_kernel[
             MutAnyOrigin,
             address_space=AddressSpace.SHARED,
             alignment=128,
-        ]((ring_base + slot * q_slot_size).as_unsafe_any_origin())
+        ]((ring_base.unsafe_offset(slot * q_slot_size)).as_unsafe_any_origin())
         var qt_view = LayoutTensor[
             dtype,
             qt_view_layout,
             MutAnyOrigin,
             address_space=AddressSpace.SHARED,
             alignment=128,
-        ]((ring_base + slot * q_slot_size).as_unsafe_any_origin())
+        ]((ring_base.unsafe_offset(slot * q_slot_size)).as_unsafe_any_origin())
         var do_view = LayoutTensor[
             dtype,
             q_smem_layout,
             MutAnyOrigin,
             address_space=AddressSpace.SHARED,
             alignment=128,
-        ]((ring_base + (slot + 1) * q_slot_size).as_unsafe_any_origin())
+        ]((ring_base.unsafe_offset((slot + 1) * q_slot_size)).as_unsafe_any_origin())
         var dot_view = LayoutTensor[
             dtype,
             qt_view_layout,
             MutAnyOrigin,
             address_space=AddressSpace.SHARED,
             alignment=128,
-        ]((ring_base + (slot + 1) * q_slot_size).as_unsafe_any_origin())
+        ]((ring_base.unsafe_offset((slot + 1) * q_slot_size)).as_unsafe_any_origin())
 
         # Launder the K/V tile pointers through a no-op asm so the
         # A-operand wgmma descriptors are REBUILT here every
@@ -752,10 +752,10 @@ def bwd_main_kernel[
             has_side_effect=True,
         ](Int32(Int(k_base)))
         var k_uni: Int = Int(warp.broadcast(k_lnd))
-        var k_base_l = k_base + ((k_uni >> 1) - (Int(k_base) >> 1))
+        var k_base_l = k_base.unsafe_offset((k_uni >> 1) - (Int(k_base) >> 1))
         # V root derived from K's (one shfl per iteration, not two:
         # shfl is an MIO op and mio_throttle is a live stall).
-        var v_base_l = k_base_l + kv_tile_size
+        var v_base_l = k_base_l.unsafe_offset(kv_tile_size)
         var k_smem_l = LayoutTensor[
             dtype,
             kv_smem_layout,
@@ -772,7 +772,7 @@ def bwd_main_kernel[
         ]((v_base_l).as_unsafe_any_origin())
 
         # S^T = K · Q^T
-        full[slot].wait(phase)
+        full[unsafe_offset=slot].wait(phase)
         # lse_log2/dpsum stay in smem (published with the Q slot) and
         # are loaded pairwise at their use sites below — keeping a
         # staged copy in a stack array put it in LOCAL memory and
@@ -786,7 +786,7 @@ def bwd_main_kernel[
         wgmma_sdp.commit_group()
 
         # dP^T = V · dO^T
-        full[slot + 1].wait(phase)
+        full[unsafe_offset=slot + 1].wait(phase)
         warpgroup_fence(dp_reg)
         wgmma_sdp.arrive()
         wgmma_sdp.wgmma[num_warp_groups=NWG, scale_c=0](
@@ -805,7 +805,7 @@ def bwd_main_kernel[
             # entries — the GQA cp.reduce no-op rows and dS
             # exactness both rely on that.
             comptime for c in range(c_frag_sdp):
-                s_reg.ptr[c] = tanh(s_reg.ptr[c] * t_scale)
+                s_reg.ptr[unsafe_offset=c] = tanh(s_reg.ptr[unsafe_offset=c] * t_scale)
 
         comptime if causal:
             comptime if varlen:
@@ -830,7 +830,7 @@ def bwd_main_kernel[
                         if vrow_lo + vrow_off > (
                             vcol_base + 2 * lane_pair + mask_dv
                         ):
-                            s_reg.ptr[c] = Scalar[accum_type](-1.0e30)
+                            s_reg.ptr[unsafe_offset=c] = Scalar[accum_type](-1.0e30)
             else:
                 if it < BN // BM:
                     var mask_d: Int = it * BM
@@ -843,7 +843,7 @@ def bwd_main_kernel[
                         if mrow_lo + crow_off > (
                             ccol_base + 2 * lane_pair + mask_d
                         ):
-                            s_reg.ptr[c] = Scalar[accum_type](-1.0e30)
+                            s_reg.ptr[unsafe_offset=c] = Scalar[accum_type](-1.0e30)
 
         comptime if window:
             # Trailing window-edge trips: q cols past kv row +
@@ -873,7 +873,7 @@ def bwd_main_kernel[
                     if wcol_base + 2 * lane_pair > (
                         wrow_lo + wrow_off + mask_w
                     ):
-                        s_reg.ptr[c] = Scalar[accum_type](-1.0e30)
+                        s_reg.ptr[unsafe_offset=c] = Scalar[accum_type](-1.0e30)
 
         comptime if varlen:
             # Ragged kv tail: garbage S^T ROWS (kv >= seqlen_k) on
@@ -889,7 +889,7 @@ def bwd_main_kernel[
                 comptime for c in range(c_frag_sdp):
                     comptime trow_off: Int = 8 if (c % 4) >= 2 else 0
                     if trow_lo + trow_off >= vl_kv_tail:
-                        s_reg.ptr[c] = Scalar[accum_type](-1.0e30)
+                        s_reg.ptr[unsafe_offset=c] = Scalar[accum_type](-1.0e30)
 
         comptime if softcap_on:
             # Softcap reorder: the dS chain factor (1 - t^2) needs
@@ -902,31 +902,33 @@ def bwd_main_kernel[
             wgmma_sdp.wait_group[0]()
             warpgroup_fence(dp_reg)
             comptime for cc in range(c_frag_sdp // 4):
-                var dp2c = (dps_smem + stat_col + cc * 8).load[
+                var dp2c = (dps_smem.unsafe_offset(stat_col + cc * 8)).unsafe_load[
                     width=2, alignment=8
                 ]()
                 comptime for ic in range(4):
                     comptime c: Int = cc * 4 + ic
                     comptime j: Int = c & 1
                     var fac: Scalar[accum_type] = max(
-                        s_reg.ptr[c].fma(
-                            -s_reg.ptr[c], Scalar[accum_type](1)
+                        s_reg.ptr[unsafe_offset=c].fma(
+                            -s_reg.ptr[unsafe_offset=c], Scalar[accum_type](1)
                         ),
                         Scalar[accum_type](0),
                     )
-                    dp_reg.ptr[c] = (dp_reg.ptr[c] - dp2c[j]) * fac
+                    dp_reg.ptr[unsafe_offset=c] = (dp_reg.ptr[unsafe_offset=c] - dp2c[j]) * fac
             comptime for cc in range(c_frag_sdp // 4):
-                var lp2c = (lse_smem + stat_col + cc * 8).load[
+                var lp2c = (lse_smem.unsafe_offset(stat_col + cc * 8)).unsafe_load[
                     width=2, alignment=8
                 ]()
                 comptime for ic in range(4):
                     comptime c: Int = cc * 4 + ic
                     comptime j: Int = c & 1
-                    s_reg.ptr[c] = exp2(
-                        s_reg.ptr[c].fma(scale_log2, -lp2c[j])
+                    s_reg.ptr[unsafe_offset=c] = exp2(
+                        s_reg.ptr[unsafe_offset=c].fma(scale_log2, -lp2c[j])
                     )
             comptime for c in range(c_frag_sdp):
-                dp_reg.ptr[c] = s_reg.ptr[c] * dp_reg.ptr[c]
+                dp_reg.ptr[unsafe_offset=c] = (
+                    s_reg.ptr[unsafe_offset=c] * dp_reg.ptr[unsafe_offset=c]
+                )
         else:
             # P^T = exp2(S^T * scale_log2 - lse_log2[q col]), f32 in
             # s_reg. NOT packed yet: FA4's order computs dS first,
@@ -935,19 +937,19 @@ def bwd_main_kernel[
             # and keeps the dS multiply off a bf16->f32 unpack
             # critical path.
             comptime for cc in range(c_frag_sdp // 4):
-                var lp2 = (lse_smem + stat_col + cc * 8).load[
+                var lp2 = (lse_smem.unsafe_offset(stat_col + cc * 8)).unsafe_load[
                     width=2, alignment=8
                 ]()
                 comptime for ic in range(4):
                     comptime c: Int = cc * 4 + ic
                     comptime j: Int = c & 1
                     comptime if PROBE_NO_EXP2:
-                        s_reg.ptr[c] = s_reg.ptr[c].fma(
+                        s_reg.ptr[unsafe_offset=c] = s_reg.ptr[unsafe_offset=c].fma(
                             scale_log2, -lp2[j]
                         )
                     else:
-                        s_reg.ptr[c] = exp2(
-                            s_reg.ptr[c].fma(scale_log2, -lp2[j])
+                        s_reg.ptr[unsafe_offset=c] = exp2(
+                            s_reg.ptr[unsafe_offset=c].fma(scale_log2, -lp2[j])
                         )
 
             # dP^T retired (wait 0: nothing else in flight — FA4's
@@ -957,27 +959,27 @@ def bwd_main_kernel[
 
             # dS^T = P^T * (dP^T - dpsum[q col]); pack P and dS bf16.
             comptime for cc in range(c_frag_sdp // 4):
-                var dp2 = (dps_smem + stat_col + cc * 8).load[
+                var dp2 = (dps_smem.unsafe_offset(stat_col + cc * 8)).unsafe_load[
                     width=2, alignment=8
                 ]()
                 comptime for ic in range(4):
                     comptime c: Int = cc * 4 + ic
                     comptime j: Int = c & 1
-                    dp_reg.ptr[c] = s_reg.ptr[c] * (
-                        dp_reg.ptr[c] - dp2[j]
+                    dp_reg.ptr[unsafe_offset=c] = s_reg.ptr[unsafe_offset=c] * (
+                        dp_reg.ptr[unsafe_offset=c] - dp2[j]
                     )
         comptime for c2 in range(c_frag_sdp // 2):
             var pp = SIMD[accum_type, 2](
-                s_reg.ptr[2 * c2], s_reg.ptr[2 * c2 + 1]
+                s_reg.ptr[unsafe_offset=2 * c2], s_reg.ptr[unsafe_offset=2 * c2 + 1]
             ).cast[dtype]()
-            p_reg.ptr[2 * c2] = pp[0]
-            p_reg.ptr[2 * c2 + 1] = pp[1]
+            p_reg.ptr[unsafe_offset=2 * c2] = pp[0]
+            p_reg.ptr[unsafe_offset=2 * c2 + 1] = pp[1]
         comptime for c2 in range(c_frag_sdp // 2):
             var dsp = SIMD[accum_type, 2](
-                dp_reg.ptr[2 * c2], dp_reg.ptr[2 * c2 + 1]
+                dp_reg.ptr[unsafe_offset=2 * c2], dp_reg.ptr[unsafe_offset=2 * c2 + 1]
             ).cast[dtype]()
-            ds_reg.ptr[2 * c2] = dsp[0]
-            ds_reg.ptr[2 * c2 + 1] = dsp[1]
+            ds_reg.ptr[unsafe_offset=2 * c2] = dsp[0]
+            ds_reg.ptr[unsafe_offset=2 * c2 + 1] = dsp[1]
 
         # Stage dS in FA4's k-major (q row, kv col) SW128 tile via 5
         # stmatrix.x4.trans per thread (each call: 16 q rows x this
@@ -987,7 +989,7 @@ def bwd_main_kernel[
         # from the ABSOLUTE smem address (addr ^ ((addr>>3)&112)),
         # which folds the dynamic-smem base phase in for free; the
         # XOR term is invariant across i (i steps 2048 B = 16 lines).
-        var sds_stage_base = sds_base + sds_stage * sds_size
+        var sds_stage_base = sds_base.unsafe_offset(sds_stage * sds_size)
         comptime if not PROBE_NO_DQ:
             var t_wg: Int = tid_in_wg
             var sds_elems: Int = (
@@ -1001,7 +1003,7 @@ def bwd_main_kernel[
             var sds_sw: Int = sds_ba ^ ((sds_ba >> 3) & 112)
             # shifts, not // 2: Int floor-div emits a 17-op signed
             # rounding-correction chain per address (see HANDOFF).
-            var sds_ptr = sds_stage_base + (
+            var sds_ptr = sds_stage_base.unsafe_offset(
                 (sds_sw >> 1) - (Int(sds_stage_base) >> 1)
             )
             comptime for i in range(c_frag_sdp // 8):
@@ -1009,15 +1011,15 @@ def bwd_main_kernel[
                 comptime for jm in range(4):
                     packed[jm] = bitcast[DType.float32, 1](
                         SIMD[dtype, 2](
-                            ds_reg.ptr[8 * i + 2 * jm],
-                            ds_reg.ptr[8 * i + 2 * jm + 1],
+                            ds_reg.ptr[unsafe_offset=8 * i + 2 * jm],
+                            ds_reg.ptr[unsafe_offset=8 * i + 2 * jm + 1],
                         )
                     )
                 # .bitcast[BFloat16]: stdlib st_matrix over-asserts
                 # bf16/f32; stmatrix.b16 is dtype-agnostic (no-op
                 # for bf16, unblocks fp16).
                 st_matrix[simd_width=4, transpose=True](
-                    (sds_ptr + i * 1024).bitcast[BFloat16](), packed
+                    (sds_ptr.unsafe_offset(i * 1024)).unsafe_bitcast[BFloat16](), packed
                 )
 
         # dV += P^T · dO — committed after the dS store (FA4's
@@ -1028,14 +1030,14 @@ def bwd_main_kernel[
         comptime if dtype == DType.float16:
             var dvb_desc = _wgmma_descriptor[
                 qt_canonical, False, swizzle
-            ](ring_base + (slot + 1) * q_slot_size)
-            var dv_simd = dv_acc.ptr.load[width=c_frag_dkv]()
+            ](ring_base.unsafe_offset((slot + 1) * q_slot_size))
+            var dv_simd = dv_acc.ptr.unsafe_load[width=c_frag_dkv]()
             comptime for k_mma in range(num_k_mmas_rs):
                 comptime if head_dim == 128:
                     dv_simd = rebind[SIMD[accum_type, c_frag_dkv]](
                         wgmma_rs_f16_m64n128(
                             rebind[SIMD[DType.float16, 8]](
-                                (p_reg.ptr + 8 * k_mma).load[width=8]()
+                                (p_reg.ptr.unsafe_offset(8 * k_mma)).unsafe_load[width=8]()
                             ),
                             (dvb_desc + k_mma * qt_k_stride).desc,
                             rebind[SIMD[DType.float32, 64]](dv_simd),
@@ -1045,13 +1047,13 @@ def bwd_main_kernel[
                     dv_simd = rebind[SIMD[accum_type, c_frag_dkv]](
                         wgmma_rs_f16_m64n64(
                             rebind[SIMD[DType.float16, 8]](
-                                (p_reg.ptr + 8 * k_mma).load[width=8]()
+                                (p_reg.ptr.unsafe_offset(8 * k_mma)).unsafe_load[width=8]()
                             ),
                             (dvb_desc + k_mma * qt_k_stride).desc,
                             rebind[SIMD[DType.float32, 32]](dv_simd),
                         )
                     )
-            dv_acc.ptr.store[width=c_frag_dkv](dv_simd)
+            dv_acc.ptr.unsafe_store[width=c_frag_dkv](dv_simd)
         else:
             wgmma_dkv.wgmma(p_reg, dot_view, dv_acc)
         wgmma_dkv.commit_group()
@@ -1117,14 +1119,14 @@ def bwd_main_kernel[
                         dq_tup,
                     )
                 comptime for c in range(c_frag_dq):
-                    dq_reg.ptr[c] = dq_tup[c]
+                    dq_reg.ptr[unsafe_offset=c] = dq_tup[c]
                 wgmma_sdp.commit_group()
 
         # Queue [dV, dQ]: wait ≤1 retires dV -> dO(n) reusable now,
         # one GEMM earlier than waiting on dQ (FA4's release point).
         wgmma_dkv.wait_group[1]()
         warpgroup_fence(dv_acc)
-        _ = empty[slot + 1].arrive()
+        _ = empty[unsafe_offset=slot + 1].arrive()
 
         # dK += dS^T · Q — committed AFTER dQ (FA4's order) so the
         # dQ drain below overlaps the dK GEMM on the tensor core.
@@ -1133,14 +1135,14 @@ def bwd_main_kernel[
         comptime if dtype == DType.float16:
             var dkb_desc = _wgmma_descriptor[
                 qt_canonical, False, swizzle
-            ](ring_base + slot * q_slot_size)
-            var dk_simd = dk_acc.ptr.load[width=c_frag_dkv]()
+            ](ring_base.unsafe_offset(slot * q_slot_size))
+            var dk_simd = dk_acc.ptr.unsafe_load[width=c_frag_dkv]()
             comptime for k_mma in range(num_k_mmas_rs):
                 comptime if head_dim == 128:
                     dk_simd = rebind[SIMD[accum_type, c_frag_dkv]](
                         wgmma_rs_f16_m64n128(
                             rebind[SIMD[DType.float16, 8]](
-                                (ds_reg.ptr + 8 * k_mma).load[width=8]()
+                                (ds_reg.ptr.unsafe_offset(8 * k_mma)).unsafe_load[width=8]()
                             ),
                             (dkb_desc + k_mma * qt_k_stride).desc,
                             rebind[SIMD[DType.float32, 64]](dk_simd),
@@ -1150,13 +1152,13 @@ def bwd_main_kernel[
                     dk_simd = rebind[SIMD[accum_type, c_frag_dkv]](
                         wgmma_rs_f16_m64n64(
                             rebind[SIMD[DType.float16, 8]](
-                                (ds_reg.ptr + 8 * k_mma).load[width=8]()
+                                (ds_reg.ptr.unsafe_offset(8 * k_mma)).unsafe_load[width=8]()
                             ),
                             (dkb_desc + k_mma * qt_k_stride).desc,
                             rebind[SIMD[DType.float32, 32]](dk_simd),
                         )
                     )
-            dk_acc.ptr.store[width=c_frag_dkv](dk_simd)
+            dk_acc.ptr.unsafe_store[width=c_frag_dkv](dk_simd)
         else:
             wgmma_dkv.wgmma(ds_reg, qt_view, dk_acc)
         wgmma_dkv.commit_group()
@@ -1171,14 +1173,14 @@ def bwd_main_kernel[
         # the dK GEMM. The drain warp owns the gmem reduce-add.
         comptime if not SKIP_MAILBOX:
             named_barrier[Int32(DRAIN_BAR)](Int32(9 + wg))
-            var mail = dq_mail + wg * DQ_MAIL_F32 + tid_in_wg * 4
+            var mail = dq_mail.unsafe_offset(wg * DQ_MAIL_F32 + tid_in_wg * 4)
             comptime for ch in range(c_frag_dq // 4):
-                (mail + ch * 512).store[width=4, alignment=16](
+                (mail.unsafe_offset(ch * 512)).unsafe_store[width=4, alignment=16](
                     SIMD[accum_type, 4](
-                        dq_reg.ptr[4 * ch],
-                        dq_reg.ptr[4 * ch + 1],
-                        dq_reg.ptr[4 * ch + 2],
-                        dq_reg.ptr[4 * ch + 3],
+                        dq_reg.ptr[unsafe_offset=4 * ch],
+                        dq_reg.ptr[unsafe_offset=4 * ch + 1],
+                        dq_reg.ptr[unsafe_offset=4 * ch + 2],
+                        dq_reg.ptr[unsafe_offset=4 * ch + 3],
                     )
                 )
             comptime if not PROBE_NO_MAIL_FENCE:
@@ -1188,7 +1190,7 @@ def bwd_main_kernel[
         # dK retired -> Q(n) slot reusable.
         wgmma_dkv.wait_group[0]()
         warpgroup_fence(dk_acc)
-        _ = empty[slot].arrive()
+        _ = empty[unsafe_offset=slot].arrive()
 
         sds_stage ^= 1
         slot += 2
@@ -1213,20 +1215,20 @@ def bwd_main_kernel[
         # path too: the group's dK/dV accumulated in registers, so
         # the store is per-KV-head exactly like MHA.)
         if vl_kv_tail < BN:
-            var taux = dk_accum_ptr.bitcast[Int64]() + 4 * Int(
-                grid_dim.x
+            var taux = dk_accum_ptr.unsafe_bitcast[Int64]().unsafe_offset(
+                4 * Int(grid_dim.x)
             )
-            var dk_g = UnsafePointer[Scalar[dtype], MutAnyOrigin](
-                unsafe_from_address=Int(taux[0])
+            var dk_g = Pointer[Scalar[dtype], MutAnyOrigin](
+                unsafe_from_address=Int(taux[unsafe_offset=0])
             )
-            var dv_g = UnsafePointer[Scalar[dtype], MutAnyOrigin](
-                unsafe_from_address=Int(taux[1])
+            var dv_g = Pointer[Scalar[dtype], MutAnyOrigin](
+                unsafe_from_address=Int(taux[unsafe_offset=1])
             )
             var vscale: Scalar[accum_type] = softmax_scale.cast[
                 accum_type
             ]()
             comptime for c in range(c_frag_dkv):
-                dk_acc.ptr[c] *= vscale
+                dk_acc.ptr[unsafe_offset=c] *= vscale
             var prow_lo: Int = wg * WGMMA_M + warp_in_wg * 16 + lane_group
             comptime for c2 in range(c_frag_dkv // 2):
                 comptime p_chunk: Int = c2 // 2
@@ -1240,14 +1242,14 @@ def bwd_main_kernel[
                         (kv_row + prow) * Int(grid_dim.y)
                         + h_idx // gqa_ratio
                     ) * D + p_chunk * 8 + 2 * lane_pair
-                    (dv_g + goff).store[width=2, alignment=4](
+                    (dv_g.unsafe_offset(goff)).unsafe_store[width=2, alignment=4](
                         SIMD[accum_type, 2](
-                            dv_acc.ptr[2 * c2], dv_acc.ptr[2 * c2 + 1]
+                            dv_acc.ptr[unsafe_offset=2 * c2], dv_acc.ptr[unsafe_offset=2 * c2 + 1]
                         ).cast[dtype]()
                     )
-                    (dk_g + goff).store[width=2, alignment=4](
+                    (dk_g.unsafe_offset(goff)).unsafe_store[width=2, alignment=4](
                         SIMD[accum_type, 2](
-                            dk_acc.ptr[2 * c2], dk_acc.ptr[2 * c2 + 1]
+                            dk_acc.ptr[unsafe_offset=2 * c2], dk_acc.ptr[unsafe_offset=2 * c2 + 1]
                         ).cast[dtype]()
                     )
             return
@@ -1275,7 +1277,7 @@ def bwd_main_kernel[
         # dead K+V smem (exactly 64 KiB) and bulk-reduce-add it into
         # the per-kv-head accumulator; a torch permute-cast converts.
         comptime for c in range(c_frag_dkv):
-            dk_acc.ptr[c] *= scale_acc
+            dk_acc.ptr[unsafe_offset=c] *= scale_acc
         # Staging area for the row-major f32 tile (BN x D x 4 B):
         # D=128 uses the dead K+V smem (exactly 64 KiB); D=64's tile
         # is 32 KiB but dead K+V is also only 32 KiB COMBINED with
@@ -1283,7 +1285,7 @@ def bwd_main_kernel[
         # (32 KiB, dead after the pre-epilogue barrier).
         var acc32 = (
             k_base if D == 128 else sds_base
-        ).bitcast[Float32]()
+        ).unsafe_bitcast[Float32]()
         var kv_acc_base: Int = 0
         comptime if not varlen:
             kv_acc_base = (
@@ -1306,13 +1308,13 @@ def bwd_main_kernel[
                 var g_pr: SIMD[accum_type, 2]
                 comptime if t == 0:
                     g_pr = SIMD[accum_type, 2](
-                        dv_acc.ptr[2 * c2], dv_acc.ptr[2 * c2 + 1]
+                        dv_acc.ptr[unsafe_offset=2 * c2], dv_acc.ptr[unsafe_offset=2 * c2 + 1]
                     )
                 else:
                     g_pr = SIMD[accum_type, 2](
-                        dk_acc.ptr[2 * c2], dk_acc.ptr[2 * c2 + 1]
+                        dk_acc.ptr[unsafe_offset=2 * c2], dk_acc.ptr[unsafe_offset=2 * c2 + 1]
                     )
-                (acc32 + g_row * D + g_col).store[width=2, alignment=8](
+                (acc32.unsafe_offset(g_row * D + g_col)).unsafe_store[width=2, alignment=8](
                     g_pr
                 )
             fence_async_view_proxy()
@@ -1335,18 +1337,18 @@ def bwd_main_kernel[
                     # per-CTA scalar stays live across the main loop
                     # for the epilogue's sake — the combined vl +
                     # GQA liveness otherwise spills ~8 B.
-                    var tblr = dk_accum_ptr.bitcast[Int32]() + 8 * Int(
-                        block_idx.x
+                    var tblr = dk_accum_ptr.unsafe_bitcast[Int32]().unsafe_offset(
+                        8 * Int(block_idx.x)
                     )
-                    var kv_row_e: Int = Int(tblr[2]) + Int(tblr[0]) * BN
-                    var taux64 = dk_accum_ptr.bitcast[Int64]() + 4 * Int(
-                        grid_dim.x
+                    var kv_row_e: Int = Int(tblr[unsafe_offset=2]) + Int(tblr[unsafe_offset=0]) * BN
+                    var taux64 = dk_accum_ptr.unsafe_bitcast[Int64]().unsafe_offset(
+                        4 * Int(grid_dim.x)
                     )
-                    var taux32 = dk_accum_ptr.bitcast[Int32]() + 8 * Int(
-                        grid_dim.x
+                    var taux32 = dk_accum_ptr.unsafe_bitcast[Int32]().unsafe_offset(
+                        8 * Int(grid_dim.x)
                     )
-                    red_dst = Int(taux64[0 if t == 1 else 1]) + (
-                        (Int(block_idx.y) // gqa_ratio) * Int(taux32[4])
+                    red_dst = Int(taux64[unsafe_offset=0 if t == 1 else 1]) + (
+                        (Int(block_idx.y) // gqa_ratio) * Int(taux32[unsafe_offset=4])
                         + kv_row_e
                     ) * D * 4
                 else:
@@ -1390,8 +1392,8 @@ def bwd_main_kernel[
             )
             var e_col: Int = e_chunk * 8 + 2 * lane_pair
             var e_pair = SIMD[dtype, 2](
-                dv_acc.ptr[2 * c2].cast[dtype](),
-                dv_acc.ptr[2 * c2 + 1].cast[dtype](),
+                dv_acc.ptr[unsafe_offset=2 * c2].cast[dtype](),
+                dv_acc.ptr[unsafe_offset=2 * c2 + 1].cast[dtype](),
             )
             var e_addr: Int = (
                 Int(v_base)
@@ -1401,8 +1403,8 @@ def bwd_main_kernel[
             )
             var e_sw: Int = e_addr ^ ((e_addr >> 3) & 112)
             (
-                v_base + ((e_sw >> 1) - (Int(v_base) >> 1))
-            ).store[width=2, alignment=4](e_pair)
+                v_base.unsafe_offset((e_sw >> 1) - (Int(v_base) >> 1))
+            ).unsafe_store[width=2, alignment=4](e_pair)
     else:
         var dv_raw: Int = Int(v_base) + 2 * st_off_raw
         comptime for i in range(c_frag_dkv // 8):
@@ -1411,7 +1413,7 @@ def bwd_main_kernel[
                 comptime p: Int = 4 * i + jm
                 packed[jm] = bitcast[DType.float32, 1](
                     SIMD[accum_type, 2](
-                        dv_acc.ptr[2 * p], dv_acc.ptr[2 * p + 1]
+                        dv_acc.ptr[unsafe_offset=2 * p], dv_acc.ptr[unsafe_offset=2 * p + 1]
                     ).cast[dtype]()
                 )
             # XOR per call: the 32-B column steps live in the
@@ -1422,8 +1424,8 @@ def bwd_main_kernel[
             var sw_i: Int = raw_i ^ ((raw_i >> 3) & 112)
             st_matrix[simd_width=4](
                 (
-                    v_base + ((sw_i >> 1) - (Int(v_base) >> 1))
-                ).bitcast[BFloat16](),
+                    v_base.unsafe_offset((sw_i >> 1) - (Int(v_base) >> 1))
+                ).unsafe_bitcast[BFloat16](),
                 packed,
             )
     fence_async_view_proxy()
@@ -1441,7 +1443,7 @@ def bwd_main_kernel[
 
     # dK *= scale; staged under dV's in-flight TMA store.
     comptime for c in range(c_frag_dkv):
-        dk_acc.ptr[c] *= scale_acc
+        dk_acc.ptr[unsafe_offset=c] *= scale_acc
     comptime if D == 64:
         comptime for c2 in range(c_frag_dkv // 2):
             comptime f_chunk: Int = c2 // 2
@@ -1452,8 +1454,8 @@ def bwd_main_kernel[
             )
             var f_col: Int = f_chunk * 8 + 2 * lane_pair
             var f_pair = SIMD[dtype, 2](
-                dk_acc.ptr[2 * c2].cast[dtype](),
-                dk_acc.ptr[2 * c2 + 1].cast[dtype](),
+                dk_acc.ptr[unsafe_offset=2 * c2].cast[dtype](),
+                dk_acc.ptr[unsafe_offset=2 * c2 + 1].cast[dtype](),
             )
             var f_addr: Int = (
                 Int(k_base)
@@ -1463,8 +1465,8 @@ def bwd_main_kernel[
             )
             var f_sw: Int = f_addr ^ ((f_addr >> 3) & 112)
             (
-                k_base + ((f_sw >> 1) - (Int(k_base) >> 1))
-            ).store[width=2, alignment=4](f_pair)
+                k_base.unsafe_offset((f_sw >> 1) - (Int(k_base) >> 1))
+            ).unsafe_store[width=2, alignment=4](f_pair)
     else:
         var dk_raw: Int = Int(k_base) + 2 * st_off_raw
         comptime for i in range(c_frag_dkv // 8):
@@ -1473,7 +1475,7 @@ def bwd_main_kernel[
                 comptime p: Int = 4 * i + jm
                 packed[jm] = bitcast[DType.float32, 1](
                     SIMD[accum_type, 2](
-                        dk_acc.ptr[2 * p], dk_acc.ptr[2 * p + 1]
+                        dk_acc.ptr[unsafe_offset=2 * p], dk_acc.ptr[unsafe_offset=2 * p + 1]
                     ).cast[dtype]()
                 )
             var raw_i: Int = (
@@ -1482,8 +1484,8 @@ def bwd_main_kernel[
             var sw_i: Int = raw_i ^ ((raw_i >> 3) & 112)
             st_matrix[simd_width=4](
                 (
-                    k_base + ((sw_i >> 1) - (Int(k_base) >> 1))
-                ).bitcast[BFloat16](),
+                    k_base.unsafe_offset((sw_i >> 1) - (Int(k_base) >> 1))
+                ).unsafe_bitcast[BFloat16](),
                 packed,
             )
     fence_async_view_proxy()
@@ -1520,14 +1522,14 @@ def bwd_preprocess_kernel[
     gqa_ratio: Int = 1,
     varlen: Bool = False,
 ](
-    o_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    do_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    lse_ptr: UnsafePointer[Float32, ImmutAnyOrigin],
-    dpsum_ptr: UnsafePointer[Float32, MutAnyOrigin],
-    lse_log2_ptr: UnsafePointer[Float32, MutAnyOrigin],
-    dq_accum_ptr: UnsafePointer[Float32, MutAnyOrigin],
-    dk_accum_ptr: UnsafePointer[Float32, MutAnyOrigin],
-    dv_accum_ptr: UnsafePointer[Float32, MutAnyOrigin],
+    o_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    do_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    lse_ptr: Pointer[Float32, ImmutAnyOrigin],
+    dpsum_ptr: Pointer[Float32, MutAnyOrigin],
+    lse_log2_ptr: Pointer[Float32, MutAnyOrigin],
+    dq_accum_ptr: Pointer[Float32, MutAnyOrigin],
+    dk_accum_ptr: Pointer[Float32, MutAnyOrigin],
+    dv_accum_ptr: Pointer[Float32, MutAnyOrigin],
     seq_len_arg: Int64,
     nheads_arg: Int64,
 ):
@@ -1552,11 +1554,11 @@ def bwd_preprocess_kernel[
         # dk_accum_ptr slot; seq_len carries total_q (packed (H,
         # total_q) LSE reads) and nheads carries total_qpad. stats
         # windows are per-seq at mpad_base*bm_main in (H, total_qpad).
-        var tbl = dk_accum_ptr.bitcast[Int32]() + 8 * Int(block_idx.x)
-        var m_local: Int = Int(tbl[0])
-        var q_base: Int = Int(tbl[1])
-        var slq: Int = Int(tbl[2])
-        var mpad_base: Int = Int(tbl[3])
+        var tbl = dk_accum_ptr.unsafe_bitcast[Int32]().unsafe_offset(8 * Int(block_idx.x))
+        var m_local: Int = Int(tbl[unsafe_offset=0])
+        var q_base: Int = Int(tbl[unsafe_offset=1])
+        var slq: Int = Int(tbl[unsafe_offset=2])
+        var mpad_base: Int = Int(tbl[unsafe_offset=3])
         var nh: Int = Int(grid_dim.y)
         var total_q: Int = seq_len
         var total_qpad: Int = nheads
@@ -1577,10 +1579,10 @@ def bwd_preprocess_kernel[
                 var off: Int = (
                     (q_base + s_loc) * nh + h_idx
                 ) * D + sub * RVEC
-                var o_v = (o_ptr + off).load[width=RVEC]().cast[
+                var o_v = (o_ptr.unsafe_offset(off)).unsafe_load[width=RVEC]().cast[
                     DType.float32
                 ]()
-                var do_v = (do_ptr + off).load[width=RVEC]().cast[
+                var do_v = (do_ptr.unsafe_offset(off)).unsafe_load[width=RVEC]().cast[
                     DType.float32
                 ]()
                 var part: Float32 = (o_v * do_v).reduce_add()
@@ -1588,18 +1590,18 @@ def bwd_preprocess_kernel[
                     part
                 )
                 if sub == 0:
-                    (dpsum_ptr + stat_row)[0] = dps
-                    (lse_log2_ptr + stat_row)[0] = (
-                        lse_ptr + h_idx * total_q + q_base + s_loc
-                    )[0] * Float32(log2e)
+                    dpsum_ptr[unsafe_offset=stat_row] = dps
+                    lse_log2_ptr[unsafe_offset=stat_row] = (
+                        lse_ptr.unsafe_offset(h_idx * total_q + q_base + s_loc)
+                    )[unsafe_offset=0] * Float32(log2e)
             else:
                 # Per-seq window pad rows: +inf/0 annihilate the main
                 # kernel's tail m-rows (same convention as dense —
                 # do NOT switch to FA4's lse_log2=0 without also
                 # adding the in-loop seqlen_q mask).
                 if sub == 0:
-                    (dpsum_ptr + stat_row)[0] = Float32(0)
-                    (lse_log2_ptr + stat_row)[0] = inf[DType.float32]()
+                    dpsum_ptr[unsafe_offset=stat_row] = Float32(0)
+                    lse_log2_ptr[unsafe_offset=stat_row] = inf[DType.float32]()
 
         # Zero this m-block's dq_accum fragment region (bm_main*D
         # f32, exactly divisible by the per-pass footprint).
@@ -1610,7 +1612,7 @@ def bwd_preprocess_kernel[
         ) * D
         var zoff: Int = tid * ZVEC
         for _ in range(zpasses):
-            (dq_accum_ptr + zbase + zoff).store[width=ZVEC](
+            (dq_accum_ptr.unsafe_offset(zbase + zoff)).unsafe_store[width=ZVEC](
                 SIMD[DType.float32, ZVEC](0)
             )
             zoff += kBwdPreThreads * ZVEC
@@ -1638,10 +1640,10 @@ def bwd_preprocess_kernel[
             var off: Int = (
                 (b_idx * seq_len + s) * nheads + h_idx
             ) * D + sub * RVEC
-            var o_v = (o_ptr + off).load[width=RVEC]().cast[
+            var o_v = (o_ptr.unsafe_offset(off)).unsafe_load[width=RVEC]().cast[
                 DType.float32
             ]()
-            var do_v = (do_ptr + off).load[width=RVEC]().cast[
+            var do_v = (do_ptr.unsafe_offset(off)).unsafe_load[width=RVEC]().cast[
                 DType.float32
             ]()
             var part: Float32 = (o_v * do_v).reduce_add()
@@ -1650,16 +1652,16 @@ def bwd_preprocess_kernel[
                 var lse_row: Int = (
                     b_idx * nheads + h_idx
                 ) * seq_len + s
-                (dpsum_ptr + bh_row)[0] = dps
-                (lse_log2_ptr + bh_row)[0] = (lse_ptr + lse_row)[
+                dpsum_ptr[unsafe_offset=bh_row] = dps
+                lse_log2_ptr[unsafe_offset=bh_row] = (lse_ptr.unsafe_offset(lse_row))[unsafe_offset=
                     0
                 ] * Float32(log2e)
         elif s < spad:
             # Pad rows: exp2(x - inf) = 0 kills P; dpsum = 0 keeps
             # dS = P * (dP - dpsum) = 0 * finite = 0.
             if sub == 0:
-                (dpsum_ptr + bh_row)[0] = Float32(0)
-                (lse_log2_ptr + bh_row)[0] = inf[DType.float32]()
+                dpsum_ptr[unsafe_offset=bh_row] = Float32(0)
+                lse_log2_ptr[unsafe_offset=bh_row] = inf[DType.float32]()
 
     # Zero dq_accum (the main kernel bulk-reduce-ADDS into it):
     # Spad*D f32 per (b, h), split as a flat contiguous range across
@@ -1673,7 +1675,7 @@ def bwd_preprocess_kernel[
     var zoff: Int = m_block * passes * ZCHUNK + tid * ZVEC
     for _ in range(passes):
         if zoff < ztot:
-            (dq_accum_ptr + zbase + zoff).store[width=ZVEC](
+            (dq_accum_ptr.unsafe_offset(zbase + zoff)).unsafe_store[width=ZVEC](
                 SIMD[DType.float32, ZVEC](0)
             )
         zoff += ZCHUNK
@@ -1693,10 +1695,10 @@ def bwd_preprocess_kernel[
             var koff: Int = m_block * kpasses * ZCHUNK + tid * ZVEC
             for _ in range(kpasses):
                 if koff < kvtot:
-                    (dk_accum_ptr + kvbase + koff).store[width=ZVEC](
+                    (dk_accum_ptr.unsafe_offset(kvbase + koff)).unsafe_store[width=ZVEC](
                         SIMD[DType.float32, ZVEC](0)
                     )
-                    (dv_accum_ptr + kvbase + koff).store[width=ZVEC](
+                    (dv_accum_ptr.unsafe_offset(kvbase + koff)).unsafe_store[width=ZVEC](
                         SIMD[DType.float32, ZVEC](0)
                     )
                 koff += ZCHUNK
@@ -1717,8 +1719,8 @@ def bwd_convert_kernel[
     causal: Bool = False,
     varlen: Bool = False,
 ](
-    dq_accum_ptr: UnsafePointer[Float32, ImmutAnyOrigin],
-    dq_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    dq_accum_ptr: Pointer[Float32, ImmutAnyOrigin],
+    dq_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
     seq_len_arg: Int64,
     nheads_arg: Int64,
     softmax_scale: Float32,
@@ -1754,15 +1756,14 @@ def bwd_convert_kernel[
     var vl_mpad_base: Int = 0
     comptime if varlen:
         var tbl = (
-            UnsafePointer[Int32, ImmutAnyOrigin](
+            Pointer[Int32, ImmutAnyOrigin](
                 unsafe_from_address=seq_len
-            )
-            + 8 * Int(block_idx.x)
+            ).unsafe_offset(8 * Int(block_idx.x))
         )
-        m_block = Int(tbl[0])
-        vl_q_base = Int(tbl[1])
-        vl_slq = Int(tbl[2])
-        vl_mpad_base = Int(tbl[3])
+        m_block = Int(tbl[unsafe_offset=0])
+        vl_q_base = Int(tbl[unsafe_offset=1])
+        vl_slq = Int(tbl[unsafe_offset=2])
+        vl_mpad_base = Int(tbl[unsafe_offset=3])
         b_idx = 0
 
     var num_m_blocks: Int = 0
@@ -1802,13 +1803,9 @@ def bwd_convert_kernel[
         var c: Int = i * 2 + sub
         var wg: Int = c // NCH
         var ch: Int = c % NCH
-        var v = (
-            dq_accum_ptr
-            + frag_base
-            + wg * WG_F32
-            + ch * (128 * 4)
-            + ft * 4
-        ).load[width=4]()
+        var v = dq_accum_ptr.unsafe_offset(
+            frag_base + wg * WG_F32 + ch * (128 * 4) + ft * 4
+        ).unsafe_load[width=4]()
         comptime for e in range(4):
             var d: Int
             var q: Int
@@ -1819,7 +1816,7 @@ def bwd_convert_kernel[
             else:
                 d = wg * 64 + d_wl + 8 * (e // 2)
                 q = ch * 8 + q_lp + (e % 2)
-            tile[q * (D + PAD) + d] = v[e]
+            tile[unsafe_offset=q * (D + PAD) + d] = v[e]
     barrier()
 
     # Phase 2: 8 lanes per row, 16 d (32B bf16) per lane, so every
@@ -1840,17 +1837,17 @@ def bwd_convert_kernel[
                     (vl_q_base + s) * Int(grid_dim.y) + h_idx
                 ) * D + d_base
                 var fv = (
-                    tile + s_local * (D + PAD) + d_base
-                ).load[width=OV, alignment=16]()
+                    tile.unsafe_offset(s_local * (D + PAD) + d_base)
+                ).unsafe_load[width=OV, alignment=16]()
                 var out = (fv * softmax_scale).cast[dtype]()
-                (dq_ptr + dq_off).store[width=OV, alignment=32](out)
+                (dq_ptr.unsafe_offset(dq_off)).unsafe_store[width=OV, alignment=32](out)
         else:
             if s_local < BM and s < seq_len:
                 var dq_off: Int = (
                     (b_idx * seq_len + s) * nheads + h_idx
                 ) * D + d_base
                 var fv = (
-                    tile + s_local * (D + PAD) + d_base
-                ).load[width=OV, alignment=16]()
+                    tile.unsafe_offset(s_local * (D + PAD) + d_base)
+                ).unsafe_load[width=OV, alignment=16]()
                 var out = (fv * softmax_scale).cast[dtype]()
-                (dq_ptr + dq_off).store[width=OV, alignment=32](out)
+                (dq_ptr.unsafe_offset(dq_off)).unsafe_store[width=OV, alignment=32](out)

--- a/torch_mojo_backend/eager_flash_attention/fa4_bwd_launch.mojo
+++ b/torch_mojo_backend/eager_flash_attention/fa4_bwd_launch.mojo
@@ -51,7 +51,7 @@ def _dump_ptx_path() -> _DumpPath:
 def _ctx_and_stream(
     ctx_handle_addr: Int,
 ) -> DeviceContext:
-    var raw_ctx_ptr = UnsafePointer[_DeviceContextCpp, MutUntrackedOrigin](
+    var raw_ctx_ptr = Pointer[_DeviceContextCpp, MutUntrackedOrigin](
         unsafe_from_address=ctx_handle_addr
     )
     return DeviceContext(_DeviceContextPtr[mut=True](raw_ctx_ptr))
@@ -99,28 +99,28 @@ def launch_bwd_preprocess[
         seq_len_arg = vl_total_q
         nheads_arg = vl_total_qpad
 
-    var dk_accum_ptr = UnsafePointer[Float32, MutAnyOrigin](
+    var dk_accum_ptr = Pointer[Float32, MutAnyOrigin](
         unsafe_from_address=dk_accum_addr_eff
     )
-    var dv_accum_ptr = UnsafePointer[Float32, MutAnyOrigin](
+    var dv_accum_ptr = Pointer[Float32, MutAnyOrigin](
         unsafe_from_address=dv_accum_addr
     )
-    var o_ptr = UnsafePointer[Scalar[dtype], ImmutAnyOrigin](
+    var o_ptr = Pointer[Scalar[dtype], ImmutAnyOrigin](
         unsafe_from_address=o_addr
     )
-    var do_ptr = UnsafePointer[Scalar[dtype], ImmutAnyOrigin](
+    var do_ptr = Pointer[Scalar[dtype], ImmutAnyOrigin](
         unsafe_from_address=do_addr
     )
-    var lse_ptr = UnsafePointer[Float32, ImmutAnyOrigin](
+    var lse_ptr = Pointer[Float32, ImmutAnyOrigin](
         unsafe_from_address=lse_addr
     )
-    var dpsum_ptr = UnsafePointer[Float32, MutAnyOrigin](
+    var dpsum_ptr = Pointer[Float32, MutAnyOrigin](
         unsafe_from_address=dpsum_addr
     )
-    var lse_log2_ptr = UnsafePointer[Float32, MutAnyOrigin](
+    var lse_log2_ptr = Pointer[Float32, MutAnyOrigin](
         unsafe_from_address=lse_log2_addr
     )
-    var dq_accum_ptr = UnsafePointer[Float32, MutAnyOrigin](
+    var dq_accum_ptr = Pointer[Float32, MutAnyOrigin](
         unsafe_from_address=dq_accum_addr
     )
 
@@ -260,31 +260,31 @@ def launch_bwd_main[
         + mbar_bytes
     )
 
-    var q_ptr = UnsafePointer[Scalar[dtype], ImmutAnyOrigin](
+    var q_ptr = Pointer[Scalar[dtype], ImmutAnyOrigin](
         unsafe_from_address=q_addr
     )
-    var k_ptr = UnsafePointer[Scalar[dtype], ImmutAnyOrigin](
+    var k_ptr = Pointer[Scalar[dtype], ImmutAnyOrigin](
         unsafe_from_address=k_addr
     )
-    var v_ptr = UnsafePointer[Scalar[dtype], ImmutAnyOrigin](
+    var v_ptr = Pointer[Scalar[dtype], ImmutAnyOrigin](
         unsafe_from_address=v_addr
     )
-    var do_ptr = UnsafePointer[Scalar[dtype], ImmutAnyOrigin](
+    var do_ptr = Pointer[Scalar[dtype], ImmutAnyOrigin](
         unsafe_from_address=do_addr
     )
-    var dk_ptr = UnsafePointer[Scalar[dtype], ImmutAnyOrigin](
+    var dk_ptr = Pointer[Scalar[dtype], ImmutAnyOrigin](
         unsafe_from_address=dk_addr
     )
-    var dv_ptr = UnsafePointer[Scalar[dtype], ImmutAnyOrigin](
+    var dv_ptr = Pointer[Scalar[dtype], ImmutAnyOrigin](
         unsafe_from_address=dv_addr
     )
-    var lse_log2_ptr = UnsafePointer[Float32, ImmutAnyOrigin](
+    var lse_log2_ptr = Pointer[Float32, ImmutAnyOrigin](
         unsafe_from_address=lse_log2_addr
     )
-    var dpsum_ptr = UnsafePointer[Float32, ImmutAnyOrigin](
+    var dpsum_ptr = Pointer[Float32, ImmutAnyOrigin](
         unsafe_from_address=dpsum_addr
     )
-    var dq_accum_ptr = UnsafePointer[Float32, MutAnyOrigin](
+    var dq_accum_ptr = Pointer[Float32, MutAnyOrigin](
         unsafe_from_address=dq_accum_addr
     )
 
@@ -316,10 +316,10 @@ def launch_bwd_main[
     # accumulators (the epilogue bulk-reduce-adds into them; a torch
     # permute-cast converts). The bf16 TMA descriptors below are
     # then unused by the kernel (comptime-dead store path).
-    var dk_accum_ptr = UnsafePointer[Float32, MutAnyOrigin](
+    var dk_accum_ptr = Pointer[Float32, MutAnyOrigin](
         unsafe_from_address=dk_accum_addr_eff
     )
-    var dv_accum_ptr = UnsafePointer[Float32, MutAnyOrigin](
+    var dv_accum_ptr = Pointer[Float32, MutAnyOrigin](
         unsafe_from_address=dv_addr
     )
     # Strided mode: Q/K/V become runtime-strided flat (B*S, H, D)
@@ -474,10 +474,10 @@ def launch_bwd_convert[
         unsafe_from_address=stream_handle_addr
     )
 
-    var dq_accum_ptr = UnsafePointer[Float32, ImmutAnyOrigin](
+    var dq_accum_ptr = Pointer[Float32, ImmutAnyOrigin](
         unsafe_from_address=dq_accum_addr
     )
-    var dq_ptr = UnsafePointer[Scalar[dtype], MutAnyOrigin](
+    var dq_ptr = Pointer[Scalar[dtype], MutAnyOrigin](
         unsafe_from_address=dq_addr
     )
 

--- a/torch_mojo_backend/eager_flash_attention/fa4_fwd_kernel.mojo
+++ b/torch_mojo_backend/eager_flash_attention/fa4_fwd_kernel.mojo
@@ -112,7 +112,7 @@ def fwd_fa4_kernel[
     k_tma: TMATensorTile[dtype, 3, kv_tile_shape, kv_desc_shape],
     v_tma: TMATensorTile[dtype, 3, kv_tile_shape, kv_desc_shape],
     o_tma: TMATensorTile[dtype, qo_rank, o_tile_shape, o_desc_shape],
-    lse_ptr: UnsafePointer[Float32, MutAnyOrigin],
+    lse_ptr: Pointer[Float32, MutAnyOrigin],
     seq_len_arg: Int64,
     softmax_scale: Float32,
     nheads_arg: Int64,
@@ -181,7 +181,7 @@ def fwd_fa4_kernel[
         address_space=AddressSpace.SHARED,
         alignment=128,
     ]((smem_base).as_unsafe_any_origin())
-    var kv_smem_base = smem_base + q_smem_size
+    var kv_smem_base = smem_base.unsafe_offset(q_smem_size)
 
     var mbar_q = stack_allocation[
         1, SharedMemBarrier, address_space=AddressSpace.SHARED, alignment=8
@@ -199,10 +199,10 @@ def fwd_fa4_kernel[
         alignment=8,
     ]()
     if thread_idx.x == 0:
-        mbar_q[0].init()
+        mbar_q[unsafe_offset=0].init()
         comptime for s in range(STAGES):
-            full[s].init(1)
-            empty[s].init(Int32(NWG * 128))
+            full[unsafe_offset=s].init(1)
+            empty[unsafe_offset=s].init(Int32(NWG * 128))
     barrier()
 
     var m_block: Int
@@ -225,18 +225,17 @@ def fwd_fa4_kernel[
         # sees it warp-uniform (same hazard class as the tid-widening
         # trap; see HANDOFF.md).
         var tbl = (
-            UnsafePointer[Int32, ImmutAnyOrigin](
+            Pointer[Int32, ImmutAnyOrigin](
                 unsafe_from_address=sched_swizzle
-            )
-            + 8 * Int(block_idx.x)
+            ).unsafe_offset(8 * Int(block_idx.x))
         )
-        m_block = Int(warp.broadcast(tbl[0]))
-        vl_q_base = Int(warp.broadcast(tbl[1]))
-        vl_k_base = Int(warp.broadcast(tbl[2]))
-        vl_seqlen_q = Int(warp.broadcast(tbl[3]))
-        vl_seqlen_k = Int(warp.broadcast(tbl[4]))
+        m_block = Int(warp.broadcast(tbl[unsafe_offset=0]))
+        vl_q_base = Int(warp.broadcast(tbl[unsafe_offset=1]))
+        vl_k_base = Int(warp.broadcast(tbl[unsafe_offset=2]))
+        vl_seqlen_q = Int(warp.broadcast(tbl[unsafe_offset=3]))
+        vl_seqlen_k = Int(warp.broadcast(tbl[unsafe_offset=4]))
         comptime if window:
-            vl_win_left = Int(warp.broadcast(tbl[5]))
+            vl_win_left = Int(warp.broadcast(tbl[unsafe_offset=5]))
         h_idx = Int(block_idx.y)
         b_idx = 0
     else:
@@ -351,12 +350,12 @@ def fwd_fa4_kernel[
         # ================= producer =================
         warpgroup_reg_dealloc[NUM_PRODUCER_REGS]()
         if thread_idx.x == 0:
-            mbar_q[0].expect_bytes(Int32(BM * D * size_of[dtype]()))
+            mbar_q[unsafe_offset=0].expect_bytes(Int32(BM * D * size_of[dtype]()))
             comptime if bhsd:
                 # (B*H, S, D) planes; S its own dim -> tail zero-fill.
                 q_tma.async_copy_3d(
                     q_smem,
-                    mbar_q[0],
+                    mbar_q[unsafe_offset=0],
                     (0, m_block * BM, b_idx * nheads + h_idx),
                 )
             elif qo_rank == 4:
@@ -365,17 +364,17 @@ def fwd_fa4_kernel[
                 # here and the store-side clamps).
                 q_tma.async_copy_4d(
                     q_smem,
-                    mbar_q[0],
+                    mbar_q[unsafe_offset=0],
                     (0, h_idx, m_block * BM, b_idx),
                 )
             elif varlen:
                 q_tma.async_copy_3d(
-                    q_smem, mbar_q[0], (0, h_idx, vl_q_base + m_block * BM)
+                    q_smem, mbar_q[unsafe_offset=0], (0, h_idx, vl_q_base + m_block * BM)
                 )
             else:
                 q_tma.async_copy_3d(
                     q_smem,
-                    mbar_q[0],
+                    mbar_q[unsafe_offset=0],
                     (0, h_idx, b_idx * seq_len + m_block * BM),
                 )
             # Incremental ring state: K(n) in slot 2n%6, V(n) in
@@ -412,38 +411,38 @@ def fwd_fa4_kernel[
             else:
                 row = b_idx * seq_len
             for _ in range(kv_trips):
-                empty[slot].wait(phase)
+                empty[unsafe_offset=slot].wait(phase)
                 var k_st = LayoutTensor[
                     dtype,
                     k_smem_layout,
                     MutAnyOrigin,
                     address_space=AddressSpace.SHARED,
                     alignment=128,
-                ]((kv_smem_base + slot * kv_slot_size).as_unsafe_any_origin())
-                full[slot].expect_bytes(Int32(BN * D * size_of[dtype]()))
+                ]((kv_smem_base.unsafe_offset(slot * kv_slot_size)).as_unsafe_any_origin())
+                full[unsafe_offset=slot].expect_bytes(Int32(BN * D * size_of[dtype]()))
                 comptime if bhsd:
-                    k_tma.async_copy_3d(k_st, full[slot], (0, row, kv_plane))
+                    k_tma.async_copy_3d(k_st, full[unsafe_offset=slot], (0, row, kv_plane))
                 else:
                     k_tma.async_copy_3d(
-                        k_st, full[slot], (0, h_idx // gqa_ratio, row)
+                        k_st, full[unsafe_offset=slot], (0, h_idx // gqa_ratio, row)
                     )
 
-                empty[slot + 1].wait(phase)
+                empty[unsafe_offset=slot + 1].wait(phase)
                 var v_st = LayoutTensor[
                     dtype,
                     v_smem_layout,
                     MutAnyOrigin,
                     address_space=AddressSpace.SHARED,
                     alignment=128,
-                ]((kv_smem_base + (slot + 1) * kv_slot_size).as_unsafe_any_origin())
-                full[slot + 1].expect_bytes(Int32(BN * D * size_of[dtype]()))
+                ]((kv_smem_base.unsafe_offset((slot + 1) * kv_slot_size)).as_unsafe_any_origin())
+                full[unsafe_offset=slot + 1].expect_bytes(Int32(BN * D * size_of[dtype]()))
                 comptime if bhsd:
                     v_tma.async_copy_3d(
-                        v_st, full[slot + 1], (0, row, kv_plane)
+                        v_st, full[unsafe_offset=slot + 1], (0, row, kv_plane)
                     )
                 else:
                     v_tma.async_copy_3d(
-                        v_st, full[slot + 1], (0, h_idx // gqa_ratio, row)
+                        v_st, full[unsafe_offset=slot + 1], (0, h_idx // gqa_ratio, row)
                     )
 
                 row += row_step
@@ -461,7 +460,7 @@ def fwd_fa4_kernel[
 
     # Unblock the producer's first ring cycle.
     comptime for s in range(STAGES):
-        _ = empty[s].arrive()
+        _ = empty[unsafe_offset=s].arrive()
 
     # Scheduler-pingpong barrier participant count: each barrier id
     # is waited by ONE warpgroup (128) and armed by its predecessor
@@ -535,8 +534,8 @@ def fwd_fa4_kernel[
     var scale_old = stack_allocation[rows_per_thread, Scalar[accum_type]]()
     var neg_inf: Scalar[accum_type] = Scalar[accum_type](-1.0e30)
     comptime for i in range(rows_per_thread):
-        rowmax[i] = neg_inf
-        rowsum[i] = Scalar[accum_type](0)
+        rowmax[unsafe_offset=i] = neg_inf
+        rowsum[unsafe_offset=i] = Scalar[accum_type](0)
 
     var scale_log2: Scalar[accum_type] = (
         softmax_scale * Scalar[DType.float32](log2e)
@@ -568,7 +567,7 @@ def fwd_fa4_kernel[
         address_space=AddressSpace.SHARED,
         alignment=128,
     ]:
-        return {(kv_smem_base + slot * kv_slot_size).as_unsafe_any_origin()}
+        return {(kv_smem_base.unsafe_offset(slot * kv_slot_size)).as_unsafe_any_origin()}
 
     @parameter
     @always_inline
@@ -579,7 +578,7 @@ def fwd_fa4_kernel[
         address_space=AddressSpace.SHARED,
         alignment=128,
     ]:
-        return {(kv_smem_base + slot * kv_slot_size).as_unsafe_any_origin()}
+        return {(kv_smem_base.unsafe_offset(slot * kv_slot_size)).as_unsafe_any_origin()}
 
     # fp16 RS fork: the stdlib's register-A wgmma overload is
     # bf16-only (hardcoded .bf16.bf16 asm); the vendored
@@ -598,15 +597,15 @@ def fwd_fa4_kernel[
     def pv_gemm(slot_arg: Int):
         comptime if dtype == DType.float16:
             var b_desc = _wgmma_descriptor[v_canonical, False, swizzle](
-                kv_smem_base + slot_arg * kv_slot_size
+                kv_smem_base.unsafe_offset(slot_arg * kv_slot_size)
             )
-            var o_simd = o_reg.ptr.load[width=c_frag_size_pv]()
+            var o_simd = o_reg.ptr.unsafe_load[width=c_frag_size_pv]()
             comptime for k_mma in range(num_k_mmas_pv):
                 comptime if head_dim == 128:
                     o_simd = rebind[SIMD[accum_type, c_frag_size_pv]](
                         wgmma_rs_f16_m64n128(
                             rebind[SIMD[DType.float16, 8]](
-                                (p_reg.ptr + 8 * k_mma).load[width=8]()
+                                (p_reg.ptr.unsafe_offset(8 * k_mma)).unsafe_load[width=8]()
                             ),
                             (b_desc + k_mma * v_k_stride).desc,
                             rebind[SIMD[DType.float32, 64]](o_simd),
@@ -616,13 +615,13 @@ def fwd_fa4_kernel[
                     o_simd = rebind[SIMD[accum_type, c_frag_size_pv]](
                         wgmma_rs_f16_m64n64(
                             rebind[SIMD[DType.float16, 8]](
-                                (p_reg.ptr + 8 * k_mma).load[width=8]()
+                                (p_reg.ptr.unsafe_offset(8 * k_mma)).unsafe_load[width=8]()
                             ),
                             (b_desc + k_mma * v_k_stride).desc,
                             rebind[SIMD[DType.float32, 32]](o_simd),
                         )
                     )
-            o_reg.ptr.store[width=c_frag_size_pv](o_simd)
+            o_reg.ptr.unsafe_store[width=c_frag_size_pv](o_simd)
         else:
             wgmma_pv.wgmma(p_reg, v_tile(slot_arg), o_reg)
 
@@ -662,7 +661,7 @@ def fwd_fa4_kernel[
             # tanh.approx.f32 — FA4's "fastmath" tanh emulates via
             # ex2 and pays 3.1x kernel time for it.
             comptime for c in range(c_frag_size_qk):
-                s_reg.ptr[c] = tanh(s_reg.ptr[c] * t_scale)
+                s_reg.ptr[unsafe_offset=c] = tanh(s_reg.ptr[unsafe_offset=c] * t_scale)
         comptime if causal:
             comptime if BM == BN and not varlen:
                 if mask_diag:
@@ -670,7 +669,7 @@ def fwd_fa4_kernel[
                         comptime col_base: Int = (c // 4) * 8 + (c & 1)
                         comptime row_off: Int = 8 if (c % 4) >= 2 else 0
                         if col_base + mask_col_lo > mask_row_lo + row_off:
-                            s_reg.ptr[c] = neg_inf
+                            s_reg.ptr[unsafe_offset=c] = neg_inf
             else:
                 # Diagonal-band tile: global mask col + mask_d > row.
                 # (Varlen causal always uses this arm — the
@@ -746,7 +745,7 @@ def fwd_fa4_kernel[
                                 if col_base > (
                                     mask_thr1 if hi_row else mask_thr0
                                 ):
-                                    s_reg.ptr[c] = neg_inf
+                                    s_reg.ptr[unsafe_offset=c] = neg_inf
         comptime if window:
             # Leading window edge (prologue tile only): cols before
             # row - left are outside the window.
@@ -758,13 +757,13 @@ def fwd_fa4_kernel[
                         col_base + mask_col_lo + win_mask_d
                         < mask_row_lo + row_off
                     ):
-                        s_reg.ptr[c] = neg_inf
+                        s_reg.ptr[unsafe_offset=c] = neg_inf
         comptime if varlen and not causal:
             if mask_tail and vl_kv_tail < BN:
                 comptime for c in range(c_frag_size_qk):
                     comptime col_base: Int = (c // 4) * 8 + (c & 1)
                     if col_base + mask_col_lo >= vl_kv_tail:
-                        s_reg.ptr[c] = neg_inf
+                        s_reg.ptr[unsafe_offset=c] = neg_inf
         # TREE-SHAPED row reductions. The natural
         # `local_max[row] = max(local_max[row], s_reg[c])` sweep is two
         # 32-deep dependent chains (~4-cycle FMNMX latency each = ~128
@@ -782,31 +781,41 @@ def fwd_fa4_kernel[
                 rows_per_thread * RED_WAYS, Scalar[accum_type]
             ]()
             comptime for i in range(rows_per_thread * RED_WAYS):
-                part_max[i] = neg_inf
+                part_max[unsafe_offset=i] = neg_inf
             comptime for c in range(c_frag_size_qk):
                 comptime row_idx: Int = 1 if (c % 4) >= 2 else 0
                 comptime part: Int = (c // 4) % RED_WAYS
-                part_max[row_idx * RED_WAYS + part] = max(
-                    part_max[row_idx * RED_WAYS + part], s_reg.ptr[c]
+                part_max[unsafe_offset=row_idx * RED_WAYS + part] = max(
+                    part_max[unsafe_offset=row_idx * RED_WAYS + part], s_reg.ptr[unsafe_offset=c]
                 )
             comptime for i in range(rows_per_thread):
-                local_max[i] = max(
-                    max(part_max[i * RED_WAYS], part_max[i * RED_WAYS + 1]),
-                    max(part_max[i * RED_WAYS + 2], part_max[i * RED_WAYS + 3]),
+                local_max[unsafe_offset=i] = max(
+                    max(
+                        part_max[unsafe_offset=i * RED_WAYS],
+                        part_max[unsafe_offset=i * RED_WAYS + 1],
+                    ),
+                    max(
+                        part_max[unsafe_offset=i * RED_WAYS + 2],
+                        part_max[unsafe_offset=i * RED_WAYS + 3],
+                    ),
                 )
         else:
             comptime for i in range(rows_per_thread):
-                local_max[i] = neg_inf
+                local_max[unsafe_offset=i] = neg_inf
             comptime for c in range(c_frag_size_qk):
                 comptime row_idx: Int = 1 if (c % 4) >= 2 else 0
-                local_max[row_idx] = max(local_max[row_idx], s_reg.ptr[c])
+                local_max[unsafe_offset=row_idx] = max(
+                    local_max[unsafe_offset=row_idx], s_reg.ptr[unsafe_offset=c]
+                )
         comptime for i in range(rows_per_thread):
-            local_max[i] = warp.lane_group_max[num_lanes=4](local_max[i])
-            var rmax_new: Scalar[accum_type] = max(
-                local_max[i] * scale_log2, rowmax[i]
+            local_max[unsafe_offset=i] = warp.lane_group_max[num_lanes=4](
+                local_max[unsafe_offset=i]
             )
-            scale_old[i] = exp2(rowmax[i] - rmax_new)
-            rowmax[i] = rmax_new
+            var rmax_new: Scalar[accum_type] = max(
+                local_max[unsafe_offset=i] * scale_log2, rowmax[unsafe_offset=i]
+            )
+            scale_old[unsafe_offset=i] = exp2(rowmax[unsafe_offset=i] - rmax_new)
+            rowmax[unsafe_offset=i] = rmax_new
 
         var local_sum = stack_allocation[
             rows_per_thread, Scalar[accum_type]
@@ -816,53 +825,60 @@ def fwd_fa4_kernel[
                 rows_per_thread * RED_WAYS, Scalar[accum_type]
             ]()
             comptime for i in range(rows_per_thread * RED_WAYS):
-                part_sum[i] = Scalar[accum_type](0)
+                part_sum[unsafe_offset=i] = Scalar[accum_type](0)
             comptime for c in range(c_frag_size_qk):
                 comptime row_idx: Int = 1 if (c % 4) >= 2 else 0
                 comptime part: Int = (c // 4) % RED_WAYS
                 var p: Scalar[accum_type] = exp2(
-                    s_reg.ptr[c].fma(scale_log2, -rowmax[row_idx])
+                    s_reg.ptr[unsafe_offset=c].fma(scale_log2, -rowmax[unsafe_offset=row_idx])
                 )
-                s_reg.ptr[c] = p
-                part_sum[row_idx * RED_WAYS + part] += p
+                s_reg.ptr[unsafe_offset=c] = p
+                part_sum[unsafe_offset=row_idx * RED_WAYS + part] += p
             # Pairwise combine (the ONLY numeric difference vs the
             # a4e8462 kernel: f32 addition is not associative, so rowsum
             # can differ in the last ulp -- tree summation of
             # non-negative exp2 outputs is the better-conditioned order,
             # and the fp64 reference check bounds it).
             comptime for i in range(rows_per_thread):
-                local_sum[i] = (
-                    part_sum[i * RED_WAYS] + part_sum[i * RED_WAYS + 1]
-                ) + (part_sum[i * RED_WAYS + 2] + part_sum[i * RED_WAYS + 3])
+                local_sum[unsafe_offset=i] = (
+                    part_sum[unsafe_offset=i * RED_WAYS]
+                    + part_sum[unsafe_offset=i * RED_WAYS + 1]
+                ) + (
+                    part_sum[unsafe_offset=i * RED_WAYS + 2]
+                    + part_sum[unsafe_offset=i * RED_WAYS + 3]
+                )
         else:
             comptime for i in range(rows_per_thread):
-                local_sum[i] = Scalar[accum_type](0)
+                local_sum[unsafe_offset=i] = Scalar[accum_type](0)
             comptime for c in range(c_frag_size_qk):
                 comptime row_idx: Int = 1 if (c % 4) >= 2 else 0
                 var p: Scalar[accum_type] = exp2(
-                    s_reg.ptr[c].fma(scale_log2, -rowmax[row_idx])
+                    s_reg.ptr[unsafe_offset=c].fma(scale_log2, -rowmax[unsafe_offset=row_idx])
                 )
-                s_reg.ptr[c] = p
-                local_sum[row_idx] += p
+                s_reg.ptr[unsafe_offset=c] = p
+                local_sum[unsafe_offset=row_idx] += p
         comptime for i in range(rows_per_thread):
-            rowsum[i] = rowsum[i] * scale_old[i] + local_sum[i]
+            rowsum[unsafe_offset=i] = (
+                rowsum[unsafe_offset=i] * scale_old[unsafe_offset=i]
+                + local_sum[unsafe_offset=i]
+            )
 
     @parameter
     @always_inline
     def pack_p():
         comptime for c in range(c_frag_size_qk):
-            p_reg.ptr[c] = s_reg.ptr[c].cast[dtype]()
+            p_reg.ptr[unsafe_offset=c] = s_reg.ptr[unsafe_offset=c].cast[dtype]()
 
     @parameter
     @always_inline
     def rescale_o():
         comptime for c in range(c_frag_size_pv):
             comptime row_idx: Int = 1 if (c % 4) >= 2 else 0
-            o_reg.ptr[c] *= scale_old[row_idx]
+            o_reg.ptr[unsafe_offset=c] *= scale_old[unsafe_offset=row_idx]
 
     # ---- Prologue: S(0) -> P(0).
-    mbar_q[0].wait(UInt32(0))
-    full[0].wait(UInt32(0))
+    mbar_q[unsafe_offset=0].wait(UInt32(0))
+    full[unsafe_offset=0].wait(UInt32(0))
     warpgroup_fence(s_reg)
     wgmma_qk.arrive()
     wgmma_qk.wgmma[num_warp_groups=NWG, scale_c=0](
@@ -871,7 +887,7 @@ def fwd_fa4_kernel[
     wgmma_qk.commit_group()
     wgmma_qk.wait_group()
     warpgroup_fence(s_reg)
-    _ = empty[0].arrive()
+    _ = empty[unsafe_offset=0].arrive()
 
     # rowmax starts at -inf -> scale_old==0, rowsum init. For causal,
     # m_block 0's single tile IS the diagonal (BM==BN) or may sit in
@@ -926,7 +942,7 @@ def fwd_fa4_kernel[
 
     for it in range(kv_trips - 1):
         # Queue QK(n+1) then PV(n) on the tensor core.
-        full[k_slot].wait(k_phase)
+        full[unsafe_offset=k_slot].wait(k_phase)
         comptime if NWG > 1:
             named_barrier[Int32(SCHED_BAR_N)](Int32(1 + wg))
         warpgroup_fence(s_reg)
@@ -936,7 +952,7 @@ def fwd_fa4_kernel[
         )
         wgmma_qk.commit_group()
 
-        full[v_slot].wait(v_phase)
+        full[unsafe_offset=v_slot].wait(v_phase)
         warpgroup_fence(o_reg)
         wgmma_pv.arrive()
         pv_gemm(v_slot)
@@ -952,7 +968,7 @@ def fwd_fa4_kernel[
         # QK(n+1) retired (PV(n) still running on the tensor core).
         wgmma_qk.wait_group[1]()
         warpgroup_fence(s_reg)
-        _ = empty[k_slot].arrive()
+        _ = empty[unsafe_offset=k_slot].arrive()
 
         # Softmax of S(n+1) overlaps PV(n). For causal the last
         # tile (BM==BN: n+1 == num_kv_blocks-1 == m_block is THE
@@ -985,7 +1001,7 @@ def fwd_fa4_kernel[
         # PV(n) retired: p_reg and o_reg are safe to touch.
         wgmma_pv.wait_group[0]()
         warpgroup_fence(o_reg)
-        _ = empty[v_slot].arrive()
+        _ = empty[unsafe_offset=v_slot].arrive()
         pack_p()  # P(n+1)
         rescale_o()
 
@@ -1003,7 +1019,7 @@ def fwd_fa4_kernel[
             v_phase ^= 1
 
     # ---- Epilogue: PV(N-1) (v_slot/v_phase left at tile N-1).
-    full[v_slot].wait(v_phase)
+    full[unsafe_offset=v_slot].wait(v_phase)
     warpgroup_fence(o_reg)
     wgmma_pv.arrive()
     pv_gemm(v_slot)
@@ -1014,12 +1030,12 @@ def fwd_fa4_kernel[
     # ---- Normalize (reciprocal; one div per row) and store.
     var inv_rowsum = stack_allocation[rows_per_thread, Scalar[accum_type]]()
     comptime for i in range(rows_per_thread):
-        rowsum[i] = warp.lane_group_sum[num_lanes=4](rowsum[i])
-        inv_rowsum[i] = Scalar[accum_type](1) / rowsum[i]
+        rowsum[unsafe_offset=i] = warp.lane_group_sum[num_lanes=4](rowsum[unsafe_offset=i])
+        inv_rowsum[unsafe_offset=i] = Scalar[accum_type](1) / rowsum[unsafe_offset=i]
 
     comptime for c in range(c_frag_size_pv):
         comptime row_idx: Int = 1 if (c % 4) >= 2 else 0
-        o_reg.ptr[c] *= inv_rowsum[row_idx]
+        o_reg.ptr[unsafe_offset=c] *= inv_rowsum[unsafe_offset=row_idx]
 
     # ---- Store: stmatrix-stage O into the dead Q tile (same SW128
     # k-major layout it was loaded with — the bwd dK/dV epilogue's
@@ -1054,7 +1070,7 @@ def fwd_fa4_kernel[
     comptime if varlen:
         if vl_rows < BM:
             full_tile_store = False
-            var o_gptr = UnsafePointer[Scalar[dtype], MutAnyOrigin](
+            var o_gptr = Pointer[Scalar[dtype], MutAnyOrigin](
                 unsafe_from_address=sched_num_hb_q
             )
             var o_row0: Int = vl_q_base + m_block * BM
@@ -1066,15 +1082,14 @@ def fwd_fa4_kernel[
                 )
                 if row < vl_rows:
                     var pair = SIMD[dtype, 2](
-                        o_reg.ptr[2 * c2].cast[dtype](),
-                        o_reg.ptr[2 * c2 + 1].cast[dtype](),
+                        o_reg.ptr[unsafe_offset=2 * c2].cast[dtype](),
+                        o_reg.ptr[unsafe_offset=2 * c2 + 1].cast[dtype](),
                     )
-                    (
-                        o_gptr
-                        + ((o_row0 + row) * nheads + h_idx) * D
+                    o_gptr.unsafe_offset(
+                        ((o_row0 + row) * nheads + h_idx) * D
                         + col_chunk * 8
                         + 2 * lane_pair
-                    ).store[width=2, alignment=4](pair)
+                    ).unsafe_store[width=2, alignment=4](pair)
 
     if full_tile_store:
         comptime if D == 64:
@@ -1091,8 +1106,8 @@ def fwd_fa4_kernel[
                 )
                 var col: Int = col_chunk * 8 + 2 * lane_pair
                 var pair = SIMD[dtype, 2](
-                    o_reg.ptr[2 * c2].cast[dtype](),
-                    o_reg.ptr[2 * c2 + 1].cast[dtype](),
+                    o_reg.ptr[unsafe_offset=2 * c2].cast[dtype](),
+                    o_reg.ptr[unsafe_offset=2 * c2 + 1].cast[dtype](),
                 )
                 var b_addr: Int = (
                     Int(smem_base)
@@ -1102,8 +1117,8 @@ def fwd_fa4_kernel[
                 )
                 var b_sw: Int = b_addr ^ ((b_addr >> 3) & 112)
                 (
-                    smem_base + ((b_sw >> 1) - (Int(smem_base) >> 1))
-                ).store[width=2, alignment=4](pair)
+                    smem_base.unsafe_offset((b_sw >> 1) - (Int(smem_base) >> 1))
+                ).unsafe_store[width=2, alignment=4](pair)
         else:
             var st_row: Int = (
                 row_warp_base + ((lane // 8) % 2) * 8 + (lane % 8)
@@ -1116,7 +1131,7 @@ def fwd_fa4_kernel[
                     comptime p: Int = 4 * i + jm
                     packed[jm] = bitcast[DType.float32, 1](
                         SIMD[accum_type, 2](
-                            o_reg.ptr[2 * p], o_reg.ptr[2 * p + 1]
+                            o_reg.ptr[unsafe_offset=2 * p], o_reg.ptr[unsafe_offset=2 * p + 1]
                         ).cast[dtype]()
                     )
                 var raw_i: Int = (
@@ -1128,10 +1143,9 @@ def fwd_fa4_kernel[
                 # (raw 16-bit stores; the payload is already bit-packed)
                 # — the cast unblocks fp16 and is a no-op for bf16.
                 st_matrix[simd_width=4](
-                    (
-                        smem_base
-                        + ((sw_i >> 1) - (Int(smem_base) >> 1))
-                    ).bitcast[BFloat16](),
+                    smem_base.unsafe_offset(
+                        (sw_i >> 1) - (Int(smem_base) >> 1)
+                    ).unsafe_bitcast[BFloat16](),
                     packed,
                 )
 
@@ -1155,8 +1169,8 @@ def fwd_fa4_kernel[
             comptime if varlen or qo_rank == 4 or bhsd:
                 lse_ok = r < vl_rows
             if lse_ok:
-                (lse_ptr + lse_row_base + r)[0] = (
-                    rowmax[i] * LN2 + log(rowsum[i])
+                lse_ptr[unsafe_offset=lse_row_base + r] = (
+                    rowmax[unsafe_offset=i] * LN2 + log(rowsum[unsafe_offset=i])
                 ).cast[DType.float32]()
 
     fence_async_view_proxy()

--- a/torch_mojo_backend/eager_flash_attention/fa4_fwd_launch.mojo
+++ b/torch_mojo_backend/eager_flash_attention/fa4_fwd_launch.mojo
@@ -96,7 +96,7 @@ def launch_fwd_fa4[
         and gqa_ratio == 1
         and softcap_x1000 == 0
     ), "strided_qkv supports only dense d64/d128 (no varlen/window/gqa/softcap)"
-    var raw_ctx_ptr = UnsafePointer[_DeviceContextCpp, MutUntrackedOrigin](
+    var raw_ctx_ptr = Pointer[_DeviceContextCpp, MutUntrackedOrigin](
         unsafe_from_address=ctx_handle_addr
     )
     var ctx = DeviceContext(_DeviceContextPtr[mut=True](raw_ctx_ptr))
@@ -118,16 +118,16 @@ def launch_fwd_fa4[
         q_bytes + kFa4KVStages * kv_slot_bytes + mbar_bytes
     )
 
-    var q_ptr = UnsafePointer[Scalar[dtype], ImmutAnyOrigin](
+    var q_ptr = Pointer[Scalar[dtype], ImmutAnyOrigin](
         unsafe_from_address=q_addr
     )
-    var k_ptr = UnsafePointer[Scalar[dtype], ImmutAnyOrigin](
+    var k_ptr = Pointer[Scalar[dtype], ImmutAnyOrigin](
         unsafe_from_address=k_addr
     )
-    var v_ptr = UnsafePointer[Scalar[dtype], ImmutAnyOrigin](
+    var v_ptr = Pointer[Scalar[dtype], ImmutAnyOrigin](
         unsafe_from_address=v_addr
     )
-    var lse_ptr = UnsafePointer[Float32, MutAnyOrigin](
+    var lse_ptr = Pointer[Float32, MutAnyOrigin](
         unsafe_from_address=lse_addr
     )
     # 3D TMA descriptors over the (B*L, H, D) gmem view.
@@ -168,7 +168,7 @@ def launch_fwd_fa4[
         var v_tma_b = create_split_tma[
             kv_smem_shape_b, gmem_shape, swizzle_mode=swizzle
         ](ctx, v_ptr, planes_kv, seqlen_int)
-        var o_imm_ptr_b = UnsafePointer[Scalar[dtype], ImmutAnyOrigin](
+        var o_imm_ptr_b = Pointer[Scalar[dtype], ImmutAnyOrigin](
             unsafe_from_address=o_addr
         )
         var o_tma_b = create_split_tma[
@@ -310,7 +310,7 @@ def launch_fwd_fa4[
     # whole-tile TMA store. (The previous unswizzled 16B-chunk
     # descriptor cost 16 serialized UTMASTG issues per CTA — ~8% of
     # a short-seq CTA, PC-sampling-verified.)
-    var o_imm_ptr = UnsafePointer[Scalar[dtype], ImmutAnyOrigin](
+    var o_imm_ptr = Pointer[Scalar[dtype], ImmutAnyOrigin](
         unsafe_from_address=o_addr
     )
     # Dense hdim64 gives Q/O RANK-4 descriptors (B, S, H, D): with

--- a/torch_mojo_backend/eager_flash_attention/fa4_fwd_selfload_kernel.mojo
+++ b/torch_mojo_backend/eager_flash_attention/fa4_fwd_selfload_kernel.mojo
@@ -137,7 +137,7 @@ def fwd_fa4_selfload_kernel[
     k_tma: TMATensorTile[dtype, 3, kv_tile_shape, kv_desc_shape],
     v_tma: TMATensorTile[dtype, 3, kv_tile_shape, kv_desc_shape],
     o_tma: TMATensorTile[dtype, qo_rank, o_tile_shape, o_desc_shape],
-    lse_ptr: UnsafePointer[Float32, MutAnyOrigin],
+    lse_ptr: Pointer[Float32, MutAnyOrigin],
     seq_len_arg: Int64,
     softmax_scale: Float32,
     nheads_arg: Int64,
@@ -262,7 +262,7 @@ def fwd_fa4_selfload_kernel[
         address_space=AddressSpace.SHARED,
         alignment=128,
     ]((smem_base).as_unsafe_any_origin())
-    var kv_smem_base = smem_base + q_smem_size
+    var kv_smem_base = smem_base.unsafe_offset(q_smem_size)
 
     var mbar_q = stack_allocation[
         1, SharedMemBarrier, address_space=AddressSpace.SHARED, alignment=8
@@ -274,9 +274,9 @@ def fwd_fa4_selfload_kernel[
         alignment=8,
     ]()
     if thread_idx.x == 0:
-        mbar_q[0].init()
+        mbar_q[unsafe_offset=0].init()
         comptime for s in range(STAGES):
-            full[s].init(1)
+            full[unsafe_offset=s].init(1)
     barrier()
 
     var m_block: Int
@@ -299,18 +299,17 @@ def fwd_fa4_selfload_kernel[
         # sees it warp-uniform (same hazard class as the tid-widening
         # trap; see HANDOFF.md).
         var tbl = (
-            UnsafePointer[Int32, ImmutAnyOrigin](
+            Pointer[Int32, ImmutAnyOrigin](
                 unsafe_from_address=sched_swizzle
-            )
-            + 8 * Int(block_idx.x)
+            ).unsafe_offset(8 * Int(block_idx.x))
         )
-        m_block = Int(warp.broadcast(tbl[0]))
-        vl_q_base = Int(warp.broadcast(tbl[1]))
-        vl_k_base = Int(warp.broadcast(tbl[2]))
-        vl_seqlen_q = Int(warp.broadcast(tbl[3]))
-        vl_seqlen_k = Int(warp.broadcast(tbl[4]))
+        m_block = Int(warp.broadcast(tbl[unsafe_offset=0]))
+        vl_q_base = Int(warp.broadcast(tbl[unsafe_offset=1]))
+        vl_k_base = Int(warp.broadcast(tbl[unsafe_offset=2]))
+        vl_seqlen_q = Int(warp.broadcast(tbl[unsafe_offset=3]))
+        vl_seqlen_k = Int(warp.broadcast(tbl[unsafe_offset=4]))
         comptime if window:
-            vl_win_left = Int(warp.broadcast(tbl[5]))
+            vl_win_left = Int(warp.broadcast(tbl[unsafe_offset=5]))
         h_idx = Int(block_idx.y)
         b_idx = 0
     else:
@@ -452,14 +451,14 @@ def fwd_fa4_selfload_kernel[
             MutAnyOrigin,
             address_space=AddressSpace.SHARED,
             alignment=128,
-        ]((kv_smem_base + slot * kv_slot_size).as_unsafe_any_origin())
-        full[slot].expect_bytes(Int32(BN * D * size_of[dtype]()))
+        ]((kv_smem_base.unsafe_offset(slot * kv_slot_size)).as_unsafe_any_origin())
+        full[unsafe_offset=slot].expect_bytes(Int32(BN * D * size_of[dtype]()))
         var row: Int = kv_row0 + n * kv_row_step
         comptime if bhsd:
-            k_tma.async_copy_3d(k_st, full[slot], (0, row, kv_plane))
+            k_tma.async_copy_3d(k_st, full[unsafe_offset=slot], (0, row, kv_plane))
         else:
             k_tma.async_copy_3d(
-                k_st, full[slot], (0, h_idx // gqa_ratio, row)
+                k_st, full[unsafe_offset=slot], (0, h_idx // gqa_ratio, row)
             )
 
     @parameter
@@ -472,38 +471,38 @@ def fwd_fa4_selfload_kernel[
             MutAnyOrigin,
             address_space=AddressSpace.SHARED,
             alignment=128,
-        ]((kv_smem_base + slot * kv_slot_size).as_unsafe_any_origin())
-        full[slot].expect_bytes(Int32(BN * D * size_of[dtype]()))
+        ]((kv_smem_base.unsafe_offset(slot * kv_slot_size)).as_unsafe_any_origin())
+        full[unsafe_offset=slot].expect_bytes(Int32(BN * D * size_of[dtype]()))
         var row: Int = kv_row0 + n * kv_row_step
         comptime if bhsd:
-            v_tma.async_copy_3d(v_st, full[slot], (0, row, kv_plane))
+            v_tma.async_copy_3d(v_st, full[unsafe_offset=slot], (0, row, kv_plane))
         else:
             v_tma.async_copy_3d(
-                v_st, full[slot], (0, h_idx // gqa_ratio, row)
+                v_st, full[unsafe_offset=slot], (0, h_idx // gqa_ratio, row)
             )
 
     # Prologue issues: Q plus PREFETCH whole tile-pairs (the ring holds
     # exactly PREFETCH pairs).
     if thread_idx.x == 0:
-        mbar_q[0].expect_bytes(Int32(BM * D * size_of[dtype]()))
+        mbar_q[unsafe_offset=0].expect_bytes(Int32(BM * D * size_of[dtype]()))
         comptime if bhsd:
             q_tma.async_copy_3d(
                 q_smem,
-                mbar_q[0],
+                mbar_q[unsafe_offset=0],
                 (0, m_block * BM, b_idx * nheads + h_idx),
             )
         elif qo_rank == 4:
             q_tma.async_copy_4d(
-                q_smem, mbar_q[0], (0, h_idx, m_block * BM, b_idx)
+                q_smem, mbar_q[unsafe_offset=0], (0, h_idx, m_block * BM, b_idx)
             )
         elif varlen:
             q_tma.async_copy_3d(
-                q_smem, mbar_q[0], (0, h_idx, vl_q_base + m_block * BM)
+                q_smem, mbar_q[unsafe_offset=0], (0, h_idx, vl_q_base + m_block * BM)
             )
         else:
             q_tma.async_copy_3d(
                 q_smem,
-                mbar_q[0],
+                mbar_q[unsafe_offset=0],
                 (0, h_idx, b_idx * seq_len + m_block * BM),
             )
         comptime for pf in range(PREFETCH):
@@ -583,8 +582,8 @@ def fwd_fa4_selfload_kernel[
     var scale_old = stack_allocation[rows_per_thread, Scalar[accum_type]]()
     var neg_inf: Scalar[accum_type] = Scalar[accum_type](-1.0e30)
     comptime for i in range(rows_per_thread):
-        rowmax[i] = neg_inf
-        rowsum[i] = Scalar[accum_type](0)
+        rowmax[unsafe_offset=i] = neg_inf
+        rowsum[unsafe_offset=i] = Scalar[accum_type](0)
 
     var scale_log2: Scalar[accum_type] = (
         softmax_scale * Scalar[DType.float32](log2e)
@@ -616,7 +615,7 @@ def fwd_fa4_selfload_kernel[
         address_space=AddressSpace.SHARED,
         alignment=128,
     ]:
-        return {(kv_smem_base + slot * kv_slot_size).as_unsafe_any_origin()}
+        return {(kv_smem_base.unsafe_offset(slot * kv_slot_size)).as_unsafe_any_origin()}
 
     @parameter
     @always_inline
@@ -627,7 +626,7 @@ def fwd_fa4_selfload_kernel[
         address_space=AddressSpace.SHARED,
         alignment=128,
     ]:
-        return {(kv_smem_base + slot * kv_slot_size).as_unsafe_any_origin()}
+        return {(kv_smem_base.unsafe_offset(slot * kv_slot_size)).as_unsafe_any_origin()}
 
     # fp16 RS fork: the stdlib's register-A wgmma overload is
     # bf16-only (hardcoded .bf16.bf16 asm); the vendored
@@ -646,15 +645,15 @@ def fwd_fa4_selfload_kernel[
     def pv_gemm(slot_arg: Int):
         comptime if dtype == DType.float16:
             var b_desc = _wgmma_descriptor[v_canonical, False, swizzle](
-                kv_smem_base + slot_arg * kv_slot_size
+                kv_smem_base.unsafe_offset(slot_arg * kv_slot_size)
             )
-            var o_simd = o_reg.ptr.load[width=c_frag_size_pv]()
+            var o_simd = o_reg.ptr.unsafe_load[width=c_frag_size_pv]()
             comptime for k_mma in range(num_k_mmas_pv):
                 comptime if head_dim == 128:
                     o_simd = rebind[SIMD[accum_type, c_frag_size_pv]](
                         wgmma_rs_f16_m64n128(
                             rebind[SIMD[DType.float16, 8]](
-                                (p_reg.ptr + 8 * k_mma).load[width=8]()
+                                (p_reg.ptr.unsafe_offset(8 * k_mma)).unsafe_load[width=8]()
                             ),
                             (b_desc + k_mma * v_k_stride).desc,
                             rebind[SIMD[DType.float32, 64]](o_simd),
@@ -664,13 +663,13 @@ def fwd_fa4_selfload_kernel[
                     o_simd = rebind[SIMD[accum_type, c_frag_size_pv]](
                         wgmma_rs_f16_m64n64(
                             rebind[SIMD[DType.float16, 8]](
-                                (p_reg.ptr + 8 * k_mma).load[width=8]()
+                                (p_reg.ptr.unsafe_offset(8 * k_mma)).unsafe_load[width=8]()
                             ),
                             (b_desc + k_mma * v_k_stride).desc,
                             rebind[SIMD[DType.float32, 32]](o_simd),
                         )
                     )
-            o_reg.ptr.store[width=c_frag_size_pv](o_simd)
+            o_reg.ptr.unsafe_store[width=c_frag_size_pv](o_simd)
         else:
             wgmma_pv.wgmma(p_reg, v_tile(slot_arg), o_reg)
 
@@ -710,7 +709,7 @@ def fwd_fa4_selfload_kernel[
             # tanh.approx.f32 — FA4's "fastmath" tanh emulates via
             # ex2 and pays 3.1x kernel time for it.
             comptime for c in range(c_frag_size_qk):
-                s_reg.ptr[c] = tanh(s_reg.ptr[c] * t_scale)
+                s_reg.ptr[unsafe_offset=c] = tanh(s_reg.ptr[unsafe_offset=c] * t_scale)
         comptime if causal:
             comptime if BM == BN and not varlen:
                 if mask_diag:
@@ -718,7 +717,7 @@ def fwd_fa4_selfload_kernel[
                         comptime col_base: Int = (c // 4) * 8 + (c & 1)
                         comptime row_off: Int = 8 if (c % 4) >= 2 else 0
                         if col_base + mask_col_lo > mask_row_lo + row_off:
-                            s_reg.ptr[c] = neg_inf
+                            s_reg.ptr[unsafe_offset=c] = neg_inf
             else:
                 # Diagonal-band tile: global mask col + mask_d > row.
                 # (Varlen causal always uses this arm — the
@@ -794,7 +793,7 @@ def fwd_fa4_selfload_kernel[
                                 if col_base > (
                                     mask_thr1 if hi_row else mask_thr0
                                 ):
-                                    s_reg.ptr[c] = neg_inf
+                                    s_reg.ptr[unsafe_offset=c] = neg_inf
         comptime if window:
             # Leading window edge (prologue tile only): cols before
             # row - left are outside the window.
@@ -806,13 +805,13 @@ def fwd_fa4_selfload_kernel[
                         col_base + mask_col_lo + win_mask_d
                         < mask_row_lo + row_off
                     ):
-                        s_reg.ptr[c] = neg_inf
+                        s_reg.ptr[unsafe_offset=c] = neg_inf
         comptime if varlen and not causal:
             if mask_tail and vl_kv_tail < BN:
                 comptime for c in range(c_frag_size_qk):
                     comptime col_base: Int = (c // 4) * 8 + (c & 1)
                     if col_base + mask_col_lo >= vl_kv_tail:
-                        s_reg.ptr[c] = neg_inf
+                        s_reg.ptr[unsafe_offset=c] = neg_inf
         # TREE-SHAPED row reductions. The natural
         # `local_max[row] = max(local_max[row], s_reg[c])` sweep is two
         # 32-deep dependent chains (~4-cycle FMNMX latency each = ~128
@@ -830,31 +829,41 @@ def fwd_fa4_selfload_kernel[
                 rows_per_thread * RED_WAYS, Scalar[accum_type]
             ]()
             comptime for i in range(rows_per_thread * RED_WAYS):
-                part_max[i] = neg_inf
+                part_max[unsafe_offset=i] = neg_inf
             comptime for c in range(c_frag_size_qk):
                 comptime row_idx: Int = 1 if (c % 4) >= 2 else 0
                 comptime part: Int = (c // 4) % RED_WAYS
-                part_max[row_idx * RED_WAYS + part] = max(
-                    part_max[row_idx * RED_WAYS + part], s_reg.ptr[c]
+                part_max[unsafe_offset=row_idx * RED_WAYS + part] = max(
+                    part_max[unsafe_offset=row_idx * RED_WAYS + part], s_reg.ptr[unsafe_offset=c]
                 )
             comptime for i in range(rows_per_thread):
-                local_max[i] = max(
-                    max(part_max[i * RED_WAYS], part_max[i * RED_WAYS + 1]),
-                    max(part_max[i * RED_WAYS + 2], part_max[i * RED_WAYS + 3]),
+                local_max[unsafe_offset=i] = max(
+                    max(
+                        part_max[unsafe_offset=i * RED_WAYS],
+                        part_max[unsafe_offset=i * RED_WAYS + 1],
+                    ),
+                    max(
+                        part_max[unsafe_offset=i * RED_WAYS + 2],
+                        part_max[unsafe_offset=i * RED_WAYS + 3],
+                    ),
                 )
         else:
             comptime for i in range(rows_per_thread):
-                local_max[i] = neg_inf
+                local_max[unsafe_offset=i] = neg_inf
             comptime for c in range(c_frag_size_qk):
                 comptime row_idx: Int = 1 if (c % 4) >= 2 else 0
-                local_max[row_idx] = max(local_max[row_idx], s_reg.ptr[c])
+                local_max[unsafe_offset=row_idx] = max(
+                    local_max[unsafe_offset=row_idx], s_reg.ptr[unsafe_offset=c]
+                )
         comptime for i in range(rows_per_thread):
-            local_max[i] = warp.lane_group_max[num_lanes=4](local_max[i])
-            var rmax_new: Scalar[accum_type] = max(
-                local_max[i] * scale_log2, rowmax[i]
+            local_max[unsafe_offset=i] = warp.lane_group_max[num_lanes=4](
+                local_max[unsafe_offset=i]
             )
-            scale_old[i] = exp2(rowmax[i] - rmax_new)
-            rowmax[i] = rmax_new
+            var rmax_new: Scalar[accum_type] = max(
+                local_max[unsafe_offset=i] * scale_log2, rowmax[unsafe_offset=i]
+            )
+            scale_old[unsafe_offset=i] = exp2(rowmax[unsafe_offset=i] - rmax_new)
+            rowmax[unsafe_offset=i] = rmax_new
 
         var local_sum = stack_allocation[
             rows_per_thread, Scalar[accum_type]
@@ -864,53 +873,60 @@ def fwd_fa4_selfload_kernel[
                 rows_per_thread * RED_WAYS, Scalar[accum_type]
             ]()
             comptime for i in range(rows_per_thread * RED_WAYS):
-                part_sum[i] = Scalar[accum_type](0)
+                part_sum[unsafe_offset=i] = Scalar[accum_type](0)
             comptime for c in range(c_frag_size_qk):
                 comptime row_idx: Int = 1 if (c % 4) >= 2 else 0
                 comptime part: Int = (c // 4) % RED_WAYS
                 var p: Scalar[accum_type] = exp2(
-                    s_reg.ptr[c].fma(scale_log2, -rowmax[row_idx])
+                    s_reg.ptr[unsafe_offset=c].fma(scale_log2, -rowmax[unsafe_offset=row_idx])
                 )
-                s_reg.ptr[c] = p
-                part_sum[row_idx * RED_WAYS + part] += p
+                s_reg.ptr[unsafe_offset=c] = p
+                part_sum[unsafe_offset=row_idx * RED_WAYS + part] += p
             # Pairwise combine (the ONLY numeric difference vs the
             # a4e8462 kernel: f32 addition is not associative, so rowsum
             # can differ in the last ulp -- tree summation of
             # non-negative exp2 outputs is the better-conditioned order,
             # and the fp64 reference check bounds it).
             comptime for i in range(rows_per_thread):
-                local_sum[i] = (
-                    part_sum[i * RED_WAYS] + part_sum[i * RED_WAYS + 1]
-                ) + (part_sum[i * RED_WAYS + 2] + part_sum[i * RED_WAYS + 3])
+                local_sum[unsafe_offset=i] = (
+                    part_sum[unsafe_offset=i * RED_WAYS]
+                    + part_sum[unsafe_offset=i * RED_WAYS + 1]
+                ) + (
+                    part_sum[unsafe_offset=i * RED_WAYS + 2]
+                    + part_sum[unsafe_offset=i * RED_WAYS + 3]
+                )
         else:
             comptime for i in range(rows_per_thread):
-                local_sum[i] = Scalar[accum_type](0)
+                local_sum[unsafe_offset=i] = Scalar[accum_type](0)
             comptime for c in range(c_frag_size_qk):
                 comptime row_idx: Int = 1 if (c % 4) >= 2 else 0
                 var p: Scalar[accum_type] = exp2(
-                    s_reg.ptr[c].fma(scale_log2, -rowmax[row_idx])
+                    s_reg.ptr[unsafe_offset=c].fma(scale_log2, -rowmax[unsafe_offset=row_idx])
                 )
-                s_reg.ptr[c] = p
-                local_sum[row_idx] += p
+                s_reg.ptr[unsafe_offset=c] = p
+                local_sum[unsafe_offset=row_idx] += p
         comptime for i in range(rows_per_thread):
-            rowsum[i] = rowsum[i] * scale_old[i] + local_sum[i]
+            rowsum[unsafe_offset=i] = (
+                rowsum[unsafe_offset=i] * scale_old[unsafe_offset=i]
+                + local_sum[unsafe_offset=i]
+            )
 
     @parameter
     @always_inline
     def pack_p():
         comptime for c in range(c_frag_size_qk):
-            p_reg.ptr[c] = s_reg.ptr[c].cast[dtype]()
+            p_reg.ptr[unsafe_offset=c] = s_reg.ptr[unsafe_offset=c].cast[dtype]()
 
     @parameter
     @always_inline
     def rescale_o():
         comptime for c in range(c_frag_size_pv):
             comptime row_idx: Int = 1 if (c % 4) >= 2 else 0
-            o_reg.ptr[c] *= scale_old[row_idx]
+            o_reg.ptr[unsafe_offset=c] *= scale_old[unsafe_offset=row_idx]
 
     # ---- Prologue: S(0) -> P(0).
-    mbar_q[0].wait(UInt32(0))
-    full[0].wait(UInt32(0))
+    mbar_q[unsafe_offset=0].wait(UInt32(0))
+    full[unsafe_offset=0].wait(UInt32(0))
     warpgroup_fence(s_reg)
     wgmma_qk.arrive()
     wgmma_qk.wgmma[num_warp_groups=NWG, scale_c=0](
@@ -979,7 +995,7 @@ def fwd_fa4_selfload_kernel[
 
     for it in range(kv_trips - 1):
         # Queue QK(n+1) then PV(n) on the tensor core.
-        full[k_slot].wait(k_phase)
+        full[unsafe_offset=k_slot].wait(k_phase)
         comptime if NWG > 1:
             named_barrier[Int32(SCHED_BAR_N)](Int32(1 + wg))
         warpgroup_fence(s_reg)
@@ -989,7 +1005,7 @@ def fwd_fa4_selfload_kernel[
         )
         wgmma_qk.commit_group()
 
-        full[v_slot].wait(v_phase)
+        full[unsafe_offset=v_slot].wait(v_phase)
         warpgroup_fence(o_reg)
         wgmma_pv.arrive()
         pv_gemm(v_slot)
@@ -1065,7 +1081,7 @@ def fwd_fa4_selfload_kernel[
             v_phase ^= 1
 
     # ---- Epilogue: PV(N-1) (v_slot/v_phase left at tile N-1).
-    full[v_slot].wait(v_phase)
+    full[unsafe_offset=v_slot].wait(v_phase)
     warpgroup_fence(o_reg)
     wgmma_pv.arrive()
     pv_gemm(v_slot)
@@ -1076,12 +1092,12 @@ def fwd_fa4_selfload_kernel[
     # ---- Normalize (reciprocal; one div per row) and store.
     var inv_rowsum = stack_allocation[rows_per_thread, Scalar[accum_type]]()
     comptime for i in range(rows_per_thread):
-        rowsum[i] = warp.lane_group_sum[num_lanes=4](rowsum[i])
-        inv_rowsum[i] = Scalar[accum_type](1) / rowsum[i]
+        rowsum[unsafe_offset=i] = warp.lane_group_sum[num_lanes=4](rowsum[unsafe_offset=i])
+        inv_rowsum[unsafe_offset=i] = Scalar[accum_type](1) / rowsum[unsafe_offset=i]
 
     comptime for c in range(c_frag_size_pv):
         comptime row_idx: Int = 1 if (c % 4) >= 2 else 0
-        o_reg.ptr[c] *= inv_rowsum[row_idx]
+        o_reg.ptr[unsafe_offset=c] *= inv_rowsum[unsafe_offset=row_idx]
 
     # ---- Store: stmatrix-stage O into the dead Q tile (same SW128
     # k-major layout it was loaded with — the bwd dK/dV epilogue's
@@ -1116,7 +1132,7 @@ def fwd_fa4_selfload_kernel[
     comptime if varlen:
         if vl_rows < BM:
             full_tile_store = False
-            var o_gptr = UnsafePointer[Scalar[dtype], MutAnyOrigin](
+            var o_gptr = Pointer[Scalar[dtype], MutAnyOrigin](
                 unsafe_from_address=sched_num_hb_q
             )
             var o_row0: Int = vl_q_base + m_block * BM
@@ -1128,15 +1144,14 @@ def fwd_fa4_selfload_kernel[
                 )
                 if row < vl_rows:
                     var pair = SIMD[dtype, 2](
-                        o_reg.ptr[2 * c2].cast[dtype](),
-                        o_reg.ptr[2 * c2 + 1].cast[dtype](),
+                        o_reg.ptr[unsafe_offset=2 * c2].cast[dtype](),
+                        o_reg.ptr[unsafe_offset=2 * c2 + 1].cast[dtype](),
                     )
-                    (
-                        o_gptr
-                        + ((o_row0 + row) * nheads + h_idx) * D
+                    o_gptr.unsafe_offset(
+                        ((o_row0 + row) * nheads + h_idx) * D
                         + col_chunk * 8
                         + 2 * lane_pair
-                    ).store[width=2, alignment=4](pair)
+                    ).unsafe_store[width=2, alignment=4](pair)
 
     if full_tile_store:
         comptime if D == 64:
@@ -1153,8 +1168,8 @@ def fwd_fa4_selfload_kernel[
                 )
                 var col: Int = col_chunk * 8 + 2 * lane_pair
                 var pair = SIMD[dtype, 2](
-                    o_reg.ptr[2 * c2].cast[dtype](),
-                    o_reg.ptr[2 * c2 + 1].cast[dtype](),
+                    o_reg.ptr[unsafe_offset=2 * c2].cast[dtype](),
+                    o_reg.ptr[unsafe_offset=2 * c2 + 1].cast[dtype](),
                 )
                 var b_addr: Int = (
                     Int(smem_base)
@@ -1164,8 +1179,8 @@ def fwd_fa4_selfload_kernel[
                 )
                 var b_sw: Int = b_addr ^ ((b_addr >> 3) & 112)
                 (
-                    smem_base + ((b_sw >> 1) - (Int(smem_base) >> 1))
-                ).store[width=2, alignment=4](pair)
+                    smem_base.unsafe_offset((b_sw >> 1) - (Int(smem_base) >> 1))
+                ).unsafe_store[width=2, alignment=4](pair)
         else:
             var st_row: Int = (
                 row_warp_base + ((lane // 8) % 2) * 8 + (lane % 8)
@@ -1178,7 +1193,7 @@ def fwd_fa4_selfload_kernel[
                     comptime p: Int = 4 * i + jm
                     packed[jm] = bitcast[DType.float32, 1](
                         SIMD[accum_type, 2](
-                            o_reg.ptr[2 * p], o_reg.ptr[2 * p + 1]
+                            o_reg.ptr[unsafe_offset=2 * p], o_reg.ptr[unsafe_offset=2 * p + 1]
                         ).cast[dtype]()
                     )
                 var raw_i: Int = (
@@ -1190,10 +1205,9 @@ def fwd_fa4_selfload_kernel[
                 # (raw 16-bit stores; the payload is already bit-packed)
                 # — the cast unblocks fp16 and is a no-op for bf16.
                 st_matrix[simd_width=4](
-                    (
-                        smem_base
-                        + ((sw_i >> 1) - (Int(smem_base) >> 1))
-                    ).bitcast[BFloat16](),
+                    smem_base.unsafe_offset(
+                        (sw_i >> 1) - (Int(smem_base) >> 1)
+                    ).unsafe_bitcast[BFloat16](),
                     packed,
                 )
 
@@ -1217,8 +1231,8 @@ def fwd_fa4_selfload_kernel[
             comptime if varlen or qo_rank == 4 or bhsd:
                 lse_ok = r < vl_rows
             if lse_ok:
-                (lse_ptr + lse_row_base + r)[0] = (
-                    rowmax[i] * LN2 + log(rowsum[i])
+                lse_ptr[unsafe_offset=lse_row_base + r] = (
+                    rowmax[unsafe_offset=i] * LN2 + log(rowsum[unsafe_offset=i])
                 ).cast[DType.float32]()
 
     fence_async_view_proxy()

--- a/torch_mojo_backend/eager_flash_attention/fa4_fwd_selfload_launch.mojo
+++ b/torch_mojo_backend/eager_flash_attention/fa4_fwd_selfload_launch.mojo
@@ -88,7 +88,7 @@ def launch_fwd_fa4_selfload[
     comptime assert (
         (head_dim == 64) and causal and softcap_x1000 == 0
     ), "self-load geometry is d64-only, dense-causal-bhsd only (d128/non-causal keep the phase-2b launcher)"
-    var raw_ctx_ptr = UnsafePointer[_DeviceContextCpp, MutUntrackedOrigin](
+    var raw_ctx_ptr = Pointer[_DeviceContextCpp, MutUntrackedOrigin](
         unsafe_from_address=ctx_handle_addr
     )
     var ctx = DeviceContext(_DeviceContextPtr[mut=True](raw_ctx_ptr))
@@ -110,16 +110,16 @@ def launch_fwd_fa4_selfload[
         q_bytes + kFa4KVStages * kv_slot_bytes + mbar_bytes
     )
 
-    var q_ptr = UnsafePointer[Scalar[dtype], ImmutAnyOrigin](
+    var q_ptr = Pointer[Scalar[dtype], ImmutAnyOrigin](
         unsafe_from_address=q_addr
     )
-    var k_ptr = UnsafePointer[Scalar[dtype], ImmutAnyOrigin](
+    var k_ptr = Pointer[Scalar[dtype], ImmutAnyOrigin](
         unsafe_from_address=k_addr
     )
-    var v_ptr = UnsafePointer[Scalar[dtype], ImmutAnyOrigin](
+    var v_ptr = Pointer[Scalar[dtype], ImmutAnyOrigin](
         unsafe_from_address=v_addr
     )
-    var lse_ptr = UnsafePointer[Float32, MutAnyOrigin](
+    var lse_ptr = Pointer[Float32, MutAnyOrigin](
         unsafe_from_address=lse_addr
     )
     # PUBLIC-layout consumption (the fix the phase-2 bhsd descriptors
@@ -142,7 +142,7 @@ def launch_fwd_fa4_selfload[
     var v_tma = create_split_tma[
         kv_smem_shape, gmem_shape, swizzle_mode=swizzle
     ](ctx, v_ptr, planes_kv, seqlen_int)
-    var o_imm_ptr = UnsafePointer[Scalar[dtype], ImmutAnyOrigin](
+    var o_imm_ptr = Pointer[Scalar[dtype], ImmutAnyOrigin](
         unsafe_from_address=o_addr
     )
     var o_tma = create_split_tma[

--- a/torch_mojo_backend/eager_flash_attention/fa4_launch_cache.mojo
+++ b/torch_mojo_backend/eager_flash_attention/fa4_launch_cache.mojo
@@ -5,7 +5,8 @@ from std.collections import OptionalReg
 from std.ffi import _get_global_or_null, external_call
 from max.gpu.host import DeviceContext, FuncAttribute
 from max.gpu.host.device_context import _DumpPath
-from std.memory import OpaquePointer, alloc
+from std.memory import OpaquePointer
+from std.memory.alloc import unsafe_alloc
 
 
 @always_inline
@@ -36,8 +37,10 @@ def enqueue_fa4_cached[
     )
     comptime FuncT = type_of(ctx.compile_function[func]())
 
-    if global_ptr := _get_global_or_null(name):
-        var fptr = global_ptr.value().bitcast[FuncT]()
+    var global_ptr = _get_global_or_null(name)
+
+    if global_ptr:
+        var fptr = global_ptr.value().unsafe_bitcast[FuncT]()
         comptime if use_external_stream:
             var stream = ctx.create_external_stream(stream_opaque)
             stream.enqueue_function(
@@ -61,11 +64,11 @@ def enqueue_fa4_cached[
         func,
         dump_asm=dump_asm,
     ](func_attribute=func_attribute)
-    var fptr = alloc[FuncT](1)
-    fptr.init_pointee_move(compiled^)
+    var fptr = unsafe_alloc[FuncT](1)
+    fptr.unsafe_write(compiled^)
     external_call["KGEN_CompilerRT_InsertGlobal", NoneType](
         StringSlice(name),
-        fptr.bitcast[NoneType](),
+        fptr.unsafe_bitcast[NoneType](),
     )
 
     comptime if use_external_stream:

--- a/torch_mojo_backend/eager_flash_attention/fa4_ops.mojo
+++ b/torch_mojo_backend/eager_flash_attention/fa4_ops.mojo
@@ -49,7 +49,7 @@ def _fa4_bhsd_selfload_waves(
     that stay on the phase-2b geometry, an unmeasured combination this
     gate must not create (NOTES.md "Phase 2c" handoff item 4).
     """
-    var raw_ctx_ptr = UnsafePointer[_DeviceContextCpp, MutUntrackedOrigin](
+    var raw_ctx_ptr = Pointer[_DeviceContextCpp, MutUntrackedOrigin](
         unsafe_from_address=ctx_handle_addr
     )
     var ctx = DeviceContext(_DeviceContextPtr[mut=True](raw_ctx_ptr))

--- a/torch_mojo_backend/eager_flash_attention/fa4_tma4.mojo
+++ b/torch_mojo_backend/eager_flash_attention/fa4_tma4.mojo
@@ -51,7 +51,7 @@ def create_split_tma_4d[
     swizzle_mode: TensorMapSwizzle,
 ](
     ctx: DeviceContext,
-    ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     runtime_dim0: Int,
     runtime_dim1: Int,
     runtime_dim2: Int,
@@ -87,7 +87,7 @@ def create_split_tma_3d_strided[
     swizzle_mode: TensorMapSwizzle,
 ](
     ctx: DeviceContext,
-    ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     dim0: Int,
     dim1: Int,
     dim2: Int,
@@ -123,7 +123,7 @@ def create_split_tma_4d_strided[
     swizzle_mode: TensorMapSwizzle,
 ](
     ctx: DeviceContext,
-    ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     dim0: Int,
     dim1: Int,
     dim2: Int,

--- a/torch_mojo_backend/eager_kernels/activation_backward_ops/activation_backward_ops.mojo
+++ b/torch_mojo_backend/eager_kernels/activation_backward_ops/activation_backward_ops.mojo
@@ -79,9 +79,9 @@ def _tanh_grad[
 
 @__name("gelu_backward_exact")
 def _gelu_backward_exact(
-    output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    input: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    input: Pointer[Scalar[DType.float32], MutAnyOrigin],
     elements_arg: Int64,
     vec_count_arg: Int64,
 ):
@@ -92,21 +92,25 @@ def _gelu_backward_exact(
     var gid = Int(block_idx.x) * _BLOCK + Int(thread_idx.x)
     if gid < vec_count:
         var base = gid * _VEC
-        var x = input.load[width=_VEC, alignment=16](base)
-        var g = grad_output.load[width=_VEC, alignment=16](base)
-        output.store[width=_VEC, alignment=16](base, _exact_grad[_VEC](x, g))
+        var x = input.unsafe_load[width=_VEC, alignment=16](base)
+        var g = grad_output.unsafe_load[width=_VEC, alignment=16](base)
+        output.unsafe_store[width=_VEC, alignment=16](
+            base, _exact_grad[_VEC](x, g)
+        )
     var i = vec_count * _VEC + gid
     var stride = Int(grid_dim.x) * _BLOCK
     while i < elements:
-        output[i] = _exact_grad[1](input[i], grad_output[i])
+        output[unsafe_offset=i] = _exact_grad[1](
+            input[unsafe_offset=i], grad_output[unsafe_offset=i]
+        )
         i += stride
 
 
 @__name("gelu_backward_tanh")
 def _gelu_backward_tanh(
-    output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    input: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    input: Pointer[Scalar[DType.float32], MutAnyOrigin],
     elements_arg: Int64,
     vec_count_arg: Int64,
 ):
@@ -117,13 +121,17 @@ def _gelu_backward_tanh(
     var gid = Int(block_idx.x) * _BLOCK + Int(thread_idx.x)
     if gid < vec_count:
         var base = gid * _VEC
-        var x = input.load[width=_VEC, alignment=16](base)
-        var g = grad_output.load[width=_VEC, alignment=16](base)
-        output.store[width=_VEC, alignment=16](base, _tanh_grad[_VEC](x, g))
+        var x = input.unsafe_load[width=_VEC, alignment=16](base)
+        var g = grad_output.unsafe_load[width=_VEC, alignment=16](base)
+        output.unsafe_store[width=_VEC, alignment=16](
+            base, _tanh_grad[_VEC](x, g)
+        )
     var i = vec_count * _VEC + gid
     var stride = Int(grid_dim.x) * _BLOCK
     while i < elements:
-        output[i] = _tanh_grad[1](input[i], grad_output[i])
+        output[unsafe_offset=i] = _tanh_grad[1](
+            input[unsafe_offset=i], grad_output[unsafe_offset=i]
+        )
         i += stride
 
 
@@ -142,9 +150,9 @@ def _grad_val[
 def _gelu_backward_f32_g4[
     tanh_mode: Bool
 ](
-    output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    input: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    input: Pointer[Scalar[DType.float32], MutAnyOrigin],
     elements_arg: Int64,
     vec_count_arg: Int64,
 ):
@@ -162,45 +170,47 @@ def _gelu_backward_f32_g4[
     var g = gid
     while g < groups:
         var b = g * 4
-        var x0 = input.load[width=_VEC, alignment=16](b * 4)
-        var x1 = input.load[width=_VEC, alignment=16]((b + 1) * 4)
-        var x2 = input.load[width=_VEC, alignment=16]((b + 2) * 4)
-        var x3 = input.load[width=_VEC, alignment=16]((b + 3) * 4)
-        var g0 = grad_output.load[width=_VEC, alignment=16](b * 4)
-        var g1 = grad_output.load[width=_VEC, alignment=16]((b + 1) * 4)
-        var g2 = grad_output.load[width=_VEC, alignment=16]((b + 2) * 4)
-        var g3 = grad_output.load[width=_VEC, alignment=16]((b + 3) * 4)
-        output.store[width=_VEC, alignment=16](
+        var x0 = input.unsafe_load[width=_VEC, alignment=16](b * 4)
+        var x1 = input.unsafe_load[width=_VEC, alignment=16]((b + 1) * 4)
+        var x2 = input.unsafe_load[width=_VEC, alignment=16]((b + 2) * 4)
+        var x3 = input.unsafe_load[width=_VEC, alignment=16]((b + 3) * 4)
+        var g0 = grad_output.unsafe_load[width=_VEC, alignment=16](b * 4)
+        var g1 = grad_output.unsafe_load[width=_VEC, alignment=16]((b + 1) * 4)
+        var g2 = grad_output.unsafe_load[width=_VEC, alignment=16]((b + 2) * 4)
+        var g3 = grad_output.unsafe_load[width=_VEC, alignment=16]((b + 3) * 4)
+        output.unsafe_store[width=_VEC, alignment=16](
             b * 4, _grad_val[_VEC, tanh_mode](x0, g0)
         )
-        output.store[width=_VEC, alignment=16](
+        output.unsafe_store[width=_VEC, alignment=16](
             (b + 1) * 4, _grad_val[_VEC, tanh_mode](x1, g1)
         )
-        output.store[width=_VEC, alignment=16](
+        output.unsafe_store[width=_VEC, alignment=16](
             (b + 2) * 4, _grad_val[_VEC, tanh_mode](x2, g2)
         )
-        output.store[width=_VEC, alignment=16](
+        output.unsafe_store[width=_VEC, alignment=16](
             (b + 3) * 4, _grad_val[_VEC, tanh_mode](x3, g3)
         )
         g += gstride
     var c = groups * 4 + gid
     if c < vec_count:
-        var x = input.load[width=_VEC, alignment=16](c * 4)
-        var gg = grad_output.load[width=_VEC, alignment=16](c * 4)
-        output.store[width=_VEC, alignment=16](
+        var x = input.unsafe_load[width=_VEC, alignment=16](c * 4)
+        var gg = grad_output.unsafe_load[width=_VEC, alignment=16](c * 4)
+        output.unsafe_store[width=_VEC, alignment=16](
             c * 4, _grad_val[_VEC, tanh_mode](x, gg)
         )
     var i = vec_count * _VEC + gid
     while i < elements:
-        output[i] = _grad_val[1, tanh_mode](input[i], grad_output[i])
+        output[unsafe_offset=i] = _grad_val[1, tanh_mode](
+            input[unsafe_offset=i], grad_output[unsafe_offset=i]
+        )
         i += gstride
 
 
 @__name("gelu_backward_exact_bf16")
 def _gelu_backward_exact_bf16(
-    output: UnsafePointer[Scalar[DType.bfloat16], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[DType.bfloat16], MutAnyOrigin],
-    input: UnsafePointer[Scalar[DType.bfloat16], MutAnyOrigin],
+    output: Pointer[Scalar[DType.bfloat16], MutAnyOrigin],
+    grad_output: Pointer[Scalar[DType.bfloat16], MutAnyOrigin],
+    input: Pointer[Scalar[DType.bfloat16], MutAnyOrigin],
     elements_arg: Int64,
     vec_count_arg: Int64,
 ):
@@ -211,30 +221,30 @@ def _gelu_backward_exact_bf16(
     var gid = Int(block_idx.x) * _BLOCK + Int(thread_idx.x)
     if gid < vec_count:
         var base = gid * _VEC_BF16
-        var x = input.load[width=_VEC_BF16, alignment=16](base).cast[
+        var x = input.unsafe_load[width=_VEC_BF16, alignment=16](base).cast[
             DType.float32
         ]()
-        var g = grad_output.load[width=_VEC_BF16, alignment=16](base).cast[
-            DType.float32
-        ]()
-        output.store[width=_VEC_BF16, alignment=16](
+        var g = grad_output.unsafe_load[width=_VEC_BF16, alignment=16](
+            base
+        ).cast[DType.float32]()
+        output.unsafe_store[width=_VEC_BF16, alignment=16](
             base, _exact_grad[_VEC_BF16](x, g).cast[DType.bfloat16]()
         )
     var i = vec_count * _VEC_BF16 + gid
     var stride = Int(grid_dim.x) * _BLOCK
     while i < elements:
-        output[i] = _exact_grad[1](
-            input[i].cast[DType.float32](),
-            grad_output[i].cast[DType.float32](),
+        output[unsafe_offset=i] = _exact_grad[1](
+            input[unsafe_offset=i].cast[DType.float32](),
+            grad_output[unsafe_offset=i].cast[DType.float32](),
         ).cast[DType.bfloat16]()
         i += stride
 
 
 @__name("gelu_backward_tanh_bf16")
 def _gelu_backward_tanh_bf16(
-    output: UnsafePointer[Scalar[DType.bfloat16], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[DType.bfloat16], MutAnyOrigin],
-    input: UnsafePointer[Scalar[DType.bfloat16], MutAnyOrigin],
+    output: Pointer[Scalar[DType.bfloat16], MutAnyOrigin],
+    grad_output: Pointer[Scalar[DType.bfloat16], MutAnyOrigin],
+    input: Pointer[Scalar[DType.bfloat16], MutAnyOrigin],
     elements_arg: Int64,
     vec_count_arg: Int64,
 ):
@@ -245,29 +255,29 @@ def _gelu_backward_tanh_bf16(
     var gid = Int(block_idx.x) * _BLOCK + Int(thread_idx.x)
     if gid < vec_count:
         var base = gid * _VEC_BF16
-        var x = input.load[width=_VEC_BF16, alignment=16](base).cast[
+        var x = input.unsafe_load[width=_VEC_BF16, alignment=16](base).cast[
             DType.float32
         ]()
-        var g = grad_output.load[width=_VEC_BF16, alignment=16](base).cast[
-            DType.float32
-        ]()
-        output.store[width=_VEC_BF16, alignment=16](
+        var g = grad_output.unsafe_load[width=_VEC_BF16, alignment=16](
+            base
+        ).cast[DType.float32]()
+        output.unsafe_store[width=_VEC_BF16, alignment=16](
             base, _tanh_grad[_VEC_BF16](x, g).cast[DType.bfloat16]()
         )
     var i = vec_count * _VEC_BF16 + gid
     var stride = Int(grid_dim.x) * _BLOCK
     while i < elements:
-        output[i] = _tanh_grad[1](
-            input[i].cast[DType.float32](),
-            grad_output[i].cast[DType.float32](),
+        output[unsafe_offset=i] = _tanh_grad[1](
+            input[unsafe_offset=i].cast[DType.float32](),
+            grad_output[unsafe_offset=i].cast[DType.float32](),
         ).cast[DType.bfloat16]()
         i += stride
 
 
 def enqueue_gelu_backward_f32(
-    output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    input: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    input: Pointer[Scalar[DType.float32], MutAnyOrigin],
     elements: Int,
     tanh_approx: Bool,
     ctx: DeviceContext,
@@ -350,9 +360,9 @@ def enqueue_gelu_backward_f32(
 
 
 def enqueue_gelu_backward_bf16(
-    output: UnsafePointer[Scalar[DType.bfloat16], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[DType.bfloat16], MutAnyOrigin],
-    input: UnsafePointer[Scalar[DType.bfloat16], MutAnyOrigin],
+    output: Pointer[Scalar[DType.bfloat16], MutAnyOrigin],
+    grad_output: Pointer[Scalar[DType.bfloat16], MutAnyOrigin],
+    input: Pointer[Scalar[DType.bfloat16], MutAnyOrigin],
     elements: Int,
     tanh_approx: Bool,
     ctx: DeviceContext,
@@ -438,15 +448,15 @@ def _gelu_backward_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         _gelu_backward_go(
-            args[0],
-            args[1],
-            args[2],
-            args[3],
-            args[4],
-            args[5],
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
         )
     except e:
         return _spec_unsupported(e)
@@ -486,15 +496,15 @@ def _gelu_backward_bf16_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         _gelu_backward_bf16_go(
-            args[0],
-            args[1],
-            args[2],
-            args[3],
-            args[4],
-            args[5],
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
         )
     except e:
         return _spec_unsupported(e)

--- a/torch_mojo_backend/eager_kernels/activation_forward_ops/activation_forward_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/activation_forward_ops/activation_forward_kernels.mojo
@@ -12,7 +12,8 @@ from std.gpu import block_idx, grid_dim, thread_idx
 from max.gpu.host import DeviceContext
 from std.math import ceildiv, exp2
 from std.math.polynomial import polynomial_evaluate
-from std.memory import alloc, bitcast
+from std.memory import bitcast
+from std.memory.alloc import unsafe_alloc
 
 
 comptime _BLOCK = 256
@@ -114,8 +115,8 @@ def _gelu_exact_bf16[
 
 @__name("gelu_forward_bf16_exact_vec16")
 def _gelu_forward_bf16_exact(
-    output: UnsafePointer[Scalar[DType.bfloat16], MutAnyOrigin],
-    input: UnsafePointer[Scalar[DType.bfloat16], MutAnyOrigin],
+    output: Pointer[Scalar[DType.bfloat16], MutAnyOrigin],
+    input: Pointer[Scalar[DType.bfloat16], MutAnyOrigin],
     elements_arg: Int64,
     vec_count_arg: Int64,
 ):
@@ -126,19 +127,23 @@ def _gelu_forward_bf16_exact(
     var gid = Int(block_idx.x) * _BLOCK + Int(thread_idx.x)
     if gid < vec_count:
         var base = gid * _VEC
-        var values = input.load[width=_VEC, alignment=16](base)
-        output.store[width=_VEC, alignment=16](base, _gelu_exact_bf16(values))
+        var values = input.unsafe_load[width=_VEC, alignment=16](base)
+        output.unsafe_store[width=_VEC, alignment=16](
+            base, _gelu_exact_bf16(values)
+        )
     var index = vec_count * _VEC + gid
     var stride = Int(grid_dim.x) * _BLOCK
     while index < elements:
-        output[index] = _gelu_exact_bf16(input.load[width=1](index))[0]
+        output[unsafe_offset=index] = _gelu_exact_bf16(
+            input.unsafe_load[width=1](index)
+        )[0]
         index += stride
 
 
 @__name("gelu_forward_bf16_tanh_vec16")
 def _gelu_forward_bf16_tanh(
-    output: UnsafePointer[Scalar[DType.bfloat16], MutAnyOrigin],
-    input: UnsafePointer[Scalar[DType.bfloat16], MutAnyOrigin],
+    output: Pointer[Scalar[DType.bfloat16], MutAnyOrigin],
+    input: Pointer[Scalar[DType.bfloat16], MutAnyOrigin],
     elements_arg: Int64,
     vec_count_arg: Int64,
 ):
@@ -149,18 +154,18 @@ def _gelu_forward_bf16_tanh(
     var gid = Int(block_idx.x) * _BLOCK + Int(thread_idx.x)
     if gid < vec_count:
         var base = gid * _VEC
-        var values = input.load[width=_VEC, alignment=16](base)
-        output.store[width=_VEC, alignment=16](base, gelu_tanh(values))
+        var values = input.unsafe_load[width=_VEC, alignment=16](base)
+        output.unsafe_store[width=_VEC, alignment=16](base, gelu_tanh(values))
     var index = vec_count * _VEC + gid
     var stride = Int(grid_dim.x) * _BLOCK
     while index < elements:
-        output[index] = gelu_tanh(input[index])
+        output[unsafe_offset=index] = gelu_tanh(input[unsafe_offset=index])
         index += stride
 
 
 def _enqueue_exact_cached(
-    output: UnsafePointer[Scalar[DType.bfloat16], MutAnyOrigin],
-    input: UnsafePointer[Scalar[DType.bfloat16], MutAnyOrigin],
+    output: Pointer[Scalar[DType.bfloat16], MutAnyOrigin],
+    input: Pointer[Scalar[DType.bfloat16], MutAnyOrigin],
     elements: Int,
     vec_count: Int,
     blocks: Int,
@@ -168,8 +173,9 @@ def _enqueue_exact_cached(
 ) raises:
     var cache_name = String(t"GELU_FORWARD_BF16_EXACT_VEC16_V1_{ctx.id()}")
     comptime FuncT = type_of(ctx.compile_function[_gelu_forward_bf16_exact]())
-    if global_ptr := _get_global_or_null(cache_name):
-        var cached = global_ptr.value().bitcast[FuncT]()
+    var global_ptr = _get_global_or_null(cache_name)
+    if global_ptr:
+        var cached = global_ptr.value().unsafe_bitcast[FuncT]()
         ctx.enqueue_function(
             cached[],
             output,
@@ -181,10 +187,10 @@ def _enqueue_exact_cached(
         )
         return
     var compiled = ctx.compile_function[_gelu_forward_bf16_exact]()
-    var cached = alloc[FuncT](1)
-    cached.init_pointee_move(compiled^)
+    var cached = unsafe_alloc[FuncT](1)
+    cached.unsafe_write(compiled^)
     external_call["KGEN_CompilerRT_InsertGlobal", NoneType](
-        StringSlice(cache_name), cached.bitcast[NoneType]()
+        StringSlice(cache_name), cached.unsafe_bitcast[NoneType]()
     )
     ctx.enqueue_function(
         cached[],
@@ -198,8 +204,8 @@ def _enqueue_exact_cached(
 
 
 def _enqueue_tanh_cached(
-    output: UnsafePointer[Scalar[DType.bfloat16], MutAnyOrigin],
-    input: UnsafePointer[Scalar[DType.bfloat16], MutAnyOrigin],
+    output: Pointer[Scalar[DType.bfloat16], MutAnyOrigin],
+    input: Pointer[Scalar[DType.bfloat16], MutAnyOrigin],
     elements: Int,
     vec_count: Int,
     blocks: Int,
@@ -207,8 +213,9 @@ def _enqueue_tanh_cached(
 ) raises:
     var cache_name = String(t"GELU_FORWARD_BF16_TANH_VEC16_V1_{ctx.id()}")
     comptime FuncT = type_of(ctx.compile_function[_gelu_forward_bf16_tanh]())
-    if global_ptr := _get_global_or_null(cache_name):
-        var cached = global_ptr.value().bitcast[FuncT]()
+    var global_ptr = _get_global_or_null(cache_name)
+    if global_ptr:
+        var cached = global_ptr.value().unsafe_bitcast[FuncT]()
         ctx.enqueue_function(
             cached[],
             output,
@@ -220,10 +227,10 @@ def _enqueue_tanh_cached(
         )
         return
     var compiled = ctx.compile_function[_gelu_forward_bf16_tanh]()
-    var cached = alloc[FuncT](1)
-    cached.init_pointee_move(compiled^)
+    var cached = unsafe_alloc[FuncT](1)
+    cached.unsafe_write(compiled^)
     external_call["KGEN_CompilerRT_InsertGlobal", NoneType](
-        StringSlice(cache_name), cached.bitcast[NoneType]()
+        StringSlice(cache_name), cached.unsafe_bitcast[NoneType]()
     )
     ctx.enqueue_function(
         cached[],
@@ -237,8 +244,8 @@ def _enqueue_tanh_cached(
 
 
 def enqueue_gelu_forward_bf16(
-    output: UnsafePointer[Scalar[DType.bfloat16], MutAnyOrigin],
-    input: UnsafePointer[Scalar[DType.bfloat16], MutAnyOrigin],
+    output: Pointer[Scalar[DType.bfloat16], MutAnyOrigin],
+    input: Pointer[Scalar[DType.bfloat16], MutAnyOrigin],
     elements: Int,
     tanh_approx: Bool,
     ctx: DeviceContext,

--- a/torch_mojo_backend/eager_kernels/argreduce_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/argreduce_kernels.mojo
@@ -185,31 +185,35 @@ def _ar_block_merge[
     var idx_smem = stack_allocation[
         AR_THREADS, DType.int64, address_space=AddressSpace.SHARED
     ]()
-    val_smem[tid] = best_val
-    idx_smem[tid] = best_idx
+    val_smem[unsafe_offset=tid] = best_val
+    idx_smem[unsafe_offset=tid] = best_idx
     barrier()
     var stride = AR_THREADS // 2
     for _ in range(AR_STAGES):
         if tid < stride:
             if _ar_better[dtype, is_min](
-                val_smem[tid + stride],
-                idx_smem[tid + stride],
-                val_smem[tid],
-                idx_smem[tid],
+                val_smem[unsafe_offset=tid + stride],
+                idx_smem[unsafe_offset=tid + stride],
+                val_smem[unsafe_offset=tid],
+                idx_smem[unsafe_offset=tid],
             ):
-                val_smem[tid] = val_smem[tid + stride]
-                idx_smem[tid] = idx_smem[tid + stride]
+                val_smem[unsafe_offset=tid] = val_smem[
+                    unsafe_offset=tid + stride
+                ]
+                idx_smem[unsafe_offset=tid] = idx_smem[
+                    unsafe_offset=tid + stride
+                ]
         barrier()
         stride //= 2
-    best_val = val_smem[0]
-    best_idx = idx_smem[0]
+    best_val = val_smem[unsafe_offset=0]
+    best_idx = idx_smem[unsafe_offset=0]
 
 
 @always_inline
 def _ar_scan_row[
     dtype: DType, is_min: Bool, VEC: Int
 ](
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     base: Int,
     start: Int,
     end: Int,
@@ -228,15 +232,14 @@ def _ar_scan_row[
     var nslots = (end - start) // VEC
     for k in range(tid, nslots, AR_THREADS):
         var off = start + k * VEC
-        var v = in_ptr.load[width=VEC, alignment=ALIGN](base + off)
+        var v = in_ptr.unsafe_load[width=VEC, alignment=ALIGN](base + off)
 
-        @parameter
-        for lane in range(VEC):
+        comptime for lane in range(VEC):
             if best_idx < 0 or _ar_take_next[dtype, is_min](v[lane], best_val):
                 best_val = v[lane]
                 best_idx = Int64(off + lane)
     for j in range(start + nslots * VEC + tid, end, AR_THREADS):
-        var v = in_ptr[base + j]
+        var v = in_ptr[unsafe_offset=base + j]
         if best_idx < 0 or _ar_take_next[dtype, is_min](v, best_val):
             best_val = v
             best_idx = Int64(j)
@@ -254,8 +257,8 @@ def _ar_scan_row[
 def _argreduce_rows_kernel[
     dtype: DType, is_min: Bool, VEC: Int
 ](
-    out_ptr: UnsafePointer[Scalar[DType.int64], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[DType.int64], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     cols_arg: Int64,
 ):
     """One block per row (grid.x = rows), for the saturated regime."""
@@ -271,7 +274,7 @@ def _argreduce_rows_kernel[
     )
     _ar_block_merge[dtype, is_min](tid, best_val, best_idx)
     if tid == 0:
-        out_ptr[r] = best_idx
+        out_ptr[unsafe_offset=r] = best_idx
 
 
 @__llvm_metadata(
@@ -281,9 +284,9 @@ def _argreduce_rows_kernel[
 def _argreduce_rows_split_kernel[
     dtype: DType, is_min: Bool, VEC: Int
 ](
-    ws_val: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    ws_idx: UnsafePointer[Scalar[DType.int64], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    ws_val: Pointer[Scalar[dtype], MutAnyOrigin],
+    ws_idx: Pointer[Scalar[DType.int64], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     cols_arg: Int64,
     chunk_arg: Int64,
 ):
@@ -305,8 +308,8 @@ def _argreduce_rows_split_kernel[
     )
     _ar_block_merge[dtype, is_min](tid, best_val, best_idx)
     if tid == 0:
-        ws_val[r * splits + s] = best_val
-        ws_idx[r * splits + s] = best_idx
+        ws_val[unsafe_offset=r * splits + s] = best_val
+        ws_idx[unsafe_offset=r * splits + s] = best_idx
 
 
 # ---------------------------------------------------------------------------
@@ -321,8 +324,8 @@ def _argreduce_rows_split_kernel[
 def _argreduce_cols_kernel[
     dtype: DType, is_min: Bool
 ](
-    out_ptr: UnsafePointer[Scalar[DType.int64], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[DType.int64], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     reduce_arg: Int64,
     inner_arg: Int64,
     lanes_arg: Int64,
@@ -343,14 +346,14 @@ def _argreduce_cols_kernel[
     if i >= inner:
         return
     var base = o * reduce_n * inner + i
-    var best_val = in_ptr[base]
+    var best_val = in_ptr[unsafe_offset=base]
     var best_idx = Int64(0)
     for r in range(1, reduce_n):
-        var v = in_ptr[base + r * inner]
+        var v = in_ptr[unsafe_offset=base + r * inner]
         if _ar_take_next[dtype, is_min](v, best_val):
             best_val = v
             best_idx = Int64(r)
-    out_ptr[o * inner + i] = best_idx
+    out_ptr[unsafe_offset=o * inner + i] = best_idx
 
 
 @__llvm_metadata(
@@ -360,9 +363,9 @@ def _argreduce_cols_kernel[
 def _argreduce_cols_split_kernel[
     dtype: DType, is_min: Bool
 ](
-    ws_val: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    ws_idx: UnsafePointer[Scalar[DType.int64], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    ws_val: Pointer[Scalar[dtype], MutAnyOrigin],
+    ws_idx: Pointer[Scalar[DType.int64], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     reduce_arg: Int64,
     inner_arg: Int64,
     lanes_arg: Int64,
@@ -386,16 +389,16 @@ def _argreduce_cols_split_kernel[
     var best_val = Scalar[dtype](0)
     var best_idx = Int64(-1)
     if start < end:
-        best_val = in_ptr[base + start * inner]
+        best_val = in_ptr[unsafe_offset=base + start * inner]
         best_idx = Int64(start)
         for r in range(start + 1, end):
-            var v = in_ptr[base + r * inner]
+            var v = in_ptr[unsafe_offset=base + r * inner]
             if _ar_take_next[dtype, is_min](v, best_val):
                 best_val = v
                 best_idx = Int64(r)
     var p = o * inner + i
-    ws_val[p * splits + s] = best_val
-    ws_idx[p * splits + s] = best_idx
+    ws_val[unsafe_offset=p * splits + s] = best_val
+    ws_idx[unsafe_offset=p * splits + s] = best_idx
 
 
 # ---------------------------------------------------------------------------
@@ -413,9 +416,9 @@ def _argreduce_cols_split_kernel[
 def _minmax_rows_kernel[
     dtype: DType, is_min: Bool, VEC: Int
 ](
-    val_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    idx_ptr: UnsafePointer[Scalar[DType.int64], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    val_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    idx_ptr: Pointer[Scalar[DType.int64], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     cols_arg: Int64,
 ):
     """One block per row (grid.x = rows), for the saturated regime."""
@@ -429,8 +432,8 @@ def _minmax_rows_kernel[
     )
     _ar_block_merge[dtype, is_min](tid, best_val, best_idx)
     if tid == 0:
-        val_ptr[r] = best_val
-        idx_ptr[r] = best_idx
+        val_ptr[unsafe_offset=r] = best_val
+        idx_ptr[unsafe_offset=r] = best_idx
 
 
 @__llvm_metadata(
@@ -440,9 +443,9 @@ def _minmax_rows_kernel[
 def _minmax_cols_kernel[
     dtype: DType, is_min: Bool
 ](
-    val_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    idx_ptr: UnsafePointer[Scalar[DType.int64], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    val_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    idx_ptr: Pointer[Scalar[DType.int64], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     reduce_arg: Int64,
     inner_arg: Int64,
     lanes_arg: Int64,
@@ -456,15 +459,15 @@ def _minmax_cols_kernel[
     if i >= inner:
         return
     var base = o * reduce_n * inner + i
-    var best_val = in_ptr[base]
+    var best_val = in_ptr[unsafe_offset=base]
     var best_idx = Int64(0)
     for r in range(1, reduce_n):
-        var v = in_ptr[base + r * inner]
+        var v = in_ptr[unsafe_offset=base + r * inner]
         if _ar_take_next[dtype, is_min](v, best_val):
             best_val = v
             best_idx = Int64(r)
-    val_ptr[o * inner + i] = best_val
-    idx_ptr[o * inner + i] = best_idx
+    val_ptr[unsafe_offset=o * inner + i] = best_val
+    idx_ptr[unsafe_offset=o * inner + i] = best_idx
 
 
 # ---------------------------------------------------------------------------
@@ -479,9 +482,9 @@ def _minmax_cols_kernel[
 def _argreduce_merge_kernel[
     dtype: DType, is_min: Bool
 ](
-    out_ptr: UnsafePointer[Scalar[DType.int64], MutAnyOrigin],
-    ws_val: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    ws_idx: UnsafePointer[Scalar[DType.int64], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[DType.int64], MutAnyOrigin],
+    ws_val: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    ws_idx: Pointer[Scalar[DType.int64], ImmutAnyOrigin],
     splits_arg: Int64,
 ):
     """One block per output element, merging its `splits` partials. The
@@ -495,13 +498,16 @@ def _argreduce_merge_kernel[
     var best_idx = Int64(-1)
     for s in range(tid, splits, AR_THREADS):
         if _ar_better[dtype, is_min](
-            ws_val[base + s], ws_idx[base + s], best_val, best_idx
+            ws_val[unsafe_offset=base + s],
+            ws_idx[unsafe_offset=base + s],
+            best_val,
+            best_idx,
         ):
-            best_val = ws_val[base + s]
-            best_idx = ws_idx[base + s]
+            best_val = ws_val[unsafe_offset=base + s]
+            best_idx = ws_idx[unsafe_offset=base + s]
     _ar_block_merge[dtype, is_min](tid, best_val, best_idx)
     if tid == 0:
-        out_ptr[p] = best_idx
+        out_ptr[unsafe_offset=p] = best_idx
 
 
 @__llvm_metadata(
@@ -511,10 +517,10 @@ def _argreduce_merge_kernel[
 def _minmax_merge_kernel[
     dtype: DType, is_min: Bool
 ](
-    val_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    idx_ptr: UnsafePointer[Scalar[DType.int64], MutAnyOrigin],
-    ws_val: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    ws_idx: UnsafePointer[Scalar[DType.int64], ImmutAnyOrigin],
+    val_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    idx_ptr: Pointer[Scalar[DType.int64], MutAnyOrigin],
+    ws_val: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    ws_idx: Pointer[Scalar[DType.int64], ImmutAnyOrigin],
     splits_arg: Int64,
 ):
     """`_argreduce_merge_kernel` keeping the winning value as well."""
@@ -526,14 +532,17 @@ def _minmax_merge_kernel[
     var best_idx = Int64(-1)
     for s in range(tid, splits, AR_THREADS):
         if _ar_better[dtype, is_min](
-            ws_val[base + s], ws_idx[base + s], best_val, best_idx
+            ws_val[unsafe_offset=base + s],
+            ws_idx[unsafe_offset=base + s],
+            best_val,
+            best_idx,
         ):
-            best_val = ws_val[base + s]
-            best_idx = ws_idx[base + s]
+            best_val = ws_val[unsafe_offset=base + s]
+            best_idx = ws_idx[unsafe_offset=base + s]
     _ar_block_merge[dtype, is_min](tid, best_val, best_idx)
     if tid == 0:
-        val_ptr[p] = best_val
-        idx_ptr[p] = best_idx
+        val_ptr[unsafe_offset=p] = best_val
+        idx_ptr[unsafe_offset=p] = best_idx
 
 
 # ---------------------------------------------------------------------------
@@ -545,7 +554,7 @@ def _minmax_merge_kernel[
 def _ar_cpu_scan[
     dtype: DType, is_min: Bool
 ](
-    in_ptr: UnsafePointer[Scalar[dtype], MutUntrackedOrigin],
+    in_ptr: Pointer[Scalar[dtype], MutUntrackedOrigin],
     base: Int,
     stride: Int,
     n: Int,
@@ -558,10 +567,10 @@ def _ar_cpu_scan[
     change the parallel-for kernel argmin/argmax emit for no reason -- without
     the scan itself existing twice.
     """
-    var best = in_ptr[base]
+    var best = in_ptr[unsafe_offset=base]
     var best_idx = 0
     for r in range(1, n):
-        var v = in_ptr[base + r * stride]
+        var v = in_ptr[unsafe_offset=base + r * stride]
         if _ar_take_next[dtype, is_min](v, best):
             best = v
             best_idx = r
@@ -595,8 +604,8 @@ def _ar_merge_launch[
 ](
     out_addr: Int,
     val_addr: Int,
-    ws_val: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    ws_idx: UnsafePointer[Scalar[DType.int64], MutAnyOrigin],
+    ws_val: Pointer[Scalar[dtype], MutAnyOrigin],
+    ws_idx: Pointer[Scalar[DType.int64], MutAnyOrigin],
     outputs: Int,
     splits: Int,
     ctx: DeviceContext,
@@ -611,8 +620,8 @@ def _ar_merge_launch[
             AR_THREADS,
             _make_ptr[dtype](val_addr).as_unsafe_any_origin(),
             _make_ptr[DType.int64](out_addr).as_unsafe_any_origin(),
-            ws_val.as_immutable(),
-            ws_idx.as_immutable(),
+            ws_val.as_imm(),
+            ws_idx.as_imm(),
             Int64(splits),
         )
     else:
@@ -624,8 +633,8 @@ def _ar_merge_launch[
             1,
             AR_THREADS,
             _make_ptr[DType.int64](out_addr).as_unsafe_any_origin(),
-            ws_val.as_immutable(),
-            ws_idx.as_immutable(),
+            ws_val.as_imm(),
+            ws_idx.as_imm(),
             Int64(splits),
         )
 
@@ -659,8 +668,8 @@ def _argreduce_rows[
                 var best, best_idx = _ar_cpu_scan[dtype, is_min](
                     in_ptr, r * cols, 1, cols
                 )
-                out_ptr[r] = Int64(best_idx)
-                val_ptr[r] = best
+                out_ptr[unsafe_offset=r] = Int64(best_idx)
+                val_ptr[unsafe_offset=r] = best
 
             _parallel_for[func_v](rows, ctx)
         else:
@@ -673,7 +682,7 @@ def _argreduce_rows[
                 var _best, best_idx = _ar_cpu_scan[dtype, is_min](
                     in_ptr, r * cols, 1, cols
                 )
-                out_ptr[r] = Int64(best_idx)
+                out_ptr[unsafe_offset=r] = Int64(best_idx)
 
             _parallel_for[func](rows, ctx)
         return
@@ -711,7 +720,7 @@ def _argreduce_rows[
                         AR_THREADS,
                         val_ptr.as_unsafe_any_origin(),
                         out_ptr.as_unsafe_any_origin(),
-                        in_ptr.as_unsafe_any_origin().as_immutable(),
+                        in_ptr.as_unsafe_any_origin().as_imm(),
                         Int64(cols),
                     )
                 else:
@@ -723,7 +732,7 @@ def _argreduce_rows[
                         1,
                         AR_THREADS,
                         out_ptr.as_unsafe_any_origin(),
-                        in_ptr.as_unsafe_any_origin().as_immutable(),
+                        in_ptr.as_unsafe_any_origin().as_imm(),
                         Int64(cols),
                     )
                 return True
@@ -740,7 +749,7 @@ def _argreduce_rows[
                 AR_THREADS,
                 ws_val_ptr,
                 ws_idx_ptr,
-                in_ptr.as_unsafe_any_origin().as_immutable(),
+                in_ptr.as_unsafe_any_origin().as_imm(),
                 Int64(cols),
                 Int64(chunk),
             )
@@ -795,8 +804,8 @@ def _argreduce_cols[
                 var best, best_idx = _ar_cpu_scan[dtype, is_min](
                     in_ptr, base, inner, reduce_n
                 )
-                out_ptr[p] = Int64(best_idx)
-                val_ptr[p] = best
+                out_ptr[unsafe_offset=p] = Int64(best_idx)
+                val_ptr[unsafe_offset=p] = best
 
             _parallel_for[func_v](outputs, ctx)
         else:
@@ -810,7 +819,7 @@ def _argreduce_cols[
                 var _best, best_idx = _ar_cpu_scan[dtype, is_min](
                     in_ptr, base, inner, reduce_n
                 )
-                out_ptr[p] = Int64(best_idx)
+                out_ptr[unsafe_offset=p] = Int64(best_idx)
 
             _parallel_for[func](outputs, ctx)
         return
@@ -831,7 +840,7 @@ def _argreduce_cols[
                     AR_THREADS,
                     val_ptr.as_unsafe_any_origin(),
                     out_ptr.as_unsafe_any_origin(),
-                    in_ptr.as_unsafe_any_origin().as_immutable(),
+                    in_ptr.as_unsafe_any_origin().as_imm(),
                     Int64(reduce_n),
                     Int64(inner),
                     Int64(lanes),
@@ -845,7 +854,7 @@ def _argreduce_cols[
                     1,
                     AR_THREADS,
                     out_ptr.as_unsafe_any_origin(),
-                    in_ptr.as_unsafe_any_origin().as_immutable(),
+                    in_ptr.as_unsafe_any_origin().as_imm(),
                     Int64(reduce_n),
                     Int64(inner),
                     Int64(lanes),
@@ -866,7 +875,7 @@ def _argreduce_cols[
             AR_THREADS,
             ws_val_ptr,
             ws_idx_ptr,
-            in_ptr.as_unsafe_any_origin().as_immutable(),
+            in_ptr.as_unsafe_any_origin().as_imm(),
             Int64(reduce_n),
             Int64(inner),
             Int64(lanes),

--- a/torch_mojo_backend/eager_kernels/conv_ops/conv_ops.mojo
+++ b/torch_mojo_backend/eager_kernels/conv_ops/conv_ops.mojo
@@ -84,9 +84,11 @@ def _im2col[
         var ih = oh * stride_h - pad_h + fh * dil_h
         var iw = ow * stride_w - pad_w + fw * dil_w
         if ih < 0 or ih >= in_h or iw < 0 or iw >= in_w:
-            out_ptr[i] = Scalar[dtype](0)
+            out_ptr[unsafe_offset=i] = Scalar[dtype](0)
         else:
-            out_ptr[i] = in_ptr[((s * channels + c) * in_h + ih) * in_w + iw]
+            out_ptr[unsafe_offset=i] = in_ptr[
+                unsafe_offset=((s * channels + c) * in_h + ih) * in_w + iw
+            ]
 
     _parallel_for[func](batch * channels * kh * kw * out_h * out_w, ctx)
 
@@ -152,9 +154,15 @@ def _im2col_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
-        _im2col_go(args[0], args[1], args[2], args[3], args[4])
+        _im2col_go(
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+        )
     except e:
         return _spec_unsupported(e)
     return _raw_ret_none()
@@ -185,7 +193,10 @@ def _bias_add_chan[
     @__copy_capture(out_ptr, bias_ptr)
     def func[width: Int, alignment: Int = 1](idx: StdCoord):
         var i = Int(idx[0].value())
-        out_ptr[i] = out_ptr[i] + bias_ptr[(i // plane) % channels]
+        out_ptr[unsafe_offset=i] = (
+            out_ptr[unsafe_offset=i]
+            + bias_ptr[unsafe_offset=(i // plane) % channels]
+        )
 
     _parallel_for[func](total, ctx)
 
@@ -222,9 +233,15 @@ def _bias_add_chan_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
-        _bias_add_chan_go(args[0], args[1], args[2], args[3], args[4])
+        _bias_add_chan_go(
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+        )
     except e:
         return _spec_unsupported(e)
     return _raw_ret_none()

--- a/torch_mojo_backend/eager_kernels/data_movement_ops/data_movement_ops.mojo
+++ b/torch_mojo_backend/eager_kernels/data_movement_ops/data_movement_ops.mojo
@@ -104,8 +104,8 @@ comptime SCATTER_DTYPES = [
 def _permute_copy_kernel[
     dtype: DType
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     d1_arg: Int64,
     d2_arg: Int64,
     d3_arg: Int64,
@@ -134,15 +134,17 @@ def _permute_copy_kernel[
         rest = rest // d2
         var i1 = rest % d1
         var i0 = rest // d1
-        out_ptr[i] = in_ptr[i0 * s0 + i1 * s1 + i2 * s2 + i3 * s3]
+        out_ptr[unsafe_offset=i] = in_ptr[
+            unsafe_offset=i0 * s0 + i1 * s1 + i2 * s2 + i3 * s3
+        ]
         i += gstride
 
 
 def _permute_copy_rows4_kernel[
     dtype: DType
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     d1_arg: Int64,
     d2_arg: Int64,
     d3_4_arg: Int64,
@@ -174,9 +176,9 @@ def _permute_copy_rows4_kernel[
         rest = rest // d2
         var i1 = rest % d1
         var i0 = rest // d1
-        out_ptr.store[width=4, alignment=vec_align](
+        out_ptr.unsafe_store[width=4, alignment=vec_align](
             c * 4,
-            in_ptr.load[width=4, alignment=vec_align](
+            in_ptr.unsafe_load[width=4, alignment=vec_align](
                 i0 * s0 + i1 * s1 + i2 * s2 + j * 4
             ),
         )
@@ -186,8 +188,8 @@ def _permute_copy_rows4_kernel[
 def _permute_copy_rowloop_kernel[
     dtype: DType
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     d1_arg: Int64,
     d2_arg: Int64,
     d3_4_arg: Int64,
@@ -221,9 +223,9 @@ def _permute_copy_rowloop_kernel[
         var src = i0 * s0 + i1 * s1 + i2 * s2
         var dst = r * d3_4 * 4
         for j in range(d3_4):
-            out_ptr.store[width=4, alignment=vec_align](
+            out_ptr.unsafe_store[width=4, alignment=vec_align](
                 dst + j * 4,
-                in_ptr.load[width=4, alignment=vec_align](src + j * 4),
+                in_ptr.unsafe_load[width=4, alignment=vec_align](src + j * 4),
             )
         r += gstride
 
@@ -242,8 +244,8 @@ def _permute_copy_rowloop_kernel[
 def _run_gather_kernel[
     dtype: DType, VEC: Int
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     d1_arg: Int64,
     d2_arg: Int64,
     spv_arg: Int64,
@@ -278,9 +280,9 @@ def _run_gather_kernel[
         var rest = run // d2
         var i1 = rest % d1
         var i0 = rest // d1
-        out_ptr.store[width=VEC, alignment=ALIGN](
+        out_ptr.unsafe_store[width=VEC, alignment=ALIGN](
             j * VEC,
-            in_ptr.load[width=VEC, alignment=ALIGN](
+            in_ptr.unsafe_load[width=VEC, alignment=ALIGN](
                 i0 * s0 + i1 * s1 + i2 * s2 + off * VEC
             ),
         )
@@ -320,7 +322,9 @@ def _permute_copy[
             rest = rest // d2
             var i1 = rest % d1
             var i0 = rest // d1
-            out_ptr[i] = in_ptr[i0 * s0 + i1 * s1 + i2 * s2 + i3 * s3]
+            out_ptr[unsafe_offset=i] = in_ptr[
+                unsafe_offset=i0 * s0 + i1 * s1 + i2 * s2 + i3 * s3
+            ]
 
         elementwise[func, simd_width=1](Coord(total), ctx)
     else:
@@ -352,7 +356,7 @@ def _permute_copy[
                     1,
                     GS_THREADS,
                     out_ptr.as_unsafe_any_origin(),
-                    in_ptr.as_unsafe_any_origin().as_immutable(),
+                    in_ptr.as_unsafe_any_origin().as_imm(),
                     Int64(d1),
                     Int64(d2),
                     Int64(d3 // VEC),
@@ -385,7 +389,7 @@ def _permute_copy[
                             1,
                             GS_THREADS,
                             out_ptr.as_unsafe_any_origin(),
-                            in_ptr.as_unsafe_any_origin().as_immutable(),
+                            in_ptr.as_unsafe_any_origin().as_imm(),
                             Int64(d1),
                             Int64(d2),
                             Int64(d3 // 4),
@@ -404,7 +408,7 @@ def _permute_copy[
                         1,
                         GS_THREADS,
                         out_ptr.as_unsafe_any_origin(),
-                        in_ptr.as_unsafe_any_origin().as_immutable(),
+                        in_ptr.as_unsafe_any_origin().as_imm(),
                         Int64(d1),
                         Int64(d2),
                         Int64(d3 // 4),
@@ -464,7 +468,7 @@ def _permute_copy[
                     min(batch, _MAX_GRID_Y),
                     TILE * _T2D_ROWS,
                     out_ptr.as_unsafe_any_origin(),
-                    in_ptr.as_unsafe_any_origin().as_immutable(),
+                    in_ptr.as_unsafe_any_origin().as_imm(),
                     Int64(d2),
                     Int64(d3),
                     Int64(s3),
@@ -481,7 +485,7 @@ def _permute_copy[
                 1,
                 GS_THREADS,
                 out_ptr.as_unsafe_any_origin(),
-                in_ptr.as_unsafe_any_origin().as_immutable(),
+                in_ptr.as_unsafe_any_origin().as_imm(),
                 Int64(d1),
                 Int64(d2),
                 Int64(d3),
@@ -693,8 +697,8 @@ def _cat_owner(
 def _cat_copy_rows[
     dtype: DType, width: Int
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    src_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    src_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     seg: CatSeg,
     slot: Int,
     outer: Int,
@@ -715,13 +719,11 @@ def _cat_copy_rows[
     src_index += row * row_len
     dst_index += row * dst_stride
     while row < outer:
-
-        @parameter
-        for step in range(ilp):
+        comptime for step in range(ilp):
             if slot + step * GS_THREADS < seg.nvec:
-                out_ptr.store[width=width, alignment=align](
+                out_ptr.unsafe_store[width=width, alignment=align](
                     dst_index + step * GS_THREADS * width,
-                    src_ptr.load[width=width, alignment=align](
+                    src_ptr.unsafe_load[width=width, alignment=align](
                         src_index + step * GS_THREADS * width
                     ),
                 )
@@ -733,7 +735,7 @@ def _cat_copy_rows[
 def _cat_batched_kernel[
     dtype: DType, width: Int
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
     segs: InlineArray[CatSeg, CAT_CAP],
     nseg_arg: Int64,
     tiles_arg: Int64,
@@ -755,9 +757,7 @@ def _cat_batched_kernel[
         if slot < seg.nvec:
             _cat_copy_rows[dtype, width](
                 out_ptr,
-                _make_ptr[dtype](seg.src_addr)
-                .as_unsafe_any_origin()
-                .as_immutable(),
+                _make_ptr[dtype](seg.src_addr).as_unsafe_any_origin().as_imm(),
                 seg,
                 slot,
                 outer,
@@ -771,15 +771,15 @@ def _cat_pick[
     dtype: DType
 ](
     slot: Int,
-    p0: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    p1: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    p2: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    p3: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    p4: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    p5: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    p6: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    p7: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-) -> UnsafePointer[Scalar[dtype], ImmutAnyOrigin]:
+    p0: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    p1: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    p2: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    p3: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    p4: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    p5: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    p6: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    p7: Pointer[Scalar[dtype], ImmutAnyOrigin],
+) -> Pointer[Scalar[dtype], ImmutAnyOrigin]:
     """Select one of the pointer ARGUMENTS (copying them into an array and
     indexing that miscompiles on Metal -- see foreach_elementwise_kernels)."""
     var selected = p0
@@ -803,15 +803,15 @@ def _cat_pick[
 def _cat_slots_kernel[
     dtype: DType, width: Int
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    p0: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    p1: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    p2: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    p3: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    p4: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    p5: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    p6: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    p7: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    p0: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    p1: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    p2: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    p3: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    p4: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    p5: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    p6: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    p7: Pointer[Scalar[dtype], ImmutAnyOrigin],
     segs: InlineArray[CatSeg, CAT_CAP],
     nseg_arg: Int64,
     tiles_arg: Int64,
@@ -846,7 +846,7 @@ def _cat_slots_kernel[
 @always_inline
 def _cat_slot_ptr[
     dtype: DType
-](segs: InlineArray[CatSeg, CAT_CAP], nseg: Int, index: Int) -> UnsafePointer[
+](segs: InlineArray[CatSeg, CAT_CAP], nseg: Int, index: Int) -> Pointer[
     Scalar[dtype], ImmutAnyOrigin
 ]:
     """A translatable pointer for every pointer argument: padding slots
@@ -855,7 +855,7 @@ def _cat_slot_ptr[
     var addr = segs[0].src_addr
     if index < nseg:
         addr = segs[index].src_addr
-    return _make_ptr[dtype](addr).as_unsafe_any_origin().as_immutable()
+    return _make_ptr[dtype](addr).as_unsafe_any_origin().as_imm()
 
 
 @always_inline
@@ -1014,17 +1014,17 @@ def _cat_n_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         _cat_n_go(
-            args[0],
-            args[1],
-            args[2],
-            args[3],
-            args[4],
-            args[5],
-            args[6],
-            args[7],
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+            args[unsafe_offset=6],
+            args[unsafe_offset=7],
         )
         return _raw_ret_none()
     except e:
@@ -1042,8 +1042,8 @@ def _cat_n_dispatcher(
 def _narrow_copy_dst_kernel2d[
     dtype: DType
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     dst_stride_arg: Int64,
     copy_len4_arg: Int64,
     dst_offset_arg: Int64,
@@ -1061,9 +1061,9 @@ def _narrow_copy_dst_kernel2d[
     var cstride = Int(grid_dim.x) * Int(block_dim.x)
     while c < copy_len4:
         var j = c * 4
-        out_ptr.store[width=4, alignment=vec_align](
+        out_ptr.unsafe_store[width=4, alignment=vec_align](
             dst_base + j,
-            in_ptr.load[width=4, alignment=vec_align](src_base + j),
+            in_ptr.unsafe_load[width=4, alignment=vec_align](src_base + j),
         )
         c += cstride
 
@@ -1071,8 +1071,8 @@ def _narrow_copy_dst_kernel2d[
 def _narrow_copy_dst_kernel4[
     dtype: DType
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     dst_stride_arg: Int64,
     copy_len_arg: Int64,
     dst_offset_arg: Int64,
@@ -1091,8 +1091,8 @@ def _narrow_copy_dst_kernel4[
         var i = c * 4
         var o = i // copy_len
         var j = i % copy_len
-        var v = in_ptr.load[width=4, alignment=vec_align](i)
-        out_ptr.store[width=4, alignment=vec_align](
+        var v = in_ptr.unsafe_load[width=4, alignment=vec_align](i)
+        out_ptr.unsafe_store[width=4, alignment=vec_align](
             o * dst_stride + dst_offset + j, v
         )
         c += gstride
@@ -1101,8 +1101,8 @@ def _narrow_copy_dst_kernel4[
 def _narrow_copy_dst_kernel1[
     dtype: DType
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     dst_stride_arg: Int64,
     copy_len_arg: Int64,
     dst_offset_arg: Int64,
@@ -1119,7 +1119,9 @@ def _narrow_copy_dst_kernel1[
     while i < total:
         var o = i // copy_len
         var j = i % copy_len
-        out_ptr[o * dst_stride + dst_offset + j] = in_ptr[i]
+        out_ptr[unsafe_offset=o * dst_stride + dst_offset + j] = in_ptr[
+            unsafe_offset=i
+        ]
         i += gstride
 
 
@@ -1162,7 +1164,7 @@ def _narrow_copy_dst[
                         1,
                         GS_THREADS,
                         out_ptr.as_unsafe_any_origin(),
-                        in_ptr.as_unsafe_any_origin().as_immutable(),
+                        in_ptr.as_unsafe_any_origin().as_imm(),
                         Int64(dst_stride),
                         Int64(copy_len4),
                         Int64(dst_offset),
@@ -1177,7 +1179,7 @@ def _narrow_copy_dst[
                     1,
                     GS_THREADS,
                     out_ptr.as_unsafe_any_origin(),
-                    in_ptr.as_unsafe_any_origin().as_immutable(),
+                    in_ptr.as_unsafe_any_origin().as_imm(),
                     Int64(dst_stride),
                     Int64(copy_len),
                     Int64(dst_offset),
@@ -1193,7 +1195,7 @@ def _narrow_copy_dst[
                     1,
                     GS_THREADS,
                     out_ptr.as_unsafe_any_origin(),
-                    in_ptr.as_unsafe_any_origin().as_immutable(),
+                    in_ptr.as_unsafe_any_origin().as_imm(),
                     Int64(dst_stride),
                     Int64(copy_len),
                     Int64(dst_offset),
@@ -1224,7 +1226,9 @@ def _narrow_copy_dst[
         var i = Int(idx[0].value())
         var o = i // copy_len
         var j = i % copy_len
-        out_ptr[o * dst_stride + dst_offset + j] = in_ptr[i]
+        out_ptr[unsafe_offset=o * dst_stride + dst_offset + j] = in_ptr[
+            unsafe_offset=i
+        ]
 
     elementwise[func, simd_width=1](Coord(outer * copy_len), ctx)
 
@@ -1327,10 +1331,10 @@ def _narrow_copy_dst_go(
 def _where_flat_vec_kernel[
     dtype: DType
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    cond_ptr: UnsafePointer[Scalar[DType.bool], ImmutAnyOrigin],
-    a_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    b_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    cond_ptr: Pointer[Scalar[DType.bool], ImmutAnyOrigin],
+    a_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    b_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     total_arg: Int64,
     a_bcast_arg: Int64,
     b_bcast_arg: Int64,
@@ -1353,26 +1357,32 @@ def _where_flat_vec_kernel[
     @always_inline
     @parameter
     def pass_over[a_b: Bool, b_b: Bool]():
-        var a_splat = SIMD[dtype, VW](a_ptr[0]) if a_b else SIMD[dtype, VW](0)
-        var b_splat = SIMD[dtype, VW](b_ptr[0]) if b_b else SIMD[dtype, VW](0)
+        var a_splat = SIMD[dtype, VW](a_ptr[unsafe_offset=0]) if a_b else SIMD[
+            dtype, VW
+        ](0)
+        var b_splat = SIMD[dtype, VW](b_ptr[unsafe_offset=0]) if b_b else SIMD[
+            dtype, VW
+        ](0)
         var c = tid
         while c < nvec:
             var i = c * VW
-            var cond = cond_ptr.load[width=VW, alignment=cond_align](i)
-            var a = a_splat if a_b else a_ptr.load[
+            var cond = cond_ptr.unsafe_load[width=VW, alignment=cond_align](i)
+            var a = a_splat if a_b else a_ptr.unsafe_load[
                 width=VW, alignment=vec_align
             ](i)
-            var b = b_splat if b_b else b_ptr.load[
+            var b = b_splat if b_b else b_ptr.unsafe_load[
                 width=VW, alignment=vec_align
             ](i)
-            out_ptr.store[width=VW, alignment=vec_align](i, cond.select(a, b))
+            out_ptr.unsafe_store[width=VW, alignment=vec_align](
+                i, cond.select(a, b)
+            )
             c += gstride
         var tail = total - nvec * VW
         if tid < tail:
             var i = nvec * VW + tid
-            var a1 = a_splat[0] if a_b else a_ptr[i]
-            var b1 = b_splat[0] if b_b else b_ptr[i]
-            out_ptr[i] = a1 if cond_ptr[i] else b1
+            var a1 = a_splat[0] if a_b else a_ptr[unsafe_offset=i]
+            var b1 = b_splat[0] if b_b else b_ptr[unsafe_offset=i]
+            out_ptr[unsafe_offset=i] = a1 if cond_ptr[unsafe_offset=i] else b1
 
     # The splat flags are loop-invariant, so each arm is INSTANTIATED rather
     # than branched on per iteration (see `_bin_flat_vec_kernel`'s note on
@@ -1392,10 +1402,10 @@ def _where_flat_vec_kernel[
 def _where_bcast_kernel[
     dtype: DType
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    cond_ptr: UnsafePointer[Scalar[DType.bool], ImmutAnyOrigin],
-    a_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    b_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    cond_ptr: Pointer[Scalar[DType.bool], ImmutAnyOrigin],
+    a_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    b_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     d1_arg: Int64,
     d2_arg: Int64,
     d3_arg: Int64,
@@ -1449,7 +1459,9 @@ def _where_bcast_kernel[
         var cbase = i0 * cs0 + i1 * cs1 + i2 * cs2 + i3 * cs3
         var abase = i0 * a_s0 + i1 * a_s1 + i2 * a_s2 + i3 * a_s3
         var bbase = i0 * b_s0 + i1 * b_s1 + i2 * b_s2 + i3 * b_s3
-        out_ptr[i] = a_ptr[abase] if cond_ptr[cbase] else b_ptr[bbase]
+        out_ptr[unsafe_offset=i] = a_ptr[unsafe_offset=abase] if cond_ptr[
+            unsafe_offset=cbase
+        ] else b_ptr[unsafe_offset=bbase]
         i += gstride
 
 
@@ -1502,7 +1514,9 @@ def _where_bcast[
             var cbase = i0 * cs0 + i1 * cs1 + i2 * cs2 + i3 * cs3
             var abase = i0 * a_s0 + i1 * a_s1 + i2 * a_s2 + i3 * a_s3
             var bbase = i0 * b_s0 + i1 * b_s1 + i2 * b_s2 + i3 * b_s3
-            out_ptr[i] = a_ptr[abase] if cond_ptr[cbase] else b_ptr[bbase]
+            out_ptr[unsafe_offset=i] = a_ptr[unsafe_offset=abase] if cond_ptr[
+                unsafe_offset=cbase
+            ] else b_ptr[unsafe_offset=bbase]
 
         elementwise[func, simd_width=1](Coord(total), ctx)
         return
@@ -1567,9 +1581,9 @@ def _where_bcast[
                     1,
                     GS_THREADS,
                     out_ptr.as_unsafe_any_origin(),
-                    cond_ptr.as_unsafe_any_origin().as_immutable(),
-                    a_ptr.as_unsafe_any_origin().as_immutable(),
-                    b_ptr.as_unsafe_any_origin().as_immutable(),
+                    cond_ptr.as_unsafe_any_origin().as_imm(),
+                    a_ptr.as_unsafe_any_origin().as_imm(),
+                    b_ptr.as_unsafe_any_origin().as_imm(),
                     Int64(total),
                     Int64(a_scalar),
                     Int64(b_scalar),
@@ -1584,9 +1598,9 @@ def _where_bcast[
                 1,
                 GS_THREADS,
                 out_ptr.as_unsafe_any_origin(),
-                cond_ptr.as_unsafe_any_origin().as_immutable(),
-                a_ptr.as_unsafe_any_origin().as_immutable(),
-                b_ptr.as_unsafe_any_origin().as_immutable(),
+                cond_ptr.as_unsafe_any_origin().as_imm(),
+                a_ptr.as_unsafe_any_origin().as_imm(),
+                b_ptr.as_unsafe_any_origin().as_imm(),
                 Int64(d1),
                 Int64(d2),
                 Int64(d3),
@@ -1630,9 +1644,9 @@ def _where_bcast[
 def _masked_fill_scalar_flat_vec_kernel[
     dtype: DType
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    cond_ptr: UnsafePointer[Scalar[DType.bool], ImmutAnyOrigin],
-    b_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    cond_ptr: Pointer[Scalar[DType.bool], ImmutAnyOrigin],
+    b_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     value: Scalar[dtype],
     total_arg: Int64,
     b_bcast_arg: Int64,
@@ -1650,23 +1664,27 @@ def _masked_fill_scalar_flat_vec_kernel[
     @always_inline
     @parameter
     def pass_over[b_b: Bool]():
-        var b_splat = SIMD[dtype, VW](b_ptr[0]) if b_b else SIMD[dtype, VW](0)
+        var b_splat = SIMD[dtype, VW](b_ptr[unsafe_offset=0]) if b_b else SIMD[
+            dtype, VW
+        ](0)
         var c = tid
         while c < nvec:
             var i = c * VW
-            var cond = cond_ptr.load[width=VW, alignment=cond_align](i)
-            var b = b_splat if b_b else b_ptr.load[
+            var cond = cond_ptr.unsafe_load[width=VW, alignment=cond_align](i)
+            var b = b_splat if b_b else b_ptr.unsafe_load[
                 width=VW, alignment=vec_align
             ](i)
-            out_ptr.store[width=VW, alignment=vec_align](
+            out_ptr.unsafe_store[width=VW, alignment=vec_align](
                 i, cond.select(a_splat, b)
             )
             c += gstride
         var tail = total - nvec * VW
         if tid < tail:
             var i = nvec * VW + tid
-            var b1 = b_splat[0] if b_b else b_ptr[i]
-            out_ptr[i] = value if cond_ptr[i] else b1
+            var b1 = b_splat[0] if b_b else b_ptr[unsafe_offset=i]
+            out_ptr[unsafe_offset=i] = value if cond_ptr[
+                unsafe_offset=i
+            ] else b1
 
     if b_bcast_arg != 0:
         pass_over[True]()
@@ -1678,9 +1696,9 @@ def _masked_fill_scalar_flat_vec_kernel[
 def _masked_fill_scalar_bcast_kernel[
     dtype: DType
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    cond_ptr: UnsafePointer[Scalar[DType.bool], ImmutAnyOrigin],
-    b_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    cond_ptr: Pointer[Scalar[DType.bool], ImmutAnyOrigin],
+    b_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     value: Scalar[dtype],
     d1_arg: Int64,
     d2_arg: Int64,
@@ -1719,7 +1737,9 @@ def _masked_fill_scalar_bcast_kernel[
         var i0 = rest // d1
         var cbase = i0 * cs0 + i1 * cs1 + i2 * cs2 + i3 * cs3
         var bbase = i0 * b_s0 + i1 * b_s1 + i2 * b_s2 + i3 * b_s3
-        out_ptr[i] = value if cond_ptr[cbase] else b_ptr[bbase]
+        out_ptr[unsafe_offset=i] = value if cond_ptr[
+            unsafe_offset=cbase
+        ] else b_ptr[unsafe_offset=bbase]
         i += gstride
 
 
@@ -1769,7 +1789,9 @@ def _masked_fill_scalar_bcast[
             var i0 = rest // d1
             var cbase = i0 * cs0 + i1 * cs1 + i2 * cs2 + i3 * cs3
             var bbase = i0 * b_s0 + i1 * b_s1 + i2 * b_s2 + i3 * b_s3
-            out_ptr[i] = value if cond_ptr[cbase] else b_ptr[bbase]
+            out_ptr[unsafe_offset=i] = value if cond_ptr[
+                unsafe_offset=cbase
+            ] else b_ptr[unsafe_offset=bbase]
 
         elementwise[func, simd_width=1](Coord(total), ctx)
         return
@@ -1813,8 +1835,8 @@ def _masked_fill_scalar_bcast[
                 1,
                 GS_THREADS,
                 out_ptr.as_unsafe_any_origin(),
-                cond_ptr.as_unsafe_any_origin().as_immutable(),
-                b_ptr.as_unsafe_any_origin().as_immutable(),
+                cond_ptr.as_unsafe_any_origin().as_imm(),
+                b_ptr.as_unsafe_any_origin().as_imm(),
                 value,
                 Int64(total),
                 Int64(b_scalar),
@@ -1829,8 +1851,8 @@ def _masked_fill_scalar_bcast[
             1,
             GS_THREADS,
             out_ptr.as_unsafe_any_origin(),
-            cond_ptr.as_unsafe_any_origin().as_immutable(),
-            b_ptr.as_unsafe_any_origin().as_immutable(),
+            cond_ptr.as_unsafe_any_origin().as_imm(),
+            b_ptr.as_unsafe_any_origin().as_imm(),
             value,
             Int64(d1),
             Int64(d2),
@@ -2126,8 +2148,8 @@ comptime CAST_THREADS = GS_THREADS
 def _cast_vec_kernel[
     src: DType, dst: DType, VEC: Int
 ](
-    out_ptr: UnsafePointer[Scalar[dst], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[src], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dst], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[src], ImmutAnyOrigin],
     nvec_arg: Int64,
     size_arg: Int64,
 ):
@@ -2142,11 +2164,11 @@ def _cast_vec_kernel[
     var gstride = Int(grid_dim.x) * Int(block_dim.x)
     var j = tid
     while j < nvec:
-        var v = in_ptr.load[width=VEC, alignment=IALIGN](j * VEC)
+        var v = in_ptr.unsafe_load[width=VEC, alignment=IALIGN](j * VEC)
         comptime if dst == DType.bool:
             # An `i1` vector is not a storable value. Torch's bool is one byte
             # holding 0 or 1, so build those bytes and store them.
-            out_ptr.bitcast[Scalar[DType.uint8]]().store[
+            out_ptr.unsafe_bitcast[Scalar[DType.uint8]]().unsafe_store[
                 width=VEC, alignment=OALIGN
             ](
                 j * VEC,
@@ -2155,19 +2177,23 @@ def _cast_vec_kernel[
                 ),
             )
         else:
-            out_ptr.store[width=VEC, alignment=OALIGN](j * VEC, v.cast[dst]())
+            out_ptr.unsafe_store[width=VEC, alignment=OALIGN](
+                j * VEC, v.cast[dst]()
+            )
         j += gstride
     # The tail is at most VEC-1 elements and the grid is never narrower than
     # one CAST_THREADS-wide block, so the leading threads cover all of it.
     var t = nvec * VEC + tid
     if t < size:
-        var a = in_ptr[t]
+        var a = in_ptr[unsafe_offset=t]
         comptime if dst == DType.bool:
             # rc1: Scalar[dst](Bool) requires an integral dtype; build the
             # concrete bool scalar first (cast is the identity here).
-            out_ptr[t] = Scalar[DType.bool](a != Scalar[src](0)).cast[dst]()
+            out_ptr[unsafe_offset=t] = Scalar[DType.bool](
+                a != Scalar[src](0)
+            ).cast[dst]()
         else:
-            out_ptr[t] = a.cast[dst]()
+            out_ptr[unsafe_offset=t] = a.cast[dst]()
 
 
 @always_inline
@@ -2186,13 +2212,15 @@ def _cast[
         @__copy_capture(out_ptr, in_ptr)
         def func[width: Int, alignment: Int = 1](idx: Coord):
             var i = Int(idx[0].value())
-            var a = in_ptr[i]
+            var a = in_ptr[unsafe_offset=i]
             comptime if dst == DType.bool:
                 # rc1: Scalar[dst](Bool) requires an integral dtype; build the
                 # concrete bool scalar first (cast is the identity here).
-                out_ptr[i] = Scalar[DType.bool](a != Scalar[src](0)).cast[dst]()
+                out_ptr[unsafe_offset=i] = Scalar[DType.bool](
+                    a != Scalar[src](0)
+                ).cast[dst]()
             else:
-                out_ptr[i] = a.cast[dst]()
+                out_ptr[unsafe_offset=i] = a.cast[dst]()
 
         elementwise[func, simd_width=1](Coord(size), ctx)
         return
@@ -2232,7 +2260,7 @@ def _cast[
                 1,
                 CAST_THREADS,
                 out_ptr.as_unsafe_any_origin(),
-                in_ptr.as_unsafe_any_origin().as_immutable(),
+                in_ptr.as_unsafe_any_origin().as_imm(),
                 Int64(nvec),
                 Int64(size),
             )
@@ -2330,7 +2358,7 @@ def _tile_copy[
             rest = rest // out_shape[d]
             src_off += (coord % in_shape[d]) * in_strides[d]
         src_off += (rest % in_shape[0]) * in_strides[0]
-        out_ptr[i] = in_ptr[src_off]
+        out_ptr[unsafe_offset=i] = in_ptr[unsafe_offset=src_off]
 
     _parallel_for[func](total, ctx)
 
@@ -2545,8 +2573,8 @@ def _repeat_first_row(orow: UInt32, rows: UInt32, nout: UInt32) -> UInt32:
 def _repeat_seg_kernel[
     dtype: DType, VEC: Int
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     rows_arg: Int64,
     cols_arg: Int64,
     cout_arg: Int64,
@@ -2586,10 +2614,12 @@ def _repeat_seg_kernel[
         var out_base = Int(orow) * cout
         var c = c0
         while c < cols:
-            var v = in_ptr.load[width=VEC, alignment=ALIGN](in_base + Int(c))
+            var v = in_ptr.unsafe_load[width=VEC, alignment=ALIGN](
+                in_base + Int(c)
+            )
             var o = out_base + Int(c)
             for _ in range(r1):
-                out_ptr.store[width=VEC, alignment=ALIGN](o, v)
+                out_ptr.unsafe_store[width=VEC, alignment=ALIGN](o, v)
                 o += Int(cols)
             c += cstride
         orow += orowstride
@@ -2602,8 +2632,8 @@ def _repeat_seg_kernel[
 def _repeat_flat_kernel[
     dtype: DType, VEC: Int
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     rows_arg: Int64,
     cols_arg: Int64,
     cout_arg: Int64,
@@ -2651,9 +2681,11 @@ def _repeat_flat_kernel[
         var slot = slot0
         var c = c0
         while slot < nslots:
-            out_ptr.store[width=VEC, alignment=ALIGN](
+            out_ptr.unsafe_store[width=VEC, alignment=ALIGN](
                 out_base + Int(slot) * VEC,
-                in_ptr.load[width=VEC, alignment=ALIGN](in_base + Int(c)),
+                in_ptr.unsafe_load[width=VEC, alignment=ALIGN](
+                    in_base + Int(c)
+                ),
             )
             slot += xstride
             c += cadv
@@ -2693,7 +2725,7 @@ def _repeat_seg_launch[
         tx,
         ty,
         out_ptr.as_unsafe_any_origin(),
-        in_ptr.as_unsafe_any_origin().as_immutable(),
+        in_ptr.as_unsafe_any_origin().as_imm(),
         Int64(rows),
         Int64(cols),
         Int64(cout),
@@ -2736,7 +2768,7 @@ def _repeat_flat_launch[
         tx,
         ty,
         out_ptr.as_unsafe_any_origin(),
-        in_ptr.as_unsafe_any_origin().as_immutable(),
+        in_ptr.as_unsafe_any_origin().as_imm(),
         Int64(rows),
         Int64(cols),
         Int64(cout),
@@ -2926,9 +2958,9 @@ def _triangular_copy[
         else:
             keep = c <= r + diagonal
         if keep:
-            out_ptr[i] = in_ptr[i]
+            out_ptr[unsafe_offset=i] = in_ptr[unsafe_offset=i]
         else:
-            out_ptr[i] = Scalar[dtype](0)
+            out_ptr[unsafe_offset=i] = Scalar[dtype](0)
 
     _parallel_for[func](total, ctx)
 
@@ -3012,10 +3044,12 @@ def _gather_rows[
     @__copy_capture(out_ptr, in_ptr, idx_ptr)
     def func[width: Int, alignment: Int = 1](coord: Coord):
         var i = Int(coord[0].value())
-        var row = Int(idx_ptr[i // row_len])
+        var row = Int(idx_ptr[unsafe_offset=i // row_len])
         if row < 0:
             row += size0
-        out_ptr[i] = in_ptr[row * row_len + i % row_len]
+        out_ptr[unsafe_offset=i] = in_ptr[
+            unsafe_offset=row * row_len + i % row_len
+        ]
 
     _parallel_for[func](n_indices * row_len, ctx)
 
@@ -3167,7 +3201,9 @@ def _scatter_dim[
         rest = rest // d2
         var i1 = rest % d1
         var i0 = rest // d1
-        var target = Int(index_ptr[i0 * xs0 + i1 * xs1 + i2 * xs2 + i3 * xs3])
+        var target = Int(
+            index_ptr[unsafe_offset=i0 * xs0 + i1 * xs1 + i2 * xs2 + i3 * xs3]
+        )
         var out_off = i0 * os0 + i1 * os1 + i2 * os2 + i3 * os3
         # Replace the coordinate along `dim_padded` with the scatter target.
         if dim_padded == 0:
@@ -3179,10 +3215,10 @@ def _scatter_dim[
         else:
             out_off += (target - i3) * os3
         if is_value != 0:
-            out_ptr[out_off] = scalar
+            out_ptr[unsafe_offset=out_off] = scalar
         else:
-            out_ptr[out_off] = src_ptr[
-                i0 * ss0 + i1 * ss1 + i2 * ss2 + i3 * ss3
+            out_ptr[unsafe_offset=out_off] = src_ptr[
+                unsafe_offset=i0 * ss0 + i1 * ss1 + i2 * ss2 + i3 * ss3
             ]
 
     _parallel_for_dt[dtype, func](total, ctx)
@@ -3269,9 +3305,16 @@ def _permute_copy_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
-        _permute_copy_go(args[0], args[1], args[2], args[3], args[4], args[5])
+        _permute_copy_go(
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+        )
     except e:
         return _spec_unsupported(e)
     return _raw_ret_none()
@@ -3282,17 +3325,17 @@ def _narrow_copy_dst_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         _narrow_copy_dst_go(
-            args[0],
-            args[1],
-            args[2],
-            args[3],
-            args[4],
-            args[5],
-            args[6],
-            args[7],
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+            args[unsafe_offset=6],
+            args[unsafe_offset=7],
         )
     except e:
         return _spec_unsupported(e)
@@ -3304,10 +3347,16 @@ def _where_select_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         _where_select_go(
-            args[0], args[1], args[2], args[3], args[4], args[5], args[6]
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+            args[unsafe_offset=6],
         )
     except e:
         return _spec_unsupported(e)
@@ -3319,10 +3368,16 @@ def _masked_fill_scalar_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         _masked_fill_scalar_go(
-            args[0], args[1], args[2], args[3], args[4], args[5], args[6]
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+            args[unsafe_offset=6],
         )
     except e:
         return _spec_unsupported(e)
@@ -3334,10 +3389,16 @@ def _tile_copy_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         _tile_copy_go(
-            args[0], args[1], args[2], args[3], args[4], args[5], args[6]
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+            args[unsafe_offset=6],
         )
     except e:
         return _spec_unsupported(e)
@@ -3349,17 +3410,17 @@ def _repeat_tiled_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         _repeat_tiled_go(
-            args[0],
-            args[1],
-            args[2],
-            args[3],
-            args[4],
-            args[5],
-            args[6],
-            args[7],
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+            args[unsafe_offset=6],
+            args[unsafe_offset=7],
         )
     except e:
         return _spec_unsupported(e)
@@ -3371,18 +3432,18 @@ def _triangular_copy_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         _triangular_copy_go(
-            args[0],
-            args[1],
-            args[2],
-            args[3],
-            args[4],
-            args[5],
-            args[6],
-            args[7],
-            args[8],
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+            args[unsafe_offset=6],
+            args[unsafe_offset=7],
+            args[unsafe_offset=8],
         )
     except e:
         return _spec_unsupported(e)
@@ -3394,18 +3455,18 @@ def _gather_rows_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         _gather_rows_go(
-            args[0],
-            args[1],
-            args[2],
-            args[3],
-            args[4],
-            args[5],
-            args[6],
-            args[7],
-            args[8],
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+            args[unsafe_offset=6],
+            args[unsafe_offset=7],
+            args[unsafe_offset=8],
         )
     except e:
         return _spec_unsupported(e)
@@ -3417,17 +3478,17 @@ def _scatter_dim_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         _scatter_dim_go(
-            args[0],
-            args[1],
-            args[2],
-            args[3],
-            args[4],
-            args[5],
-            args[6],
-            args[7],
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+            args[unsafe_offset=6],
+            args[unsafe_offset=7],
         )
     except e:
         return _spec_unsupported(e)

--- a/torch_mojo_backend/eager_kernels/elementwise_ops/elementwise_ops.mojo
+++ b/torch_mojo_backend/eager_kernels/elementwise_ops/elementwise_ops.mojo
@@ -121,9 +121,9 @@ comptime OP_MIN = 5
 def _bin_contig_kernel4[
     dtype: DType, op_code: Int
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    lhs_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    rhs_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    lhs_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    rhs_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     n4_arg: Int64,
 ):
     # Int is not device-passable (host/device width mismatch); scalars cross
@@ -134,30 +134,30 @@ def _bin_contig_kernel4[
     var gstride = Int(grid_dim.x) * Int(block_dim.x)
     while c < n4:
         var i = c * 4
-        var a = lhs_ptr.load[width=4, alignment=vec_align](i)
-        var b = rhs_ptr.load[width=4, alignment=vec_align](i)
+        var a = lhs_ptr.unsafe_load[width=4, alignment=vec_align](i)
+        var b = rhs_ptr.unsafe_load[width=4, alignment=vec_align](i)
         comptime if op_code == OP_ADD:
-            out_ptr.store[width=4, alignment=vec_align](i, a + b)
+            out_ptr.unsafe_store[width=4, alignment=vec_align](i, a + b)
         comptime if op_code == OP_SUB:
-            out_ptr.store[width=4, alignment=vec_align](i, a - b)
+            out_ptr.unsafe_store[width=4, alignment=vec_align](i, a - b)
         comptime if op_code == OP_MUL:
-            out_ptr.store[width=4, alignment=vec_align](i, a * b)
+            out_ptr.unsafe_store[width=4, alignment=vec_align](i, a * b)
         comptime if op_code == OP_DIV:
             comptime if dtype.is_floating_point():
-                out_ptr.store[width=4, alignment=vec_align](i, a / b)
+                out_ptr.unsafe_store[width=4, alignment=vec_align](i, a / b)
         comptime if op_code == OP_MAX:
-            out_ptr.store[width=4, alignment=vec_align](i, max(a, b))
+            out_ptr.unsafe_store[width=4, alignment=vec_align](i, max(a, b))
         comptime if op_code == OP_MIN:
-            out_ptr.store[width=4, alignment=vec_align](i, min(a, b))
+            out_ptr.unsafe_store[width=4, alignment=vec_align](i, min(a, b))
         c += gstride
 
 
 def _bin_contig_kernel[
     dtype: DType, op_code: Int
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    lhs_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    rhs_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    lhs_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    rhs_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     size_arg: Int64,
 ):
     # Int is not device-passable (host/device width mismatch); scalars cross
@@ -166,21 +166,21 @@ def _bin_contig_kernel[
     var i = Int(block_idx.x) * Int(block_dim.x) + Int(thread_idx.x)
     var gstride = Int(grid_dim.x) * Int(block_dim.x)
     while i < size:
-        var a = lhs_ptr[i]
-        var b = rhs_ptr[i]
+        var a = lhs_ptr[unsafe_offset=i]
+        var b = rhs_ptr[unsafe_offset=i]
         comptime if op_code == OP_ADD:
-            out_ptr[i] = a + b
+            out_ptr[unsafe_offset=i] = a + b
         comptime if op_code == OP_SUB:
-            out_ptr[i] = a - b
+            out_ptr[unsafe_offset=i] = a - b
         comptime if op_code == OP_MUL:
-            out_ptr[i] = a * b
+            out_ptr[unsafe_offset=i] = a * b
         comptime if op_code == OP_DIV:
             comptime if dtype.is_floating_point():
-                out_ptr[i] = a / b
+                out_ptr[unsafe_offset=i] = a / b
         comptime if op_code == OP_MAX:
-            out_ptr[i] = max(a, b)
+            out_ptr[unsafe_offset=i] = max(a, b)
         comptime if op_code == OP_MIN:
-            out_ptr[i] = min(a, b)
+            out_ptr[unsafe_offset=i] = min(a, b)
         i += gstride
 
 
@@ -188,9 +188,9 @@ def _bin_contig_kernel[
 def _bin_elementwise[
     dtype: DType, op_code: Int
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutUntrackedOrigin],
-    lhs_ptr: UnsafePointer[Scalar[dtype], MutUntrackedOrigin],
-    rhs_ptr: UnsafePointer[Scalar[dtype], MutUntrackedOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutUntrackedOrigin],
+    lhs_ptr: Pointer[Scalar[dtype], MutUntrackedOrigin],
+    rhs_ptr: Pointer[Scalar[dtype], MutUntrackedOrigin],
     size: Int,
     ctx: DeviceContext,
 ) raises:
@@ -206,20 +206,20 @@ def _bin_elementwise[
             @__copy_capture(out_ptr, lhs_ptr, rhs_ptr)
             def func[width: Int, alignment: Int = 1](idx: Coord):
                 var i = Int(idx[0].value())
-                var a = lhs_ptr.load[width=width](i)
-                var b = rhs_ptr.load[width=width](i)
+                var a = lhs_ptr.unsafe_load[width=width](i)
+                var b = rhs_ptr.unsafe_load[width=width](i)
                 comptime if op_code == OP_ADD:
-                    out_ptr.store[width=width](i, a + b)
+                    out_ptr.unsafe_store[width=width](i, a + b)
                 comptime if op_code == OP_SUB:
-                    out_ptr.store[width=width](i, a - b)
+                    out_ptr.unsafe_store[width=width](i, a - b)
                 comptime if op_code == OP_MUL:
-                    out_ptr.store[width=width](i, a * b)
+                    out_ptr.unsafe_store[width=width](i, a * b)
                 comptime if op_code == OP_DIV:
-                    out_ptr.store[width=width](i, a / b)
+                    out_ptr.unsafe_store[width=width](i, a / b)
                 comptime if op_code == OP_MAX:
-                    out_ptr.store[width=width](i, max(a, b))
+                    out_ptr.unsafe_store[width=width](i, max(a, b))
                 comptime if op_code == OP_MIN:
-                    out_ptr.store[width=width](i, min(a, b))
+                    out_ptr.unsafe_store[width=width](i, min(a, b))
 
             elementwise[func, simd_width=simd_width_of[dtype]()](
                 Coord(size), ctx
@@ -237,8 +237,8 @@ def _bin_elementwise[
                             1,
                             GS_THREADS,
                             out_ptr.as_unsafe_any_origin(),
-                            lhs_ptr.as_unsafe_any_origin().as_immutable(),
-                            rhs_ptr.as_unsafe_any_origin().as_immutable(),
+                            lhs_ptr.as_unsafe_any_origin().as_imm(),
+                            rhs_ptr.as_unsafe_any_origin().as_imm(),
                             Int64(n4),
                         )
                         return
@@ -250,8 +250,8 @@ def _bin_elementwise[
                         1,
                         GS_THREADS,
                         out_ptr.as_unsafe_any_origin(),
-                        lhs_ptr.as_unsafe_any_origin().as_immutable(),
-                        rhs_ptr.as_unsafe_any_origin().as_immutable(),
+                        lhs_ptr.as_unsafe_any_origin().as_imm(),
+                        rhs_ptr.as_unsafe_any_origin().as_imm(),
                         Int64(size),
                     )
                 else:
@@ -426,8 +426,8 @@ def _float_unary[
 def _unary_contig_kernel[
     dtype: DType, op_code: Int
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     size_arg: Int64,
 ):
     # Int is not device-passable (host/device width mismatch); scalars cross
@@ -442,28 +442,28 @@ def _unary_contig_kernel[
     var i = Int(block_idx.x) * Int(block_dim.x) + Int(thread_idx.x)
     var gstride = Int(grid_dim.x) * Int(block_dim.x)
     while i < size:
-        var a = in_ptr[i]
+        var a = in_ptr[unsafe_offset=i]
         comptime if op_code == UOP_RELU:
-            out_ptr[i] = max(a, Scalar[dtype](0))
+            out_ptr[unsafe_offset=i] = max(a, Scalar[dtype](0))
         comptime if op_code == UOP_ABS:
-            out_ptr[i] = abs(a)
+            out_ptr[unsafe_offset=i] = abs(a)
         comptime if op_code == UOP_NEG:
             # `-a` (pop.neg) wraps for unsigned/overflow exactly like torch.
-            out_ptr[i] = -a
+            out_ptr[unsafe_offset=i] = -a
         comptime if op_code == UOP_SIGN:
             var zero = Scalar[dtype](0)
             var pos = a.gt(zero).cast[dtype]()
             var neg = a.lt(zero).cast[dtype]()
             # NaN compares false on both sides -> 0, matching torch.
-            out_ptr[i] = pos - neg
+            out_ptr[unsafe_offset=i] = pos - neg
         comptime if not is_direct:
             comptime if dtype == DType.float16 or dtype == DType.bfloat16:
                 var af = a.cast[DType.float32]()
-                out_ptr[i] = _float_unary[DType.float32, 1, op_code](af).cast[
-                    dtype
-                ]()
+                out_ptr[unsafe_offset=i] = _float_unary[
+                    DType.float32, 1, op_code
+                ](af).cast[dtype]()
             elif dtype.is_floating_point():
-                out_ptr[i] = _float_unary[dtype, 1, op_code](a)
+                out_ptr[unsafe_offset=i] = _float_unary[dtype, 1, op_code](a)
         i += gstride
 
 
@@ -506,8 +506,8 @@ def _unary_apply[
 def _unary_contig_kernel4[
     dtype: DType, op_code: Int
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     size_arg: Int64,
     vec_count_arg: Int64,
 ):
@@ -528,32 +528,34 @@ def _unary_contig_kernel4[
     var g = gid
     while g < groups:
         var b = g * 4
-        var a0 = in_ptr.load[width=4, alignment=vec_align](b * 4)
-        var a1 = in_ptr.load[width=4, alignment=vec_align]((b + 1) * 4)
-        var a2 = in_ptr.load[width=4, alignment=vec_align]((b + 2) * 4)
-        var a3 = in_ptr.load[width=4, alignment=vec_align]((b + 3) * 4)
-        out_ptr.store[width=4, alignment=vec_align](
+        var a0 = in_ptr.unsafe_load[width=4, alignment=vec_align](b * 4)
+        var a1 = in_ptr.unsafe_load[width=4, alignment=vec_align]((b + 1) * 4)
+        var a2 = in_ptr.unsafe_load[width=4, alignment=vec_align]((b + 2) * 4)
+        var a3 = in_ptr.unsafe_load[width=4, alignment=vec_align]((b + 3) * 4)
+        out_ptr.unsafe_store[width=4, alignment=vec_align](
             b * 4, _unary_apply[dtype, 4, op_code](a0)
         )
-        out_ptr.store[width=4, alignment=vec_align](
+        out_ptr.unsafe_store[width=4, alignment=vec_align](
             (b + 1) * 4, _unary_apply[dtype, 4, op_code](a1)
         )
-        out_ptr.store[width=4, alignment=vec_align](
+        out_ptr.unsafe_store[width=4, alignment=vec_align](
             (b + 2) * 4, _unary_apply[dtype, 4, op_code](a2)
         )
-        out_ptr.store[width=4, alignment=vec_align](
+        out_ptr.unsafe_store[width=4, alignment=vec_align](
             (b + 3) * 4, _unary_apply[dtype, 4, op_code](a3)
         )
         g += gstride
     var c = groups * 4 + gid
     if c < vec_count:
-        var a = in_ptr.load[width=4, alignment=vec_align](c * 4)
-        out_ptr.store[width=4, alignment=vec_align](
+        var a = in_ptr.unsafe_load[width=4, alignment=vec_align](c * 4)
+        out_ptr.unsafe_store[width=4, alignment=vec_align](
             c * 4, _unary_apply[dtype, 4, op_code](a)
         )
     var i = vec_count * 4 + gid
     while i < size:
-        out_ptr[i] = _unary_apply[dtype, 1, op_code](in_ptr[i])
+        out_ptr[unsafe_offset=i] = _unary_apply[dtype, 1, op_code](
+            in_ptr[unsafe_offset=i]
+        )
         i += gstride
 
 
@@ -561,8 +563,8 @@ def _unary_contig_kernel4[
 def _unary_elementwise[
     dtype: DType, op_code: Int
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutUntrackedOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], MutUntrackedOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutUntrackedOrigin],
+    in_ptr: Pointer[Scalar[dtype], MutUntrackedOrigin],
     size: Int,
     ctx: DeviceContext,
 ) raises:
@@ -585,30 +587,32 @@ def _unary_elementwise[
             @__copy_capture(out_ptr, in_ptr)
             def func[width: Int, alignment: Int = 1](idx: Coord):
                 var i = Int(idx[0].value())
-                var a = in_ptr.load[width=width](i)
+                var a = in_ptr.unsafe_load[width=width](i)
                 comptime if op_code == UOP_RELU:
-                    out_ptr.store[width=width](i, max(a, SIMD[dtype, width](0)))
+                    out_ptr.unsafe_store[width=width](
+                        i, max(a, SIMD[dtype, width](0))
+                    )
                 comptime if op_code == UOP_ABS:
-                    out_ptr.store[width=width](i, abs(a))
+                    out_ptr.unsafe_store[width=width](i, abs(a))
                 comptime if op_code == UOP_NEG:
                     # `-a` (pop.neg) wraps for unsigned/overflow like torch.
-                    out_ptr.store[width=width](i, -a)
+                    out_ptr.unsafe_store[width=width](i, -a)
                 comptime if op_code == UOP_SIGN:
                     var zero = SIMD[dtype, width](0)
                     var pos = a.gt(zero).cast[dtype]()
                     var neg = a.lt(zero).cast[dtype]()
                     # NaN compares false on both sides -> 0, matching torch.
-                    out_ptr.store[width=width](i, pos - neg)
+                    out_ptr.unsafe_store[width=width](i, pos - neg)
                 comptime if not is_direct:
                     comptime if (
                         dtype == DType.float16 or dtype == DType.bfloat16
                     ):
                         var af = a.cast[DType.float32]()
-                        out_ptr.store[width=width](
+                        out_ptr.unsafe_store[width=width](
                             i, _float_unary[op_code=op_code](af).cast[dtype]()
                         )
                     elif dtype.is_floating_point():
-                        out_ptr.store[width=width](
+                        out_ptr.unsafe_store[width=width](
                             i, _float_unary[op_code=op_code](a)
                         )
 
@@ -639,7 +643,7 @@ def _unary_elementwise[
                             1,
                             GS_THREADS,
                             out_ptr.as_unsafe_any_origin(),
-                            in_ptr.as_unsafe_any_origin().as_immutable(),
+                            in_ptr.as_unsafe_any_origin().as_imm(),
                             Int64(size),
                             Int64(vec_count),
                         )
@@ -652,7 +656,7 @@ def _unary_elementwise[
                         1,
                         GS_THREADS,
                         out_ptr.as_unsafe_any_origin(),
-                        in_ptr.as_unsafe_any_origin().as_immutable(),
+                        in_ptr.as_unsafe_any_origin().as_imm(),
                         Int64(size),
                     )
                 else:
@@ -690,8 +694,8 @@ def _unary_bool_vec[
 def _unary_bool[
     dtype: DType, op_code: Int
 ](
-    out_ptr: UnsafePointer[Scalar[DType.bool], MutUntrackedOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], MutUntrackedOrigin],
+    out_ptr: Pointer[Scalar[DType.bool], MutUntrackedOrigin],
+    in_ptr: Pointer[Scalar[dtype], MutUntrackedOrigin],
     size: Int,
     ctx: DeviceContext,
 ) raises:
@@ -702,10 +706,10 @@ def _unary_bool[
         # Same body as the vectorized path above, through the same helper:
         # the 0/1 uint8 it returns is bit-identical to the bool stored here.
         var i = Int(idx[0].value())
-        out_ptr.store[width=width](
+        out_ptr.unsafe_store[width=width](
             i,
             _unary_bool_vec[dtype, op_code, width](
-                in_ptr.load[width=width](i)
+                in_ptr.unsafe_load[width=width](i)
             ).cast[DType.bool](),
         )
 
@@ -741,8 +745,8 @@ comptime SOP_POW = 2
 def _scalar_elementwise[
     dtype: DType, op_code: Int
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutUntrackedOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], MutUntrackedOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutUntrackedOrigin],
+    in_ptr: Pointer[Scalar[dtype], MutUntrackedOrigin],
     scalar: Float32,
     size: Int,
     ctx: DeviceContext,
@@ -756,14 +760,14 @@ def _scalar_elementwise[
         @__copy_capture(out_ptr, in_ptr, scalar)
         def func[width: Int, alignment: Int = 1](idx: Coord):
             var i = Int(idx[0].value())
-            var a = in_ptr.load[width=width](i).cast[DType.float32]()
+            var a = in_ptr.unsafe_load[width=width](i).cast[DType.float32]()
             var s = SIMD[DType.float32, width](scalar)
             comptime if op_code == SOP_ADD:
-                out_ptr.store[width=width](i, (a + s).cast[dtype]())
+                out_ptr.unsafe_store[width=width](i, (a + s).cast[dtype]())
             comptime if op_code == SOP_MUL:
-                out_ptr.store[width=width](i, (a * s).cast[dtype]())
+                out_ptr.unsafe_store[width=width](i, (a * s).cast[dtype]())
             comptime if op_code == SOP_POW:
-                out_ptr.store[width=width](i, pow(a, s).cast[dtype]())
+                out_ptr.unsafe_store[width=width](i, pow(a, s).cast[dtype]())
 
         if ctx.api() == "cpu":
             elementwise[func, simd_width=simd_width_of[dtype]()](
@@ -784,8 +788,8 @@ comptime IOP_MUL = 1
 def _int_scalar_elementwise[
     dtype: DType, op_code: Int
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutUntrackedOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], MutUntrackedOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutUntrackedOrigin],
+    in_ptr: Pointer[Scalar[dtype], MutUntrackedOrigin],
     scalar: Int,
     size: Int,
     ctx: DeviceContext,
@@ -795,11 +799,11 @@ def _int_scalar_elementwise[
     @__copy_capture(out_ptr, in_ptr, scalar)
     def func[width: Int, alignment: Int = 1](idx: Coord):
         var i = Int(idx[0].value())
-        var a = in_ptr.load[width=width](i)
+        var a = in_ptr.unsafe_load[width=width](i)
         comptime if op_code == IOP_ADD:
-            out_ptr.store[width=width](i, a + SIMD[dtype, width](scalar))
+            out_ptr.unsafe_store[width=width](i, a + SIMD[dtype, width](scalar))
         comptime if op_code == IOP_MUL:
-            out_ptr.store[width=width](i, a * SIMD[dtype, width](scalar))
+            out_ptr.unsafe_store[width=width](i, a * SIMD[dtype, width](scalar))
 
     if ctx.api() == "cpu":
         elementwise[func, simd_width=simd_width_of[dtype]()](Coord(size), ctx)
@@ -832,7 +836,7 @@ def _fill[
 def _arange[
     dtype: DType
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutUntrackedOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutUntrackedOrigin],
     start: Float64,
     step: Float64,
     size: Int,
@@ -849,7 +853,9 @@ def _arange[
             @__copy_capture(out_ptr, start, step)
             def cpu_f32[width: Int, alignment: Int = 1](idx: Coord):
                 var i = Int(idx[0].value())
-                out_ptr[i] = (start + Float64(i) * step).cast[dtype]()
+                out_ptr[unsafe_offset=i] = (start + Float64(i) * step).cast[
+                    dtype
+                ]()
 
             elementwise[cpu_f32, simd_width=1](Coord(size), ctx)
         else:
@@ -861,7 +867,7 @@ def _arange[
             @__copy_capture(out_ptr, start_f32, step_f32)
             def gpu_f32[width: Int, alignment: Int = 1](idx: Coord):
                 var i = Int(idx[0].value())
-                out_ptr[i] = (
+                out_ptr[unsafe_offset=i] = (
                     start_f32 + Scalar[DType.float32](i) * step_f32
                 ).cast[dtype]()
 
@@ -880,9 +886,9 @@ def _arange[
         @__copy_capture(out_ptr, start_f32, step_f32)
         def lowp[width: Int, alignment: Int = 1](idx: Coord):
             var i = Int(idx[0].value())
-            out_ptr[i] = (start_f32 + Scalar[DType.float32](i) * step_f32).cast[
-                dtype
-            ]()
+            out_ptr[unsafe_offset=i] = (
+                start_f32 + Scalar[DType.float32](i) * step_f32
+            ).cast[dtype]()
 
         if ctx.api() == "cpu":
             elementwise[lowp, simd_width=1](Coord(size), ctx)
@@ -900,9 +906,9 @@ def _arange[
         @__copy_capture(out_ptr, start_i64, step_i64)
         def integral[width: Int, alignment: Int = 1](idx: Coord):
             var i = Int(idx[0].value())
-            out_ptr[i] = (start_i64 + Scalar[DType.int64](i) * step_i64).cast[
-                dtype
-            ]()
+            out_ptr[unsafe_offset=i] = (
+                start_i64 + Scalar[DType.int64](i) * step_i64
+            ).cast[dtype]()
 
         if ctx.api() == "cpu":
             elementwise[integral, simd_width=1](Coord(size), ctx)
@@ -920,7 +926,7 @@ def _arange[
         @__copy_capture(out_ptr, start, step)
         def f64[width: Int, alignment: Int = 1](idx: Coord):
             var i = Int(idx[0].value())
-            out_ptr[i] = (start + Float64(i) * step).cast[dtype]()
+            out_ptr[unsafe_offset=i] = (start + Float64(i) * step).cast[dtype]()
 
         if ctx.api() == "cpu":
             elementwise[f64, simd_width=1](Coord(size), ctx)
@@ -986,9 +992,16 @@ def _bin_dispatcher[
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
-        _bin_go[op_code](args[0], args[1], args[2], args[3], args[4], args[5])
+        _bin_go[op_code](
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+        )
     except e:
         return _spec_unsupported(e)
     return _raw_ret_none()
@@ -999,9 +1012,16 @@ def _arange_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
-        _arange_go(args[0], args[1], args[2], args[3], args[4], args[5])
+        _arange_go(
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+        )
     except e:
         return _spec_unsupported(e)
     return _raw_ret_none()
@@ -1192,9 +1212,11 @@ def _scalar_inplace_dispatcher[
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
-        return _scalar_inplace_go[op_code](args[0], args[1])
+        return _scalar_inplace_go[op_code](
+            args[unsafe_offset=0], args[unsafe_offset=1]
+        )
     except e:
         return _spec_unsupported(e)
 

--- a/torch_mojo_backend/eager_kernels/embedding_backward_ops/embedding_backward_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/embedding_backward_ops/embedding_backward_kernels.mojo
@@ -55,7 +55,8 @@ from max.gpu.sync import barrier
 from std.gpu import block_idx, grid_dim, thread_idx
 from max.gpu.host import DeviceAttribute, DeviceContext
 from std.math import ceildiv
-from std.memory import AddressSpace, alloc, stack_allocation
+from std.memory import AddressSpace, stack_allocation
+from std.memory.alloc import unsafe_alloc
 from std.sys import inlined_assembly, is_amd_gpu, is_nvidia_gpu
 from std.sys.info import _is_sm_9x_or_newer, has_apple_gpu_accelerator
 
@@ -92,18 +93,19 @@ def _cached_max_grid(ctx: DeviceContext) raises -> Int:
     the per-op path.
     """
     var name = String(t"TMB_EMB_BWD_MAXGRID_{ctx.id()}")
-    if global_ptr := _get_global_or_null(name):
-        return global_ptr.value().bitcast[Int]()[]
+    var global_ptr = _get_global_or_null(name)
+    if global_ptr:
+        return global_ptr.value().unsafe_bitcast[Int]()[]
     var sm_count: Int
     try:
         sm_count = ctx.get_attribute(DeviceAttribute.MULTIPROCESSOR_COUNT)
     except:
         sm_count = 64
     var value = max(1, sm_count) * 16
-    var cached = alloc[Int](1)
+    var cached = unsafe_alloc[Int](1)
     cached[] = value
     external_call["KGEN_CompilerRT_InsertGlobal", NoneType](
-        StringSlice(name), cached.bitcast[NoneType]()
+        StringSlice(name), cached.unsafe_bitcast[NoneType]()
     )
     return value
 
@@ -122,7 +124,7 @@ def _device_scope() -> StaticString:
 
 @always_inline
 def _atomic_add_f32(
-    ptr: UnsafePointer[Scalar[DType.float32], MutAnyOrigin], value: Float32
+    ptr: Pointer[Scalar[DType.float32], MutAnyOrigin], value: Float32
 ):
     _ = Atomic[DType.float32, scope=_device_scope()].fetch_add[
         ordering=Ordering.RELAXED
@@ -131,7 +133,7 @@ def _atomic_add_f32(
 
 @always_inline
 def _atomic_add_f32_vec4(
-    ptr: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    ptr: Pointer[Scalar[DType.float32], MutAnyOrigin],
     value: SIMD[DType.float32, _VEC],
 ):
     # One 128-bit vector reduction replaces four scalar L2 atomic ops; the
@@ -146,12 +148,12 @@ def _atomic_add_f32_vec4(
         ](UInt64(Int(ptr)), value[0], value[1], value[2], value[3])
     else:
         comptime for k in range(_VEC):
-            _atomic_add_f32(ptr + k, value[k])
+            _atomic_add_f32(ptr.unsafe_offset(k), value[k])
 
 
 @__name("embedding_dense_backward_zero_vec4")
 def _zero_vec4(
-    grad_weight: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_weight: Pointer[Scalar[DType.float32], MutAnyOrigin],
     head_arg: Int64,
     vec_count_arg: Int64,
     tail_arg: Int64,
@@ -165,19 +167,21 @@ def _zero_vec4(
     var stride = Int(grid_dim.x) * _BLOCK
     # head/tail are < _VEC scalars around the 16-byte-aligned body.
     if tid < head:
-        grad_weight[tid] = 0.0
+        grad_weight[unsafe_offset=tid] = 0.0
     if tid < tail:
-        grad_weight[head + vec_count * _VEC + tid] = 0.0
+        grad_weight[unsafe_offset=head + vec_count * _VEC + tid] = 0.0
     var zeros = SIMD[DType.float32, _VEC](0.0)
     var v = tid
     while v < vec_count:
-        grad_weight.store[width=_VEC, alignment=16](head + v * _VEC, zeros)
+        grad_weight.unsafe_store[width=_VEC, alignment=16](
+            head + v * _VEC, zeros
+        )
         v += stride
 
 
 @__name("embedding_dense_backward_zero_scalar")
 def _zero_scalar(
-    grad_weight: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_weight: Pointer[Scalar[DType.float32], MutAnyOrigin],
     elements_arg: Int64,
 ):
     # Int is not device-passable (host/device width mismatch); scalars cross
@@ -186,15 +190,15 @@ def _zero_scalar(
     var index = Int(block_idx.x) * _BLOCK + Int(thread_idx.x)
     var stride = Int(grid_dim.x) * _BLOCK
     while index < elements:
-        grad_weight[index] = 0.0
+        grad_weight[unsafe_offset=index] = 0.0
         index += stride
 
 
 @__name("embedding_dense_backward_scatter_vec4")
 def _scatter_vec4(
-    grad_weight: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    indices: UnsafePointer[Scalar[DType.int64], MutAnyOrigin],
+    grad_weight: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    indices: Pointer[Scalar[DType.int64], MutAnyOrigin],
     num_indices_arg: Int64,
     vec_cols_arg: Int64,
     padding_idx_arg: Int64,
@@ -210,20 +214,20 @@ def _scatter_vec4(
     while e < total:
         var row = e // vec_cols
         var col = e - row * vec_cols
-        var target = Int(indices[row])
+        var target = Int(indices[unsafe_offset=row])
         if target != padding_idx:
-            var v = grad_output.load[width=_VEC, alignment=16](e * _VEC)
+            var v = grad_output.unsafe_load[width=_VEC, alignment=16](e * _VEC)
             _atomic_add_f32_vec4(
-                grad_weight + (target * vec_cols + col) * _VEC, v
+                grad_weight.unsafe_offset((target * vec_cols + col) * _VEC), v
             )
         e += stride
 
 
 @__name("embedding_dense_backward_scatter_scalar")
 def _scatter_scalar(
-    grad_weight: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    indices: UnsafePointer[Scalar[DType.int64], MutAnyOrigin],
+    grad_weight: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    indices: Pointer[Scalar[DType.int64], MutAnyOrigin],
     num_indices_arg: Int64,
     embedding_dim_arg: Int64,
     padding_idx_arg: Int64,
@@ -239,17 +243,18 @@ def _scatter_scalar(
     while e < total:
         var row = e // embedding_dim
         var col = e - row * embedding_dim
-        var target = Int(indices[row])
+        var target = Int(indices[unsafe_offset=row])
         if target != padding_idx:
             _atomic_add_f32(
-                grad_weight + target * embedding_dim + col, grad_output[e]
+                grad_weight.unsafe_offset(target * embedding_dim + col),
+                grad_output[unsafe_offset=e],
             )
         e += stride
 
 
 @__name("embedding_dense_backward_count_zero")
 def _count_zero(
-    counts: UnsafePointer[Scalar[DType.int32], MutAnyOrigin],
+    counts: Pointer[Scalar[DType.int32], MutAnyOrigin],
     num_weights_arg: Int64,
 ):
     # Int is not device-passable (host/device width mismatch); scalars cross
@@ -258,14 +263,14 @@ def _count_zero(
     var index = Int(block_idx.x) * _BLOCK + Int(thread_idx.x)
     var stride = Int(grid_dim.x) * _BLOCK
     while index < num_weights:
-        counts[index] = 0
+        counts[unsafe_offset=index] = 0
         index += stride
 
 
 @__name("embedding_dense_backward_count")
 def _count(
-    counts: UnsafePointer[Scalar[DType.int32], MutAnyOrigin],
-    indices: UnsafePointer[Scalar[DType.int64], MutAnyOrigin],
+    counts: Pointer[Scalar[DType.int32], MutAnyOrigin],
+    indices: Pointer[Scalar[DType.int64], MutAnyOrigin],
     num_indices_arg: Int64,
     padding_idx_arg: Int64,
 ):
@@ -276,18 +281,18 @@ def _count(
     var index = Int(block_idx.x) * _BLOCK + Int(thread_idx.x)
     var stride = Int(grid_dim.x) * _BLOCK
     while index < num_indices:
-        var target = Int(indices[index])
+        var target = Int(indices[unsafe_offset=index])
         if target != padding_idx:
             _ = Atomic[DType.int32, scope=_device_scope()].fetch_add[
                 ordering=Ordering.RELAXED
-            ](counts + target, 1)
+            ](counts.unsafe_offset(target), 1)
         index += stride
 
 
 @__name("embedding_dense_backward_zero_untouched")
 def _zero_untouched(
-    grad_weight: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    counts: UnsafePointer[Scalar[DType.int32], MutAnyOrigin],
+    grad_weight: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    counts: Pointer[Scalar[DType.int32], MutAnyOrigin],
     num_weights_arg: Int64,
     vec_cols_arg: Int64,
 ):
@@ -306,8 +311,8 @@ def _zero_untouched(
     if col >= vec_cols:
         return
     while row < num_weights:
-        if counts[row] != 1:
-            grad_weight.store[width=_VEC, alignment=16](
+        if counts[unsafe_offset=row] != 1:
+            grad_weight.unsafe_store[width=_VEC, alignment=16](
                 (row * vec_cols + col) * _VEC, zeros
             )
         row += row_stride
@@ -315,10 +320,10 @@ def _zero_untouched(
 
 @__name("embedding_dense_backward_scatter_hist_vec4")
 def _scatter_hist_vec4(
-    grad_weight: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    indices: UnsafePointer[Scalar[DType.int64], MutAnyOrigin],
-    counts: UnsafePointer[Scalar[DType.int32], MutAnyOrigin],
+    grad_weight: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    indices: Pointer[Scalar[DType.int64], MutAnyOrigin],
+    counts: Pointer[Scalar[DType.int32], MutAnyOrigin],
     num_indices_arg: Int64,
     vec_cols_arg: Int64,
     padding_idx_arg: Int64,
@@ -334,26 +339,26 @@ def _scatter_hist_vec4(
     if col >= vec_cols:
         return
     while row < num_indices:
-        var target = Int(indices[row])
+        var target = Int(indices[unsafe_offset=row])
         if target != padding_idx:
-            var v = grad_output.load[width=_VEC, alignment=16](
+            var v = grad_output.unsafe_load[width=_VEC, alignment=16](
                 (row * vec_cols + col) * _VEC
             )
             var dst = (target * vec_cols + col) * _VEC
-            if counts[target] == 1:
+            if counts[unsafe_offset=target] == 1:
                 # Sole contributor: plain store skips the atomic
                 # read-modify-write and the zero-pass write for this row.
-                grad_weight.store[width=_VEC, alignment=16](dst, v)
+                grad_weight.unsafe_store[width=_VEC, alignment=16](dst, v)
             else:
-                _atomic_add_f32_vec4(grad_weight + dst, v)
+                _atomic_add_f32_vec4(grad_weight.unsafe_offset(dst), v)
         row += row_stride
 
 
 @__name("embedding_dense_backward_owner_vec4")
 def _owner_vec4(
-    grad_weight: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    indices: UnsafePointer[Scalar[DType.int64], MutAnyOrigin],
+    grad_weight: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    indices: Pointer[Scalar[DType.int64], MutAnyOrigin],
     num_indices_arg: Int64,
     vec_cols_arg: Int64,
     num_weights_arg: Int64,
@@ -384,13 +389,15 @@ def _owner_vec4(
     while base < num_indices:
         var count = min(_OWN_TILE, num_indices - base)
         if tid < count:
-            var t = Int(indices[base + tid])
-            tile[tid] = Int32(-1) if t == padding_idx else Int32(t)
+            var t = Int(indices[unsafe_offset=base + tid])
+            tile[unsafe_offset=tid] = Int32(-1) if t == padding_idx else Int32(
+                t
+            )
         barrier()
         if active:
             for k in range(count):
-                if Int(tile[k]) == row:
-                    acc += grad_output.load[width=_VEC, alignment=16](
+                if Int(tile[unsafe_offset=k]) == row:
+                    acc += grad_output.unsafe_load[width=_VEC, alignment=16](
                         ((base + k) * vec_cols + col) * _VEC
                     )
         barrier()
@@ -398,16 +405,16 @@ def _owner_vec4(
     if active:
         # Full ownership: the plain store doubles as the zero pass for rows
         # no index touched.
-        grad_weight.store[width=_VEC, alignment=16](
+        grad_weight.unsafe_store[width=_VEC, alignment=16](
             (row * vec_cols + col) * _VEC, acc
         )
 
 
 @__name("embedding_dense_backward_owner_scalar")
 def _owner_scalar(
-    grad_weight: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    indices: UnsafePointer[Scalar[DType.int64], MutAnyOrigin],
+    grad_weight: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    indices: Pointer[Scalar[DType.int64], MutAnyOrigin],
     num_indices_arg: Int64,
     embedding_dim_arg: Int64,
     num_weights_arg: Int64,
@@ -433,24 +440,28 @@ def _owner_scalar(
     while base < num_indices:
         var count = min(_OWN_TILE, num_indices - base)
         if tid < count:
-            var t = Int(indices[base + tid])
-            tile[tid] = Int32(-1) if t == padding_idx else Int32(t)
+            var t = Int(indices[unsafe_offset=base + tid])
+            tile[unsafe_offset=tid] = Int32(-1) if t == padding_idx else Int32(
+                t
+            )
         barrier()
         if active:
             for k in range(count):
-                if Int(tile[k]) == row:
-                    acc += grad_output[(base + k) * embedding_dim + col]
+                if Int(tile[unsafe_offset=k]) == row:
+                    acc += grad_output[
+                        unsafe_offset=(base + k) * embedding_dim + col
+                    ]
         barrier()
         base += _OWN_TILE
     if active:
-        grad_weight[row * embedding_dim + col] = acc
+        grad_weight[unsafe_offset=row * embedding_dim + col] = acc
 
 
 @__name("embedding_dense_backward_table_accum")
 def _table_accum(
-    scratch: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    indices: UnsafePointer[Scalar[DType.int64], MutAnyOrigin],
+    scratch: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    indices: Pointer[Scalar[DType.int64], MutAnyOrigin],
     num_indices_arg: Int64,
     embedding_dim_arg: Int64,
     num_weights_arg: Int64,
@@ -480,7 +491,7 @@ def _table_accum(
     var used = num_weights * _TABLE_COLS
     var i = tid
     while i < used:
-        table[i] = 0.0
+        table[unsafe_offset=i] = 0.0
         i += _TABLE_COLS * _TABLE_ROWG
     barrier()
 
@@ -498,23 +509,23 @@ def _table_accum(
             var t = InlineArray[Int, _TABLE_UNROLL](uninitialized=True)
             var v = InlineArray[Float32, _TABLE_UNROLL](uninitialized=True)
             comptime for u in range(_TABLE_UNROLL):
-                t[u] = Int(indices[row + u * _TABLE_ROWG])
+                t[u] = Int(indices[unsafe_offset=row + u * _TABLE_ROWG])
             comptime for u in range(_TABLE_UNROLL):
                 v[u] = grad_output[
-                    (row + u * _TABLE_ROWG) * embedding_dim + col
+                    unsafe_offset=(row + u * _TABLE_ROWG) * embedding_dim + col
                 ]
             comptime for u in range(_TABLE_UNROLL):
                 if t[u] != padding_idx:
                     _ = Atomic[DType.float32].fetch_add[
                         ordering=Ordering.RELAXED
-                    ](table + t[u] * _TABLE_COLS + tx, v[u])
+                    ](table.unsafe_offset(t[u] * _TABLE_COLS + tx), v[u])
             row += _TABLE_UNROLL * _TABLE_ROWG
         while row < row_end:
-            var t = Int(indices[row])
+            var t = Int(indices[unsafe_offset=row])
             if t != padding_idx:
                 _ = Atomic[DType.float32].fetch_add[ordering=Ordering.RELAXED](
-                    table + t * _TABLE_COLS + tx,
-                    grad_output[row * embedding_dim + col],
+                    table.unsafe_offset(t * _TABLE_COLS + tx),
+                    grad_output[unsafe_offset=row * embedding_dim + col],
                 )
             row += _TABLE_ROWG
     barrier()
@@ -525,16 +536,16 @@ def _table_accum(
         var chunk_base = Int(block_idx.y) * num_weights
         var r = ty
         while r < num_weights:
-            scratch[(chunk_base + r) * dim_pad + col] = table[
-                r * _TABLE_COLS + tx
+            scratch[unsafe_offset=(chunk_base + r) * dim_pad + col] = table[
+                unsafe_offset=r * _TABLE_COLS + tx
             ]
             r += _TABLE_ROWG
 
 
 @__name("embedding_dense_backward_table_reduce")
 def _table_reduce(
-    grad_weight: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    scratch: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_weight: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    scratch: Pointer[Scalar[DType.float32], MutAnyOrigin],
     num_weights_arg: Int64,
     embedding_dim_arg: Int64,
     dim_pad_arg: Int64,
@@ -575,51 +586,53 @@ def _table_reduce(
             var base = r * dim_pad + (e - r * vec_pad) * _VEC
             var k = ty
             while k + 3 * _RED_TY < chunks:
-                acc0 += scratch.load[width=_VEC, alignment=16](
+                acc0 += scratch.unsafe_load[width=_VEC, alignment=16](
                     base + k * chunk_stride
                 )
-                acc1 += scratch.load[width=_VEC, alignment=16](
+                acc1 += scratch.unsafe_load[width=_VEC, alignment=16](
                     base + (k + _RED_TY) * chunk_stride
                 )
-                acc2 += scratch.load[width=_VEC, alignment=16](
+                acc2 += scratch.unsafe_load[width=_VEC, alignment=16](
                     base + (k + 2 * _RED_TY) * chunk_stride
                 )
-                acc3 += scratch.load[width=_VEC, alignment=16](
+                acc3 += scratch.unsafe_load[width=_VEC, alignment=16](
                     base + (k + 3 * _RED_TY) * chunk_stride
                 )
                 k += 4 * _RED_TY
             while k < chunks:
-                acc0 += scratch.load[width=_VEC, alignment=16](
+                acc0 += scratch.unsafe_load[width=_VEC, alignment=16](
                     base + k * chunk_stride
                 )
                 k += _RED_TY
-        partials.store[width=_VEC, alignment=16](
+        partials.unsafe_store[width=_VEC, alignment=16](
             (ty * _RED_TX + tx) * _VEC, (acc0 + acc1) + (acc2 + acc3)
         )
         barrier()
         if ty == 0 and e < total:
             var acc = SIMD[DType.float32, _VEC](0.0)
             comptime for y in range(_RED_TY):
-                acc += partials.load[width=_VEC, alignment=16](
+                acc += partials.unsafe_load[width=_VEC, alignment=16](
                     (y * _RED_TX + tx) * _VEC
                 )
             var r = e // vec_pad
             var c = (e - r * vec_pad) * _VEC
             var out_offset = r * embedding_dim + c
             if out_vec_ok != 0:
-                grad_weight.store[width=_VEC, alignment=16](out_offset, acc)
+                grad_weight.unsafe_store[width=_VEC, alignment=16](
+                    out_offset, acc
+                )
             else:
                 comptime for j in range(_VEC):
                     if c + j < embedding_dim:
-                        grad_weight[out_offset + j] = acc[j]
+                        grad_weight[unsafe_offset=out_offset + j] = acc[j]
         barrier()
         block_base += grid_stride
 
 
 def enqueue_embedding_dense_backward_f32_i64(
-    grad_weight: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    indices: UnsafePointer[Scalar[DType.int64], MutAnyOrigin],
+    grad_weight: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    indices: Pointer[Scalar[DType.int64], MutAnyOrigin],
     num_indices: Int,
     embedding_dim: Int,
     num_weights: Int,

--- a/torch_mojo_backend/eager_kernels/flash_attention_ops/flash_attention_bwd_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/flash_attention_ops/flash_attention_bwd_kernels.mojo
@@ -206,13 +206,13 @@ def _sched_fence() -> None:
 def _bwd_dq_baseline[
     dtype: DType
 ](
-    dq: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    query: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    key: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    value: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    out_fwd: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    lse: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
+    dq: Pointer[Scalar[dtype], MutAnyOrigin],
+    grad_output: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    query: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    key: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    value: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    out_fwd: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    lse: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
     g_st: RowStrides,
     q_st: RowStrides,
     k_st: RowStrides,
@@ -259,9 +259,13 @@ def _bwd_dq_baseline[
 
     var d = tid
     while d < head_dim:
-        q_s[d] = query[q_row + d].cast[DType.float32]()
-        do_s[d] = grad_output[g_row + d].cast[DType.float32]()
-        acc[d] = 0.0
+        q_s[unsafe_offset=d] = query[unsafe_offset=q_row + d].cast[
+            DType.float32
+        ]()
+        do_s[unsafe_offset=d] = grad_output[unsafe_offset=g_row + d].cast[
+            DType.float32
+        ]()
+        acc[unsafe_offset=d] = 0.0
         d += THREADS
     barrier()
 
@@ -269,10 +273,13 @@ def _bwd_dq_baseline[
     var partial = Float32(0.0)
     var dd = tid
     while dd < head_dim:
-        partial += do_s[dd] * out_fwd[o_row + dd].cast[DType.float32]()
+        partial += (
+            do_s[unsafe_offset=dd]
+            * out_fwd[unsafe_offset=o_row + dd].cast[DType.float32]()
+        )
         dd += THREADS
     var row_d = block.sum[block_size=THREADS](partial)
-    var row_lse = lse[bh * seq_q + qi]
+    var row_lse = lse[unsafe_offset=bh * seq_q + qi]
 
     var limit = seq_kv
     if causal != 0:
@@ -287,8 +294,14 @@ def _bwd_dq_baseline[
         var dp = Float32(0.0)
         var e = tid
         while e < head_dim:
-            sp += q_s[e] * key[krow + e].cast[DType.float32]()
-            dp += do_s[e] * value[vrow + e].cast[DType.float32]()
+            sp += (
+                q_s[unsafe_offset=e]
+                * key[unsafe_offset=krow + e].cast[DType.float32]()
+            )
+            dp += (
+                do_s[unsafe_offset=e]
+                * value[unsafe_offset=vrow + e].cast[DType.float32]()
+            )
             e += THREADS
         var s_dot = block.sum[block_size=THREADS](sp)
         var dp_dot = block.sum[block_size=THREADS](dp)
@@ -296,13 +309,15 @@ def _bwd_dq_baseline[
         var ds = p * (dp_dot - row_d)
         var e2 = tid
         while e2 < head_dim:
-            acc[e2] += ds * key[krow + e2].cast[DType.float32]() * scale
+            acc[unsafe_offset=e2] += (
+                ds * key[unsafe_offset=krow + e2].cast[DType.float32]() * scale
+            )
             e2 += THREADS
         barrier()
 
     var o = tid
     while o < head_dim:
-        dq[dq_row + o] = acc[o].cast[dtype]()
+        dq[unsafe_offset=dq_row + o] = acc[unsafe_offset=o].cast[dtype]()
         o += THREADS
 
 
@@ -310,14 +325,14 @@ def _bwd_dq_baseline[
 def _bwd_dkv_baseline[
     dtype: DType
 ](
-    dk: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    dv: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    query: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    key: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    value: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    out_fwd: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    lse: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
+    dk: Pointer[Scalar[dtype], MutAnyOrigin],
+    dv: Pointer[Scalar[dtype], MutAnyOrigin],
+    grad_output: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    query: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    key: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    value: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    out_fwd: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    lse: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
     g_st: RowStrides,
     q_st: RowStrides,
     k_st: RowStrides,
@@ -374,10 +389,14 @@ def _bwd_dkv_baseline[
 
     var d = tid
     while d < head_dim:
-        k_s[d] = key[k_row + d].cast[DType.float32]()
-        v_s[d] = value[v_row + d].cast[DType.float32]()
-        acc_k[d] = 0.0
-        acc_v[d] = 0.0
+        k_s[unsafe_offset=d] = key[unsafe_offset=k_row + d].cast[
+            DType.float32
+        ]()
+        v_s[unsafe_offset=d] = value[unsafe_offset=v_row + d].cast[
+            DType.float32
+        ]()
+        acc_k[unsafe_offset=d] = 0.0
+        acc_v[unsafe_offset=d] = 0.0
         d += THREADS
     barrier()
 
@@ -395,27 +414,36 @@ def _bwd_dkv_baseline[
         var dsum = Float32(0.0)
         var e = tid
         while e < head_dim:
-            var dov = grad_output[g_row + e].cast[DType.float32]()
-            sp += k_s[e] * query[q_row + e].cast[DType.float32]()
-            dp += dov * v_s[e]
-            dsum += dov * out_fwd[o_row + e].cast[DType.float32]()
+            var dov = grad_output[unsafe_offset=g_row + e].cast[DType.float32]()
+            sp += (
+                k_s[unsafe_offset=e]
+                * query[unsafe_offset=q_row + e].cast[DType.float32]()
+            )
+            dp += dov * v_s[unsafe_offset=e]
+            dsum += dov * out_fwd[unsafe_offset=o_row + e].cast[DType.float32]()
             e += THREADS
         var s_dot = block.sum[block_size=THREADS](sp)
         var dp_dot = block.sum[block_size=THREADS](dp)
         var row_d = block.sum[block_size=THREADS](dsum)
-        var p = exp(s_dot * scale - lse[bh * seq_q + qi])
+        var p = exp(s_dot * scale - lse[unsafe_offset=bh * seq_q + qi])
         var ds = p * (dp_dot - row_d)
         var e2 = tid
         while e2 < head_dim:
-            acc_v[e2] += p * grad_output[g_row + e2].cast[DType.float32]()
-            acc_k[e2] += ds * query[q_row + e2].cast[DType.float32]() * scale
+            acc_v[unsafe_offset=e2] += (
+                p * grad_output[unsafe_offset=g_row + e2].cast[DType.float32]()
+            )
+            acc_k[unsafe_offset=e2] += (
+                ds
+                * query[unsafe_offset=q_row + e2].cast[DType.float32]()
+                * scale
+            )
             e2 += THREADS
         barrier()
 
     var o = tid
     while o < head_dim:
-        dk[dk_row + o] = acc_k[o].cast[dtype]()
-        dv[dv_row + o] = acc_v[o].cast[dtype]()
+        dk[unsafe_offset=dk_row + o] = acc_k[unsafe_offset=o].cast[dtype]()
+        dv[unsafe_offset=dv_row + o] = acc_v[unsafe_offset=o].cast[dtype]()
         o += THREADS
 
 
@@ -424,7 +452,7 @@ def _bwd_dkv_baseline[
 # accumulator to scratch. 256 threads is four wave64, one per SIMD.
 @__llvm_metadata(
     MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(THREADS)),
-    `rocdl.waves_per_eu`=SIMDSize(WAVES_PER_EU),
+    `rocdl.waves_per_eu`=SIMDLength(WAVES_PER_EU),
 )
 @__name(t"fa_bwd_dq_mfma_{dtype}_h{HD}_n{BN}_q{QT}_x{EXACT}_d{DENSE}")
 def _bwd_dq_mfma[
@@ -438,13 +466,13 @@ def _bwd_dq_mfma[
     IGLP: Int,
     PEEL: Bool,
 ](
-    dq: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    query: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    key: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    value: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    out_fwd: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    lse: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
+    dq: Pointer[Scalar[dtype], MutAnyOrigin],
+    grad_output: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    query: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    key: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    value: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    out_fwd: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    lse: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
     g_st: RowStrides,
     q_st: RowStrides,
     k_st: RowStrides,
@@ -494,8 +522,8 @@ def _bwd_dq_mfma[
             LDS_ELEMS, dtype, address_space=AddressSpace.SHARED, alignment=16
         ]()
         var k_smem = smem
-        var v_smem = smem + BN * KPAD
-        var kt_smem = smem + 2 * BN * KPAD
+        var v_smem = smem.unsafe_offset(BN * KPAD)
+        var kt_smem = smem.unsafe_offset(2 * BN * KPAD)
 
         var tid = Int(thread_idx.x)
         var wave = tid // 64
@@ -590,11 +618,11 @@ def _bwd_dq_mfma[
                 comptime if not EXACT:
                     ok = ok and (8 * s + 4 * hi < head_dim)
                 if ok:
-                    qv = query.load[width=4](qrow + 8 * s)
-                    gv = grad_output.load[width=4](grow + 8 * s)
-                    ov = out_fwd.load[width=4](orow + 8 * s)
-                q_frag.store((qt * KSTEPS + s) * 4, qv)
-                do_frag.store((qt * KSTEPS + s) * 4, gv)
+                    qv = query.unsafe_load[width=4](qrow + 8 * s)
+                    gv = grad_output.unsafe_load[width=4](grow + 8 * s)
+                    ov = out_fwd.unsafe_load[width=4](orow + 8 * s)
+                q_frag.unsafe_store((qt * KSTEPS + s) * 4, qv)
+                do_frag.unsafe_store((qt * KSTEPS + s) * 4, gv)
                 dsum += (
                     gv.cast[DType.float32]() * ov.cast[DType.float32]()
                 ).reduce_add()
@@ -602,19 +630,19 @@ def _bwd_dq_mfma[
             dsum += shuffle_xor(dsum, 32)
             var nl = NEG_ROW
             if live:
-                nl = -lse[lse_base + qg] * LOG2E
+                nl = -lse[unsafe_offset=lse_base + qg] * LOG2E
             else:
                 dsum = 0.0
-            nlse[qt] = nl
-            dval[qt] = dsum
+            nlse[unsafe_offset=qt] = nl
+            dval[unsafe_offset=qt] = dsum
             var lm = seq_kv
             if causal != 0:
                 lm = min(seq_kv, qg + delta + 1)
-            qlim[qt] = Int32(lm)
+            qlim[unsafe_offset=qt] = Int32(lm)
 
         var dq_acc = stack_allocation[DT * QT * 16, DType.float32]()
         comptime for i in range(DT * QT):
-            dq_acc.store(i * 16, SIMD[DType.float32, 16](0))
+            dq_acc.unsafe_store(i * 16, SIMD[DType.float32, 16](0))
 
         var sl = scale * LOG2E
 
@@ -624,8 +652,8 @@ def _bwd_dq_mfma[
         var k_col = (tid % (HD // 8)) * 8
         var t_col = tid % HD
         var t_kvg0 = tid // HD
-        var k_ptr = key + (k_base + k_row0 * kss + k_col)
-        var v_ptr = value + (v_base + k_row0 * vss + k_col)
+        var k_ptr = key.unsafe_offset(k_base + k_row0 * kss + k_col)
+        var v_ptr = value.unsafe_offset(v_base + k_row0 * vss + k_col)
         var k_tile_step = BN * kss
         var v_tile_step = BN * vss
         var k_lds0 = k_row0 * KPAD + k_col
@@ -650,34 +678,44 @@ def _bwd_dq_mfma[
                     var kvals = SIMD[dtype, 8](0)
                     var vvals = SIMD[dtype, 8](0)
                     comptime if EXACT:
-                        kvals = k_ptr.load[width=8](ci * KROW_STEP * kss)
-                        vvals = v_ptr.load[width=8](ci * KROW_STEP * vss)
+                        kvals = k_ptr.unsafe_load[width=8](ci * KROW_STEP * kss)
+                        vvals = v_ptr.unsafe_load[width=8](ci * KROW_STEP * vss)
                     else:
                         if k_col < head_dim:
-                            kvals = k_ptr.load[width=8](ci * KROW_STEP * kss)
-                            vvals = v_ptr.load[width=8](ci * KROW_STEP * vss)
-                    kreg.store(ci * 8, kvals)
-                    vreg.store(ci * 8, vvals)
+                            kvals = k_ptr.unsafe_load[width=8](
+                                ci * KROW_STEP * kss
+                            )
+                            vvals = v_ptr.unsafe_load[width=8](
+                                ci * KROW_STEP * vss
+                            )
+                    kreg.unsafe_store(ci * 8, kvals)
+                    vreg.unsafe_store(ci * 8, vvals)
             else:
                 comptime for ci in range(KITERS):
                     var row = min(kv0 + k_row0 + ci * KROW_STEP, last_row)
                     var kvals = SIMD[dtype, 8](0)
                     var vvals = SIMD[dtype, 8](0)
                     if EXACT or k_col < head_dim:
-                        kvals = key.load[width=8](k_base + row * kss + k_col)
-                        vvals = value.load[width=8](v_base + row * vss + k_col)
-                    kreg.store(ci * 8, kvals)
-                    vreg.store(ci * 8, vvals)
+                        kvals = key.unsafe_load[width=8](
+                            k_base + row * kss + k_col
+                        )
+                        vvals = value.unsafe_load[width=8](
+                            v_base + row * vss + k_col
+                        )
+                    kreg.unsafe_store(ci * 8, kvals)
+                    vreg.unsafe_store(ci * 8, vvals)
             comptime for ci in range(KITERS):
-                k_smem.store(
-                    k_lds0 + ci * KROW_STEP * KPAD, kreg.load[width=8](ci * 8)
+                k_smem.unsafe_store(
+                    k_lds0 + ci * KROW_STEP * KPAD,
+                    kreg.unsafe_load[width=8](ci * 8),
                 )
-                v_smem.store(
-                    k_lds0 + ci * KROW_STEP * KPAD, vreg.load[width=8](ci * 8)
+                v_smem.unsafe_store(
+                    k_lds0 + ci * KROW_STEP * KPAD,
+                    vreg.unsafe_load[width=8](ci * 8),
                 )
 
-            k_ptr += k_tile_step
-            v_ptr += v_tile_step
+            k_ptr = k_ptr.unsafe_offset(k_tile_step)
+            v_ptr = v_ptr.unsafe_offset(v_tile_step)
             barrier()
 
             # ---- K^T comes out of the row-major K tile, not out of a second
@@ -688,8 +726,8 @@ def _bwd_dq_mfma[
                 var kv0l = (t_kvg0 + ti * TKV_STEP) * 4
                 var tv = SIMD[dtype, 4](0)
                 comptime for j in range(4):
-                    tv[j] = k_smem[(kv0l + j) * KPAD + t_col]
-                kt_smem.store(t_lds0 + ti * TKV_STEP * 4, tv)
+                    tv[j] = k_smem[unsafe_offset=(kv0l + j) * KPAD + t_col]
+                kt_smem.unsafe_store(t_lds0 + ti * TKV_STEP * 4, tv)
             barrier()
 
             llvm_intrinsic["llvm.amdgcn.iglp.opt", NoneType](Int32(IGLP))
@@ -701,8 +739,8 @@ def _bwd_dq_mfma[
                     comptime for s in range(KSTEPS):
                         mma(
                             s_acc,
-                            k_smem.load[width=4](abase + 8 * s),
-                            q_frag.load[width=4]((qt * KSTEPS + s) * 4),
+                            k_smem.unsafe_load[width=4](abase + 8 * s),
+                            q_frag.unsafe_load[width=4]((qt * KSTEPS + s) * 4),
                             s_acc,
                         )
                     # ---- GEMM 2: dP^T[kv, q] = sum_d V[kv, d] * dO[q, d]
@@ -710,8 +748,8 @@ def _bwd_dq_mfma[
                     comptime for s in range(KSTEPS):
                         mma(
                             p_acc,
-                            v_smem.load[width=4](abase + 8 * s),
-                            do_frag.load[width=4]((qt * KSTEPS + s) * 4),
+                            v_smem.unsafe_load[width=4](abase + 8 * s),
+                            do_frag.unsafe_load[width=4]((qt * KSTEPS + s) * 4),
                             p_acc,
                         )
 
@@ -722,18 +760,21 @@ def _bwd_dq_mfma[
                             SIMD[DType.int32, 16](kv0 + kt * 32 + 4 * hi)
                             + ACC_ROWS
                         )
-                        s_acc = kvv.lt(SIMD[DType.int32, 16](qlim[qt])).select(
-                            s_acc, NEG_BIG
-                        )
+                        s_acc = kvv.lt(
+                            SIMD[DType.int32, 16](qlim[unsafe_offset=qt])
+                        ).select(s_acc, NEG_BIG)
                     var pv = exp2(
                         s_acc.fma(
                             SIMD[DType.float32, 16](sl),
-                            SIMD[DType.float32, 16](nlse[qt]),
+                            SIMD[DType.float32, 16](nlse[unsafe_offset=qt]),
                         )
                     )
                     var dsv = (
                         pv
-                        * (p_acc - SIMD[DType.float32, 16](dval[qt]))
+                        * (
+                            p_acc
+                            - SIMD[DType.float32, 16](dval[unsafe_offset=qt])
+                        )
                         * SIMD[DType.float32, 16](scale)
                     )
                     var ds_frag = _pack_half[dtype, 16](dsv)
@@ -742,10 +783,12 @@ def _bwd_dq_mfma[
                     comptime for g in range(4):
                         var b = ds_frag.slice[4, offset=g * 4]()
                         comptime for dt in range(DT):
-                            var acc = dq_acc.load[width=16]((dt * QT + qt) * 16)
+                            var acc = dq_acc.unsafe_load[width=16](
+                                (dt * QT + qt) * 16
+                            )
                             mma(
                                 acc,
-                                kt_smem.load[width=4](
+                                kt_smem.unsafe_load[width=4](
                                     (dt * 32 + lo) * TPAD
                                     + kt * 32
                                     + 8 * g
@@ -754,7 +797,7 @@ def _bwd_dq_mfma[
                                 b,
                                 acc,
                             )
-                            dq_acc.store((dt * QT + qt) * 16, acc)
+                            dq_acc.unsafe_store((dt * QT + qt) * 16, acc)
 
             barrier()
 
@@ -773,8 +816,9 @@ def _bwd_dq_mfma[
         _sched_fence()
         var packed = stack_allocation[DT * QT * 16, dtype]()
         comptime for i in range(DT * QT):
-            packed.store(
-                i * 16, _pack_half[dtype, 16](dq_acc.load[width=16](i * 16))
+            packed.unsafe_store(
+                i * 16,
+                _pack_half[dtype, 16](dq_acc.unsafe_load[width=16](i * 16)),
             )
         _sched_fence()
 
@@ -785,9 +829,9 @@ def _bwd_dq_mfma[
             barrier()
             comptime for qt in range(QT):
                 var row = wave * (32 * QT) + qt * 32 + lo
-                var ob = packed.load[width=16]((dt * QT + qt) * 16)
+                var ob = packed.unsafe_load[width=16]((dt * QT + qt) * 16)
                 comptime for g in range(4):
-                    smem.store(
+                    smem.unsafe_store(
                         row * OPAD + 8 * g + 4 * hi,
                         ob.slice[4, offset=g * 4](),
                     )
@@ -801,15 +845,15 @@ def _bwd_dq_mfma[
                 comptime if not EXACT:
                     store = store and dcol < head_dim
                 if store:
-                    dq.store(
+                    dq.unsafe_store(
                         dq_base + qg * dqss + dcol,
-                        smem.load[width=8](r * OPAD + cc),
+                        smem.unsafe_load[width=8](r * OPAD + cc),
                     )
 
 
 @__llvm_metadata(
     MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(THREADS)),
-    `rocdl.waves_per_eu`=SIMDSize(WAVES_PER_EU),
+    `rocdl.waves_per_eu`=SIMDLength(WAVES_PER_EU),
 )
 @__name(t"fa_bwd_dkv_mfma_{dtype}_h{HD}_m{BM}_k{KT}_x{EXACT}_d{DENSE}")
 def _bwd_dkv_mfma[
@@ -822,14 +866,14 @@ def _bwd_dkv_mfma[
     WAVES_PER_EU: Int,
     IGLP: Int,
 ](
-    dk: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    dv: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    query: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    key: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    value: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    out_fwd: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    lse: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
+    dk: Pointer[Scalar[dtype], MutAnyOrigin],
+    dv: Pointer[Scalar[dtype], MutAnyOrigin],
+    grad_output: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    query: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    key: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    value: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    out_fwd: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    lse: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
     g_st: RowStrides,
     q_st: RowStrides,
     k_st: RowStrides,
@@ -881,9 +925,9 @@ def _bwd_dkv_mfma[
             LDS_ELEMS, dtype, address_space=AddressSpace.SHARED, alignment=16
         ]()
         var q_smem = smem
-        var do_smem = smem + BM * QPAD
-        var qt_smem = smem + 2 * BM * QPAD
-        var dot_smem = smem + 2 * BM * QPAD + HD * TPAD
+        var do_smem = smem.unsafe_offset(BM * QPAD)
+        var qt_smem = smem.unsafe_offset(2 * BM * QPAD)
+        var dot_smem = smem.unsafe_offset(2 * BM * QPAD + HD * TPAD)
         # `[-lse * log2(e), D]` per query row of the tile, read back as one
         # broadcast `ds_read_b64` per accumulator row.
         var aux = stack_allocation[
@@ -962,16 +1006,16 @@ def _bwd_dkv_mfma[
                 comptime if not EXACT:
                     ok = ok and (8 * s + 4 * hi < head_dim)
                 if ok:
-                    kv4 = key.load[width=4](krow + 8 * s)
-                    vv4 = value.load[width=4](vrow + 8 * s)
-                k_frag.store((kt * KSTEPS + s) * 4, kv4)
-                v_frag.store((kt * KSTEPS + s) * 4, vv4)
+                    kv4 = key.unsafe_load[width=4](krow + 8 * s)
+                    vv4 = value.unsafe_load[width=4](vrow + 8 * s)
+                k_frag.unsafe_store((kt * KSTEPS + s) * 4, kv4)
+                v_frag.unsafe_store((kt * KSTEPS + s) * 4, vv4)
 
         var dk_acc = stack_allocation[DT * KT * 16, DType.float32]()
         var dv_acc = stack_allocation[DT * KT * 16, DType.float32]()
         comptime for i in range(DT * KT):
-            dk_acc.store(i * 16, SIMD[DType.float32, 16](0))
-            dv_acc.store(i * 16, SIMD[DType.float32, 16](0))
+            dk_acc.unsafe_store(i * 16, SIMD[DType.float32, 16](0))
+            dv_acc.unsafe_store(i * 16, SIMD[DType.float32, 16](0))
 
         var sl = scale * LOG2E
 
@@ -1025,28 +1069,33 @@ def _bwd_dkv_mfma[
                 comptime if not EXACT:
                     ok = r_col < head_dim
                 if ok:
-                    qv = query.load[width=8](q_base + grow * qss + r_col)
-                    gv = grad_output.load[width=8](g_base + grow * gss + r_col)
-                    ov = out_fwd.load[width=8](o_base + grow * oss + r_col)
-                qreg.store(ci * 8, qv)
-                greg.store(ci * 8, gv)
-                oreg.store(ci * 8, ov)
+                    qv = query.unsafe_load[width=8](q_base + grow * qss + r_col)
+                    gv = grad_output.unsafe_load[width=8](
+                        g_base + grow * gss + r_col
+                    )
+                    ov = out_fwd.unsafe_load[width=8](
+                        o_base + grow * oss + r_col
+                    )
+                qreg.unsafe_store(ci * 8, qv)
+                greg.unsafe_store(ci * 8, gv)
+                oreg.unsafe_store(ci * 8, ov)
             if tid < BM:
                 var qg = q0 + tid
                 if qg < seq_q:
-                    lval = -lse[lse_base + qg] * LOG2E
+                    lval = -lse[unsafe_offset=lse_base + qg] * LOG2E
 
             # ---- Stage Q and dO row-major, and the per-row `[-lse*log2e, D]`.
             comptime for ci in range(QITERS):
                 var lrow = r_row0 + ci * RSTEP
-                var gv = greg.load[width=8](ci * 8)
-                q_smem.store(
-                    r_lds0 + ci * RSTEP * QPAD, qreg.load[width=8](ci * 8)
+                var gv = greg.unsafe_load[width=8](ci * 8)
+                q_smem.unsafe_store(
+                    r_lds0 + ci * RSTEP * QPAD,
+                    qreg.unsafe_load[width=8](ci * 8),
                 )
-                do_smem.store(r_lds0 + ci * RSTEP * QPAD, gv)
+                do_smem.unsafe_store(r_lds0 + ci * RSTEP * QPAD, gv)
                 var part = (
                     gv.cast[DType.float32]()
-                    * oreg.load[width=8](ci * 8).cast[DType.float32]()
+                    * oreg.unsafe_load[width=8](ci * 8).cast[DType.float32]()
                 ).reduce_add()
                 part += shuffle_xor(part, 1)
                 part += shuffle_xor(part, 2)
@@ -1056,9 +1105,9 @@ def _bwd_dkv_mfma[
                 comptime if LPR > 16:
                     part += shuffle_xor(part, 16)
                 if row_lane == 0:
-                    aux[2 * lrow + 1] = part
+                    aux[unsafe_offset=2 * lrow + 1] = part
             if tid < BM:
-                aux[2 * tid] = lval
+                aux[unsafe_offset=2 * tid] = lval
             barrier()
 
             # ---- Q^T and dO^T come out of the row-major tiles, not out of a
@@ -1071,10 +1120,10 @@ def _bwd_dkv_mfma[
                 var qv4 = SIMD[dtype, 4](0)
                 var gv4 = SIMD[dtype, 4](0)
                 comptime for j in range(4):
-                    qv4[j] = q_smem[(q0l + j) * QPAD + t_col]
-                    gv4[j] = do_smem[(q0l + j) * QPAD + t_col]
-                qt_smem.store(t_lds0 + ti * TQ_STEP * 4, qv4)
-                dot_smem.store(t_lds0 + ti * TQ_STEP * 4, gv4)
+                    qv4[j] = q_smem[unsafe_offset=(q0l + j) * QPAD + t_col]
+                    gv4[j] = do_smem[unsafe_offset=(q0l + j) * QPAD + t_col]
+                qt_smem.unsafe_store(t_lds0 + ti * TQ_STEP * 4, qv4)
+                dot_smem.unsafe_store(t_lds0 + ti * TQ_STEP * 4, gv4)
             barrier()
 
             llvm_intrinsic["llvm.amdgcn.iglp.opt", NoneType](Int32(IGLP))
@@ -1085,7 +1134,9 @@ def _bwd_dkv_mfma[
                 var dd_v = SIMD[DType.float32, 16](0)
                 comptime for p in range(16):
                     comptime dr = 8 * (p // 4) + (p % 4)
-                    var pair = aux.load[width=2](2 * (mt * 32 + dr + 4 * hi))
+                    var pair = aux.unsafe_load[width=2](
+                        2 * (mt * 32 + dr + 4 * hi)
+                    )
                     nl_v[p] = pair[0]
                     dd_v[p] = pair[1]
 
@@ -1095,8 +1146,8 @@ def _bwd_dkv_mfma[
                     comptime for s in range(KSTEPS):
                         mma(
                             s_acc,
-                            q_smem.load[width=4](abase + 8 * s),
-                            k_frag.load[width=4]((kt * KSTEPS + s) * 4),
+                            q_smem.unsafe_load[width=4](abase + 8 * s),
+                            k_frag.unsafe_load[width=4]((kt * KSTEPS + s) * 4),
                             s_acc,
                         )
                     # ---- GEMM 2: dP[q, kv] = sum_d dO[q, d] * V[kv, d]
@@ -1104,8 +1155,8 @@ def _bwd_dkv_mfma[
                     comptime for s in range(KSTEPS):
                         mma(
                             p_acc,
-                            do_smem.load[width=4](abase + 8 * s),
-                            v_frag.load[width=4]((kt * KSTEPS + s) * 4),
+                            do_smem.unsafe_load[width=4](abase + 8 * s),
+                            v_frag.unsafe_load[width=4]((kt * KSTEPS + s) * 4),
                             p_acc,
                         )
 
@@ -1137,12 +1188,16 @@ def _bwd_dkv_mfma[
                             var toff = (
                                 (dt * 32 + lo) * TPAD + mt * 32 + 8 * g + 4 * hi
                             )
-                            var va = dv_acc.load[width=16]((dt * KT + kt) * 16)
-                            mma(va, dot_smem.load[width=4](toff), bp, va)
-                            dv_acc.store((dt * KT + kt) * 16, va)
-                            var ka = dk_acc.load[width=16]((dt * KT + kt) * 16)
-                            mma(ka, qt_smem.load[width=4](toff), bd, ka)
-                            dk_acc.store((dt * KT + kt) * 16, ka)
+                            var va = dv_acc.unsafe_load[width=16](
+                                (dt * KT + kt) * 16
+                            )
+                            mma(va, dot_smem.unsafe_load[width=4](toff), bp, va)
+                            dv_acc.unsafe_store((dt * KT + kt) * 16, va)
+                            var ka = dk_acc.unsafe_load[width=16](
+                                (dt * KT + kt) * 16
+                            )
+                            mma(ka, qt_smem.unsafe_load[width=4](toff), bd, ka)
+                            dk_acc.unsafe_store((dt * KT + kt) * 16, ka)
 
             barrier()
 
@@ -1162,11 +1217,13 @@ def _bwd_dkv_mfma[
         var pk_v = stack_allocation[DT * KT * 16, dtype]()
         var pk_k = stack_allocation[DT * KT * 16, dtype]()
         comptime for i in range(DT * KT):
-            pk_v.store(
-                i * 16, _pack_half[dtype, 16](dv_acc.load[width=16](i * 16))
+            pk_v.unsafe_store(
+                i * 16,
+                _pack_half[dtype, 16](dv_acc.unsafe_load[width=16](i * 16)),
             )
-            pk_k.store(
-                i * 16, _pack_half[dtype, 16](dk_acc.load[width=16](i * 16))
+            pk_k.unsafe_store(
+                i * 16,
+                _pack_half[dtype, 16](dk_acc.unsafe_load[width=16](i * 16)),
             )
         _sched_fence()
 
@@ -1175,11 +1232,11 @@ def _bwd_dkv_mfma[
                 barrier()
                 comptime for kt in range(KT):
                     var row = wave * (32 * KT) + kt * 32 + lo
-                    var ob = pk_v.load[width=16]((dt * KT + kt) * 16)
+                    var ob = pk_v.unsafe_load[width=16]((dt * KT + kt) * 16)
                     comptime if pass_id == 1:
-                        ob = pk_k.load[width=16]((dt * KT + kt) * 16)
+                        ob = pk_k.unsafe_load[width=16]((dt * KT + kt) * 16)
                     comptime for g in range(4):
-                        smem.store(
+                        smem.unsafe_store(
                             row * OPAD + 8 * g + 4 * hi,
                             ob.slice[4, offset=g * 4](),
                         )
@@ -1193,11 +1250,11 @@ def _bwd_dkv_mfma[
                     comptime if not EXACT:
                         store = store and dcol < head_dim
                     if store:
-                        var vals = smem.load[width=8](r * OPAD + cc)
+                        var vals = smem.unsafe_load[width=8](r * OPAD + cc)
                         comptime if pass_id == 0:
-                            dv.store(dv_base + kvg * dvss + dcol, vals)
+                            dv.unsafe_store(dv_base + kvg * dvss + dcol, vals)
                         else:
-                            dk.store(dk_base + kvg * dkss + dcol, vals)
+                            dk.unsafe_store(dk_base + kvg * dkss + dcol, vals)
 
 
 def _enqueue_mfma_pair[
@@ -1213,15 +1270,15 @@ def _enqueue_mfma_pair[
     IGLP: Int = 1,
     PEEL: Bool = True,
 ](
-    dq: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    dk: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    dv: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    query: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    key: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    value: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    out_fwd: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    softmax_lse: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
+    dq: Pointer[Scalar[dtype], MutAnyOrigin],
+    dk: Pointer[Scalar[dtype], MutAnyOrigin],
+    dv: Pointer[Scalar[dtype], MutAnyOrigin],
+    grad_output: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    query: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    key: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    value: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    out_fwd: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    softmax_lse: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
     g_st: RowStrides,
     q_st: RowStrides,
     k_st: RowStrides,
@@ -1354,15 +1411,15 @@ def _enqueue_mfma_pair[
 def enqueue_flash_attention_bwd[
     dtype: DType
 ](
-    dq: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    dk: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    dv: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    query: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    key: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    value: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    out_fwd: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    softmax_lse: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
+    dq: Pointer[Scalar[dtype], MutAnyOrigin],
+    dk: Pointer[Scalar[dtype], MutAnyOrigin],
+    dv: Pointer[Scalar[dtype], MutAnyOrigin],
+    grad_output: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    query: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    key: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    value: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    out_fwd: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    softmax_lse: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
     g_st: RowStrides,
     q_st: RowStrides,
     k_st: RowStrides,

--- a/torch_mojo_backend/eager_kernels/flash_attention_ops/flash_attention_fwd_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/flash_attention_ops/flash_attention_fwd_kernels.mojo
@@ -268,11 +268,11 @@ def _pack_half[
 def _flash_attention_fwd_baseline[
     dtype: DType
 ](
-    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    lse: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    query: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    key: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    value: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    output: Pointer[Scalar[dtype], MutAnyOrigin],
+    lse: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    query: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    key: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    value: Pointer[Scalar[dtype], ImmutAnyOrigin],
     q_st: RowStrides,
     k_st: RowStrides,
     v_st: RowStrides,
@@ -316,8 +316,10 @@ def _flash_attention_fwd_baseline[
 
     var d = tid
     while d < head_dim:
-        q_smem[d] = query[q_row + d].cast[DType.float32]()
-        acc_smem[d] = 0.0
+        q_smem[unsafe_offset=d] = query[unsafe_offset=q_row + d].cast[
+            DType.float32
+        ]()
+        acc_smem[unsafe_offset=d] = 0.0
         d += THREADS
     barrier()
 
@@ -337,17 +339,22 @@ def _flash_attention_fwd_baseline[
             var krow = k_base + j * k_st.seq
             var dot = Float32(0.0)
             for e in range(head_dim):
-                dot += q_smem[e] * key[krow + e].cast[DType.float32]()
+                dot += (
+                    q_smem[unsafe_offset=e]
+                    * key[unsafe_offset=krow + e].cast[DType.float32]()
+                )
             s = dot * scale
-        s_smem[tid] = s
+        s_smem[unsafe_offset=tid] = s
         barrier()
 
         var tile_max = block.max[block_size=THREADS](s)
         var new_max = max(running_max, tile_max)
         var correction = exp(running_max - new_max)
 
-        var p = exp(s_smem[tid] - new_max) if j < limit else Float32(0.0)
-        s_smem[tid] = p
+        var p = exp(
+            s_smem[unsafe_offset=tid] - new_max
+        ) if j < limit else Float32(0.0)
+        s_smem[unsafe_offset=tid] = p
         var tile_sum = block.sum[block_size=THREADS](p)
         barrier()
 
@@ -362,12 +369,14 @@ def _flash_attention_fwd_baseline[
                 var jj = kv_start + t
                 if jj < limit:
                     partial += (
-                        s_smem[t]
-                        * value[v_base + jj * v_st.seq + dd].cast[
+                        s_smem[unsafe_offset=t]
+                        * value[unsafe_offset=v_base + jj * v_st.seq + dd].cast[
                             DType.float32
                         ]()
                     )
-            acc_smem[dd] = acc_smem[dd] * correction + partial
+            acc_smem[unsafe_offset=dd] = (
+                acc_smem[unsafe_offset=dd] * correction + partial
+            )
             dd += THREADS
         barrier()
         kv_start += BK
@@ -380,10 +389,12 @@ def _flash_attention_fwd_baseline[
         var l = Float32(0.0)
         if running_sum > 0.0 and running_max > RAW_FLOOR:
             l = running_max + log(running_sum)
-        lse[bh * seq_q + qi] = l
+        lse[unsafe_offset=bh * seq_q + qi] = l
     var do = tid
     while do < head_dim:
-        output[o_row + do] = (acc_smem[do] * inv).cast[dtype]()
+        output[unsafe_offset=o_row + do] = (
+            acc_smem[unsafe_offset=do] * inv
+        ).cast[dtype]()
         do += THREADS
 
 
@@ -392,7 +403,7 @@ def _flash_attention_fwd_baseline[
 # accumulator to scratch. 256 threads is four wave64, one per SIMD.
 @__llvm_metadata(
     MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(THREADS)),
-    `rocdl.waves_per_eu`=SIMDSize(WAVES_PER_EU),
+    `rocdl.waves_per_eu`=SIMDLength(WAVES_PER_EU),
 )
 @__name(t"fa_mfma_{dtype}_h{HD}_n{BN}_q{QT}_x{EXACT}_d{DENSE}")
 def _fa_mfma[
@@ -406,11 +417,11 @@ def _fa_mfma[
     IGLP: Int,
     PEEL: Bool,
 ](
-    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    lse: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    query: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    key: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    value: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    output: Pointer[Scalar[dtype], MutAnyOrigin],
+    lse: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    query: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    key: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    value: Pointer[Scalar[dtype], ImmutAnyOrigin],
     q_st: RowStrides,
     k_st: RowStrides,
     v_st: RowStrides,
@@ -474,7 +485,7 @@ def _fa_mfma[
             LDS_ELEMS, dtype, address_space=AddressSpace.SHARED, alignment=16
         ]()
         var k_smem = smem
-        var v_smem = smem + BN * KPAD
+        var v_smem = smem.unsafe_offset(BN * KPAD)
 
         var tid = Int(thread_idx.x)
         var wave = tid // 64
@@ -543,30 +554,30 @@ def _fa_mfma[
                 var v = SIMD[dtype, 4](0)
                 comptime if EXACT:
                     if live:
-                        v = query.load[width=4](qrow + 8 * s)
+                        v = query.unsafe_load[width=4](qrow + 8 * s)
                 else:
                     if live and 8 * s + 4 * hi < head_dim:
-                        v = query.load[width=4](qrow + 8 * s)
-                q_frag.store((qt * KSTEPS + s) * 4, v)
+                        v = query.unsafe_load[width=4](qrow + 8 * s)
+                q_frag.unsafe_store((qt * KSTEPS + s) * 4, v)
 
         # ---- Online-softmax state: one scalar per lane per query tile.
         var run_m = stack_allocation[QT, DType.float32]()
         var run_s = stack_allocation[QT, DType.float32]()
         var qlim = stack_allocation[QT, DType.int32]()
         comptime for qt in range(QT):
-            run_m[qt] = Float32.MIN_FINITE
-            run_s[qt] = 0.0
+            run_m[unsafe_offset=qt] = Float32.MIN_FINITE
+            run_s[unsafe_offset=qt] = 0.0
             var qg = q_row0 + qt * 32 + lo
             var lm = seq_kv
             if causal != 0:
                 lm = min(seq_kv, qg + delta + 1)
-            qlim[qt] = Int32(lm)
+            qlim[unsafe_offset=qt] = Int32(lm)
 
         var s_acc = stack_allocation[KVT * QT * 16, DType.float32]()
         var p_frag = stack_allocation[KVT * QT * 16, dtype]()
         var o_acc = stack_allocation[DT * QT * 16, DType.float32]()
         comptime for i in range(DT * QT):
-            o_acc.store(i * 16, SIMD[DType.float32, 16](0))
+            o_acc.unsafe_store(i * 16, SIMD[DType.float32, 16](0))
 
         var sl = scale * LOG2E
 
@@ -582,8 +593,8 @@ def _fa_mfma[
         var k_col = (tid % (HD // 8)) * 8
         var v_col = tid % HD
         var v_kvg0 = tid // HD
-        var k_ptr = key + (k_base + k_row0 * kss + k_col)
-        var v_ptr = value + (v_base + v_kvg0 * 4 * vss + v_col)
+        var k_ptr = key.unsafe_offset(k_base + k_row0 * kss + k_col)
+        var v_ptr = value.unsafe_offset(v_base + v_kvg0 * 4 * vss + v_col)
         var k_tile_step = BN * kss
         var v_tile_step = BN * vss
         var k_lds0 = k_row0 * KPAD + k_col
@@ -613,11 +624,13 @@ def _fa_mfma[
                 comptime for ci in range(KITERS):
                     var vals = SIMD[dtype, 8](0)
                     comptime if EXACT:
-                        vals = k_ptr.load[width=8](ci * KROW_STEP * kss)
+                        vals = k_ptr.unsafe_load[width=8](ci * KROW_STEP * kss)
                     else:
                         if k_col < head_dim:
-                            vals = k_ptr.load[width=8](ci * KROW_STEP * kss)
-                    k_smem.store(k_lds0 + ci * KROW_STEP * KPAD, vals)
+                            vals = k_ptr.unsafe_load[width=8](
+                                ci * KROW_STEP * kss
+                            )
+                    k_smem.unsafe_store(k_lds0 + ci * KROW_STEP * KPAD, vals)
                 comptime for vi in range(VITERS):
                     var vv = SIMD[dtype, 4](0)
                     var live = True
@@ -625,53 +638,61 @@ def _fa_mfma[
                         live = v_col < head_dim
                     if live:
                         comptime for j in range(4):
-                            vv[j] = v_ptr[(vi * VKV_STEP * 4 + j) * vss]
-                    v_smem.store(v_lds0 + vi * VKV_STEP * 4, vv)
+                            vv[j] = v_ptr[
+                                unsafe_offset=(vi * VKV_STEP * 4 + j) * vss
+                            ]
+                    v_smem.unsafe_store(v_lds0 + vi * VKV_STEP * 4, vv)
             else:
                 comptime for ci in range(KITERS):
                     var row = min(kv0 + k_row0 + ci * KROW_STEP, last_row)
                     var vals = SIMD[dtype, 8](0)
                     if EXACT or k_col < head_dim:
-                        vals = key.load[width=8](k_base + row * kss + k_col)
-                    k_smem.store(k_lds0 + ci * KROW_STEP * KPAD, vals)
+                        vals = key.unsafe_load[width=8](
+                            k_base + row * kss + k_col
+                        )
+                    k_smem.unsafe_store(k_lds0 + ci * KROW_STEP * KPAD, vals)
                 comptime for vi in range(VITERS):
                     var vv = SIMD[dtype, 4](0)
                     if EXACT or v_col < head_dim:
                         var g = kv0 + (v_kvg0 + vi * VKV_STEP) * 4
                         comptime for j in range(4):
                             vv[j] = value[
-                                v_base + min(g + j, last_row) * vss + v_col
+                                unsafe_offset=v_base
+                                + min(g + j, last_row) * vss
+                                + v_col
                             ]
-                    v_smem.store(v_lds0 + vi * VKV_STEP * 4, vv)
+                    v_smem.unsafe_store(v_lds0 + vi * VKV_STEP * 4, vv)
 
-            k_ptr += k_tile_step
-            v_ptr += v_tile_step
+            k_ptr = k_ptr.unsafe_offset(k_tile_step)
+            v_ptr = v_ptr.unsafe_offset(v_tile_step)
             barrier()
 
             llvm_intrinsic["llvm.amdgcn.iglp.opt", NoneType](Int32(IGLP))
             # ---- GEMM 1: S^T[kv, q] = sum_d K[kv, d] * Q[q, d] ----
             comptime for i in range(KVT * QT):
-                s_acc.store(i * 16, SIMD[DType.float32, 16](0))
+                s_acc.unsafe_store(i * 16, SIMD[DType.float32, 16](0))
             var kbase = lo * KPAD + 4 * hi
             comptime for s in range(KSTEPS):
                 var afrag = stack_allocation[KVT * 4, dtype]()
                 comptime for kt in range(KVT):
-                    afrag.store(
+                    afrag.unsafe_store(
                         kt * 4,
-                        k_smem.load[width=4](kbase + kt * 32 * KPAD + 8 * s),
+                        k_smem.unsafe_load[width=4](
+                            kbase + kt * 32 * KPAD + 8 * s
+                        ),
                     )
                 comptime for qt in range(QT):
-                    var b = q_frag.load[width=4]((qt * KSTEPS + s) * 4)
+                    var b = q_frag.unsafe_load[width=4]((qt * KSTEPS + s) * 4)
                     comptime for kt in range(KVT):
-                        var d = s_acc.load[width=16]((kt * QT + qt) * 16)
-                        mma(d, afrag.load[width=4](kt * 4), b, d)
-                        s_acc.store((kt * QT + qt) * 16, d)
+                        var d = s_acc.unsafe_load[width=16]((kt * QT + qt) * 16)
+                        mma(d, afrag.unsafe_load[width=4](kt * 4), b, d)
+                        s_acc.unsafe_store((kt * QT + qt) * 16, d)
 
             # ---- Online softmax, entirely within a lane plus one exchange ----
             comptime for qt in range(QT):
                 var tmax = Float32.MIN_FINITE
                 comptime for kt in range(KVT):
-                    var v16 = s_acc.load[width=16]((kt * QT + qt) * 16)
+                    var v16 = s_acc.unsafe_load[width=16]((kt * QT + qt) * 16)
                     comptime if MASKED:
                         # `kv` of element p is `kv0 + 32*kt + 4*hi + ACC_ROWS[p]`
                         # and the causal bound is one scalar per lane, so the
@@ -680,50 +701,54 @@ def _fa_mfma[
                             SIMD[DType.int32, 16](kv0 + kt * 32 + 4 * hi)
                             + ACC_ROWS
                         )
-                        v16 = kvv.lt(SIMD[DType.int32, 16](qlim[qt])).select(
-                            v16, NEG_BIG
-                        )
-                    s_acc.store((kt * QT + qt) * 16, v16)
+                        v16 = kvv.lt(
+                            SIMD[DType.int32, 16](qlim[unsafe_offset=qt])
+                        ).select(v16, NEG_BIG)
+                    s_acc.unsafe_store((kt * QT + qt) * 16, v16)
                     tmax = max(tmax, v16.reduce_max())
                 # Lanes L and L^32 hold the same query column.
                 tmax = max(tmax, shuffle_xor(tmax, 32))
-                var nm = max(max(run_m[qt], tmax), RAW_FLOOR)
-                var corr = exp2((run_m[qt] - nm) * sl)
-                run_m[qt] = nm
+                var nm = max(max(run_m[unsafe_offset=qt], tmax), RAW_FLOOR)
+                var corr = exp2((run_m[unsafe_offset=qt] - nm) * sl)
+                run_m[unsafe_offset=qt] = nm
                 var negm = -nm * sl
 
                 var psum = Float32(0)
                 comptime for kt in range(KVT):
                     var pv = exp2(
-                        s_acc.load[width=16]((kt * QT + qt) * 16).fma(
+                        s_acc.unsafe_load[width=16]((kt * QT + qt) * 16).fma(
                             SIMD[DType.float32, 16](sl),
                             SIMD[DType.float32, 16](negm),
                         )
                     )
-                    p_frag.store((kt * QT + qt) * 16, _pack_half[dtype, 16](pv))
+                    p_frag.unsafe_store(
+                        (kt * QT + qt) * 16, _pack_half[dtype, 16](pv)
+                    )
                     psum += pv.reduce_add()
-                run_s[qt] = run_s[qt] * corr + psum
+                run_s[unsafe_offset=qt] = run_s[unsafe_offset=qt] * corr + psum
                 comptime for dt in range(DT):
-                    var acc = o_acc.load[width=16]((dt * QT + qt) * 16)
-                    o_acc.store((dt * QT + qt) * 16, acc * corr)
+                    var acc = o_acc.unsafe_load[width=16]((dt * QT + qt) * 16)
+                    o_acc.unsafe_store((dt * QT + qt) * 16, acc * corr)
 
             # ---- GEMM 2: O^T[d, q] += sum_kv V^T[d, kv] * P^T[kv, q] ----
             var vbase = lo * VPAD + 4 * hi
             comptime for ks in range(PKS):
                 var vfrag = stack_allocation[DT * 4, dtype]()
                 comptime for dt in range(DT):
-                    vfrag.store(
+                    vfrag.unsafe_store(
                         dt * 4,
-                        v_smem.load[width=4](vbase + dt * 32 * VPAD + 8 * ks),
+                        v_smem.unsafe_load[width=4](
+                            vbase + dt * 32 * VPAD + 8 * ks
+                        ),
                     )
                 comptime for qt in range(QT):
-                    var b = p_frag.load[width=4](
+                    var b = p_frag.unsafe_load[width=4](
                         ((ks // 4) * QT + qt) * 16 + (ks % 4) * 4
                     )
                     comptime for dt in range(DT):
-                        var d = o_acc.load[width=16]((dt * QT + qt) * 16)
-                        mma(d, vfrag.load[width=4](dt * 4), b, d)
-                        o_acc.store((dt * QT + qt) * 16, d)
+                        var d = o_acc.unsafe_load[width=16]((dt * QT + qt) * 16)
+                        mma(d, vfrag.unsafe_load[width=4](dt * 4), b, d)
+                        o_acc.unsafe_store((dt * QT + qt) * 16, d)
 
             barrier()
 
@@ -741,11 +766,13 @@ def _fa_mfma[
         # time and read back in row-major order for coalesced global stores.
         var inv = stack_allocation[QT, DType.float32]()
         comptime for qt in range(QT):
-            var tot = run_s[qt] + shuffle_xor(run_s[qt], 32)
+            var tot = run_s[unsafe_offset=qt] + shuffle_xor(
+                run_s[unsafe_offset=qt], 32
+            )
             var r = Float32(0)
-            if tot > 0.0 and run_m[qt] > RAW_FLOOR:
+            if tot > 0.0 and run_m[unsafe_offset=qt] > RAW_FLOOR:
                 r = 1.0 / tot
-            inv[qt] = r
+            inv[unsafe_offset=qt] = r
             # `run_m` is the max of the RAW dot product and the exponent used is
             # `(s_raw - run_m) * scale`, so the natural-log row log-sum-exp is
             # `run_m * scale + ln(tot)`. Lanes L and L^32 hold the same query
@@ -754,9 +781,9 @@ def _fa_mfma[
             var qg_l = q_block + wave * (32 * QT) + qt * 32 + lo
             if hi == 0 and qg_l < seq_q:
                 var l = Float32(0.0)
-                if tot > 0.0 and run_m[qt] > RAW_FLOOR:
-                    l = run_m[qt] * scale + log(tot)
-                lse[bh * seq_q + qg_l] = l
+                if tot > 0.0 and run_m[unsafe_offset=qt] > RAW_FLOOR:
+                    l = run_m[unsafe_offset=qt] * scale + log(tot)
+                lse[unsafe_offset=bh * seq_q + qg_l] = l
 
         # STRIDE FIRST, INDEX SECOND. That reads naturally, and on this target
         # it is also LOAD-BEARING -- see the note at the top of this file on the
@@ -771,10 +798,13 @@ def _fa_mfma[
             barrier()
             comptime for qt in range(QT):
                 var row = wave * (32 * QT) + qt * 32 + lo
-                var acc = o_acc.load[width=16]((dt * QT + qt) * 16) * inv[qt]
+                var acc = (
+                    o_acc.unsafe_load[width=16]((dt * QT + qt) * 16)
+                    * inv[unsafe_offset=qt]
+                )
                 var ob = _pack_half[dtype, 16](acc)
                 comptime for g in range(4):
-                    smem.store(
+                    smem.unsafe_store(
                         row * OPAD + 8 * g + 4 * hi,
                         ob.slice[4, offset=g * 4](),
                     )
@@ -788,9 +818,9 @@ def _fa_mfma[
                 comptime if not EXACT:
                     store = store and dcol < head_dim
                 if store:
-                    output.store(
+                    output.unsafe_store(
                         o_base + qg * oss + dcol,
-                        smem.load[width=8](r * OPAD + cc),
+                        smem.unsafe_load[width=8](r * OPAD + cc),
                     )
 
 
@@ -814,11 +844,11 @@ def _enqueue_fa_mfma[
     IGLP: Int = 1,
     PEEL: Bool = True,
 ](
-    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    lse: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    query: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    key: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    value: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    output: Pointer[Scalar[dtype], MutAnyOrigin],
+    lse: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    query: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    key: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    value: Pointer[Scalar[dtype], ImmutAnyOrigin],
     q_st: RowStrides,
     k_st: RowStrides,
     v_st: RowStrides,
@@ -885,11 +915,11 @@ def _enqueue_fa_mfma[
 def enqueue_flash_attention_fwd[
     dtype: DType
 ](
-    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    lse: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    query: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    key: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    value: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    output: Pointer[Scalar[dtype], MutAnyOrigin],
+    lse: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    query: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    key: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    value: Pointer[Scalar[dtype], ImmutAnyOrigin],
     q_st: RowStrides,
     k_st: RowStrides,
     v_st: RowStrides,

--- a/torch_mojo_backend/eager_kernels/flash_attention_ops/flash_attention_ops.mojo
+++ b/torch_mojo_backend/eager_kernels/flash_attention_ops/flash_attention_ops.mojo
@@ -84,13 +84,13 @@ def _flash_attention_forward_go(
                     lse.as_unsafe_any_origin(),
                     _make_ptr[dt](_raw_int(q_obj))
                     .as_unsafe_any_origin()
-                    .as_immutable(),
+                    .as_imm(),
                     _make_ptr[dt](_raw_int(k_obj))
                     .as_unsafe_any_origin()
-                    .as_immutable(),
+                    .as_imm(),
                     _make_ptr[dt](_raw_int(v_obj))
                     .as_unsafe_any_origin()
-                    .as_immutable(),
+                    .as_imm(),
                     q_st,
                     k_st,
                     v_st,
@@ -181,20 +181,20 @@ def _flash_attention_backward_go(
                     dv.as_unsafe_any_origin(),
                     _make_ptr[dt](_raw_int(grad_obj))
                     .as_unsafe_any_origin()
-                    .as_immutable(),
+                    .as_imm(),
                     _make_ptr[dt](_raw_int(q_obj))
                     .as_unsafe_any_origin()
-                    .as_immutable(),
+                    .as_imm(),
                     _make_ptr[dt](_raw_int(k_obj))
                     .as_unsafe_any_origin()
-                    .as_immutable(),
+                    .as_imm(),
                     _make_ptr[dt](_raw_int(v_obj))
                     .as_unsafe_any_origin()
-                    .as_immutable(),
+                    .as_imm(),
                     _make_ptr[dt](_raw_int(out_obj))
                     .as_unsafe_any_origin()
-                    .as_immutable(),
-                    lse.as_unsafe_any_origin().as_immutable(),
+                    .as_imm(),
+                    lse.as_unsafe_any_origin().as_imm(),
                     g_st,
                     q_st,
                     k_st,

--- a/torch_mojo_backend/eager_kernels/foreach_batched_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/foreach_batched_kernels.mojo
@@ -130,7 +130,6 @@ def _few_addrs[op: Int]() -> Int:
         # Not a fallthrough default: an op with no entry here would otherwise
         # get a plausible-looking arity and mispack its metadata in silence.
         comptime assert False, "no metadata arity for this foreach op"
-        return 0
 
 
 @always_inline
@@ -177,7 +176,6 @@ def _few_label[op: Int]() -> StaticString:
         # A wrong name here would be printed to users by CUPTI/Nsight and would
         # name the wrong algorithm, so this is a build error, not a default.
         comptime assert False, "no kernel-name fragment for this foreach op"
-        return "unknown"
 
 
 @always_inline
@@ -215,7 +213,6 @@ def _few_scalar_family_code[op: Int]() -> Int:
         return FES_DIV
     else:
         comptime assert False, "not a foreach scalar-family op"
-        return FES_MUL
 
 
 @always_inline
@@ -227,7 +224,6 @@ def _few_addc_family_code[op: Int]() -> Int:
         return FEA_ADDCDIV
     else:
         comptime assert False, "not a foreach addc-family op"
-        return FEA_ADDCMUL
 
 
 struct ForeachEwDesc(
@@ -279,10 +275,10 @@ def empty_foreach_ew_desc() -> ForeachEwDesc:
 def _few_element[
     dtype: DType, op: Int, width: Int, alignment: Int
 ](
-    a_ptr: UnsafePointer[Scalar[dtype], MutUntrackedOrigin],
-    b_ptr: UnsafePointer[Scalar[dtype], MutUntrackedOrigin],
-    c_ptr: UnsafePointer[Scalar[dtype], MutUntrackedOrigin],
-    out_ptr: UnsafePointer[Scalar[dtype], MutUntrackedOrigin],
+    a_ptr: Pointer[Scalar[dtype], MutUntrackedOrigin],
+    b_ptr: Pointer[Scalar[dtype], MutUntrackedOrigin],
+    c_ptr: Pointer[Scalar[dtype], MutUntrackedOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutUntrackedOrigin],
     index: Int,
     scalar: Float32,
     weight: Float32,
@@ -295,10 +291,10 @@ def _few_element[
     and the scalar peel/tail of `_foreach_ew_kernel` are calls to this, and so
     is nothing else: an op's arithmetic exists once.
     """
-    var a = a_ptr.load[width=width, alignment=alignment](index).cast[
+    var a = a_ptr.unsafe_load[width=width, alignment=alignment](index).cast[
         DType.float32
     ]()
-    var result = a
+    var result: SIMD[DType.float32, width]
     comptime if op == FEW_MUL or op == FEW_MUL_TENSOR:
         result = a * scalar
     elif op == FEW_ADD:
@@ -316,19 +312,19 @@ def _few_element[
         # Metal path in `foreach_elementwise_kernels` blocks that contraction
         # with `_no_fuse`; the volatile round-trip it needs is not worth
         # paying here for one ulp.)
-        var finish = b_ptr.load[width=width, alignment=alignment](index).cast[
-            DType.float32
-        ]()
+        var finish = b_ptr.unsafe_load[width=width, alignment=alignment](
+            index
+        ).cast[DType.float32]()
         var difference = finish - a
         if low_branch == 0:
             result = finish - one_minus_weight * difference
         else:
             result = a + weight * difference
     elif op == FEW_ADDCMUL or op == FEW_ADDCDIV:
-        var b = b_ptr.load[width=width, alignment=alignment](index).cast[
+        var b = b_ptr.unsafe_load[width=width, alignment=alignment](index).cast[
             DType.float32
         ]()
-        var c = c_ptr.load[width=width, alignment=alignment](index).cast[
+        var c = c_ptr.unsafe_load[width=width, alignment=alignment](index).cast[
             DType.float32
         ]()
         comptime if op == FEW_ADDCMUL:
@@ -339,7 +335,9 @@ def _few_element[
         # No default arithmetic: an op with no arm here would otherwise write
         # back its own input, or another op's answer, without a diagnostic.
         comptime assert False, "no element math for this foreach op"
-    out_ptr.store[width=width, alignment=alignment](index, result.cast[dtype]())
+    out_ptr.unsafe_store[width=width, alignment=alignment](
+        index, result.cast[dtype]()
+    )
 
 
 @__name(t"foreach_{_few_label[op]()}_desc_{dtype}_t{FEW_THREADS}")
@@ -377,7 +375,9 @@ def _foreach_ew_kernel[
     comptime if _few_has_scalar[op]():
         scalar = scalars[desc_index]
     comptime if op == FEW_MUL_TENSOR:
-        scalar = _make_ptr[dtype](Int(scalar_addr_arg))[0].cast[DType.float32]()
+        scalar = _make_ptr[dtype](Int(scalar_addr_arg))[unsafe_offset=0].cast[
+            DType.float32
+        ]()
 
     var a_ptr = _make_ptr[dtype](desc.addr0)
     var b_ptr = _make_ptr[dtype](desc.addr1)

--- a/torch_mojo_backend/eager_kernels/foreach_clip_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/foreach_clip_kernels.mojo
@@ -13,7 +13,7 @@ from std.gpu import block_idx, thread_idx
 from max.gpu.host import DeviceContext
 from max.gpu.primitives import block
 from std.math import min
-from std.memory import alloc
+from std.memory.alloc import unsafe_alloc
 from std.sys.info import has_apple_gpu_accelerator
 
 from foreach_clip_contract import (
@@ -38,8 +38,8 @@ comptime _VEC = 4
 
 
 @always_inline
-def _ptr(addr: Int) -> UnsafePointer[Scalar[DType.float32], MutUntrackedOrigin]:
-    return UnsafePointer[Scalar[DType.float32], MutUntrackedOrigin](
+def _ptr(addr: Int) -> Pointer[Scalar[DType.float32], MutUntrackedOrigin]:
+    return Pointer[Scalar[DType.float32], MutUntrackedOrigin](
         unsafe_from_address=addr
     )
 
@@ -78,7 +78,7 @@ def _norm_chunk_partials(
     var index = begin + Int(thread_idx.x) * _VEC
     var stride = FOREACH_THREADS * _VEC
     while index + _VEC <= end:
-        var value = values.load[width=_VEC, alignment=4](index)
+        var value = values.unsafe_load[width=_VEC, alignment=4](index)
         accum = value.fma(value, accum)
         index += stride
 
@@ -87,7 +87,7 @@ def _norm_chunk_partials(
     # of a tensor can need this scalar tail.
     index = begin + ((end - begin) // _VEC) * _VEC + Int(thread_idx.x)
     while index < end:
-        var value = values[index]
+        var value = values[unsafe_offset=index]
         scalar_accum += value * value
         index += FOREACH_THREADS
 
@@ -95,7 +95,7 @@ def _norm_chunk_partials(
         scalar_accum
     )
     if thread_idx.x == 0:
-        _ptr(partials_addr)[chunk] = total
+        _ptr(partials_addr)[unsafe_offset=chunk] = total
 
 
 @__name("foreach_l2_norm_f32_finalize_v1")
@@ -119,10 +119,10 @@ def _norm_finalize(
     for chunk in range(
         begin + Int(thread_idx.x), desc.chunk_end, FOREACH_THREADS
     ):
-        accum += _ptr(partials_addr)[chunk]
+        accum += _ptr(partials_addr)[unsafe_offset=chunk]
     var total = block.sum[block_size=FOREACH_THREADS, broadcast=False](accum)
     if thread_idx.x == 0:
-        _ptr(desc.output_addr)[0] = ieee_sqrt(total)
+        _ptr(desc.output_addr)[unsafe_offset=0] = ieee_sqrt(total)
 
 
 # ---------------------------------------------------------------------------
@@ -137,8 +137,8 @@ def _norm_finalize(
 # bitwise identical to the former per-tensor-launch variants.
 # ---------------------------------------------------------------------------
 
-comptime _ImmutPtr = UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin]
-comptime _MutPtr = UnsafePointer[Scalar[DType.float32], MutAnyOrigin]
+comptime _ImmutPtr = Pointer[Scalar[DType.float32], ImmutAnyOrigin]
+comptime _MutPtr = Pointer[Scalar[DType.float32], MutAnyOrigin]
 
 
 def _norm_partials_batched_apple(
@@ -162,7 +162,7 @@ def _norm_partials_batched_apple(
     var index = begin + Int(thread_idx.x) * _VEC
     var stride = FOREACH_THREADS * _VEC
     while index + _VEC <= end:
-        var value = values.load[width=_VEC, alignment=4](index)
+        var value = values.unsafe_load[width=_VEC, alignment=4](index)
         accum = value.fma(value, accum)
         index += stride
 
@@ -171,7 +171,7 @@ def _norm_partials_batched_apple(
     # tensor can need this scalar tail.
     index = begin + ((end - begin) // _VEC) * _VEC + Int(thread_idx.x)
     while index < end:
-        var value = values[index]
+        var value = values[unsafe_offset=index]
         scalar_accum += value * value
         index += FOREACH_THREADS
 
@@ -179,7 +179,7 @@ def _norm_partials_batched_apple(
         scalar_accum
     )
     if thread_idx.x == 0:
-        partials_ptr[Int(block_idx.x)] = total
+        partials_ptr[unsafe_offset=Int(block_idx.x)] = total
 
 
 def _norm_finalize_batched_apple(
@@ -208,11 +208,11 @@ def _norm_finalize_batched_apple(
     for chunk in range(
         first_chunk + Int(thread_idx.x), Int(chunk_ends[slot]), FOREACH_THREADS
     ):
-        accum += partials_ptr[chunk]
+        accum += partials_ptr[unsafe_offset=chunk]
     var total = block.sum[block_size=FOREACH_THREADS, broadcast=False](accum)
     if thread_idx.x == 0:
         var out_ptr = _pick_mut(slot, o0, o1, o2, o3, o4, o5, o6, o7)
-        out_ptr[0] = ieee_sqrt(total)
+        out_ptr[unsafe_offset=0] = ieee_sqrt(total)
 
 
 def _enqueue_norm_partials_cached(
@@ -224,8 +224,9 @@ def _enqueue_norm_partials_cached(
 ) raises:
     var cache_name = String(t"FOREACH_NORM_PARTIALS_F32_V1_{ctx.id()}")
     comptime FuncT = type_of(ctx.compile_function[_norm_chunk_partials]())
-    if global_ptr := _get_global_or_null(cache_name):
-        var cached = global_ptr.value().bitcast[FuncT]()
+    var global_ptr = _get_global_or_null(cache_name)
+    if global_ptr:
+        var cached = global_ptr.value().unsafe_bitcast[FuncT]()
         ctx.enqueue_function(
             cached[],
             descs,
@@ -236,10 +237,10 @@ def _enqueue_norm_partials_cached(
         )
         return
     var compiled = ctx.compile_function[_norm_chunk_partials]()
-    var cached = alloc[FuncT](1)
-    cached.init_pointee_move(compiled^)
+    var cached = unsafe_alloc[FuncT](1)
+    cached.unsafe_write(compiled^)
     external_call["KGEN_CompilerRT_InsertGlobal", NoneType](
-        StringSlice(cache_name), cached.bitcast[NoneType]()
+        StringSlice(cache_name), cached.unsafe_bitcast[NoneType]()
     )
     ctx.enqueue_function(
         cached[],
@@ -259,8 +260,9 @@ def _enqueue_norm_finalize_cached(
 ) raises:
     var cache_name = String(t"FOREACH_NORM_FINALIZE_F32_V1_{ctx.id()}")
     comptime FuncT = type_of(ctx.compile_function[_norm_finalize]())
-    if global_ptr := _get_global_or_null(cache_name):
-        var cached = global_ptr.value().bitcast[FuncT]()
+    var global_ptr = _get_global_or_null(cache_name)
+    if global_ptr:
+        var cached = global_ptr.value().unsafe_bitcast[FuncT]()
         ctx.enqueue_function(
             cached[],
             descs,
@@ -271,10 +273,10 @@ def _enqueue_norm_finalize_cached(
         )
         return
     var compiled = ctx.compile_function[_norm_finalize]()
-    var cached = alloc[FuncT](1)
-    cached.init_pointee_move(compiled^)
+    var cached = unsafe_alloc[FuncT](1)
+    cached.unsafe_write(compiled^)
     external_call["KGEN_CompilerRT_InsertGlobal", NoneType](
-        StringSlice(cache_name), cached.bitcast[NoneType]()
+        StringSlice(cache_name), cached.unsafe_bitcast[NoneType]()
     )
     ctx.enqueue_function(
         cached[],
@@ -339,14 +341,14 @@ def enqueue_foreach_l2_norm_f32(
                     1,
                     FOREACH_THREADS,
                     partials,
-                    _ptr(in_addrs[0]).as_unsafe_any_origin().as_immutable(),
-                    _ptr(in_addrs[1]).as_unsafe_any_origin().as_immutable(),
-                    _ptr(in_addrs[2]).as_unsafe_any_origin().as_immutable(),
-                    _ptr(in_addrs[3]).as_unsafe_any_origin().as_immutable(),
-                    _ptr(in_addrs[4]).as_unsafe_any_origin().as_immutable(),
-                    _ptr(in_addrs[5]).as_unsafe_any_origin().as_immutable(),
-                    _ptr(in_addrs[6]).as_unsafe_any_origin().as_immutable(),
-                    _ptr(in_addrs[7]).as_unsafe_any_origin().as_immutable(),
+                    _ptr(in_addrs[0]).as_unsafe_any_origin().as_imm(),
+                    _ptr(in_addrs[1]).as_unsafe_any_origin().as_imm(),
+                    _ptr(in_addrs[2]).as_unsafe_any_origin().as_imm(),
+                    _ptr(in_addrs[3]).as_unsafe_any_origin().as_imm(),
+                    _ptr(in_addrs[4]).as_unsafe_any_origin().as_imm(),
+                    _ptr(in_addrs[5]).as_unsafe_any_origin().as_imm(),
+                    _ptr(in_addrs[6]).as_unsafe_any_origin().as_imm(),
+                    _ptr(in_addrs[7]).as_unsafe_any_origin().as_imm(),
                     _slot_ints(chunk_ends),
                     _slot_ints(numels),
                 )
@@ -365,7 +367,7 @@ def enqueue_foreach_l2_norm_f32(
                 _ptr(out_addrs[5]).as_unsafe_any_origin(),
                 _ptr(out_addrs[6]).as_unsafe_any_origin(),
                 _ptr(out_addrs[7]).as_unsafe_any_origin(),
-                partials.as_immutable(),
+                partials.as_imm(),
                 _slot_ints(chunk_ends),
                 Int64(used_slots),
             )

--- a/torch_mojo_backend/eager_kernels/foreach_elementwise_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/foreach_elementwise_kernels.mojo
@@ -43,8 +43,8 @@ comptime FES_DIV = 2
 comptime FEA_ADDCMUL = 0
 comptime FEA_ADDCDIV = 1
 
-comptime _MutPtr = UnsafePointer[Scalar[DType.float32], MutAnyOrigin]
-comptime _ImmutPtr = UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin]
+comptime _MutPtr = Pointer[Scalar[DType.float32], MutAnyOrigin]
+comptime _ImmutPtr = Pointer[Scalar[DType.float32], ImmutAnyOrigin]
 
 # Per-slot chunk offsets and lengths as they cross the launch ABI. `Int` is
 # not device-passable (its width differs between host and device, and Metal's
@@ -56,7 +56,7 @@ comptime _SlotInts = InlineArray[Int64, FOREACH_EW_SLOTS]
 
 @always_inline
 def _addr_ptr(addr: Int) -> _MutPtr:
-    return UnsafePointer[Scalar[DType.float32], MutUntrackedOrigin](
+    return Pointer[Scalar[DType.float32], MutUntrackedOrigin](
         unsafe_from_address=addr
     ).as_unsafe_any_origin()
 
@@ -84,9 +84,9 @@ def _no_fuse[
     is spelled as volatile memory traffic instead.)
     """
     var tmp = x
-    var pointer = UnsafePointer(to=tmp).bitcast[Scalar[DType.float32]]()
-    pointer.store[volatile=True](0, x)
-    return pointer.load[width=width, volatile=True](0)
+    var pointer = Pointer(to=tmp).unsafe_bitcast[Scalar[DType.float32]]()
+    pointer.unsafe_store[volatile=True](0, x)
+    return pointer.unsafe_load[width=width, volatile=True](0)
 
 
 @always_inline
@@ -200,28 +200,28 @@ def _foreach_scalar_kernel[
     var index = begin + Int(thread_idx.x) * _VEC
     var stride = FOREACH_EW_THREADS * _VEC
     while index + _VEC <= end:
-        var value = values.load[width=_VEC, alignment=4](index)
+        var value = values.unsafe_load[width=_VEC, alignment=4](index)
         comptime if op_code == FES_MUL:
             value = value * scalar
         comptime if op_code == FES_ADD:
             value = value + scalar
         comptime if op_code == FES_DIV:
             value = value / scalar
-        values.store[width=_VEC, alignment=4](index, value)
+        values.unsafe_store[width=_VEC, alignment=4](index, value)
         index += stride
 
     # The chunk size is divisible by _VEC, so only a tensor's last chunk can
     # need this scalar tail.
     index = begin + ((end - begin) // _VEC) * _VEC + Int(thread_idx.x)
     while index < end:
-        var value = values[index]
+        var value = values[unsafe_offset=index]
         comptime if op_code == FES_MUL:
             value = value * scalar
         comptime if op_code == FES_ADD:
             value = value + scalar
         comptime if op_code == FES_DIV:
             value = value / scalar
-        values[index] = value
+        values[unsafe_offset=index] = value
         index += FOREACH_EW_THREADS
 
 
@@ -243,7 +243,7 @@ def _foreach_mul_tensor_kernel(
     `aten::_foreach_mul_.Tensor`; element math matches the `mul_.Tensor`
     sequential fallback.
     """
-    var scalar = scalar_ptr[0]
+    var scalar = scalar_ptr[unsafe_offset=0]
     var slot, begin = _slot_begin(chunk_ends, Int(block_idx.x))
     var end = min(begin + FOREACH_EW_CHUNK, Int(numels[slot]))
     var values = _pick_mut(slot, p0, p1, p2, p3, p4, p5, p6, p7)
@@ -251,15 +251,15 @@ def _foreach_mul_tensor_kernel(
     var index = begin + Int(thread_idx.x) * _VEC
     var stride = FOREACH_EW_THREADS * _VEC
     while index + _VEC <= end:
-        var value = values.load[width=_VEC, alignment=4](index)
-        values.store[width=_VEC, alignment=4](index, value * scalar)
+        var value = values.unsafe_load[width=_VEC, alignment=4](index)
+        values.unsafe_store[width=_VEC, alignment=4](index, value * scalar)
         index += stride
 
     # The chunk size is divisible by _VEC, so only a tensor's last chunk can
     # need this scalar tail.
     index = begin + ((end - begin) // _VEC) * _VEC + Int(thread_idx.x)
     while index < end:
-        values[index] = values[index] * scalar
+        values[unsafe_offset=index] = values[unsafe_offset=index] * scalar
         index += FOREACH_EW_THREADS
 
 
@@ -303,24 +303,24 @@ def _foreach_lerp_kernel(
     var index = begin + Int(thread_idx.x) * _VEC
     var stride = FOREACH_EW_THREADS * _VEC
     while index + _VEC <= end:
-        var start = self_values.load[width=_VEC, alignment=4](index)
-        var finish = end_values.load[width=_VEC, alignment=4](index)
+        var start = self_values.unsafe_load[width=_VEC, alignment=4](index)
+        var finish = end_values.unsafe_load[width=_VEC, alignment=4](index)
         var difference = finish - start
         var result = start + _no_fuse[_VEC](weight * difference)
         if low_branch == 0:
             result = finish - _no_fuse[_VEC](one_minus_weight * difference)
-        self_values.store[width=_VEC, alignment=4](index, result)
+        self_values.unsafe_store[width=_VEC, alignment=4](index, result)
         index += stride
 
     index = begin + ((end - begin) // _VEC) * _VEC + Int(thread_idx.x)
     while index < end:
-        var start = self_values[index]
-        var finish = end_values[index]
+        var start = self_values[unsafe_offset=index]
+        var finish = end_values[unsafe_offset=index]
         var difference = finish - start
         var result = start + _no_fuse[1](weight * difference)
         if low_branch == 0:
             result = finish - _no_fuse[1](one_minus_weight * difference)
-        self_values[index] = result
+        self_values[unsafe_offset=index] = result
         index += FOREACH_EW_THREADS
 
 
@@ -369,26 +369,26 @@ def _foreach_addc_kernel[
     var index = begin + Int(thread_idx.x) * _VEC
     var stride = FOREACH_EW_THREADS * _VEC
     while index + _VEC <= end:
-        var a = self_values.load[width=_VEC, alignment=4](index)
-        var b = first_values.load[width=_VEC, alignment=4](index)
-        var c = second_values.load[width=_VEC, alignment=4](index)
+        var a = self_values.unsafe_load[width=_VEC, alignment=4](index)
+        var b = first_values.unsafe_load[width=_VEC, alignment=4](index)
+        var c = second_values.unsafe_load[width=_VEC, alignment=4](index)
         comptime if op_code == FEA_ADDCMUL:
             a = a + scalar * (b * c)
         else:
             a = a + scalar * (b / c)
-        self_values.store[width=_VEC, alignment=4](index, a)
+        self_values.unsafe_store[width=_VEC, alignment=4](index, a)
         index += stride
 
     index = begin + ((end - begin) // _VEC) * _VEC + Int(thread_idx.x)
     while index < end:
-        var a = self_values[index]
-        var b = first_values[index]
-        var c = second_values[index]
+        var a = self_values[unsafe_offset=index]
+        var b = first_values[unsafe_offset=index]
+        var c = second_values[unsafe_offset=index]
         comptime if op_code == FEA_ADDCMUL:
             a = a + scalar * (b * c)
         else:
             a = a + scalar * (b / c)
-        self_values[index] = a
+        self_values[unsafe_offset=index] = a
         index += FOREACH_EW_THREADS
 
 
@@ -421,13 +421,17 @@ def _foreach_sqrt_kernel(
     var index = begin + Int(thread_idx.x) * _VEC
     var stride = FOREACH_EW_THREADS * _VEC
     while index + _VEC <= end:
-        var value = in_values.load[width=_VEC, alignment=4](index)
-        out_values.store[width=_VEC, alignment=4](index, ieee_sqrt(value))
+        var value = in_values.unsafe_load[width=_VEC, alignment=4](index)
+        out_values.unsafe_store[width=_VEC, alignment=4](
+            index, ieee_sqrt(value)
+        )
         index += stride
 
     index = begin + ((end - begin) // _VEC) * _VEC + Int(thread_idx.x)
     while index < end:
-        out_values[index] = ieee_sqrt(in_values[index])
+        out_values[unsafe_offset=index] = ieee_sqrt(
+            in_values[unsafe_offset=index]
+        )
         index += FOREACH_EW_THREADS
 
 
@@ -452,7 +456,9 @@ def _gather_scalars_kernel(
     var count = Int(count_arg)
     var i = Int(thread_idx.x)
     if i < count:
-        out_ptr[base + i] = _pick_immut(i, s0, s1, s2, s3, s4, s5, s6, s7)[0]
+        out_ptr[unsafe_offset=base + i] = _pick_immut(
+            i, s0, s1, s2, s3, s4, s5, s6, s7
+        )[unsafe_offset=0]
 
 
 def enqueue_foreach_gather_scalars_f32(
@@ -471,14 +477,14 @@ def enqueue_foreach_gather_scalars_f32(
             1,
             FOREACH_EW_SLOTS,
             _addr_ptr(out_addr),
-            _addr_ptr(in_addrs[0]).as_immutable(),
-            _addr_ptr(in_addrs[1]).as_immutable(),
-            _addr_ptr(in_addrs[2]).as_immutable(),
-            _addr_ptr(in_addrs[3]).as_immutable(),
-            _addr_ptr(in_addrs[4]).as_immutable(),
-            _addr_ptr(in_addrs[5]).as_immutable(),
-            _addr_ptr(in_addrs[6]).as_immutable(),
-            _addr_ptr(in_addrs[7]).as_immutable(),
+            _addr_ptr(in_addrs[0]).as_imm(),
+            _addr_ptr(in_addrs[1]).as_imm(),
+            _addr_ptr(in_addrs[2]).as_imm(),
+            _addr_ptr(in_addrs[3]).as_imm(),
+            _addr_ptr(in_addrs[4]).as_imm(),
+            _addr_ptr(in_addrs[5]).as_imm(),
+            _addr_ptr(in_addrs[6]).as_imm(),
+            _addr_ptr(in_addrs[7]).as_imm(),
             Int64(base),
             Int64(count),
         )
@@ -544,7 +550,7 @@ def enqueue_foreach_mul_tensor_f32(
             _addr_ptr(addrs[5]),
             _addr_ptr(addrs[6]),
             _addr_ptr(addrs[7]),
-            _addr_ptr(scalar_addr).as_immutable(),
+            _addr_ptr(scalar_addr).as_imm(),
             _slot_ints(chunk_ends),
             _slot_ints(numels),
         )
@@ -579,14 +585,14 @@ def enqueue_foreach_lerp_f32(
             _addr_ptr(self_addrs[5]),
             _addr_ptr(self_addrs[6]),
             _addr_ptr(self_addrs[7]),
-            _addr_ptr(end_addrs[0]).as_immutable(),
-            _addr_ptr(end_addrs[1]).as_immutable(),
-            _addr_ptr(end_addrs[2]).as_immutable(),
-            _addr_ptr(end_addrs[3]).as_immutable(),
-            _addr_ptr(end_addrs[4]).as_immutable(),
-            _addr_ptr(end_addrs[5]).as_immutable(),
-            _addr_ptr(end_addrs[6]).as_immutable(),
-            _addr_ptr(end_addrs[7]).as_immutable(),
+            _addr_ptr(end_addrs[0]).as_imm(),
+            _addr_ptr(end_addrs[1]).as_imm(),
+            _addr_ptr(end_addrs[2]).as_imm(),
+            _addr_ptr(end_addrs[3]).as_imm(),
+            _addr_ptr(end_addrs[4]).as_imm(),
+            _addr_ptr(end_addrs[5]).as_imm(),
+            _addr_ptr(end_addrs[6]).as_imm(),
+            _addr_ptr(end_addrs[7]).as_imm(),
             _slot_ints(chunk_ends),
             _slot_ints(numels),
             weight,
@@ -625,22 +631,22 @@ def enqueue_foreach_addc_f32[
             _addr_ptr(self_addrs[5]),
             _addr_ptr(self_addrs[6]),
             _addr_ptr(self_addrs[7]),
-            _addr_ptr(first_addrs[0]).as_immutable(),
-            _addr_ptr(first_addrs[1]).as_immutable(),
-            _addr_ptr(first_addrs[2]).as_immutable(),
-            _addr_ptr(first_addrs[3]).as_immutable(),
-            _addr_ptr(first_addrs[4]).as_immutable(),
-            _addr_ptr(first_addrs[5]).as_immutable(),
-            _addr_ptr(first_addrs[6]).as_immutable(),
-            _addr_ptr(first_addrs[7]).as_immutable(),
-            _addr_ptr(second_addrs[0]).as_immutable(),
-            _addr_ptr(second_addrs[1]).as_immutable(),
-            _addr_ptr(second_addrs[2]).as_immutable(),
-            _addr_ptr(second_addrs[3]).as_immutable(),
-            _addr_ptr(second_addrs[4]).as_immutable(),
-            _addr_ptr(second_addrs[5]).as_immutable(),
-            _addr_ptr(second_addrs[6]).as_immutable(),
-            _addr_ptr(second_addrs[7]).as_immutable(),
+            _addr_ptr(first_addrs[0]).as_imm(),
+            _addr_ptr(first_addrs[1]).as_imm(),
+            _addr_ptr(first_addrs[2]).as_imm(),
+            _addr_ptr(first_addrs[3]).as_imm(),
+            _addr_ptr(first_addrs[4]).as_imm(),
+            _addr_ptr(first_addrs[5]).as_imm(),
+            _addr_ptr(first_addrs[6]).as_imm(),
+            _addr_ptr(first_addrs[7]).as_imm(),
+            _addr_ptr(second_addrs[0]).as_imm(),
+            _addr_ptr(second_addrs[1]).as_imm(),
+            _addr_ptr(second_addrs[2]).as_imm(),
+            _addr_ptr(second_addrs[3]).as_imm(),
+            _addr_ptr(second_addrs[4]).as_imm(),
+            _addr_ptr(second_addrs[5]).as_imm(),
+            _addr_ptr(second_addrs[6]).as_imm(),
+            _addr_ptr(second_addrs[7]).as_imm(),
             _slot_ints(chunk_ends),
             _slot_ints(numels),
             scalars,
@@ -665,14 +671,14 @@ def enqueue_foreach_sqrt_f32(
             1,
             1,
             FOREACH_EW_THREADS,
-            _addr_ptr(in_addrs[0]).as_immutable(),
-            _addr_ptr(in_addrs[1]).as_immutable(),
-            _addr_ptr(in_addrs[2]).as_immutable(),
-            _addr_ptr(in_addrs[3]).as_immutable(),
-            _addr_ptr(in_addrs[4]).as_immutable(),
-            _addr_ptr(in_addrs[5]).as_immutable(),
-            _addr_ptr(in_addrs[6]).as_immutable(),
-            _addr_ptr(in_addrs[7]).as_immutable(),
+            _addr_ptr(in_addrs[0]).as_imm(),
+            _addr_ptr(in_addrs[1]).as_imm(),
+            _addr_ptr(in_addrs[2]).as_imm(),
+            _addr_ptr(in_addrs[3]).as_imm(),
+            _addr_ptr(in_addrs[4]).as_imm(),
+            _addr_ptr(in_addrs[5]).as_imm(),
+            _addr_ptr(in_addrs[6]).as_imm(),
+            _addr_ptr(in_addrs[7]).as_imm(),
             _addr_ptr(out_addrs[0]),
             _addr_ptr(out_addrs[1]),
             _addr_ptr(out_addrs[2]),

--- a/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_bmm_v5_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_bmm_v5_kernels.mojo
@@ -88,9 +88,9 @@ from gemm16_dtype import _GEMM16_DT, _GEMM16_TAG
 
 comptime _B5_DT = _GEMM16_DT
 comptime _B5_F32 = DType.float32
-comptime _B5_PTR = UnsafePointer[Scalar[_B5_DT], MutAnyOrigin]
+comptime _B5_PTR = Pointer[Scalar[_B5_DT], MutAnyOrigin]
 comptime _B5_F32_PTR = UnsafePointer[Scalar[_B5_F32], MutAnyOrigin]
-comptime _B5_SMEM = UnsafePointer[
+comptime _B5_SMEM = Pointer[
     Scalar[_B5_DT], MutAnyOrigin, address_space=AddressSpace.SHARED
 ]
 comptime _B5_BK = 64
@@ -342,8 +342,8 @@ def _b5_bmm_nn_persistent_ws[
                 alignment=1024,
             ]().as_unsafe_any_origin()
             a_smem = smem_base
-            b_smem = smem_base + stages * bm * _B5_BK
-            c_smem = b_smem + stages * bn * _B5_BK
+            b_smem = smem_base.unsafe_offset(stages * bm * _B5_BK)
+            c_smem = b_smem.unsafe_offset(stages * bn * _B5_BK)
         var full_barriers = stack_allocation[
             stages,
             SharedMemBarrier,
@@ -358,8 +358,10 @@ def _b5_bmm_nn_persistent_ws[
         ]()
         if thread_idx.x == 0:
             comptime for stage in range(stages):
-                full_barriers[stage].init()
-                empty_barriers[stage].init(Int32(consumers * cluster_m))
+                full_barriers[unsafe_offset=stage].init()
+                empty_barriers[unsafe_offset=stage].init(
+                    Int32(consumers * cluster_m)
+                )
             a_tma.prefetch_descriptor()
             b_tma.prefetch_descriptor()
             comptime if tma_store:
@@ -392,7 +394,7 @@ def _b5_bmm_nn_persistent_ws[
         # Release every pipeline slot to the producers (cluster-wide).
         if warp_group_idx > 0 and warp_group_thread_idx < cluster_m:
             comptime for stage in range(stages):
-                empty_barriers[stage].arrive_cluster(
+                empty_barriers[unsafe_offset=stage].arrive_cluster(
                     UInt32(warp_group_thread_idx)
                 )
 
@@ -418,18 +420,22 @@ def _b5_bmm_nn_persistent_ws[
                     while t < num_tiles:
                         var stage = gt % stages
                         var phase = UInt32((gt // stages) % 2)
-                        empty_barriers[stage].wait(phase)
-                        full_barriers[stage].expect_bytes(Int32(TMA_BYTES))
+                        empty_barriers[unsafe_offset=stage].wait(phase)
+                        full_barriers[unsafe_offset=stage].expect_bytes(
+                            Int32(TMA_BYTES)
+                        )
                         var a_tile = LayoutTensor[
                             _B5_DT,
                             A_LAYOUT,
                             MutAnyOrigin,
                             address_space=AddressSpace.SHARED,
                             alignment=128,
-                        ](a_smem + stage * bm * _B5_BK)
+                        ](a_smem.unsafe_offset(stage * bm * _B5_BK))
                         var k0 = t * _B5_BK
                         a_tma.async_copy_3d(
-                            a_tile, full_barriers[stage], (k0, m0, ab)
+                            a_tile,
+                            full_barriers[unsafe_offset=stage],
+                            (k0, m0, ab),
                         )
                         # Cooperative B load: each cluster rank reads its
                         # share of the 64-column chunks once from L2 and
@@ -443,18 +449,22 @@ def _b5_bmm_nn_persistent_ws[
                                 MutAnyOrigin,
                                 address_space=AddressSpace.SHARED,
                                 alignment=128,
-                            ](b_smem + stage * bn * _B5_BK + cc * 64 * _B5_BK)
+                            ](
+                                b_smem.unsafe_offset(
+                                    stage * bn * _B5_BK + cc * 64 * _B5_BK
+                                )
+                            )
                             comptime if cluster_m > 1:
                                 b_tma.async_multicast_load_3d(
                                     b_chunk,
-                                    full_barriers[stage],
+                                    full_barriers[unsafe_offset=stage],
                                     (n0 + cc * 64, k0, bb),
                                     MCAST_MASK,
                                 )
                             else:
                                 b_tma.async_copy_3d(
                                     b_chunk,
-                                    full_barriers[stage],
+                                    full_barriers[unsafe_offset=stage],
                                     (n0 + cc * 64, k0, bb),
                                 )
                             cc += 1
@@ -505,21 +515,21 @@ def _b5_bmm_nn_persistent_ws[
                 while t < num_tiles:
                     var stage = gt % stages
                     var phase = UInt32((gt // stages) % 2)
-                    full_barriers[stage].wait(phase)
+                    full_barriers[unsafe_offset=stage].wait(phase)
                     var a_tile = LayoutTensor[
                         _B5_DT,
                         A_LAYOUT,
                         MutAnyOrigin,
                         address_space=AddressSpace.SHARED,
                         alignment=128,
-                    ](a_smem + stage * bm * _B5_BK)
+                    ](a_smem.unsafe_offset(stage * bm * _B5_BK))
                     var b_tile = LayoutTensor[
                         _B5_DT,
                         B_LAYOUT,
                         MutAnyOrigin,
                         address_space=AddressSpace.SHARED,
                         alignment=128,
-                    ](b_smem + stage * bn * _B5_BK)
+                    ](b_smem.unsafe_offset(stage * bn * _B5_BK))
                     warpgroup_fence(accum)
                     wgmma.arrive()
                     wgmma.wgmma[consumers](
@@ -529,7 +539,7 @@ def _b5_bmm_nn_persistent_ws[
                     warpgroup_fence(accum)
                     wgmma.wait_group()
                     if warp_group_thread_idx < cluster_m:
-                        empty_barriers[stage].arrive_cluster(
+                        empty_barriers[unsafe_offset=stage].arrive_cluster(
                             UInt32(warp_group_thread_idx)
                         )
                     t += 1
@@ -556,8 +566,8 @@ def _b5_bmm_nn_persistent_ws[
                         )
                         var col = base_col + (q // 2) * 8
                         var pair = SIMD[_B5_DT, 2](
-                            accum.ptr[e].cast[_B5_DT](),
-                            accum.ptr[e + 1].cast[_B5_DT](),
+                            accum.ptr[unsafe_offset=e].cast[_B5_DT](),
+                            accum.ptr[unsafe_offset=e + 1].cast[_B5_DT](),
                         )
                         # 128B-swizzled staging layout: 16B units within each
                         # 64-element row are XORed with (row % 8).
@@ -568,7 +578,7 @@ def _b5_bmm_nn_persistent_ws[
                             + ((lcol // 8) ^ (row % 8)) * 8
                             + lcol % 8
                         )
-                        c_smem.store[alignment=4](elem, pair)
+                        c_smem.unsafe_store[alignment=4](elem, pair)
                     fence_async_view_proxy()
                     named_barrier[NCONS](1)
                     if warp_group_idx == 1 and warp_group_thread_idx == 0:
@@ -579,7 +589,7 @@ def _b5_bmm_nn_persistent_ws[
                                 MutAnyOrigin,
                                 address_space=AddressSpace.SHARED,
                                 alignment=128,
-                            ](c_smem + chunk * bm * 64)
+                            ](c_smem.unsafe_offset(chunk * bm * 64))
                             c_tma.async_store_3d(
                                 c_chunk, (n0 + chunk * 64, m0, bidx)
                             )
@@ -598,15 +608,21 @@ def _b5_bmm_nn_persistent_ws[
                         if m0 + row < m:
                             var off = bidx * c_bs + (m0 + row) * n + n0 + col
                             if n0 + col + 1 < n:
-                                output.store[alignment=2](
+                                output.unsafe_store[alignment=2](
                                     off,
                                     SIMD[_B5_DT, 2](
-                                        accum.ptr[e].cast[_B5_DT](),
-                                        accum.ptr[e + 1].cast[_B5_DT](),
+                                        accum.ptr[unsafe_offset=e].cast[
+                                            _B5_DT
+                                        ](),
+                                        accum.ptr[unsafe_offset=e + 1].cast[
+                                            _B5_DT
+                                        ](),
                                     ),
                                 )
                             elif n0 + col < n:
-                                output[off] = accum.ptr[e].cast[_B5_DT]()
+                                output[unsafe_offset=off] = accum.ptr[
+                                    unsafe_offset=e
+                                ].cast[_B5_DT]()
                 w += num_clusters
             # Outstanding bulk stores must complete before kernel exit.
             comptime if tma_store:
@@ -618,7 +634,7 @@ def _b5_bmm_nn_persistent_ws[
 
 @always_inline
 def _b5_p(addr: Int) -> _B5_PTR:
-    return UnsafePointer[Scalar[_B5_DT], MutUntrackedOrigin](
+    return Pointer[Scalar[_B5_DT], MutUntrackedOrigin](
         unsafe_from_address=addr
     ).as_unsafe_any_origin()
 
@@ -722,8 +738,8 @@ def _b5_bmm_nn_tiny[
                 alignment=1024,
             ]().as_unsafe_any_origin()
             a_smem = smem_base
-            b_smem = smem_base + stages * bm * _B5_BK
-            c_smem = b_smem + stages * bn * _B5_BK
+            b_smem = smem_base.unsafe_offset(stages * bm * _B5_BK)
+            c_smem = b_smem.unsafe_offset(stages * bn * _B5_BK)
         var full_barriers = stack_allocation[
             stages,
             SharedMemBarrier,
@@ -732,7 +748,7 @@ def _b5_bmm_nn_tiny[
         ]()
         if thread_idx.x == 0:
             comptime for stage in range(stages):
-                full_barriers[stage].init()
+                full_barriers[unsafe_offset=stage].init()
             a_tma.prefetch_descriptor()
             b_tma.prefetch_descriptor()
             comptime if tma_store:
@@ -759,7 +775,7 @@ def _b5_bmm_nn_tiny[
         @always_inline
         def issue_tile(t: Int):
             var stage = t % stages
-            full_barriers[stage].expect_bytes(Int32(TMA_BYTES))
+            full_barriers[unsafe_offset=stage].expect_bytes(Int32(TMA_BYTES))
             var k0 = t * _B5_BK
             var a_tile = LayoutTensor[
                 _B5_DT,
@@ -767,8 +783,10 @@ def _b5_bmm_nn_tiny[
                 MutAnyOrigin,
                 address_space=AddressSpace.SHARED,
                 alignment=128,
-            ](a_smem + stage * bm * _B5_BK)
-            a_tma.async_copy_3d(a_tile, full_barriers[stage], (k0, m0, ab))
+            ](a_smem.unsafe_offset(stage * bm * _B5_BK))
+            a_tma.async_copy_3d(
+                a_tile, full_barriers[unsafe_offset=stage], (k0, m0, ab)
+            )
             comptime for cc in range(B_CHUNKS):
                 var b_chunk = LayoutTensor[
                     _B5_DT,
@@ -776,9 +794,11 @@ def _b5_bmm_nn_tiny[
                     MutAnyOrigin,
                     address_space=AddressSpace.SHARED,
                     alignment=128,
-                ](b_smem + stage * bn * _B5_BK + cc * 64 * _B5_BK)
+                ](b_smem.unsafe_offset(stage * bn * _B5_BK + cc * 64 * _B5_BK))
                 b_tma.async_copy_3d(
-                    b_chunk, full_barriers[stage], (n0 + cc * 64, k0, bb)
+                    b_chunk,
+                    full_barriers[unsafe_offset=stage],
+                    (n0 + cc * 64, k0, bb),
                 )
 
         if thread_idx.x == 0:
@@ -807,21 +827,21 @@ def _b5_bmm_nn_tiny[
         while t < num_tiles:
             var stage = t % stages
             var phase = UInt32((t // stages) % 2)
-            full_barriers[stage].wait(phase)
+            full_barriers[unsafe_offset=stage].wait(phase)
             var a_tile = LayoutTensor[
                 _B5_DT,
                 A_LAYOUT,
                 MutAnyOrigin,
                 address_space=AddressSpace.SHARED,
                 alignment=128,
-            ](a_smem + stage * bm * _B5_BK)
+            ](a_smem.unsafe_offset(stage * bm * _B5_BK))
             var b_tile = LayoutTensor[
                 _B5_DT,
                 B_LAYOUT,
                 MutAnyOrigin,
                 address_space=AddressSpace.SHARED,
                 alignment=128,
-            ](b_smem + stage * bn * _B5_BK)
+            ](b_smem.unsafe_offset(stage * bn * _B5_BK))
             warpgroup_fence(accum)
             wgmma.arrive()
             wgmma.wgmma[1](a_tile, b_tile, accum, 0)
@@ -849,8 +869,8 @@ def _b5_bmm_nn_tiny[
                 var row = base_row + (q % 2) * 8
                 var col = base_col + (q // 2) * 8
                 var pair = SIMD[_B5_DT, 2](
-                    accum.ptr[e].cast[_B5_DT](),
-                    accum.ptr[e + 1].cast[_B5_DT](),
+                    accum.ptr[unsafe_offset=e].cast[_B5_DT](),
+                    accum.ptr[unsafe_offset=e + 1].cast[_B5_DT](),
                 )
                 var lcol = col % 64
                 var elem = (
@@ -859,7 +879,7 @@ def _b5_bmm_nn_tiny[
                     + ((lcol // 8) ^ (row % 8)) * 8
                     + lcol % 8
                 )
-                c_smem.store[alignment=4](elem, pair)
+                c_smem.unsafe_store[alignment=4](elem, pair)
             fence_async_view_proxy()
             barrier()
             if thread_idx.x == 0:
@@ -870,7 +890,7 @@ def _b5_bmm_nn_tiny[
                         MutAnyOrigin,
                         address_space=AddressSpace.SHARED,
                         alignment=128,
-                    ](c_smem + chunk * bm * 64)
+                    ](c_smem.unsafe_offset(chunk * bm * 64))
                     c_tma.async_store_3d(c_chunk, (n0 + chunk * 64, m0, bidx))
                 c_tma.commit_group()
                 c_tma.wait_group[0]()
@@ -882,15 +902,17 @@ def _b5_bmm_nn_tiny[
                 if m0 + row < m:
                     var off = bidx * c_bs + (m0 + row) * n + n0 + col
                     if n0 + col + 1 < n:
-                        output.store[alignment=2](
+                        output.unsafe_store[alignment=2](
                             off,
                             SIMD[_B5_DT, 2](
-                                accum.ptr[e].cast[_B5_DT](),
-                                accum.ptr[e + 1].cast[_B5_DT](),
+                                accum.ptr[unsafe_offset=e].cast[_B5_DT](),
+                                accum.ptr[unsafe_offset=e + 1].cast[_B5_DT](),
                             ),
                         )
                     elif n0 + col < n:
-                        output[off] = accum.ptr[e].cast[_B5_DT]()
+                        output[unsafe_offset=off] = accum.ptr[
+                            unsafe_offset=e
+                        ].cast[_B5_DT]()
 
 
 def _b5_enqueue_tiny[
@@ -919,7 +941,10 @@ def _b5_enqueue_tiny[
     var b_stride = k * b_row_stride if b_bs == 0 else b_bs
     var a_desc = create_tma_descriptor[_B5_DT, 3, _B5_SWIZZLE](
         DeviceBuffer(
-            ctx, a.address_space_cast[AddressSpace.GENERIC](), 1, owning=False
+            ctx,
+            a.unsafe_address_space_cast[AddressSpace.GENERIC](),
+            1,
+            owning=False,
         ),
         IndexList[3](a_items, m, k),
         IndexList[3](a_stride, a_row_stride, 1),
@@ -927,7 +952,10 @@ def _b5_enqueue_tiny[
     )
     var b_desc = create_tma_descriptor[_B5_DT, 3, _B5_SWIZZLE](
         DeviceBuffer(
-            ctx, b.address_space_cast[AddressSpace.GENERIC](), 1, owning=False
+            ctx,
+            b.unsafe_address_space_cast[AddressSpace.GENERIC](),
+            1,
+            owning=False,
         ),
         IndexList[3](b_items, k, n),
         IndexList[3](b_stride, b_row_stride, 1),
@@ -941,7 +969,7 @@ def _b5_enqueue_tiny[
     var c_desc = create_tma_descriptor[_B5_DT, 3, _B5_SWIZZLE](
         DeviceBuffer(
             ctx,
-            output.address_space_cast[AddressSpace.GENERIC](),
+            output.unsafe_address_space_cast[AddressSpace.GENERIC](),
             1,
             owning=False,
         ),
@@ -1015,7 +1043,10 @@ def _b5_enqueue_batched[
     var b_stride = k * b_row_stride if b_bs == 0 else b_bs
     var a_desc = create_tma_descriptor[_B5_DT, 3, _B5_SWIZZLE](
         DeviceBuffer(
-            ctx, a.address_space_cast[AddressSpace.GENERIC](), 1, owning=False
+            ctx,
+            a.unsafe_address_space_cast[AddressSpace.GENERIC](),
+            1,
+            owning=False,
         ),
         IndexList[3](a_items, m, k),
         IndexList[3](a_stride, a_row_stride, 1),
@@ -1023,7 +1054,10 @@ def _b5_enqueue_batched[
     )
     var b_desc = create_tma_descriptor[_B5_DT, 3, _B5_SWIZZLE](
         DeviceBuffer(
-            ctx, b.address_space_cast[AddressSpace.GENERIC](), 1, owning=False
+            ctx,
+            b.unsafe_address_space_cast[AddressSpace.GENERIC](),
+            1,
+            owning=False,
         ),
         IndexList[3](b_items, k, n),
         IndexList[3](b_stride, b_row_stride, 1),
@@ -1039,7 +1073,7 @@ def _b5_enqueue_batched[
     var c_desc = create_tma_descriptor[_B5_DT, 3, _B5_SWIZZLE](
         DeviceBuffer(
             ctx,
-            output.address_space_cast[AddressSpace.GENERIC](),
+            output.unsafe_address_space_cast[AddressSpace.GENERIC](),
             1,
             owning=False,
         ),
@@ -1313,17 +1347,19 @@ def _b5_repack2_kernel(
         # legalizes them (same idiom as the v2 kernels' guarded loads).
         var c = lane * 8
         while c + 8 <= row_len:
-            var v = src.load[width=8, alignment=2](src_base + c)
-            dst.store[alignment=16](dst_base + c, v)
+            var v = src.unsafe_load[width=8, alignment=2](src_base + c)
+            dst.unsafe_store[alignment=16](dst_base + c, v)
             c += 32 * 8
         if c < row_len:
             comptime for e in range(8):
                 if c + e < row_len:
-                    dst[dst_base + c + e] = src[src_base + c + e]
+                    dst[unsafe_offset=dst_base + c + e] = src[
+                        unsafe_offset=src_base + c + e
+                    ]
         r += rstride
 
 
-comptime _B5_UPTR = UnsafePointer[Scalar[_B5_DT], MutUntrackedOrigin]
+comptime _B5_UPTR = Pointer[Scalar[_B5_DT], MutUntrackedOrigin]
 
 
 struct _B5RepackOp(ImplicitlyCopyable):

--- a/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_kernels.mojo
@@ -66,8 +66,8 @@ comptime _THREADS = 256
 comptime _GROUP_M = 8
 comptime _DT = _GEMM16_DT
 comptime _F32 = DType.float32
-comptime _Ptr = UnsafePointer[Scalar[_DT], MutAnyOrigin]
-comptime _F32Ptr = UnsafePointer[Scalar[_F32], MutAnyOrigin]
+comptime _Ptr = Pointer[Scalar[_DT], MutAnyOrigin]
+comptime _F32Ptr = Pointer[Scalar[_F32], MutAnyOrigin]
 comptime _I32_MAX = 2_147_483_647
 comptime _I64_MAX = 9_223_372_036_854_775_807
 
@@ -90,8 +90,7 @@ def _g2r_kc[
     # 16B-store phase land 4 rows (320B = 64 mod 128B) apart: conflict-free.
     # Index math stays in Int32 (dims are < 2^31) so loop-carried values take
     # one register, not a 64-bit pair; flat offsets widen to Int at the use.
-    @parameter
-    for it in range(CH):
+    comptime for it in range(CH):
         var q = tid // 4
         var r = (q * 4) % 64 + q // 16 + Int32(it * 64)
         var kc = (tid % 4) * 8
@@ -99,36 +98,34 @@ def _g2r_kc[
         var gk = k0 + kc
         var v = SIMD[_DT, 8]()
 
-        @parameter
-        if FAST:
+        comptime if FAST:
             # FAST proves 16B base alignment and kdim % 8 == 0 for every
             # batch, so each 8-wide chunk is aligned and entirely in or out
             # of bounds.
             if gr < rows and gk < kdim:
-                v = src.load[width=8, alignment=16](
+                v = src.unsafe_load[width=8, alignment=16](
                     Int(gr) * Int(kdim) + Int(gk)
                 )
         else:
             if fast != 0:
                 # Per-batch proof of the same property.
                 if gr < rows and gk < kdim:
-                    v = src.load[width=8, alignment=16](
+                    v = src.unsafe_load[width=8, alignment=16](
                         Int(gr) * Int(kdim) + Int(gk)
                     )
             else:
                 if gr < rows and gk < kdim:
                     if gk + 8 <= kdim:
                         # Whole chunk in bounds; 2B element alignment only.
-                        v = src.load[width=8, alignment=2](
+                        v = src.unsafe_load[width=8, alignment=2](
                             Int(gr) * Int(kdim) + Int(gk)
                         )
                     else:
                         var flat = Int(gr) * Int(kdim) + Int(gk)
 
-                        @parameter
-                        for e in range(8):
+                        comptime for e in range(8):
                             if gk + Int32(e) < kdim:
-                                v[e] = src[flat + e]
+                                v[e] = src[unsafe_offset=flat + e]
         regs[it] = v
 
 
@@ -155,13 +152,11 @@ def _g2r_mc[
     # quad mapping packs four lanes into each pair of sectors.  Used by the
     # small-tile guarded builds together with the k-major staging stores in
     # store_tile, whose addressing must match this mapping exactly.
-    @parameter
-    for it in range(CH):
+    comptime for it in range(CH):
         var kr: Int32
         var rc: Int32
 
-        @parameter
-        if QUAD:
+        comptime if QUAD:
             kr = (tid // 4) % Int32(_BK)
             rc = (tid % 4) * 8 + (tid // 128) * 32 + Int32(it * 64)
         else:
@@ -172,35 +167,33 @@ def _g2r_mc[
         var gr = row0 + rc
         var v = SIMD[_DT, 8]()
 
-        @parameter
-        if FAST:
+        comptime if FAST:
             # FAST proves 16B base alignment and rows % 8 == 0 for every
             # batch.
             if gk < kdim and gr < rows:
-                v = src.load[width=8, alignment=16](
+                v = src.unsafe_load[width=8, alignment=16](
                     Int(gk) * Int(rows) + Int(gr)
                 )
         else:
             if fast != 0:
                 # Per-batch proof of the same property.
                 if gk < kdim and gr < rows:
-                    v = src.load[width=8, alignment=16](
+                    v = src.unsafe_load[width=8, alignment=16](
                         Int(gk) * Int(rows) + Int(gr)
                     )
             else:
                 if gk < kdim and gr < rows:
                     if gr + 8 <= rows:
                         # Whole chunk in bounds; 2B element alignment only.
-                        v = src.load[width=8, alignment=2](
+                        v = src.unsafe_load[width=8, alignment=2](
                             Int(gk) * Int(rows) + Int(gr)
                         )
                     else:
                         var flat = Int(gk) * Int(rows) + Int(gr)
 
-                        @parameter
-                        for e in range(8):
+                        comptime for e in range(8):
                             if gr + Int32(e) < rows:
-                                v[e] = src[flat + e]
+                                v[e] = src[unsafe_offset=flat + e]
         regs[it] = v
 
 
@@ -325,14 +318,12 @@ def _mma_tile_impl[
     @parameter
     @always_inline
     def load_tile(k0: Int32):
-        @parameter
-        if TA:
+        comptime if TA:
             _g2r_mc[ACH, FASTK, QKMAJ](ap, bm0, mi, k0, ki, tid, af, va)
         else:
             _g2r_kc[ACH, FASTK](ap, bm0, mi, k0, ki, tid, af, va)
 
-        @parameter
-        if TB:
+        comptime if TB:
             _g2r_kc[BCH, FASTK](bp, bn0, ni, k0, ki, tid, bf, vb)
         else:
             _g2r_mc[BCH, FASTK, QKMAJ](bp, bn0, ni, k0, ki, tid, bf, vb)
@@ -343,93 +334,79 @@ def _mma_tile_impl[
         var base_a = Int32(stage * STAGE_A)
         var base_b = Int32(stage * STAGE_B)
 
-        @parameter
-        if TA and FASTK:
-
-            @parameter
-            for it in range(ACH):
+        comptime if TA and FASTK:
+            comptime for it in range(ACH):
                 var item = tid + Int32(it * _THREADS)
                 var kr = item % _BK
                 var rc = (item // _BK) * 8
-                smem_a.store[alignment=16](
+                smem_a.unsafe_store[alignment=16](
                     Int(base_a + kr * Int32(LDA_K) + rc), va[it]
                 )
         elif TA and QKMAJ:
             # Must mirror the QUAD mapping in _g2r_mc.  rc is a multiple of
             # 8 and the pitch is 144B, so every store keeps 16B alignment.
-            @parameter
-            for it in range(ACH):
+            comptime for it in range(ACH):
                 var kr = (tid // 4) % Int32(_BK)
                 var rc = (tid % 4) * 8 + (tid // 128) * 32 + Int32(it * 64)
-                smem_a.store[alignment=16](
+                smem_a.unsafe_store[alignment=16](
                     Int(base_a + kr * Int32(LDA_K) + rc), va[it]
                 )
         elif TA:
-
-            @parameter
-            for it in range(ACH):
+            comptime for it in range(ACH):
                 var item = tid + Int32(it * _THREADS)
                 var kr = item % _BK
                 var rc = (item // _BK) * 8
 
-                @parameter
-                for e in range(8):
+                comptime for e in range(8):
                     smem_a[
-                        Int(base_a + (rc + Int32(e)) * Int32(_LDS) + kr)
+                        unsafe_offset=Int(
+                            base_a + (rc + Int32(e)) * Int32(_LDS) + kr
+                        )
                     ] = va[it][e]
         else:
-
-            @parameter
-            for it in range(ACH):
+            comptime for it in range(ACH):
                 var q = tid // 4
                 var r = (q * 4) % 64 + q // 16 + Int32(it * 64)
                 var kc = (tid % 4) * 8
-                smem_a.store[alignment=16](
+                smem_a.unsafe_store[alignment=16](
                     Int(base_a + r * Int32(_LDS) + kc), va[it]
                 )
 
-        @parameter
-        if TB:
-
-            @parameter
-            for it in range(BCH):
+        comptime if TB:
+            comptime for it in range(BCH):
                 var q = tid // 4
                 var r = (q * 4) % 64 + q // 16 + Int32(it * 64)
                 var kc = (tid % 4) * 8
-                smem_b.store[alignment=16](
+                smem_b.unsafe_store[alignment=16](
                     Int(base_b + r * Int32(_LDS) + kc), vb[it]
                 )
         elif FASTK:
-
-            @parameter
-            for it in range(BCH):
+            comptime for it in range(BCH):
                 var item = tid + Int32(it * _THREADS)
                 var kr = item % _BK
                 var rc = (item // _BK) * 8
-                smem_b.store[alignment=16](
+                smem_b.unsafe_store[alignment=16](
                     Int(base_b + kr * Int32(LDB_K) + rc), vb[it]
                 )
         elif QKMAJ:
             # Must mirror the QUAD mapping in _g2r_mc (see the A branch).
-            @parameter
-            for it in range(BCH):
+            comptime for it in range(BCH):
                 var kr = (tid // 4) % Int32(_BK)
                 var rc = (tid % 4) * 8 + (tid // 128) * 32 + Int32(it * 64)
-                smem_b.store[alignment=16](
+                smem_b.unsafe_store[alignment=16](
                     Int(base_b + kr * Int32(LDB_K) + rc), vb[it]
                 )
         else:
-
-            @parameter
-            for it in range(BCH):
+            comptime for it in range(BCH):
                 var item = tid + Int32(it * _THREADS)
                 var kr = item % _BK
                 var rc = (item // _BK) * 8
 
-                @parameter
-                for e in range(8):
+                comptime for e in range(8):
                     smem_b[
-                        Int(base_b + (rc + Int32(e)) * Int32(_LDS) + kr)
+                        unsafe_offset=Int(
+                            base_b + (rc + Int32(e)) * Int32(_LDS) + kr
+                        )
                     ] = vb[it][e]
 
     @parameter
@@ -438,68 +415,62 @@ def _mma_tile_impl[
         var base_a = Int32(stage * STAGE_A)
         var base_b = Int32(stage * STAGE_B)
 
-        @parameter
-        for ks in range(2):
+        comptime for ks in range(2):
             var kb = Int32(ks * 16) + 2 * tg
             var afr = InlineArray[SIMD[_DT, 8], 2](fill=SIMD[_DT, 8]())
 
-            @parameter
-            for mt in range(2):
+            comptime for mt in range(2):
                 var row = wm + Int32(mt * 16) + g
 
-                @parameter
-                if TA and (FASTK or QKMAJ):
+                comptime if TA and (FASTK or QKMAJ):
                     var c0 = Int(base_a + kb * Int32(LDA_K) + row)
                     afr[mt] = SIMD[_DT, 8](
-                        smem_a[c0],
-                        smem_a[c0 + LDA_K],
-                        smem_a[c0 + 8],
-                        smem_a[c0 + LDA_K + 8],
-                        smem_a[c0 + 8 * LDA_K],
-                        smem_a[c0 + 9 * LDA_K],
-                        smem_a[c0 + 8 * LDA_K + 8],
-                        smem_a[c0 + 9 * LDA_K + 8],
+                        smem_a[unsafe_offset=c0],
+                        smem_a[unsafe_offset=c0 + LDA_K],
+                        smem_a[unsafe_offset=c0 + 8],
+                        smem_a[unsafe_offset=c0 + LDA_K + 8],
+                        smem_a[unsafe_offset=c0 + 8 * LDA_K],
+                        smem_a[unsafe_offset=c0 + 9 * LDA_K],
+                        smem_a[unsafe_offset=c0 + 8 * LDA_K + 8],
+                        smem_a[unsafe_offset=c0 + 9 * LDA_K + 8],
                     )
                 else:
-                    var a01 = smem_a.load[width=2, alignment=4](
+                    var a01 = smem_a.unsafe_load[width=2, alignment=4](
                         Int(base_a + row * Int32(_LDS) + kb)
                     )
-                    var a23 = smem_a.load[width=2, alignment=4](
+                    var a23 = smem_a.unsafe_load[width=2, alignment=4](
                         Int(base_a + (row + 8) * Int32(_LDS) + kb)
                     )
-                    var a45 = smem_a.load[width=2, alignment=4](
+                    var a45 = smem_a.unsafe_load[width=2, alignment=4](
                         Int(base_a + row * Int32(_LDS) + kb + 8)
                     )
-                    var a67 = smem_a.load[width=2, alignment=4](
+                    var a67 = smem_a.unsafe_load[width=2, alignment=4](
                         Int(base_a + (row + 8) * Int32(_LDS) + kb + 8)
                     )
                     afr[mt] = a01.join(a23).join(a45.join(a67))
 
-            @parameter
-            for nt in range(NT):
+            comptime for nt in range(NT):
                 var nr = wn + Int32(nt * 8) + g
-                var bfr = SIMD[_DT, 4]()
+                var bfr: SIMD[_DT, 4]
 
-                @parameter
-                if TB or not (FASTK or QKMAJ):
-                    var b01 = smem_b.load[width=2, alignment=4](
+                comptime if TB or not (FASTK or QKMAJ):
+                    var b01 = smem_b.unsafe_load[width=2, alignment=4](
                         Int(base_b + nr * Int32(_LDS) + kb)
                     )
-                    var b23 = smem_b.load[width=2, alignment=4](
+                    var b23 = smem_b.unsafe_load[width=2, alignment=4](
                         Int(base_b + nr * Int32(_LDS) + kb + 8)
                     )
                     bfr = b01.join(b23)
                 else:
                     var d0 = Int(base_b + kb * Int32(LDB_K) + nr)
                     bfr = SIMD[_DT, 4](
-                        smem_b[d0],
-                        smem_b[d0 + LDB_K],
-                        smem_b[d0 + 8 * LDB_K],
-                        smem_b[d0 + 9 * LDB_K],
+                        smem_b[unsafe_offset=d0],
+                        smem_b[unsafe_offset=d0 + LDB_K],
+                        smem_b[unsafe_offset=d0 + 8 * LDB_K],
+                        smem_b[unsafe_offset=d0 + 9 * LDB_K],
                     )
 
-                @parameter
-                for mt in range(2):
+                comptime for mt in range(2):
                     mma(acc[mt * NT + nt], afr[mt], bfr, acc[mt * NT + nt])
 
     var kt = (ki + Int32(_BK - 1)) // Int32(_BK)
@@ -508,16 +479,14 @@ def _mma_tile_impl[
     var t0: Int32 = 0
     var t_end: Int32 = kt
 
-    @parameter
-    if SPLITK:
+    comptime if SPLITK:
         t0 = Int32(Int(block_idx.y)) * Int32(chunk_tiles)
         t_end = min(kt, t0 + Int32(chunk_tiles))
 
     @parameter
     @always_inline
     def run_tiles():
-        @parameter
-        for i in range(2 * NT):
+        comptime for i in range(2 * NT):
             acc[i] = SIMD[_F32, 4]()
 
         load_tile(t0 * Int32(_BK))
@@ -537,8 +506,7 @@ def _mma_tile_impl[
             t += 1
         compute_tile(cur)
 
-        @parameter
-        if SPLITK:
+        comptime if SPLITK:
             # Tile-blocked FP32 partial store: each block owns a private
             # BM x BN image at (slice, logical row-major tile id), so every
             # pair store is 8B-aligned and fully coalesced no matter how
@@ -547,46 +515,39 @@ def _mma_tile_impl[
             # out-of-range lanes hold zeros (their staged loads zero-fill).
             var blocks_n_t = (ni + Int32(BN - 1)) // Int32(BN)
             var tile_id = (bm0 // Int32(BM)) * blocks_n_t + bn0 // Int32(BN)
-            var sp = (
-                ws
-                + Int(Int32(Int(block_idx.y))) * ws_pitch
+            var sp = ws.unsafe_offset(
+                Int(Int32(Int(block_idx.y))) * ws_pitch
                 + Int(tile_id) * (BM * BN)
             )
 
-            @parameter
-            for mt in range(2):
+            comptime for mt in range(2):
                 var r0 = wm + Int32(mt * 16) + g
 
-                @parameter
-                for nt in range(NT):
+                comptime for nt in range(NT):
                     var c = wn + Int32(nt * 8) + 2 * tg
                     var frag = acc[mt * NT + nt]
 
-                    @parameter
-                    for h in range(2):
+                    comptime for h in range(2):
                         var r = r0 + Int32(h * 8)
                         var pair = SIMD[_F32, 2](frag[2 * h], frag[2 * h + 1])
-                        sp.store[alignment=8](Int(r) * BN + Int(c), pair)
+                        sp.unsafe_store[alignment=8](Int(r) * BN + Int(c), pair)
             return
 
-        @parameter
-        for mt in range(2):
+        comptime for mt in range(2):
             var row0 = bm0 + wm + Int32(mt * 16) + g
 
-            @parameter
-            for nt in range(NT):
+            comptime for nt in range(NT):
                 var col = bn0 + wn + Int32(nt * 8) + 2 * tg
                 if col < ni:
                     var frag = acc[mt * NT + nt]
                     var add0 = Float32(0)
                     var add1 = Float32(0)
                     if has_bias != 0:
-                        add0 = bias[Int(col)].cast[_F32]()
+                        add0 = bias[unsafe_offset=Int(col)].cast[_F32]()
                         if col + 1 < ni:
-                            add1 = bias[Int(col) + 1].cast[_F32]()
+                            add1 = bias[unsafe_offset=Int(col) + 1].cast[_F32]()
 
-                    @parameter
-                    for h in range(2):
+                    comptime for h in range(2):
                         var row = row0 + Int32(h * 8)
                         if row < mi:
                             var base_idx = Int(row) * n + Int(col)
@@ -595,19 +556,18 @@ def _mma_tile_impl[
                                 var pair = SIMD[_DT, 2](
                                     v0, (frag[2 * h + 1] + add1).cast[_DT]()
                                 )
-                                cp.store[alignment=4](base_idx, pair)
+                                cp.unsafe_store[alignment=4](base_idx, pair)
                             else:
-                                cp[base_idx] = v0
+                                cp[unsafe_offset=base_idx] = v0
                                 if col + 1 < ni:
-                                    cp[base_idx + 1] = (
+                                    cp[unsafe_offset=base_idx + 1] = (
                                         frag[2 * h + 1] + add1
                                     ).cast[_DT]()
 
     @parameter
     @always_inline
     def set_flags():
-        @parameter
-        if FASTK:
+        comptime if FASTK:
             af = 1
             bf = 1
             cpair = 1
@@ -616,14 +576,13 @@ def _mma_tile_impl[
             bf = 1 if (b_fast != 0 and Int(bp) % 16 == 0) else 0
             cpair = 1 if (c_pair != 0 and Int(cp) % 4 == 0) else 0
 
-    @parameter
-    if BATCHED:
+    comptime if BATCHED:
         var bc = Int32(batch_count)
         var first_batch = True
         while bz < bc:
-            ap = a + Int(bz) * a_bstride
-            bp = b + Int(bz) * b_bstride
-            cp = output + Int(bz) * c_bstride
+            ap = a.unsafe_offset(Int(bz) * a_bstride)
+            bp = b.unsafe_offset(Int(bz) * b_bstride)
+            cp = output.unsafe_offset(Int(bz) * c_bstride)
             set_flags()
             if not first_batch:
                 # The previous batch's final compute_tile still reads shared
@@ -636,9 +595,9 @@ def _mma_tile_impl[
         # One batch per grid.z block; GEMM passes zero strides so this folds
         # to the base pointers. Launches with more than 65,535 batches take
         # the grid-striding BATCHED kernels instead.
-        ap = a + Int(bz) * a_bstride
-        bp = b + Int(bz) * b_bstride
-        cp = output + Int(bz) * c_bstride
+        ap = a.unsafe_offset(Int(bz) * a_bstride)
+        bp = b.unsafe_offset(Int(bz) * b_bstride)
+        cp = output.unsafe_offset(Int(bz) * c_bstride)
         set_flags()
         run_tiles()
 
@@ -728,7 +687,7 @@ def _gemm_entry[
         b_fast,
         c_pair,
         batch_count,
-        output.bitcast[Scalar[_F32]](),
+        output.unsafe_bitcast[Scalar[_F32]](),
         0,
         0,
     )
@@ -768,7 +727,7 @@ def _gemm_splitk_entry[
     # `output`/`bias` are unread under SPLITK; the workspace and `a` stand in
     # as dummies the same way BMM reuses `a` for its unread bias pointer.
     _mma_tile_impl[TA, TB, BM, BN, False, False, SPLITK=True](
-        ws.bitcast[Scalar[_DT]](),
+        ws.unsafe_bitcast[Scalar[_DT]](),
         a,
         b,
         a,
@@ -839,30 +798,28 @@ def _gemm_splitk_reduce[
         fill=SIMD[_F32, 4]()
     )
 
-    @parameter
-    for gr in range(_SPLITK_RED_GROUPS):
-        acc[gr] = ws.load[width=4, alignment=16](t * TILE + idx0 + gr * GSTRIDE)
+    comptime for gr in range(_SPLITK_RED_GROUPS):
+        acc[gr] = ws.unsafe_load[width=4, alignment=16](
+            t * TILE + idx0 + gr * GSTRIDE
+        )
     # Two accumulators per group keep pairs of slice loads in flight instead
     # of one serial load-add chain.
     var s = 1
     while s + 1 < splits:
-
-        @parameter
-        for gr in range(_SPLITK_RED_GROUPS):
+        comptime for gr in range(_SPLITK_RED_GROUPS):
             var base = t * TILE + idx0 + gr * GSTRIDE
-            acc[gr] += ws.load[width=4, alignment=16](s * pitch + base)
-            acc_b[gr] += ws.load[width=4, alignment=16]((s + 1) * pitch + base)
+            acc[gr] += ws.unsafe_load[width=4, alignment=16](s * pitch + base)
+            acc_b[gr] += ws.unsafe_load[width=4, alignment=16](
+                (s + 1) * pitch + base
+            )
         s += 2
     if s < splits:
-
-        @parameter
-        for gr in range(_SPLITK_RED_GROUPS):
-            acc[gr] += ws.load[width=4, alignment=16](
+        comptime for gr in range(_SPLITK_RED_GROUPS):
+            acc[gr] += ws.unsafe_load[width=4, alignment=16](
                 s * pitch + t * TILE + idx0 + gr * GSTRIDE
             )
 
-    @parameter
-    for gr in range(_SPLITK_RED_GROUPS):
+    comptime for gr in range(_SPLITK_RED_GROUPS):
         var idx = idx0 + gr * GSTRIDE
         var acc4 = acc[gr] + acc_b[gr]
         # idx is a multiple of 4 and BN is a multiple of 4, so the vec4
@@ -871,20 +828,16 @@ def _gemm_splitk_reduce[
         var col0 = (t % blocks_n) * BN + idx % BN
         if row < m:
             if has_bias != 0:
-
-                @parameter
-                for e in range(4):
+                comptime for e in range(4):
                     if col0 + e < n:
-                        acc4[e] += bias[col0 + e].cast[_F32]()
+                        acc4[e] += bias[unsafe_offset=col0 + e].cast[_F32]()
             var obase = row * n + col0
             if col0 + 4 <= n:
-                output.store[alignment=2](obase, acc4.cast[_DT]())
+                output.unsafe_store[alignment=2](obase, acc4.cast[_DT]())
             else:
-
-                @parameter
-                for e in range(4):
+                comptime for e in range(4):
                     if col0 + e < n:
-                        output[obase + e] = acc4[e].cast[_DT]()
+                        output[unsafe_offset=obase + e] = acc4[e].cast[_DT]()
 
 
 @always_inline
@@ -975,7 +928,7 @@ def _bmm_entry[
         b_fast,
         c_pair,
         batch_count,
-        output.bitcast[Scalar[_F32]](),
+        output.unsafe_bitcast[Scalar[_F32]](),
         0,
         0,
     )
@@ -995,8 +948,7 @@ def _g2r_kc_wide(
     # Full-width copy of the accepted-v1 K-contiguous staging: element
     # (r, kk) lives at src[r * kdim + kk]. Every coordinate and flat offset
     # stays machine Int; the host proved rows * kdim fits in Int.
-    @parameter
-    for it in range(2):
+    comptime for it in range(2):
         var q = tid // 4
         var r = (q * 4) % 64 + q // 16 + it * 64
         var kc = (tid % 4) * 8
@@ -1007,18 +959,16 @@ def _g2r_kc_wide(
             # fast proves 16B base alignment and kdim % 8 == 0, so each
             # 8-wide chunk is aligned and entirely in or out of bounds.
             if gr < rows and gk < kdim:
-                v = src.load[width=8, alignment=16](gr * kdim + gk)
+                v = src.unsafe_load[width=8, alignment=16](gr * kdim + gk)
         else:
             if gr < rows and gk < kdim:
                 if gk + 8 <= kdim:
                     # Whole chunk in bounds; only 2B element alignment holds.
-                    v = src.load[width=8, alignment=2](gr * kdim + gk)
+                    v = src.unsafe_load[width=8, alignment=2](gr * kdim + gk)
                 else:
-
-                    @parameter
-                    for e in range(8):
+                    comptime for e in range(8):
                         if gk + e < kdim:
-                            v[e] = src[gr * kdim + gk + e]
+                            v[e] = src[unsafe_offset=gr * kdim + gk + e]
         regs[it] = v
 
 
@@ -1035,8 +985,7 @@ def _g2r_mc_wide(
 ):
     # Full-width copy of the accepted-v1 row-contiguous staging: element
     # (r, kk) lives at src[kk * rows + r].
-    @parameter
-    for it in range(2):
+    comptime for it in range(2):
         var item = tid + it * _THREADS
         var kr = item % _BK
         var rc = (item // _BK) * 8
@@ -1046,18 +995,16 @@ def _g2r_mc_wide(
         if fast != 0:
             # fast proves 16B base alignment and rows % 8 == 0.
             if gk < kdim and gr < rows:
-                v = src.load[width=8, alignment=16](gk * rows + gr)
+                v = src.unsafe_load[width=8, alignment=16](gk * rows + gr)
         else:
             if gk < kdim and gr < rows:
                 if gr + 8 <= rows:
                     # Whole chunk in bounds; only 2B element alignment holds.
-                    v = src.load[width=8, alignment=2](gk * rows + gr)
+                    v = src.unsafe_load[width=8, alignment=2](gk * rows + gr)
                 else:
-
-                    @parameter
-                    for e in range(8):
+                    comptime for e in range(8):
                         if gr + e < rows:
-                            v[e] = src[gk * rows + gr + e]
+                            v[e] = src[unsafe_offset=gk * rows + gr + e]
         regs[it] = v
 
 
@@ -1108,8 +1055,8 @@ def _mma_tile_wide[
     var gdz = Int(grid_dim.z)
     var lin = Int(block_idx.x)
 
-    var bm0 = 0
-    var bn0 = 0
+    var bm0: Int
+    var bn0: Int
     var ap = a
     var bp = b
     var cp = output
@@ -1134,14 +1081,12 @@ def _mma_tile_wide[
     @parameter
     @always_inline
     def load_tile(k0: Int):
-        @parameter
-        if TA:
+        comptime if TA:
             _g2r_mc_wide(ap, bm0, m, k0, k, tid, af, va)
         else:
             _g2r_kc_wide(ap, bm0, m, k0, k, tid, af, va)
 
-        @parameter
-        if TB:
+        comptime if TB:
             _g2r_kc_wide(bp, bn0, n, k0, k, tid, bf, vb)
         else:
             _g2r_mc_wide(bp, bn0, n, k0, k, tid, bf, vb)
@@ -1152,47 +1097,43 @@ def _mma_tile_wide[
         var base_a = stage * _STAGE_A
         var base_b = stage * _STAGE_B
 
-        @parameter
-        if TA:
-
-            @parameter
-            for it in range(2):
+        comptime if TA:
+            comptime for it in range(2):
                 var item = tid + it * _THREADS
                 var kr = item % _BK
                 var rc = (item // _BK) * 8
 
-                @parameter
-                for e in range(8):
-                    smem_a[base_a + (rc + e) * _LDS + kr] = va[it][e]
+                comptime for e in range(8):
+                    smem_a[unsafe_offset=base_a + (rc + e) * _LDS + kr] = va[
+                        it
+                    ][e]
         else:
-
-            @parameter
-            for it in range(2):
+            comptime for it in range(2):
                 var q = tid // 4
                 var r = (q * 4) % 64 + q // 16 + it * 64
                 var kc = (tid % 4) * 8
-                smem_a.store[alignment=16](base_a + r * _LDS + kc, va[it])
+                smem_a.unsafe_store[alignment=16](
+                    base_a + r * _LDS + kc, va[it]
+                )
 
-        @parameter
-        if TB:
-
-            @parameter
-            for it in range(2):
+        comptime if TB:
+            comptime for it in range(2):
                 var q = tid // 4
                 var r = (q * 4) % 64 + q // 16 + it * 64
                 var kc = (tid % 4) * 8
-                smem_b.store[alignment=16](base_b + r * _LDS + kc, vb[it])
+                smem_b.unsafe_store[alignment=16](
+                    base_b + r * _LDS + kc, vb[it]
+                )
         else:
-
-            @parameter
-            for it in range(2):
+            comptime for it in range(2):
                 var item = tid + it * _THREADS
                 var kr = item % _BK
                 var rc = (item // _BK) * 8
 
-                @parameter
-                for e in range(8):
-                    smem_b[base_b + (rc + e) * _LDS + kr] = vb[it][e]
+                comptime for e in range(8):
+                    smem_b[unsafe_offset=base_b + (rc + e) * _LDS + kr] = vb[
+                        it
+                    ][e]
 
     @parameter
     @always_inline
@@ -1200,41 +1141,37 @@ def _mma_tile_wide[
         var base_a = stage * _STAGE_A
         var base_b = stage * _STAGE_B
 
-        @parameter
-        for ks in range(2):
+        comptime for ks in range(2):
             var kb = ks * 16 + 2 * tg
             var afr = InlineArray[SIMD[_DT, 8], 2](fill=SIMD[_DT, 8]())
 
-            @parameter
-            for mt in range(2):
+            comptime for mt in range(2):
                 var row = wm + mt * 16 + g
-                var a01 = smem_a.load[width=2, alignment=4](
+                var a01 = smem_a.unsafe_load[width=2, alignment=4](
                     base_a + row * _LDS + kb
                 )
-                var a23 = smem_a.load[width=2, alignment=4](
+                var a23 = smem_a.unsafe_load[width=2, alignment=4](
                     base_a + (row + 8) * _LDS + kb
                 )
-                var a45 = smem_a.load[width=2, alignment=4](
+                var a45 = smem_a.unsafe_load[width=2, alignment=4](
                     base_a + row * _LDS + kb + 8
                 )
-                var a67 = smem_a.load[width=2, alignment=4](
+                var a67 = smem_a.unsafe_load[width=2, alignment=4](
                     base_a + (row + 8) * _LDS + kb + 8
                 )
                 afr[mt] = a01.join(a23).join(a45.join(a67))
 
-            @parameter
-            for nt in range(8):
+            comptime for nt in range(8):
                 var nr = wn + nt * 8 + g
-                var b01 = smem_b.load[width=2, alignment=4](
+                var b01 = smem_b.unsafe_load[width=2, alignment=4](
                     base_b + nr * _LDS + kb
                 )
-                var b23 = smem_b.load[width=2, alignment=4](
+                var b23 = smem_b.unsafe_load[width=2, alignment=4](
                     base_b + nr * _LDS + kb + 8
                 )
                 var bfr = b01.join(b23)
 
-                @parameter
-                for mt in range(2):
+                comptime for mt in range(2):
                     mma(acc[mt * 8 + nt], afr[mt], bfr, acc[mt * 8 + nt])
 
     var kt = (k - 1) // _BK + 1
@@ -1248,9 +1185,9 @@ def _mma_tile_wide[
 
         var bz = Int(block_idx.z)
         while bz < batch_count:
-            ap = a + bz * a_bstride
-            bp = b + bz * b_bstride
-            cp = output + bz * c_bstride
+            ap = a.unsafe_offset(bz * a_bstride)
+            bp = b.unsafe_offset(bz * b_bstride)
+            cp = output.unsafe_offset(bz * c_bstride)
             af = 1 if (a_fast != 0 and Int(ap) % 16 == 0) else 0
             bf = 1 if (b_fast != 0 and Int(bp) % 16 == 0) else 0
             cpair = 1 if (c_pair != 0 and Int(cp) % 4 == 0) else 0
@@ -1263,8 +1200,7 @@ def _mma_tile_wide[
                 barrier()
             first_work = False
 
-            @parameter
-            for i in range(16):
+            comptime for i in range(16):
                 acc[i] = SIMD[_F32, 4]()
 
             load_tile(0)
@@ -1282,24 +1218,21 @@ def _mma_tile_wide[
                 cur = 1 - cur
             compute_tile(cur)
 
-            @parameter
-            for mt in range(2):
+            comptime for mt in range(2):
                 var row0 = bm0 + wm + mt * 16 + g
 
-                @parameter
-                for nt in range(8):
+                comptime for nt in range(8):
                     var col = bn0 + wn + nt * 8 + 2 * tg
                     if col < n:
                         var frag = acc[mt * 8 + nt]
                         var add0 = Float32(0)
                         var add1 = Float32(0)
                         if has_bias != 0:
-                            add0 = bias[col].cast[_F32]()
+                            add0 = bias[unsafe_offset=col].cast[_F32]()
                             if col + 1 < n:
-                                add1 = bias[col + 1].cast[_F32]()
+                                add1 = bias[unsafe_offset=col + 1].cast[_F32]()
 
-                        @parameter
-                        for h in range(2):
+                        comptime for h in range(2):
                             var row = row0 + h * 8
                             if row < m:
                                 var base_idx = row * n + col
@@ -1309,11 +1242,11 @@ def _mma_tile_wide[
                                         v0,
                                         (frag[2 * h + 1] + add1).cast[_DT](),
                                     )
-                                    cp.store[alignment=4](base_idx, pair)
+                                    cp.unsafe_store[alignment=4](base_idx, pair)
                                 else:
-                                    cp[base_idx] = v0
+                                    cp[unsafe_offset=base_idx] = v0
                                     if col + 1 < n:
-                                        cp[base_idx + 1] = (
+                                        cp[unsafe_offset=base_idx + 1] = (
                                             frag[2 * h + 1] + add1
                                         ).cast[_DT]()
 
@@ -1829,10 +1762,10 @@ def _enqueue_gemm_splitk(
 
 
 def enqueue_gemm16_gemm(
-    output: UnsafePointer[Scalar[_DT], MutAnyOrigin],
-    a: UnsafePointer[Scalar[_DT], MutAnyOrigin],
-    b: UnsafePointer[Scalar[_DT], MutAnyOrigin],
-    bias: UnsafePointer[Scalar[_DT], MutAnyOrigin],
+    output: Pointer[Scalar[_DT], MutAnyOrigin],
+    a: Pointer[Scalar[_DT], MutAnyOrigin],
+    b: Pointer[Scalar[_DT], MutAnyOrigin],
+    bias: Pointer[Scalar[_DT], MutAnyOrigin],
     m: Int,
     n: Int,
     k: Int,
@@ -1988,9 +1921,9 @@ def enqueue_gemm16_gemm(
 
 
 def enqueue_gemm16_bmm(
-    output: UnsafePointer[Scalar[_DT], MutAnyOrigin],
-    a: UnsafePointer[Scalar[_DT], MutAnyOrigin],
-    b: UnsafePointer[Scalar[_DT], MutAnyOrigin],
+    output: Pointer[Scalar[_DT], MutAnyOrigin],
+    a: Pointer[Scalar[_DT], MutAnyOrigin],
+    b: Pointer[Scalar[_DT], MutAnyOrigin],
     batch_count: Int,
     m: Int,
     n: Int,
@@ -2079,21 +2012,17 @@ def enqueue_gemm16_bmm(
     # prologue already derived from it, which keeps the old tree's
     # else-catch-all: anything that is not the narrow-N or narrow-M regime
     # runs the 128x128 tiles.
-    @parameter
-    for RI in range(4):
+    comptime for RI in range(4):
         comptime BM = _regime_bm(RI)
         comptime BN = _regime_bn(RI)
 
-        @parameter
-        for FI in range(2):
+        comptime for FI in range(2):
             comptime FASTK = FI == 1
 
-            @parameter
-            for TAI in range(2):
+            comptime for TAI in range(2):
                 comptime TA = TAI == 1
 
-                @parameter
-                for TBI in range(2):
+                comptime for TBI in range(2):
                     comptime TB = TBI == 1
                     if (
                         bm == BM

--- a/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_nn_v4_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_nn_v4_kernels.mojo
@@ -92,7 +92,7 @@ from gemm16_dtype import _GEMM16_DT, _GEMM16_TAG
 
 comptime _V4_DT = _GEMM16_DT
 comptime _V4_F32 = DType.float32
-comptime _V4_PTR = UnsafePointer[Scalar[_V4_DT], MutAnyOrigin]
+comptime _V4_PTR = Pointer[Scalar[_V4_DT], MutAnyOrigin]
 comptime _V4_BK = 64
 # Macro-rows per rasterization group: consecutive work indices cover
 # _V4_GROUP macro rows before advancing one BN column, keeping the in-flight
@@ -168,14 +168,13 @@ def _v4_dyn_smem_tile[
         address_space=AddressSpace.SHARED,
         alignment=align,
     ](
-        (
-            external_memory[
-                Scalar[_V4_DT],
-                address_space=AddressSpace.SHARED,
-                alignment=_V4_DYN_SMEM_ALIGN,
-            ]()
-            + offset
-        ).as_unsafe_any_origin()
+        external_memory[
+            Scalar[_V4_DT],
+            address_space=AddressSpace.SHARED,
+            alignment=_V4_DYN_SMEM_ALIGN,
+        ]()
+        .unsafe_offset(offset)
+        .as_unsafe_any_origin()
     )
 
 
@@ -212,10 +211,10 @@ def _v4_mma_tile[
     A_LAYOUT: Layout,
     B_LAYOUT: Layout,
 ](
-    a_smem: UnsafePointer[
+    a_smem: Pointer[
         Scalar[_V4_DT], MutAnyOrigin, address_space=AddressSpace.SHARED
     ],
-    b_smem: UnsafePointer[
+    b_smem: Pointer[
         Scalar[_V4_DT], MutAnyOrigin, address_space=AddressSpace.SHARED
     ],
     accum: LayoutTensor[
@@ -422,11 +421,13 @@ def _v4_nn_persistent_ws[
         ]()
         if thread_idx.x == 0:
             comptime for stage in range(stages):
-                full_barriers[stage].init()
+                full_barriers[unsafe_offset=stage].init()
                 # Released by every consumer warp group of every CTA in the
                 # cluster: the multicast source must not overwrite a peer's
                 # tile while that peer is still reading it.
-                empty_barriers[stage].init(Int32(consumers * cluster_m))
+                empty_barriers[unsafe_offset=stage].init(
+                    Int32(consumers * cluster_m)
+                )
             a_tma.prefetch_descriptor()
             b_tma.prefetch_descriptor()
             comptime if tma_store:
@@ -460,7 +461,7 @@ def _v4_nn_persistent_ws[
         # Release every pipeline slot to the producers (cluster-wide).
         if warp_group_idx > 0 and warp_group_thread_idx < cluster_m:
             comptime for stage in range(stages):
-                empty_barriers[stage].arrive_cluster(
+                empty_barriers[unsafe_offset=stage].arrive_cluster(
                     UInt32(warp_group_thread_idx)
                 )
 
@@ -482,26 +483,32 @@ def _v4_nn_persistent_ws[
                     while t < num_tiles:
                         var stage = gt % stages
                         var phase = UInt32((gt // stages) % 2)
-                        empty_barriers[stage].wait(phase)
-                        full_barriers[stage].expect_bytes(Int32(TMA_BYTES))
+                        empty_barriers[unsafe_offset=stage].wait(phase)
+                        full_barriers[unsafe_offset=stage].expect_bytes(
+                            Int32(TMA_BYTES)
+                        )
                         var a_tile = LayoutTensor[
                             _V4_DT,
                             A_LAYOUT,
                             MutAnyOrigin,
                             address_space=AddressSpace.SHARED,
                             alignment=128,
-                        ](a_pipeline.ptr + stage * bm * _V4_BK)
+                        ](a_pipeline.ptr.unsafe_offset(stage * bm * _V4_BK))
                         var k0 = t * _V4_BK
                         # TMA coordinates are (fastest dim, slower dim) of
                         # the global tensor the descriptor was built over:
                         # (m, k) for the col-major (K, M) wgrad operand.
                         comptime if col_a:
                             a_tma.async_copy(
-                                a_tile, full_barriers[stage], (m0, k0)
+                                a_tile,
+                                full_barriers[unsafe_offset=stage],
+                                (m0, k0),
                             )
                         else:
                             a_tma.async_copy(
-                                a_tile, full_barriers[stage], (k0, m0)
+                                a_tile,
+                                full_barriers[unsafe_offset=stage],
+                                (k0, m0),
                             )
                         # Cooperative B load: each cluster rank reads its
                         # share of the 64-column chunks once from L2 and
@@ -518,9 +525,9 @@ def _v4_nn_persistent_ws[
                                 address_space=AddressSpace.SHARED,
                                 alignment=128,
                             ](
-                                b_pipeline.ptr
-                                + stage * bn * _V4_BK
-                                + cc * 64 * _V4_BK
+                                b_pipeline.ptr.unsafe_offset(
+                                    stage * bn * _V4_BK + cc * 64 * _V4_BK
+                                )
                             )
                             # B TMA coordinates follow the descriptor's
                             # global tensor: (k, n) for the K-major (N, K)
@@ -530,14 +537,14 @@ def _v4_nn_persistent_ws[
                                 comptime if kmaj_b:
                                     b_tma.async_multicast_load(
                                         b_chunk,
-                                        full_barriers[stage],
+                                        full_barriers[unsafe_offset=stage],
                                         (k0, n0 + cc * 64),
                                         MCAST_MASK,
                                     )
                                 else:
                                     b_tma.async_multicast_load(
                                         b_chunk,
-                                        full_barriers[stage],
+                                        full_barriers[unsafe_offset=stage],
                                         (n0 + cc * 64, k0),
                                         MCAST_MASK,
                                     )
@@ -545,13 +552,13 @@ def _v4_nn_persistent_ws[
                                 comptime if kmaj_b:
                                     b_tma.async_copy(
                                         b_chunk,
-                                        full_barriers[stage],
+                                        full_barriers[unsafe_offset=stage],
                                         (k0, n0 + cc * 64),
                                     )
                                 else:
                                     b_tma.async_copy(
                                         b_chunk,
-                                        full_barriers[stage],
+                                        full_barriers[unsafe_offset=stage],
                                         (n0 + cc * 64, k0),
                                     )
                             cc += 1
@@ -597,21 +604,21 @@ def _v4_nn_persistent_ws[
                 while t < num_tiles:
                     var stage = gt % stages
                     var phase = UInt32((gt // stages) % 2)
-                    full_barriers[stage].wait(phase)
+                    full_barriers[unsafe_offset=stage].wait(phase)
                     var a_tile = LayoutTensor[
                         _V4_DT,
                         A_LAYOUT,
                         MutAnyOrigin,
                         address_space=AddressSpace.SHARED,
                         alignment=128,
-                    ](a_pipeline.ptr + stage * bm * _V4_BK)
+                    ](a_pipeline.ptr.unsafe_offset(stage * bm * _V4_BK))
                     var b_tile = LayoutTensor[
                         _V4_DT,
                         B_LAYOUT,
                         MutAnyOrigin,
                         address_space=AddressSpace.SHARED,
                         alignment=128,
-                    ](b_pipeline.ptr + stage * bn * _V4_BK)
+                    ](b_pipeline.ptr.unsafe_offset(stage * bn * _V4_BK))
                     comptime if col_a or kmaj_b:
                         # Raw descriptor path: TensorCoreAsync has no
                         # col-major A mode (and the TT instantiation's
@@ -630,7 +637,7 @@ def _v4_nn_persistent_ws[
                         warpgroup_fence(accum)
                         wgmma.wait_group()
                     if warp_group_thread_idx < cluster_m:
-                        empty_barriers[stage].arrive_cluster(
+                        empty_barriers[unsafe_offset=stage].arrive_cluster(
                             UInt32(warp_group_thread_idx)
                         )
                     t += 1
@@ -658,8 +665,8 @@ def _v4_nn_persistent_ws[
                         )
                         var col = base_col + (q // 2) * 8
                         var pair = SIMD[_V4_DT, 2](
-                            accum.ptr[e].cast[_V4_DT](),
-                            accum.ptr[e + 1].cast[_V4_DT](),
+                            accum.ptr[unsafe_offset=e].cast[_V4_DT](),
+                            accum.ptr[unsafe_offset=e + 1].cast[_V4_DT](),
                         )
                         # 128B-swizzled staging layout: 16B units within
                         # each 64-element row are XORed with (row % 8).
@@ -670,7 +677,7 @@ def _v4_nn_persistent_ws[
                             + ((lcol // 8) ^ (row % 8)) * 8
                             + lcol % 8
                         )
-                        c_smem.ptr.store[alignment=4](elem, pair)
+                        c_smem.ptr.unsafe_store[alignment=4](elem, pair)
                     fence_async_view_proxy()
                     named_barrier[NCONS](1)
                     if warp_group_idx == 1 and warp_group_thread_idx == 0:
@@ -681,7 +688,7 @@ def _v4_nn_persistent_ws[
                                 MutAnyOrigin,
                                 address_space=AddressSpace.SHARED,
                                 alignment=128,
-                            ](c_smem.ptr + chunk * bm * 64)
+                            ](c_smem.ptr.unsafe_offset(chunk * bm * 64))
                             c_tma.async_store(c_chunk, (n0 + chunk * 64, m0))
                         c_tma.commit_group()
                 else:
@@ -692,11 +699,11 @@ def _v4_nn_persistent_ws[
                         )
                         var col = base_col + (q // 2) * 8
                         var pair = SIMD[_V4_DT, 2](
-                            accum.ptr[e].cast[_V4_DT](),
-                            accum.ptr[e + 1].cast[_V4_DT](),
+                            accum.ptr[unsafe_offset=e].cast[_V4_DT](),
+                            accum.ptr[unsafe_offset=e + 1].cast[_V4_DT](),
                         )
                         if m0 + row < m and n0 + col + 1 < n:
-                            output.store[alignment=4](
+                            output.unsafe_store[alignment=4](
                                 (m0 + row) * n + n0 + col, pair
                             )
                 w += num_clusters
@@ -743,7 +750,7 @@ def _v4_enqueue_nn_persistent[
     var a_desc = create_tma_descriptor[_V4_DT, 2, _V4_SWIZZLE](
         DeviceBuffer(
             ctx,
-            a.address_space_cast[AddressSpace.GENERIC](),
+            a.unsafe_address_space_cast[AddressSpace.GENERIC](),
             1,
             owning=False,
         ),
@@ -756,7 +763,7 @@ def _v4_enqueue_nn_persistent[
     var b_desc = create_tma_descriptor[_V4_DT, 2, _V4_SWIZZLE](
         DeviceBuffer(
             ctx,
-            b.address_space_cast[AddressSpace.GENERIC](),
+            b.unsafe_address_space_cast[AddressSpace.GENERIC](),
             1,
             owning=False,
         ),
@@ -767,7 +774,7 @@ def _v4_enqueue_nn_persistent[
     var c_desc = create_tma_descriptor[_V4_DT, 2, _V4_SWIZZLE](
         DeviceBuffer(
             ctx,
-            output.address_space_cast[AddressSpace.GENERIC](),
+            output.unsafe_address_space_cast[AddressSpace.GENERIC](),
             1,
             owning=False,
         ),
@@ -941,7 +948,7 @@ def maybe_enqueue_gemm16_nn_v4(
                     #    persistent body wins 16.2 us vs 19.8, likewise at
                     #    k = 4096 (49.9 vs 60.1), and its margin only grows
                     #    with fill (768x4224x1024: 17.7 vs 24.6).
-                    var small_route_wins = False
+                    var small_route_wins: Bool
                     if n % _V4_PROD_BN == 0:
                         small_route_wins = (
                             m % 64 == 0 and total_works * 8 < sm_count

--- a/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_nt_v4_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_nt_v4_kernels.mojo
@@ -70,7 +70,7 @@ from gemm16_nn_v4_kernels import (
 
 comptime _V4_DT = _GEMM16_DT
 comptime _V4_F32 = DType.float32
-comptime _V4_PTR = UnsafePointer[Scalar[_V4_DT], MutAnyOrigin]
+comptime _V4_PTR = Pointer[Scalar[_V4_DT], MutAnyOrigin]
 comptime _V4_SWIZZLE = TensorMapSwizzle.SWIZZLE_128B
 
 comptime _V4_BM = 128
@@ -117,7 +117,7 @@ def _v4c_nt_smem_bytes[bn: Int, stages: Int]() -> Int:
 def _v4_store_accum_stmatrix[
     bn: Int
 ](
-    wg_half: UnsafePointer[
+    wg_half: Pointer[
         Scalar[_V4_DT], MutAnyOrigin, address_space=AddressSpace.SHARED
     ],
     accum: LayoutTensor[
@@ -154,30 +154,30 @@ def _v4_store_accum_stmatrix[
         var data = SIMD[DType.float32, 4](
             bitcast[DType.float32, 1](
                 SIMD[_V4_DT, 2](
-                    accum.ptr[8 * t].cast[_V4_DT](),
-                    accum.ptr[8 * t + 1].cast[_V4_DT](),
+                    accum.ptr[unsafe_offset=8 * t].cast[_V4_DT](),
+                    accum.ptr[unsafe_offset=8 * t + 1].cast[_V4_DT](),
                 )
             ),
             bitcast[DType.float32, 1](
                 SIMD[_V4_DT, 2](
-                    accum.ptr[8 * t + 2].cast[_V4_DT](),
-                    accum.ptr[8 * t + 3].cast[_V4_DT](),
+                    accum.ptr[unsafe_offset=8 * t + 2].cast[_V4_DT](),
+                    accum.ptr[unsafe_offset=8 * t + 3].cast[_V4_DT](),
                 )
             ),
             bitcast[DType.float32, 1](
                 SIMD[_V4_DT, 2](
-                    accum.ptr[8 * t + 4].cast[_V4_DT](),
-                    accum.ptr[8 * t + 5].cast[_V4_DT](),
+                    accum.ptr[unsafe_offset=8 * t + 4].cast[_V4_DT](),
+                    accum.ptr[unsafe_offset=8 * t + 5].cast[_V4_DT](),
                 )
             ),
             bitcast[DType.float32, 1](
                 SIMD[_V4_DT, 2](
-                    accum.ptr[8 * t + 6].cast[_V4_DT](),
-                    accum.ptr[8 * t + 7].cast[_V4_DT](),
+                    accum.ptr[unsafe_offset=8 * t + 6].cast[_V4_DT](),
+                    accum.ptr[unsafe_offset=8 * t + 7].cast[_V4_DT](),
                 )
             ),
         )
-        st_matrix[simd_width=4](wg_half + off, data)
+        st_matrix[simd_width=4](wg_half.unsafe_offset(off), data)
 
 
 @always_inline
@@ -282,10 +282,12 @@ def _v4c_nt_persistent[
         ]()
         if thread_idx.x == 0:
             comptime for stage in range(stages):
-                full_barriers[stage].init()
+                full_barriers[unsafe_offset=stage].init()
                 # Each of the two consumer warp groups in BOTH cluster CTAs
                 # signals every slot release (arrive_cluster below).
-                empty_barriers[stage].init(Int32(_V4_CONSUMERS * _V4_CLUSTER))
+                empty_barriers[unsafe_offset=stage].init(
+                    Int32(_V4_CONSUMERS * _V4_CLUSTER)
+                )
             a_tma.prefetch_descriptor()
             b_tma.prefetch_descriptor()
             c_tma.prefetch_descriptor()
@@ -306,7 +308,7 @@ def _v4c_nt_persistent[
 
         if warp_group_idx > 0 and warp_group_thread_idx < _V4_CLUSTER:
             comptime for stage in range(stages):
-                empty_barriers[stage].arrive_cluster(
+                empty_barriers[unsafe_offset=stage].arrive_cluster(
                     UInt32(warp_group_thread_idx)
                 )
         barrier()
@@ -346,17 +348,21 @@ def _v4c_nt_persistent[
                     while kt < num_k_tiles:
                         var stage = gkt % stages
                         var phase = UInt32((gkt // stages) % 2)
-                        empty_barriers[stage].wait(phase)
-                        full_barriers[stage].expect_bytes(Int32(TMA_BYTES))
+                        empty_barriers[unsafe_offset=stage].wait(phase)
+                        full_barriers[unsafe_offset=stage].expect_bytes(
+                            Int32(TMA_BYTES)
+                        )
                         var a_tile = LayoutTensor[
                             _V4_DT,
                             _V4_A_LAYOUT,
                             MutAnyOrigin,
                             address_space=AddressSpace.SHARED,
                             alignment=128,
-                        ](a_pipeline.ptr + stage * _V4_BM * _V4_BK)
+                        ](a_pipeline.ptr.unsafe_offset(stage * _V4_BM * _V4_BK))
                         var k0 = kt * _V4_BK
-                        a_tma.async_copy(a_tile, full_barriers[stage], (k0, m0))
+                        a_tma.async_copy(
+                            a_tile, full_barriers[unsafe_offset=stage], (k0, m0)
+                        )
                         if can_multicast:
                             # Load our half of B, multicast to both CTAs.
                             var b_half = LayoutTensor[
@@ -366,13 +372,13 @@ def _v4c_nt_persistent[
                                 address_space=AddressSpace.SHARED,
                                 alignment=128,
                             ](
-                                b_pipeline.ptr
-                                + stage * bn * _V4_BK
-                                + rank * B_HALF * _V4_BK
+                                b_pipeline.ptr.unsafe_offset(
+                                    stage * bn * _V4_BK + rank * B_HALF * _V4_BK
+                                )
                             )
                             b_tma.async_multicast_load(
                                 b_half,
-                                full_barriers[stage],
+                                full_barriers[unsafe_offset=stage],
                                 (k0, n0 + rank * B_HALF),
                                 UInt16(0b11),
                             )
@@ -386,13 +392,14 @@ def _v4c_nt_persistent[
                                     address_space=AddressSpace.SHARED,
                                     alignment=128,
                                 ](
-                                    b_pipeline.ptr
-                                    + stage * bn * _V4_BK
-                                    + half * B_HALF * _V4_BK
+                                    b_pipeline.ptr.unsafe_offset(
+                                        stage * bn * _V4_BK
+                                        + half * B_HALF * _V4_BK
+                                    )
                                 )
                                 b_tma.async_copy(
                                     b_half,
-                                    full_barriers[stage],
+                                    full_barriers[unsafe_offset=stage],
                                     (k0, n0 + half * B_HALF),
                                 )
                         kt += 1
@@ -419,7 +426,7 @@ def _v4c_nt_persistent[
             var tid = warp_group_thread_idx
             var warp = tid // 32
             var lane = tid % 32
-            var wg_half = c_staging.ptr + (
+            var wg_half = c_staging.ptr.unsafe_offset(
                 (warp_group_idx - 1) * _V4_WG_ROWS * bn
             )
 
@@ -438,21 +445,21 @@ def _v4c_nt_persistent[
                 while kt < num_k_tiles:
                     var stage = gkt % stages
                     var phase = UInt32((gkt // stages) % 2)
-                    full_barriers[stage].wait(phase)
+                    full_barriers[unsafe_offset=stage].wait(phase)
                     var a_tile = LayoutTensor[
                         _V4_DT,
                         _V4_A_LAYOUT,
                         MutAnyOrigin,
                         address_space=AddressSpace.SHARED,
                         alignment=128,
-                    ](a_pipeline.ptr + stage * _V4_BM * _V4_BK)
+                    ](a_pipeline.ptr.unsafe_offset(stage * _V4_BM * _V4_BK))
                     var b_tile = LayoutTensor[
                         _V4_DT,
                         B_LAYOUT,
                         MutAnyOrigin,
                         address_space=AddressSpace.SHARED,
                         alignment=128,
-                    ](b_pipeline.ptr + stage * bn * _V4_BK)
+                    ](b_pipeline.ptr.unsafe_offset(stage * bn * _V4_BK))
                     warpgroup_fence(accum)
                     wgmma.arrive()
                     if kt == 0:
@@ -478,14 +485,14 @@ def _v4c_nt_persistent[
                             prev_stage >= 0
                             and warp_group_thread_idx < _V4_CLUSTER
                         ):
-                            empty_barriers[prev_stage].arrive_cluster(
-                                UInt32(warp_group_thread_idx)
-                            )
+                            empty_barriers[
+                                unsafe_offset=prev_stage
+                            ].arrive_cluster(UInt32(warp_group_thread_idx))
                         prev_stage = stage
                     else:
                         wgmma.wait_group()
                         if warp_group_thread_idx < _V4_CLUSTER:
-                            empty_barriers[stage].arrive_cluster(
+                            empty_barriers[unsafe_offset=stage].arrive_cluster(
                                 UInt32(warp_group_thread_idx)
                             )
                     kt += 1
@@ -493,7 +500,7 @@ def _v4c_nt_persistent[
                 comptime if defer_release:
                     wgmma.wait_group[0]()
                     if prev_stage >= 0 and warp_group_thread_idx < _V4_CLUSTER:
-                        empty_barriers[prev_stage].arrive_cluster(
+                        empty_barriers[unsafe_offset=prev_stage].arrive_cluster(
                             UInt32(warp_group_thread_idx)
                         )
 
@@ -552,7 +559,7 @@ def _v4c_enqueue_nt_persistent[
     var a_desc = create_tma_descriptor[_V4_DT, 2, _V4_SWIZZLE](
         DeviceBuffer(
             ctx,
-            a.address_space_cast[AddressSpace.GENERIC](),
+            a.unsafe_address_space_cast[AddressSpace.GENERIC](),
             1,
             owning=False,
         ),
@@ -563,7 +570,7 @@ def _v4c_enqueue_nt_persistent[
     var b_desc = create_tma_descriptor[_V4_DT, 2, _V4_SWIZZLE](
         DeviceBuffer(
             ctx,
-            b.address_space_cast[AddressSpace.GENERIC](),
+            b.unsafe_address_space_cast[AddressSpace.GENERIC](),
             1,
             owning=False,
         ),
@@ -574,7 +581,7 @@ def _v4c_enqueue_nt_persistent[
     var c_desc = create_tma_descriptor[_V4_DT, 2, _V4_SWIZZLE](
         DeviceBuffer(
             ctx,
-            output.address_space_cast[AddressSpace.GENERIC](),
+            output.unsafe_address_space_cast[AddressSpace.GENERIC](),
             1,
             owning=False,
         ),

--- a/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_tn_v4_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_tn_v4_kernels.mojo
@@ -63,8 +63,8 @@ from gemm16_dtype import _GEMM16_DT, _GEMM16_TAG
 
 comptime _V4_DT = _GEMM16_DT
 comptime _V4_F32 = DType.float32
-comptime _V4_PTR = UnsafePointer[Scalar[_V4_DT], MutAnyOrigin]
-comptime _V4_F32_PTR = UnsafePointer[Scalar[_V4_F32], MutAnyOrigin]
+comptime _V4_PTR = Pointer[Scalar[_V4_DT], MutAnyOrigin]
+comptime _V4_F32_PTR = Pointer[Scalar[_V4_F32], MutAnyOrigin]
 comptime _V4_BM = 128
 comptime _V4_BK = 64
 comptime _V4_SWIZZLE = TensorMapSwizzle.SWIZZLE_128B
@@ -181,8 +181,8 @@ def _v4_tn_ws_body[
         ]()
         if thread_idx.x == 0:
             comptime for stage in range(STAGES):
-                full_barriers[stage].init()
-                empty_barriers[stage].init(Int32(CONSUMERS))
+                full_barriers[unsafe_offset=stage].init()
+                empty_barriers[unsafe_offset=stage].init(Int32(CONSUMERS))
             a_tma.prefetch_descriptor()
             b_tma.prefetch_descriptor()
         # Order barrier initialization before cross-warp-group arrivals.
@@ -216,7 +216,7 @@ def _v4_tn_ws_body[
         # finish.
         if warp_group_idx > 0 and warp_group_thread_idx == 0:
             comptime for stage in range(STAGES):
-                _ = empty_barriers[stage].arrive()
+                _ = empty_barriers[unsafe_offset=stage].arrive()
         barrier()
 
         if warp_group_idx == 0:
@@ -226,8 +226,10 @@ def _v4_tn_ws_body[
                 while it < my_tiles:
                     var stage = it % STAGES
                     var phase = UInt32((it // STAGES) % 2)
-                    empty_barriers[stage].wait(phase)
-                    full_barriers[stage].expect_bytes(Int32(TMA_BYTES))
+                    empty_barriers[unsafe_offset=stage].wait(phase)
+                    full_barriers[unsafe_offset=stage].expect_bytes(
+                        Int32(TMA_BYTES)
+                    )
 
                     var a_tile = LayoutTensor[
                         _V4_DT,
@@ -235,25 +237,33 @@ def _v4_tn_ws_body[
                         MutAnyOrigin,
                         address_space=AddressSpace.SHARED,
                         alignment=128,
-                    ](a_pipeline.ptr + stage * BM * _V4_BK)
+                    ](a_pipeline.ptr.unsafe_offset(stage * BM * _V4_BK))
                     var b_tile = LayoutTensor[
                         _V4_DT,
                         B_LAYOUT,
                         MutAnyOrigin,
                         address_space=AddressSpace.SHARED,
                         alignment=128,
-                    ](b_pipeline.ptr + stage * BN * _V4_BK)
+                    ](b_pipeline.ptr.unsafe_offset(stage * BN * _V4_BK))
                     var k0 = (tile_start + it) * _V4_BK
                     # TMA coordinates are (fastest dim, slower dim) of the
                     # global tensor each descriptor was built over.
                     comptime if COL_A:
-                        a_tma.async_copy(a_tile, full_barriers[stage], (m0, k0))
+                        a_tma.async_copy(
+                            a_tile, full_barriers[unsafe_offset=stage], (m0, k0)
+                        )
                     else:
-                        a_tma.async_copy(a_tile, full_barriers[stage], (k0, m0))
+                        a_tma.async_copy(
+                            a_tile, full_barriers[unsafe_offset=stage], (k0, m0)
+                        )
                     comptime if KMAJ_B:
-                        b_tma.async_copy(b_tile, full_barriers[stage], (k0, n0))
+                        b_tma.async_copy(
+                            b_tile, full_barriers[unsafe_offset=stage], (k0, n0)
+                        )
                     else:
-                        b_tma.async_copy(b_tile, full_barriers[stage], (n0, k0))
+                        b_tma.async_copy(
+                            b_tile, full_barriers[unsafe_offset=stage], (n0, k0)
+                        )
                     it += 1
         else:
             warpgroup_reg_alloc[232]()
@@ -269,28 +279,28 @@ def _v4_tn_ws_body[
             while it < my_tiles:
                 var stage = it % STAGES
                 var phase = UInt32((it // STAGES) % 2)
-                full_barriers[stage].wait(phase)
+                full_barriers[unsafe_offset=stage].wait(phase)
                 var a_tile = LayoutTensor[
                     _V4_DT,
                     A_LAYOUT,
                     MutAnyOrigin,
                     address_space=AddressSpace.SHARED,
                     alignment=128,
-                ](a_pipeline.ptr + stage * BM * _V4_BK)
+                ](a_pipeline.ptr.unsafe_offset(stage * BM * _V4_BK))
                 var b_tile = LayoutTensor[
                     _V4_DT,
                     B_LAYOUT,
                     MutAnyOrigin,
                     address_space=AddressSpace.SHARED,
                     alignment=128,
-                ](b_pipeline.ptr + stage * BN * _V4_BK)
+                ](b_pipeline.ptr.unsafe_offset(stage * BN * _V4_BK))
                 # Majorness-generic raw WGMMA slab, shared with the
                 # persistent body in gemm16_nn_v4_kernels.mojo.
                 _v4_mma_tile[BN, COL_A, KMAJ_B, A_LAYOUT, B_LAYOUT](
                     a_tile.ptr, b_tile.ptr, accum, warp_group_idx
                 )
                 if warp_group_thread_idx == 0:
-                    _ = empty_barriers[stage].arrive()
+                    _ = empty_barriers[unsafe_offset=stage].arrive()
                 it += 1
 
             var tid = warp_group_thread_idx
@@ -299,14 +309,17 @@ def _v4_tn_ws_body[
             var base_row = warp * 16 + lane // 4
             var base_col = (lane % 4) * 2
             comptime if SPLITK:
-                var ws_base = ws + Int(block_idx.y) * (m * n)
+                var ws_base = ws.unsafe_offset(Int(block_idx.y) * (m * n))
                 comptime for q in range(CFRAG // 2):
                     var e = q * 2
                     var row = (warp_group_idx - 1) * 64 + base_row + (q % 2) * 8
                     var col = base_col + (q // 2) * 8
-                    var pair = SIMD[_V4_F32, 2](accum.ptr[e], accum.ptr[e + 1])
+                    var pair = SIMD[_V4_F32, 2](
+                        accum.ptr[unsafe_offset=e],
+                        accum.ptr[unsafe_offset=e + 1],
+                    )
                     if m0 + row < m and n0 + col + 1 < n:
-                        ws_base.store[alignment=8](
+                        ws_base.unsafe_store[alignment=8](
                             (m0 + row) * n + n0 + col, pair
                         )
             else:
@@ -315,11 +328,11 @@ def _v4_tn_ws_body[
                     var row = (warp_group_idx - 1) * 64 + base_row + (q % 2) * 8
                     var col = base_col + (q // 2) * 8
                     var pair = SIMD[_V4_DT, 2](
-                        accum.ptr[e].cast[_V4_DT](),
-                        accum.ptr[e + 1].cast[_V4_DT](),
+                        accum.ptr[unsafe_offset=e].cast[_V4_DT](),
+                        accum.ptr[unsafe_offset=e + 1].cast[_V4_DT](),
                     )
                     if m0 + row < m and n0 + col + 1 < n:
-                        output.store[alignment=4](
+                        output.unsafe_store[alignment=4](
                             (m0 + row) * n + n0 + col, pair
                         )
 
@@ -349,7 +362,14 @@ def _v4_tn_splitk_m128n256_s4(
     var k = Int(k_arg)
     var chunk_tiles = Int(chunk_tiles_arg)
     _v4_tn_ws_body[256, 4, True, 8](
-        a_tma, b_tma, ws.bitcast[Scalar[_V4_DT]](), ws, m, n, k, chunk_tiles
+        a_tma,
+        b_tma,
+        ws.unsafe_bitcast[Scalar[_V4_DT]](),
+        ws,
+        m,
+        n,
+        k,
+        chunk_tiles,
     )
 
 
@@ -382,7 +402,14 @@ def _v4_nt_splitk_m128n256_s4(
     var k = Int(k_arg)
     var chunk_tiles = Int(chunk_tiles_arg)
     _v4_tn_ws_body[256, 4, True, 8, False, True](
-        a_tma, b_tma, ws.bitcast[Scalar[_V4_DT]](), ws, m, n, k, chunk_tiles
+        a_tma,
+        b_tma,
+        ws.unsafe_bitcast[Scalar[_V4_DT]](),
+        ws,
+        m,
+        n,
+        k,
+        chunk_tiles,
     )
 
 
@@ -410,7 +437,14 @@ def _v4_nn_splitk_m128n256_s4(
     var k = Int(k_arg)
     var chunk_tiles = Int(chunk_tiles_arg)
     _v4_tn_ws_body[256, 4, True, 8, False, False](
-        a_tma, b_tma, ws.bitcast[Scalar[_V4_DT]](), ws, m, n, k, chunk_tiles
+        a_tma,
+        b_tma,
+        ws.unsafe_bitcast[Scalar[_V4_DT]](),
+        ws,
+        m,
+        n,
+        k,
+        chunk_tiles,
     )
 
 
@@ -436,7 +470,14 @@ def _v4_tt_splitk_m128n256_s4(
     var k = Int(k_arg)
     var chunk_tiles = Int(chunk_tiles_arg)
     _v4_tn_ws_body[256, 4, True, 8, True, True](
-        a_tma, b_tma, ws.bitcast[Scalar[_V4_DT]](), ws, m, n, k, chunk_tiles
+        a_tma,
+        b_tma,
+        ws.unsafe_bitcast[Scalar[_V4_DT]](),
+        ws,
+        m,
+        n,
+        k,
+        chunk_tiles,
     )
 
 
@@ -460,7 +501,14 @@ def _v4_tn_direct_m128n192_s4(
     var n = Int(n_arg)
     var k = Int(k_arg)
     _v4_tn_ws_body[192, 4, False, 8](
-        a_tma, b_tma, output, output.bitcast[Scalar[_V4_F32]](), m, n, k, 0
+        a_tma,
+        b_tma,
+        output,
+        output.unsafe_bitcast[Scalar[_V4_F32]](),
+        m,
+        n,
+        k,
+        0,
     )
 
 
@@ -487,7 +535,14 @@ def _v4_tn_direct_m128n192_s3g16(
     var n = Int(n_arg)
     var k = Int(k_arg)
     _v4_tn_ws_body[192, 3, False, 16](
-        a_tma, b_tma, output, output.bitcast[Scalar[_V4_F32]](), m, n, k, 0
+        a_tma,
+        b_tma,
+        output,
+        output.unsafe_bitcast[Scalar[_V4_F32]](),
+        m,
+        n,
+        k,
+        0,
     )
 
 
@@ -519,7 +574,14 @@ def _v4_tt_direct_m128n64_s4(
     var n = Int(n_arg)
     var k = Int(k_arg)
     _v4_tn_ws_body[64, 4, False, 8, True, True](
-        a_tma, b_tma, output, output.bitcast[Scalar[_V4_F32]](), m, n, k, 0
+        a_tma,
+        b_tma,
+        output,
+        output.unsafe_bitcast[Scalar[_V4_F32]](),
+        m,
+        n,
+        k,
+        0,
     )
 
 
@@ -546,7 +608,14 @@ def _v4_tt_direct_m64n128_s3(
     var n = Int(n_arg)
     var k = Int(k_arg)
     _v4_tn_ws_body[128, 3, False, 8, True, True, 64, 1](
-        a_tma, b_tma, output, output.bitcast[Scalar[_V4_F32]](), m, n, k, 0
+        a_tma,
+        b_tma,
+        output,
+        output.unsafe_bitcast[Scalar[_V4_F32]](),
+        m,
+        n,
+        k,
+        0,
     )
 
 
@@ -578,33 +647,33 @@ def _v4_tn_splitk_reduce(
         # Fast path: all four chains fully in range.
         var acc = StaticTuple[SIMD[_V4_F32, 4], _V4_RED_GROUPS]()
         comptime for g in range(_V4_RED_GROUPS):
-            acc[g] = ws.load[width=4, alignment=16](
+            acc[g] = ws.unsafe_load[width=4, alignment=16](
                 base + g * _V4_RED_THREADS * 4
             )
         for s in range(1, splits):
             var slice_base = s * count + base
             comptime for g in range(_V4_RED_GROUPS):
-                acc[g] += ws.load[width=4, alignment=16](
+                acc[g] += ws.unsafe_load[width=4, alignment=16](
                     slice_base + g * _V4_RED_THREADS * 4
                 )
         comptime for g in range(_V4_RED_GROUPS):
-            output.store[alignment=8](
+            output.unsafe_store[alignment=8](
                 base + g * _V4_RED_THREADS * 4, acc[g].cast[_V4_DT]()
             )
     else:
         comptime for g in range(_V4_RED_GROUPS):
             var i = base + g * _V4_RED_THREADS * 4
             if i + 4 <= count:
-                var acc4 = ws.load[width=4, alignment=16](i)
+                var acc4 = ws.unsafe_load[width=4, alignment=16](i)
                 for s in range(1, splits):
-                    acc4 += ws.load[width=4, alignment=16](s * count + i)
-                output.store[alignment=8](i, acc4.cast[_V4_DT]())
+                    acc4 += ws.unsafe_load[width=4, alignment=16](s * count + i)
+                output.unsafe_store[alignment=8](i, acc4.cast[_V4_DT]())
             else:
                 while i < count:
-                    var acc1 = ws[i]
+                    var acc1 = ws[unsafe_offset=i]
                     for s in range(1, splits):
-                        acc1 += ws[s * count + i]
-                    output[i] = acc1.cast[_V4_DT]()
+                        acc1 += ws[unsafe_offset=s * count + i]
+                    output[unsafe_offset=i] = acc1.cast[_V4_DT]()
                     i += 1
 
 
@@ -619,7 +688,7 @@ def _v4_make_a_tma[
     var a_desc = create_tma_descriptor[_V4_DT, 2, _V4_SWIZZLE](
         DeviceBuffer(
             ctx,
-            a.address_space_cast[AddressSpace.GENERIC](),
+            a.unsafe_address_space_cast[AddressSpace.GENERIC](),
             1,
             owning=False,
         ),
@@ -642,7 +711,7 @@ def _v4_make_a_row_tma(
     var a_desc = create_tma_descriptor[_V4_DT, 2, _V4_SWIZZLE](
         DeviceBuffer(
             ctx,
-            a.address_space_cast[AddressSpace.GENERIC](),
+            a.unsafe_address_space_cast[AddressSpace.GENERIC](),
             1,
             owning=False,
         ),
@@ -664,7 +733,7 @@ def _v4_make_b_mn_tma[
     var b_desc = create_tma_descriptor[_V4_DT, 2, _V4_SWIZZLE](
         DeviceBuffer(
             ctx,
-            b.address_space_cast[AddressSpace.GENERIC](),
+            b.unsafe_address_space_cast[AddressSpace.GENERIC](),
             1,
             owning=False,
         ),
@@ -686,7 +755,7 @@ def _v4_make_b_kmaj_tma[
     var b_desc = create_tma_descriptor[_V4_DT, 2, _V4_SWIZZLE](
         DeviceBuffer(
             ctx,
-            b.address_space_cast[AddressSpace.GENERIC](),
+            b.unsafe_address_space_cast[AddressSpace.GENERIC](),
             1,
             owning=False,
         ),
@@ -801,7 +870,7 @@ def _v4_enqueue_direct_m128n192(
     var b_desc = create_tma_descriptor[_V4_DT, 2, _V4_SWIZZLE](
         DeviceBuffer(
             ctx,
-            b.address_space_cast[AddressSpace.GENERIC](),
+            b.unsafe_address_space_cast[AddressSpace.GENERIC](),
             1,
             owning=False,
         ),

--- a/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_v3_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/gemm16_matmul_ops/gemm16_v3_kernels.mojo
@@ -61,7 +61,7 @@ from gemm16_dtype import _GEMM16_DT, _GEMM16_TAG
 
 comptime _V3_DT = _GEMM16_DT
 comptime _V3_F32 = DType.float32
-comptime _V3_PTR = UnsafePointer[Scalar[_V3_DT], MutAnyOrigin]
+comptime _V3_PTR = Pointer[Scalar[_V3_DT], MutAnyOrigin]
 comptime _V3_BM = 64
 comptime _V3_BN = 128
 comptime _V3_BK = 64
@@ -291,8 +291,10 @@ def _v3_nn_ws_m128n256_tma_s3(
         ]()
         if thread_idx.x == 0:
             comptime for stage in range(_V3_NN_STAGES):
-                full_barriers[stage].init()
-                empty_barriers[stage].init(Int32(_V3_NN_CONSUMERS))
+                full_barriers[unsafe_offset=stage].init()
+                empty_barriers[unsafe_offset=stage].init(
+                    Int32(_V3_NN_CONSUMERS)
+                )
             a_tma.prefetch_descriptor()
             b_tma.prefetch_descriptor()
         # Publish barrier initialization before consumer warp groups mark the
@@ -317,7 +319,7 @@ def _v3_nn_ws_m128n256_tma_s3(
 
         if warp_group_idx > 0 and warp_group_thread_idx == 0:
             comptime for stage in range(_V3_NN_STAGES):
-                _ = empty_barriers[stage].arrive()
+                _ = empty_barriers[unsafe_offset=stage].arrive()
         barrier()
 
         if warp_group_idx == 0:
@@ -327,25 +329,39 @@ def _v3_nn_ws_m128n256_tma_s3(
                 while tile < num_tiles:
                     var stage = tile % _V3_NN_STAGES
                     var phase = UInt32((tile // _V3_NN_STAGES) % 2)
-                    empty_barriers[stage].wait(phase)
-                    full_barriers[stage].expect_bytes(Int32(TMA_BYTES))
+                    empty_barriers[unsafe_offset=stage].wait(phase)
+                    full_barriers[unsafe_offset=stage].expect_bytes(
+                        Int32(TMA_BYTES)
+                    )
                     var a_tile = LayoutTensor[
                         _V3_DT,
                         _V3_NN_A_LAYOUT,
                         MutAnyOrigin,
                         address_space=AddressSpace.SHARED,
                         alignment=128,
-                    ](a_pipeline.ptr + stage * _V3_NN_BM * _V3_NN_BK)
+                    ](
+                        a_pipeline.ptr.unsafe_offset(
+                            stage * _V3_NN_BM * _V3_NN_BK
+                        )
+                    )
                     var b_tile = LayoutTensor[
                         _V3_DT,
                         _V3_NN_B_LAYOUT,
                         MutAnyOrigin,
                         address_space=AddressSpace.SHARED,
                         alignment=128,
-                    ](b_pipeline.ptr + stage * _V3_NN_BN * _V3_NN_BK)
+                    ](
+                        b_pipeline.ptr.unsafe_offset(
+                            stage * _V3_NN_BN * _V3_NN_BK
+                        )
+                    )
                     var k0 = tile * _V3_NN_BK
-                    a_tma.async_copy(a_tile, full_barriers[stage], (k0, m0))
-                    b_tma.async_copy(b_tile, full_barriers[stage], (n0, k0))
+                    a_tma.async_copy(
+                        a_tile, full_barriers[unsafe_offset=stage], (k0, m0)
+                    )
+                    b_tma.async_copy(
+                        b_tile, full_barriers[unsafe_offset=stage], (n0, k0)
+                    )
                     tile += 1
         else:
             warpgroup_reg_alloc[232]()
@@ -370,21 +386,21 @@ def _v3_nn_ws_m128n256_tma_s3(
             while tile < num_tiles:
                 var stage = tile % _V3_NN_STAGES
                 var phase = UInt32((tile // _V3_NN_STAGES) % 2)
-                full_barriers[stage].wait(phase)
+                full_barriers[unsafe_offset=stage].wait(phase)
                 var a_tile = LayoutTensor[
                     _V3_DT,
                     _V3_NN_A_LAYOUT,
                     MutAnyOrigin,
                     address_space=AddressSpace.SHARED,
                     alignment=128,
-                ](a_pipeline.ptr + stage * _V3_NN_BM * _V3_NN_BK)
+                ](a_pipeline.ptr.unsafe_offset(stage * _V3_NN_BM * _V3_NN_BK))
                 var b_tile = LayoutTensor[
                     _V3_DT,
                     _V3_NN_B_LAYOUT,
                     MutAnyOrigin,
                     address_space=AddressSpace.SHARED,
                     alignment=128,
-                ](b_pipeline.ptr + stage * _V3_NN_BN * _V3_NN_BK)
+                ](b_pipeline.ptr.unsafe_offset(stage * _V3_NN_BN * _V3_NN_BK))
                 warpgroup_fence(accum)
                 wgmma.arrive()
                 wgmma.wgmma[_V3_NN_CONSUMERS](
@@ -394,7 +410,7 @@ def _v3_nn_ws_m128n256_tma_s3(
                 warpgroup_fence(accum)
                 wgmma.wait_group()
                 if warp_group_thread_idx == 0:
-                    _ = empty_barriers[stage].arrive()
+                    _ = empty_barriers[unsafe_offset=stage].arrive()
                 tile += 1
 
             var tid = warp_group_thread_idx
@@ -407,11 +423,13 @@ def _v3_nn_ws_m128n256_tma_s3(
                 var row = (warp_group_idx - 1) * 64 + base_row + (q % 2) * 8
                 var col = base_col + (q // 2) * 8
                 var pair = SIMD[_V3_DT, 2](
-                    accum.ptr[e].cast[_V3_DT](),
-                    accum.ptr[e + 1].cast[_V3_DT](),
+                    accum.ptr[unsafe_offset=e].cast[_V3_DT](),
+                    accum.ptr[unsafe_offset=e + 1].cast[_V3_DT](),
                 )
                 if m0 + row < m and n0 + col + 1 < n:
-                    output.store[alignment=4]((m0 + row) * n + n0 + col, pair)
+                    output.unsafe_store[alignment=4](
+                        (m0 + row) * n + n0 + col, pair
+                    )
 
 
 def _v3_enqueue_nn_ws_m128n256_tma_s3(
@@ -427,7 +445,7 @@ def _v3_enqueue_nn_ws_m128n256_tma_s3(
     var a_desc = create_tma_descriptor[_V3_DT, 2, _V3_SWIZZLE](
         DeviceBuffer(
             ctx,
-            a.address_space_cast[AddressSpace.GENERIC](),
+            a.unsafe_address_space_cast[AddressSpace.GENERIC](),
             1,
             owning=False,
         ),
@@ -438,7 +456,7 @@ def _v3_enqueue_nn_ws_m128n256_tma_s3(
     var b_desc = create_tma_descriptor[_V3_DT, 2, _V3_SWIZZLE](
         DeviceBuffer(
             ctx,
-            b.address_space_cast[AddressSpace.GENERIC](),
+            b.unsafe_address_space_cast[AddressSpace.GENERIC](),
             1,
             owning=False,
         ),
@@ -521,8 +539,10 @@ def _v3_nn_ws_m64n128_tma_s3(
         ]()
         if thread_idx.x == 0:
             comptime for stage in range(_V3_NN_SMALL_STAGES):
-                full_barriers[stage].init()
-                empty_barriers[stage].init(Int32(_V3_NN_SMALL_CONSUMERS))
+                full_barriers[unsafe_offset=stage].init()
+                empty_barriers[unsafe_offset=stage].init(
+                    Int32(_V3_NN_SMALL_CONSUMERS)
+                )
             a_tma.prefetch_descriptor()
             b_tma.prefetch_descriptor()
         barrier()
@@ -546,7 +566,7 @@ def _v3_nn_ws_m64n128_tma_s3(
 
         if warp_group_idx > 0 and warp_group_thread_idx == 0:
             comptime for stage in range(_V3_NN_SMALL_STAGES):
-                _ = empty_barriers[stage].arrive()
+                _ = empty_barriers[unsafe_offset=stage].arrive()
         barrier()
 
         if warp_group_idx == 0:
@@ -556,8 +576,10 @@ def _v3_nn_ws_m64n128_tma_s3(
                 while tile < num_tiles:
                     var stage = tile % _V3_NN_SMALL_STAGES
                     var phase = UInt32((tile // _V3_NN_SMALL_STAGES) % 2)
-                    empty_barriers[stage].wait(phase)
-                    full_barriers[stage].expect_bytes(Int32(TMA_BYTES))
+                    empty_barriers[unsafe_offset=stage].wait(phase)
+                    full_barriers[unsafe_offset=stage].expect_bytes(
+                        Int32(TMA_BYTES)
+                    )
                     var a_tile = LayoutTensor[
                         _V3_DT,
                         _V3_NN_SMALL_A_LAYOUT,
@@ -565,8 +587,9 @@ def _v3_nn_ws_m64n128_tma_s3(
                         address_space=AddressSpace.SHARED,
                         alignment=128,
                     ](
-                        a_pipeline.ptr
-                        + stage * _V3_NN_SMALL_BM * _V3_NN_SMALL_BK
+                        a_pipeline.ptr.unsafe_offset(
+                            stage * _V3_NN_SMALL_BM * _V3_NN_SMALL_BK
+                        )
                     )
                     var b_tile = LayoutTensor[
                         _V3_DT,
@@ -575,12 +598,17 @@ def _v3_nn_ws_m64n128_tma_s3(
                         address_space=AddressSpace.SHARED,
                         alignment=128,
                     ](
-                        b_pipeline.ptr
-                        + stage * _V3_NN_SMALL_BN * _V3_NN_SMALL_BK
+                        b_pipeline.ptr.unsafe_offset(
+                            stage * _V3_NN_SMALL_BN * _V3_NN_SMALL_BK
+                        )
                     )
                     var k0 = tile * _V3_NN_SMALL_BK
-                    a_tma.async_copy(a_tile, full_barriers[stage], (k0, m0))
-                    b_tma.async_copy(b_tile, full_barriers[stage], (n0, k0))
+                    a_tma.async_copy(
+                        a_tile, full_barriers[unsafe_offset=stage], (k0, m0)
+                    )
+                    b_tma.async_copy(
+                        b_tile, full_barriers[unsafe_offset=stage], (n0, k0)
+                    )
                     tile += 1
         else:
             warpgroup_reg_alloc[232]()
@@ -605,21 +633,29 @@ def _v3_nn_ws_m64n128_tma_s3(
             while tile < num_tiles:
                 var stage = tile % _V3_NN_SMALL_STAGES
                 var phase = UInt32((tile // _V3_NN_SMALL_STAGES) % 2)
-                full_barriers[stage].wait(phase)
+                full_barriers[unsafe_offset=stage].wait(phase)
                 var a_tile = LayoutTensor[
                     _V3_DT,
                     _V3_NN_SMALL_A_LAYOUT,
                     MutAnyOrigin,
                     address_space=AddressSpace.SHARED,
                     alignment=128,
-                ](a_pipeline.ptr + stage * _V3_NN_SMALL_BM * _V3_NN_SMALL_BK)
+                ](
+                    a_pipeline.ptr.unsafe_offset(
+                        stage * _V3_NN_SMALL_BM * _V3_NN_SMALL_BK
+                    )
+                )
                 var b_tile = LayoutTensor[
                     _V3_DT,
                     _V3_NN_SMALL_B_LAYOUT,
                     MutAnyOrigin,
                     address_space=AddressSpace.SHARED,
                     alignment=128,
-                ](b_pipeline.ptr + stage * _V3_NN_SMALL_BN * _V3_NN_SMALL_BK)
+                ](
+                    b_pipeline.ptr.unsafe_offset(
+                        stage * _V3_NN_SMALL_BN * _V3_NN_SMALL_BK
+                    )
+                )
                 warpgroup_fence(accum)
                 wgmma.arrive()
                 wgmma.wgmma[_V3_NN_SMALL_CONSUMERS](
@@ -629,7 +665,7 @@ def _v3_nn_ws_m64n128_tma_s3(
                 warpgroup_fence(accum)
                 wgmma.wait_group()
                 if warp_group_thread_idx == 0:
-                    _ = empty_barriers[stage].arrive()
+                    _ = empty_barriers[unsafe_offset=stage].arrive()
                 tile += 1
 
             var tid = warp_group_thread_idx
@@ -642,11 +678,13 @@ def _v3_nn_ws_m64n128_tma_s3(
                 var row = base_row + (q % 2) * 8
                 var col = base_col + (q // 2) * 8
                 var pair = SIMD[_V3_DT, 2](
-                    accum.ptr[e].cast[_V3_DT](),
-                    accum.ptr[e + 1].cast[_V3_DT](),
+                    accum.ptr[unsafe_offset=e].cast[_V3_DT](),
+                    accum.ptr[unsafe_offset=e + 1].cast[_V3_DT](),
                 )
                 if m0 + row < m and n0 + col + 1 < n:
-                    output.store[alignment=4]((m0 + row) * n + n0 + col, pair)
+                    output.unsafe_store[alignment=4](
+                        (m0 + row) * n + n0 + col, pair
+                    )
 
 
 def _v3_enqueue_nn_ws_m64n128_tma_s3(
@@ -662,7 +700,7 @@ def _v3_enqueue_nn_ws_m64n128_tma_s3(
     var a_desc = create_tma_descriptor[_V3_DT, 2, _V3_SWIZZLE](
         DeviceBuffer(
             ctx,
-            a.address_space_cast[AddressSpace.GENERIC](),
+            a.unsafe_address_space_cast[AddressSpace.GENERIC](),
             1,
             owning=False,
         ),
@@ -673,7 +711,7 @@ def _v3_enqueue_nn_ws_m64n128_tma_s3(
     var b_desc = create_tma_descriptor[_V3_DT, 2, _V3_SWIZZLE](
         DeviceBuffer(
             ctx,
-            b.address_space_cast[AddressSpace.GENERIC](),
+            b.unsafe_address_space_cast[AddressSpace.GENERIC](),
             1,
             owning=False,
         ),
@@ -748,8 +786,10 @@ def _v3_nt_ws_m128n256_tma_s3(
         ]()
         if thread_idx.x == 0:
             comptime for stage in range(_V3_NT_STAGES):
-                full_barriers[stage].init()
-                empty_barriers[stage].init(Int32(_V3_NT_CONSUMERS))
+                full_barriers[unsafe_offset=stage].init()
+                empty_barriers[unsafe_offset=stage].init(
+                    Int32(_V3_NT_CONSUMERS)
+                )
             a_tma.prefetch_descriptor()
             b_tma.prefetch_descriptor()
         barrier()
@@ -771,7 +811,7 @@ def _v3_nt_ws_m128n256_tma_s3(
 
         if warp_group_idx > 0 and warp_group_thread_idx == 0:
             comptime for stage in range(_V3_NT_STAGES):
-                _ = empty_barriers[stage].arrive()
+                _ = empty_barriers[unsafe_offset=stage].arrive()
         barrier()
 
         if warp_group_idx == 0:
@@ -781,8 +821,10 @@ def _v3_nt_ws_m128n256_tma_s3(
                 while tile < num_tiles:
                     var stage = tile % _V3_NT_STAGES
                     var phase = UInt32((tile // _V3_NT_STAGES) % 2)
-                    empty_barriers[stage].wait(phase)
-                    full_barriers[stage].expect_bytes(Int32(TMA_BYTES))
+                    empty_barriers[unsafe_offset=stage].wait(phase)
+                    full_barriers[unsafe_offset=stage].expect_bytes(
+                        Int32(TMA_BYTES)
+                    )
 
                     var a_tile = LayoutTensor[
                         _V3_DT,
@@ -790,17 +832,29 @@ def _v3_nt_ws_m128n256_tma_s3(
                         MutAnyOrigin,
                         address_space=AddressSpace.SHARED,
                         alignment=128,
-                    ](a_pipeline.ptr + stage * _V3_NT_BM * _V3_NT_BK)
+                    ](
+                        a_pipeline.ptr.unsafe_offset(
+                            stage * _V3_NT_BM * _V3_NT_BK
+                        )
+                    )
                     var b_tile = LayoutTensor[
                         _V3_DT,
                         _V3_B_K_LAYOUT,
                         MutAnyOrigin,
                         address_space=AddressSpace.SHARED,
                         alignment=128,
-                    ](b_pipeline.ptr + stage * _V3_NT_BN * _V3_NT_BK)
+                    ](
+                        b_pipeline.ptr.unsafe_offset(
+                            stage * _V3_NT_BN * _V3_NT_BK
+                        )
+                    )
                     var k0 = tile * _V3_NT_BK
-                    a_tma.async_copy(a_tile, full_barriers[stage], (k0, m0))
-                    b_tma.async_copy(b_tile, full_barriers[stage], (k0, n0))
+                    a_tma.async_copy(
+                        a_tile, full_barriers[unsafe_offset=stage], (k0, m0)
+                    )
+                    b_tma.async_copy(
+                        b_tile, full_barriers[unsafe_offset=stage], (k0, n0)
+                    )
                     tile += 1
         else:
             warpgroup_reg_alloc[232]()
@@ -825,21 +879,21 @@ def _v3_nt_ws_m128n256_tma_s3(
             while tile < num_tiles:
                 var stage = tile % _V3_NT_STAGES
                 var phase = UInt32((tile // _V3_NT_STAGES) % 2)
-                full_barriers[stage].wait(phase)
+                full_barriers[unsafe_offset=stage].wait(phase)
                 var a_tile = LayoutTensor[
                     _V3_DT,
                     _V3_NT_A_LAYOUT,
                     MutAnyOrigin,
                     address_space=AddressSpace.SHARED,
                     alignment=128,
-                ](a_pipeline.ptr + stage * _V3_NT_BM * _V3_NT_BK)
+                ](a_pipeline.ptr.unsafe_offset(stage * _V3_NT_BM * _V3_NT_BK))
                 var b_tile = LayoutTensor[
                     _V3_DT,
                     _V3_B_K_LAYOUT,
                     MutAnyOrigin,
                     address_space=AddressSpace.SHARED,
                     alignment=128,
-                ](b_pipeline.ptr + stage * _V3_NT_BN * _V3_NT_BK)
+                ](b_pipeline.ptr.unsafe_offset(stage * _V3_NT_BN * _V3_NT_BK))
                 warpgroup_fence(accum)
                 wgmma.arrive()
                 wgmma.wgmma[_V3_NT_CONSUMERS](
@@ -849,7 +903,7 @@ def _v3_nt_ws_m128n256_tma_s3(
                 warpgroup_fence(accum)
                 wgmma.wait_group()
                 if warp_group_thread_idx == 0:
-                    _ = empty_barriers[stage].arrive()
+                    _ = empty_barriers[unsafe_offset=stage].arrive()
                 tile += 1
 
             var tid = warp_group_thread_idx
@@ -862,11 +916,13 @@ def _v3_nt_ws_m128n256_tma_s3(
                 var row = (warp_group_idx - 1) * 64 + base_row + (q % 2) * 8
                 var col = base_col + (q // 2) * 8
                 var pair = SIMD[_V3_DT, 2](
-                    accum.ptr[e].cast[_V3_DT](),
-                    accum.ptr[e + 1].cast[_V3_DT](),
+                    accum.ptr[unsafe_offset=e].cast[_V3_DT](),
+                    accum.ptr[unsafe_offset=e + 1].cast[_V3_DT](),
                 )
                 if m0 + row < m and n0 + col + 1 < n:
-                    output.store[alignment=4]((m0 + row) * n + n0 + col, pair)
+                    output.unsafe_store[alignment=4](
+                        (m0 + row) * n + n0 + col, pair
+                    )
 
 
 def _v3_enqueue_nt_ws_m128n256_tma_s3(
@@ -882,7 +938,7 @@ def _v3_enqueue_nt_ws_m128n256_tma_s3(
     var a_desc = create_tma_descriptor[_V3_DT, 2, _V3_SWIZZLE](
         DeviceBuffer(
             ctx,
-            a.address_space_cast[AddressSpace.GENERIC](),
+            a.unsafe_address_space_cast[AddressSpace.GENERIC](),
             1,
             owning=False,
         ),
@@ -893,7 +949,7 @@ def _v3_enqueue_nt_ws_m128n256_tma_s3(
     var b_desc = create_tma_descriptor[_V3_DT, 2, _V3_SWIZZLE](
         DeviceBuffer(
             ctx,
-            b.address_space_cast[AddressSpace.GENERIC](),
+            b.unsafe_address_space_cast[AddressSpace.GENERIC](),
             1,
             owning=False,
         ),
@@ -976,8 +1032,10 @@ def _v3_tn_ws_m64n128_tma_col_a_s3(
         ]()
         if thread_idx.x == 0:
             comptime for stage in range(_V3_TN_SMALL_STAGES):
-                full_barriers[stage].init()
-                empty_barriers[stage].init(Int32(_V3_TN_SMALL_CONSUMERS))
+                full_barriers[unsafe_offset=stage].init()
+                empty_barriers[unsafe_offset=stage].init(
+                    Int32(_V3_TN_SMALL_CONSUMERS)
+                )
             a_tma.prefetch_descriptor()
             b_tma.prefetch_descriptor()
         # Barrier objects must be initialized before the consumer performs
@@ -1004,7 +1062,7 @@ def _v3_tn_ws_m64n128_tma_col_a_s3(
 
         if warp_group_idx > 0 and warp_group_thread_idx == 0:
             comptime for stage in range(_V3_TN_SMALL_STAGES):
-                _ = empty_barriers[stage].arrive()
+                _ = empty_barriers[unsafe_offset=stage].arrive()
         barrier()
 
         if warp_group_idx == 0:
@@ -1014,8 +1072,10 @@ def _v3_tn_ws_m64n128_tma_col_a_s3(
                 while tile < num_tiles:
                     var stage = tile % _V3_TN_SMALL_STAGES
                     var phase = UInt32((tile // _V3_TN_SMALL_STAGES) % 2)
-                    empty_barriers[stage].wait(phase)
-                    full_barriers[stage].expect_bytes(Int32(TMA_BYTES))
+                    empty_barriers[unsafe_offset=stage].wait(phase)
+                    full_barriers[unsafe_offset=stage].expect_bytes(
+                        Int32(TMA_BYTES)
+                    )
                     var a_tile = LayoutTensor[
                         _V3_DT,
                         _V3_TN_SMALL_A_LAYOUT,
@@ -1023,8 +1083,9 @@ def _v3_tn_ws_m64n128_tma_col_a_s3(
                         address_space=AddressSpace.SHARED,
                         alignment=128,
                     ](
-                        a_pipeline.ptr
-                        + stage * _V3_TN_SMALL_BM * _V3_TN_SMALL_BK
+                        a_pipeline.ptr.unsafe_offset(
+                            stage * _V3_TN_SMALL_BM * _V3_TN_SMALL_BK
+                        )
                     )
                     var b_tile = LayoutTensor[
                         _V3_DT,
@@ -1033,12 +1094,17 @@ def _v3_tn_ws_m64n128_tma_col_a_s3(
                         address_space=AddressSpace.SHARED,
                         alignment=128,
                     ](
-                        b_pipeline.ptr
-                        + stage * _V3_TN_SMALL_BN * _V3_TN_SMALL_BK
+                        b_pipeline.ptr.unsafe_offset(
+                            stage * _V3_TN_SMALL_BN * _V3_TN_SMALL_BK
+                        )
                     )
                     var k0 = tile * _V3_TN_SMALL_BK
-                    a_tma.async_copy(a_tile, full_barriers[stage], (m0, k0))
-                    b_tma.async_copy(b_tile, full_barriers[stage], (n0, k0))
+                    a_tma.async_copy(
+                        a_tile, full_barriers[unsafe_offset=stage], (m0, k0)
+                    )
+                    b_tma.async_copy(
+                        b_tile, full_barriers[unsafe_offset=stage], (n0, k0)
+                    )
                     tile += 1
         else:
             warpgroup_reg_alloc[232]()
@@ -1067,21 +1133,29 @@ def _v3_tn_ws_m64n128_tma_col_a_s3(
             while tile < num_tiles:
                 var stage = tile % _V3_TN_SMALL_STAGES
                 var phase = UInt32((tile // _V3_TN_SMALL_STAGES) % 2)
-                full_barriers[stage].wait(phase)
+                full_barriers[unsafe_offset=stage].wait(phase)
                 var a_tile = LayoutTensor[
                     _V3_DT,
                     _V3_TN_SMALL_A_LAYOUT,
                     MutAnyOrigin,
                     address_space=AddressSpace.SHARED,
                     alignment=128,
-                ](a_pipeline.ptr + stage * _V3_TN_SMALL_BM * _V3_TN_SMALL_BK)
+                ](
+                    a_pipeline.ptr.unsafe_offset(
+                        stage * _V3_TN_SMALL_BM * _V3_TN_SMALL_BK
+                    )
+                )
                 var b_tile = LayoutTensor[
                     _V3_DT,
                     _V3_TN_SMALL_B_LAYOUT,
                     MutAnyOrigin,
                     address_space=AddressSpace.SHARED,
                     alignment=128,
-                ](b_pipeline.ptr + stage * _V3_TN_SMALL_BN * _V3_TN_SMALL_BK)
+                ](
+                    b_pipeline.ptr.unsafe_offset(
+                        stage * _V3_TN_SMALL_BN * _V3_TN_SMALL_BK
+                    )
+                )
                 var a_desc = _wgmma_descriptor[
                     a_canonical_layout, False, _V3_SWIZZLE
                 ](a_tile.ptr)
@@ -1113,7 +1187,7 @@ def _v3_tn_ws_m64n128_tma_col_a_s3(
                 warpgroup_fence(accum)
                 wgmma_wait_group_sync()
                 if warp_group_thread_idx == 0:
-                    _ = empty_barriers[stage].arrive()
+                    _ = empty_barriers[unsafe_offset=stage].arrive()
                 tile += 1
 
             var tid = warp_group_thread_idx
@@ -1126,11 +1200,13 @@ def _v3_tn_ws_m64n128_tma_col_a_s3(
                 var row = base_row + (q % 2) * 8
                 var col = base_col + (q // 2) * 8
                 var pair = SIMD[_V3_DT, 2](
-                    accum.ptr[e].cast[_V3_DT](),
-                    accum.ptr[e + 1].cast[_V3_DT](),
+                    accum.ptr[unsafe_offset=e].cast[_V3_DT](),
+                    accum.ptr[unsafe_offset=e + 1].cast[_V3_DT](),
                 )
                 if m0 + row < m and n0 + col + 1 < n:
-                    output.store[alignment=4]((m0 + row) * n + n0 + col, pair)
+                    output.unsafe_store[alignment=4](
+                        (m0 + row) * n + n0 + col, pair
+                    )
 
 
 def _v3_enqueue_tn_ws_m64n128_tma_col_a_s3(
@@ -1146,7 +1222,7 @@ def _v3_enqueue_tn_ws_m64n128_tma_col_a_s3(
     var a_desc = create_tma_descriptor[_V3_DT, 2, _V3_SWIZZLE](
         DeviceBuffer(
             ctx,
-            a.address_space_cast[AddressSpace.GENERIC](),
+            a.unsafe_address_space_cast[AddressSpace.GENERIC](),
             1,
             owning=False,
         ),
@@ -1157,7 +1233,7 @@ def _v3_enqueue_tn_ws_m64n128_tma_col_a_s3(
     var b_desc = create_tma_descriptor[_V3_DT, 2, _V3_SWIZZLE](
         DeviceBuffer(
             ctx,
-            b.address_space_cast[AddressSpace.GENERIC](),
+            b.unsafe_address_space_cast[AddressSpace.GENERIC](),
             1,
             owning=False,
         ),
@@ -1239,8 +1315,10 @@ def _v3_tn_ws_m128n256_tma_col_a_s3(
         ]()
         if thread_idx.x == 0:
             comptime for stage in range(_V3_TN_WS_STAGES):
-                full_barriers[stage].init()
-                empty_barriers[stage].init(Int32(_V3_TN_WS_CONSUMERS))
+                full_barriers[unsafe_offset=stage].init()
+                empty_barriers[unsafe_offset=stage].init(
+                    Int32(_V3_TN_WS_CONSUMERS)
+                )
             a_tma.prefetch_descriptor()
             b_tma.prefetch_descriptor()
         # Order barrier initialization before cross-warp-group arrivals.
@@ -1265,7 +1343,7 @@ def _v3_tn_ws_m128n256_tma_col_a_s3(
         # both consumer warp groups arrive only after their WGMMA reads finish.
         if warp_group_idx > 0 and warp_group_thread_idx == 0:
             comptime for stage in range(_V3_TN_WS_STAGES):
-                _ = empty_barriers[stage].arrive()
+                _ = empty_barriers[unsafe_offset=stage].arrive()
         barrier()
 
         if warp_group_idx == 0:
@@ -1275,8 +1353,10 @@ def _v3_tn_ws_m128n256_tma_col_a_s3(
                 while tile < num_tiles:
                     var stage = tile % _V3_TN_WS_STAGES
                     var phase = UInt32((tile // _V3_TN_WS_STAGES) % 2)
-                    empty_barriers[stage].wait(phase)
-                    full_barriers[stage].expect_bytes(Int32(TMA_BYTES))
+                    empty_barriers[unsafe_offset=stage].wait(phase)
+                    full_barriers[unsafe_offset=stage].expect_bytes(
+                        Int32(TMA_BYTES)
+                    )
 
                     var a_tile = LayoutTensor[
                         _V3_DT,
@@ -1284,17 +1364,29 @@ def _v3_tn_ws_m128n256_tma_col_a_s3(
                         MutAnyOrigin,
                         address_space=AddressSpace.SHARED,
                         alignment=128,
-                    ](a_pipeline.ptr + stage * _V3_TN_WS_BM * _V3_TN_WS_BK)
+                    ](
+                        a_pipeline.ptr.unsafe_offset(
+                            stage * _V3_TN_WS_BM * _V3_TN_WS_BK
+                        )
+                    )
                     var b_tile = LayoutTensor[
                         _V3_DT,
                         _V3_TN_WS_B_LAYOUT,
                         MutAnyOrigin,
                         address_space=AddressSpace.SHARED,
                         alignment=128,
-                    ](b_pipeline.ptr + stage * _V3_TN_WS_BN * _V3_TN_WS_BK)
+                    ](
+                        b_pipeline.ptr.unsafe_offset(
+                            stage * _V3_TN_WS_BN * _V3_TN_WS_BK
+                        )
+                    )
                     var k0 = tile * _V3_TN_WS_BK
-                    a_tma.async_copy(a_tile, full_barriers[stage], (m0, k0))
-                    b_tma.async_copy(b_tile, full_barriers[stage], (n0, k0))
+                    a_tma.async_copy(
+                        a_tile, full_barriers[unsafe_offset=stage], (m0, k0)
+                    )
+                    b_tma.async_copy(
+                        b_tile, full_barriers[unsafe_offset=stage], (n0, k0)
+                    )
                     tile += 1
         else:
             warpgroup_reg_alloc[232]()
@@ -1330,21 +1422,29 @@ def _v3_tn_ws_m128n256_tma_col_a_s3(
             while tile < num_tiles:
                 var stage = tile % _V3_TN_WS_STAGES
                 var phase = UInt32((tile // _V3_TN_WS_STAGES) % 2)
-                full_barriers[stage].wait(phase)
+                full_barriers[unsafe_offset=stage].wait(phase)
                 var a_tile = LayoutTensor[
                     _V3_DT,
                     _V3_TN_WS_A_LAYOUT,
                     MutAnyOrigin,
                     address_space=AddressSpace.SHARED,
                     alignment=128,
-                ](a_pipeline.ptr + stage * _V3_TN_WS_BM * _V3_TN_WS_BK)
+                ](
+                    a_pipeline.ptr.unsafe_offset(
+                        stage * _V3_TN_WS_BM * _V3_TN_WS_BK
+                    )
+                )
                 var b_tile = LayoutTensor[
                     _V3_DT,
                     _V3_TN_WS_B_LAYOUT,
                     MutAnyOrigin,
                     address_space=AddressSpace.SHARED,
                     alignment=128,
-                ](b_pipeline.ptr + stage * _V3_TN_WS_BN * _V3_TN_WS_BK)
+                ](
+                    b_pipeline.ptr.unsafe_offset(
+                        stage * _V3_TN_WS_BN * _V3_TN_WS_BK
+                    )
+                )
                 var a_desc = _wgmma_descriptor[
                     a_canonical_layout, False, _V3_SWIZZLE
                 ](a_tile.ptr)
@@ -1377,7 +1477,7 @@ def _v3_tn_ws_m128n256_tma_col_a_s3(
                 warpgroup_fence(accum)
                 wgmma_wait_group_sync()
                 if warp_group_thread_idx == 0:
-                    _ = empty_barriers[stage].arrive()
+                    _ = empty_barriers[unsafe_offset=stage].arrive()
                 tile += 1
 
             var tid = warp_group_thread_idx
@@ -1390,11 +1490,13 @@ def _v3_tn_ws_m128n256_tma_col_a_s3(
                 var row = (warp_group_idx - 1) * 64 + base_row + (q % 2) * 8
                 var col = base_col + (q // 2) * 8
                 var pair = SIMD[_V3_DT, 2](
-                    accum.ptr[e].cast[_V3_DT](),
-                    accum.ptr[e + 1].cast[_V3_DT](),
+                    accum.ptr[unsafe_offset=e].cast[_V3_DT](),
+                    accum.ptr[unsafe_offset=e + 1].cast[_V3_DT](),
                 )
                 if m0 + row < m and n0 + col + 1 < n:
-                    output.store[alignment=4]((m0 + row) * n + n0 + col, pair)
+                    output.unsafe_store[alignment=4](
+                        (m0 + row) * n + n0 + col, pair
+                    )
 
 
 def _v3_enqueue_tn_ws_m128n256_tma_col_a_s3(
@@ -1410,7 +1512,7 @@ def _v3_enqueue_tn_ws_m128n256_tma_col_a_s3(
     var a_desc = create_tma_descriptor[_V3_DT, 2, _V3_SWIZZLE](
         DeviceBuffer(
             ctx,
-            a.address_space_cast[AddressSpace.GENERIC](),
+            a.unsafe_address_space_cast[AddressSpace.GENERIC](),
             1,
             owning=False,
         ),
@@ -1421,7 +1523,7 @@ def _v3_enqueue_tn_ws_m128n256_tma_col_a_s3(
     var b_desc = create_tma_descriptor[_V3_DT, 2, _V3_SWIZZLE](
         DeviceBuffer(
             ctx,
-            b.address_space_cast[AddressSpace.GENERIC](),
+            b.unsafe_address_space_cast[AddressSpace.GENERIC](),
             1,
             owning=False,
         ),
@@ -1558,10 +1660,10 @@ def _try_enqueue_gemm16_tn_route(
 
 
 def enqueue_gemm16_gemm(
-    output: UnsafePointer[Scalar[_V3_DT], MutAnyOrigin],
-    a: UnsafePointer[Scalar[_V3_DT], MutAnyOrigin],
-    b: UnsafePointer[Scalar[_V3_DT], MutAnyOrigin],
-    bias: UnsafePointer[Scalar[_V3_DT], MutAnyOrigin],
+    output: Pointer[Scalar[_V3_DT], MutAnyOrigin],
+    a: Pointer[Scalar[_V3_DT], MutAnyOrigin],
+    b: Pointer[Scalar[_V3_DT], MutAnyOrigin],
+    bias: Pointer[Scalar[_V3_DT], MutAnyOrigin],
     m: Int,
     n: Int,
     k: Int,
@@ -1817,9 +1919,9 @@ def enqueue_gemm16_gemm(
 
 
 def enqueue_gemm16_bmm(
-    output: UnsafePointer[Scalar[_V3_DT], MutAnyOrigin],
-    a: UnsafePointer[Scalar[_V3_DT], MutAnyOrigin],
-    b: UnsafePointer[Scalar[_V3_DT], MutAnyOrigin],
+    output: Pointer[Scalar[_V3_DT], MutAnyOrigin],
+    a: Pointer[Scalar[_V3_DT], MutAnyOrigin],
+    b: Pointer[Scalar[_V3_DT], MutAnyOrigin],
     batch_count: Int,
     m: Int,
     n: Int,
@@ -1899,9 +2001,11 @@ def enqueue_gemm16_bmm(
                     and _try_enqueue_gemm16_tn_route(output, a, b, m, n, k, ctx)
                 ):
                     for bidx in range(1, batch_count):
-                        var oo = output + bidx * output_batch_stride
-                        var ao = a + bidx * a_batch_stride
-                        var bo = b + bidx * b_batch_stride
+                        var oo = output.unsafe_offset(
+                            bidx * output_batch_stride
+                        )
+                        var ao = a.unsafe_offset(bidx * a_batch_stride)
+                        var bo = b.unsafe_offset(bidx * b_batch_stride)
                         if not _try_enqueue_gemm16_tn_route(
                             oo, ao, bo, m, n, k, ctx
                         ):

--- a/torch_mojo_backend/eager_kernels/logic_ops/logic_ops.mojo
+++ b/torch_mojo_backend/eager_kernels/logic_ops/logic_ops.mojo
@@ -169,9 +169,9 @@ comptime _ADD_F32_BF16_VEC = 4
 
 @__name("torch_mojo_add_f32_bf16_vec4")
 def _add_f32_bf16_contig_kernel(
-    output_f32: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    input_f32: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
-    input_bf16: UnsafePointer[Scalar[DType.bfloat16], ImmutAnyOrigin],
+    output_f32: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    input_f32: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
+    input_bf16: Pointer[Scalar[DType.bfloat16], ImmutAnyOrigin],
     elements_arg: Int64,
     vec_count_arg: Int64,
 ):
@@ -183,28 +183,33 @@ def _add_f32_bf16_contig_kernel(
     var gid = Int(block_idx.x) * _ADD_F32_BF16_BLOCK + Int(thread_idx.x)
     if gid < vec_count:
         var base = gid * _ADD_F32_BF16_VEC
-        var lhs = input_f32.load[width=_ADD_F32_BF16_VEC, alignment=16](base)
-        var rhs = input_bf16.load[width=_ADD_F32_BF16_VEC, alignment=8](
+        var lhs = input_f32.unsafe_load[width=_ADD_F32_BF16_VEC, alignment=16](
+            base
+        )
+        var rhs = input_bf16.unsafe_load[width=_ADD_F32_BF16_VEC, alignment=8](
             base
         ).cast[DType.float32]()
-        output_f32.store[width=_ADD_F32_BF16_VEC, alignment=16](base, lhs + rhs)
+        output_f32.unsafe_store[width=_ADD_F32_BF16_VEC, alignment=16](
+            base, lhs + rhs
+        )
 
     # The vector body leaves at most three elements.  With an unaligned base,
     # vec_count is zero and this same launch covers the full input scalarly.
     var index = vec_count * _ADD_F32_BF16_VEC + gid
     var stride = Int(grid_dim.x) * _ADD_F32_BF16_BLOCK
     while index < elements:
-        output_f32[index] = (
-            input_f32[index] + input_bf16[index].cast[DType.float32]()
+        output_f32[unsafe_offset=index] = (
+            input_f32[unsafe_offset=index]
+            + input_bf16[unsafe_offset=index].cast[DType.float32]()
         )
         index += stride
 
 
 @always_inline
 def _add_f32_bf16_contig(
-    output_f32: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    input_f32: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
-    input_bf16: UnsafePointer[Scalar[DType.bfloat16], ImmutAnyOrigin],
+    output_f32: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    input_f32: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
+    input_bf16: Pointer[Scalar[DType.bfloat16], ImmutAnyOrigin],
     elements: Int,
     ctx: DeviceContext,
 ) raises:
@@ -416,9 +421,9 @@ def _bin_vec_op[
 def _bin_bcast_kernel[
     dtype: DType, out_dtype: DType, op_code: Int, is_cmp: Bool
 ](
-    out_ptr: UnsafePointer[Scalar[out_dtype], MutAnyOrigin],
-    l_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    r_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[out_dtype], MutAnyOrigin],
+    l_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    r_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     d1_arg: Int64,
     d2_arg: Int64,
     d3_arg: Int64,
@@ -460,9 +465,11 @@ def _bin_bcast_kernel[
         rest = rest // d2
         var i1 = rest % d1
         var i0 = rest // d1
-        var a = l_ptr[i0 * ls0 + i1 * ls1 + i2 * ls2 + i3 * ls3]
-        var b = r_ptr[i0 * rs0 + i1 * rs1 + i2 * rs2 + i3 * rs3]
-        out_ptr[i] = _bin_vec_op[dtype, out_dtype, op_code, is_cmp, 1](a, b)[0]
+        var a = l_ptr[unsafe_offset=i0 * ls0 + i1 * ls1 + i2 * ls2 + i3 * ls3]
+        var b = r_ptr[unsafe_offset=i0 * rs0 + i1 * rs1 + i2 * rs2 + i3 * rs3]
+        out_ptr[unsafe_offset=i] = _bin_vec_op[
+            dtype, out_dtype, op_code, is_cmp, 1
+        ](a, b)[0]
         i += gstride
 
 
@@ -470,9 +477,9 @@ def _bin_bcast_kernel[
 def _bin_flat_vec_kernel[
     dtype: DType, out_dtype: DType, op_code: Int, is_cmp: Bool
 ](
-    out_ptr: UnsafePointer[Scalar[out_dtype], MutAnyOrigin],
-    l_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    r_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[out_dtype], MutAnyOrigin],
+    l_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    r_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     total_arg: Int64,
     l_bcast_arg: Int64,
     r_bcast_arg: Int64,
@@ -503,29 +510,33 @@ def _bin_flat_vec_kernel[
         # A flagged operand holds exactly one element, so this read is in
         # range whenever the output is (the launcher returns early on
         # total == 0), and it happens once per thread, not once per element.
-        var l_splat = SIMD[dtype, VW](l_ptr[0]) if l_b else SIMD[dtype, VW](0)
-        var r_splat = SIMD[dtype, VW](r_ptr[0]) if r_b else SIMD[dtype, VW](0)
+        var l_splat = SIMD[dtype, VW](l_ptr[unsafe_offset=0]) if l_b else SIMD[
+            dtype, VW
+        ](0)
+        var r_splat = SIMD[dtype, VW](r_ptr[unsafe_offset=0]) if r_b else SIMD[
+            dtype, VW
+        ](0)
         var c = tid
         while c < nvec:
             var i = c * VW
-            var a = l_splat if l_b else l_ptr.load[
+            var a = l_splat if l_b else l_ptr.unsafe_load[
                 width=VW, alignment=vec_align
             ](i)
-            var b = r_splat if r_b else r_ptr.load[
+            var b = r_splat if r_b else r_ptr.unsafe_load[
                 width=VW, alignment=vec_align
             ](i)
-            out_ptr.store[width=VW, alignment=out_align](
+            out_ptr.unsafe_store[width=VW, alignment=out_align](
                 i, _bin_vec_op[dtype, out_dtype, op_code, is_cmp, VW](a, b)
             )
             c += gstride
         var tail = total - nvec * VW
         if tid < tail:
             var i = nvec * VW + tid
-            var a = l_splat[0] if l_b else l_ptr[i]
-            var b = r_splat[0] if r_b else r_ptr[i]
-            out_ptr[i] = _bin_vec_op[dtype, out_dtype, op_code, is_cmp, 1](
-                a, b
-            )[0]
+            var a = l_splat[0] if l_b else l_ptr[unsafe_offset=i]
+            var b = r_splat[0] if r_b else r_ptr[unsafe_offset=i]
+            out_ptr[unsafe_offset=i] = _bin_vec_op[
+                dtype, out_dtype, op_code, is_cmp, 1
+            ](a, b)[0]
 
     # The splat flags are loop-invariant, so each arm is INSTANTIATED rather
     # than branched on per iteration: that keeps the tensor-tensor arm the
@@ -548,9 +559,9 @@ def _bin_flat_vec_kernel[
 def _bin_rowvec_kernel[
     dtype: DType, out_dtype: DType, op_code: Int, is_cmp: Bool
 ](
-    out_ptr: UnsafePointer[Scalar[out_dtype], MutAnyOrigin],
-    l_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    r_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[out_dtype], MutAnyOrigin],
+    l_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    r_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     d1_arg: Int64,
     d2_arg: Int64,
     d3_arg: Int64,
@@ -593,9 +604,9 @@ def _bin_rowvec_kernel[
         var j = Int(thread_idx.x) * VW
         var step = Int(block_dim.x) * VW
         while j < d3:
-            var a = l_ptr.load[width=VW, alignment=vec_align](lbase + j)
-            var b = r_ptr.load[width=VW, alignment=vec_align](rbase + j)
-            out_ptr.store[width=VW, alignment=out_align](
+            var a = l_ptr.unsafe_load[width=VW, alignment=vec_align](lbase + j)
+            var b = r_ptr.unsafe_load[width=VW, alignment=vec_align](rbase + j)
+            out_ptr.unsafe_store[width=VW, alignment=out_align](
                 obase + j,
                 _bin_vec_op[dtype, out_dtype, op_code, is_cmp, VW](a, b),
             )
@@ -655,9 +666,13 @@ def _binary_bcast[
                     rest = rest // d2
                     var i1 = rest % d1
                     var i0 = rest // d1
-                    var a = l_ptr[i0 * ls0 + i1 * ls1 + i2 * ls2 + i3 * ls3]
-                    var b = r_ptr[i0 * rs0 + i1 * rs1 + i2 * rs2 + i3 * rs3]
-                    out_ptr[i] = _bin_vec_op[
+                    var a = l_ptr[
+                        unsafe_offset=i0 * ls0 + i1 * ls1 + i2 * ls2 + i3 * ls3
+                    ]
+                    var b = r_ptr[
+                        unsafe_offset=i0 * rs0 + i1 * rs1 + i2 * rs2 + i3 * rs3
+                    ]
+                    out_ptr[unsafe_offset=i] = _bin_vec_op[
                         dtype,
                         out_dtype,
                         op_code,
@@ -761,8 +776,8 @@ def _binary_bcast[
                                 1,
                                 GS_THREADS,
                                 out_ptr.as_unsafe_any_origin(),
-                                l_ptr.as_unsafe_any_origin().as_immutable(),
-                                r_ptr.as_unsafe_any_origin().as_immutable(),
+                                l_ptr.as_unsafe_any_origin().as_imm(),
+                                r_ptr.as_unsafe_any_origin().as_imm(),
                                 Int64(total),
                                 Int64(l_scalar),
                                 Int64(r_scalar),
@@ -783,8 +798,8 @@ def _binary_bcast[
                                 1,
                                 GS_THREADS,
                                 out_ptr.as_unsafe_any_origin(),
-                                l_ptr.as_unsafe_any_origin().as_immutable(),
-                                r_ptr.as_unsafe_any_origin().as_immutable(),
+                                l_ptr.as_unsafe_any_origin().as_imm(),
+                                r_ptr.as_unsafe_any_origin().as_imm(),
                                 Int64(d1),
                                 Int64(d2),
                                 Int64(d3),
@@ -811,8 +826,8 @@ def _binary_bcast[
                                 1,
                                 GS_THREADS,
                                 out_ptr.as_unsafe_any_origin(),
-                                l_ptr.as_unsafe_any_origin().as_immutable(),
-                                r_ptr.as_unsafe_any_origin().as_immutable(),
+                                l_ptr.as_unsafe_any_origin().as_imm(),
+                                r_ptr.as_unsafe_any_origin().as_imm(),
                                 Int64(d1),
                                 Int64(d2),
                                 Int64(d3),
@@ -863,7 +878,7 @@ def _bitwise_not[
     @__copy_capture(out_ptr, in_ptr)
     def func[width: Int, alignment: Int = 1](idx: Coord):
         var i = Int(idx[0].value())
-        out_ptr[i] = ~in_ptr[i]
+        out_ptr[unsafe_offset=i] = ~in_ptr[unsafe_offset=i]
 
     _parallel_for[func](size, ctx)
 
@@ -905,9 +920,15 @@ def _bitwise_not_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
-        _bitwise_not_go(args[0], args[1], args[2], args[3], args[4])
+        _bitwise_not_go(
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+        )
     except e:
         return _spec_unsupported(e)
     return _raw_ret_none()
@@ -943,12 +964,12 @@ def _isin[
         var i = Int(idx[0].value())
         var found = False
         for j in range(n_test):
-            if in_ptr[i] == test_ptr[j]:
+            if in_ptr[unsafe_offset=i] == test_ptr[unsafe_offset=j]:
                 found = True
                 break
         if invert != 0:
             found = not found
-        out_ptr[i] = found
+        out_ptr[unsafe_offset=i] = found
 
     _parallel_for[func](size, ctx)
 
@@ -995,17 +1016,17 @@ def _isin_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         _isin_go(
-            args[0],
-            args[1],
-            args[2],
-            args[3],
-            args[4],
-            args[5],
-            args[6],
-            args[7],
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+            args[unsafe_offset=6],
+            args[unsafe_offset=7],
         )
     except e:
         return _spec_unsupported(e)
@@ -1043,12 +1064,12 @@ def _clamp_scalar[
     @__copy_capture(out_ptr, in_ptr, lo_s, hi_s, has_min, has_max)
     def func[width: Int, alignment: Int = 1](idx: Coord):
         var i = Int(idx[0].value())
-        var v = in_ptr[i]
+        var v = in_ptr[unsafe_offset=i]
         if has_min != 0:
             v = max(v, lo_s)
         if has_max != 0:
             v = min(v, hi_s)
-        out_ptr[i] = v
+        out_ptr[unsafe_offset=i] = v
 
     _parallel_for[func](size, ctx)
 
@@ -1107,18 +1128,18 @@ def _clamp_scalar_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         _clamp_scalar_go(
-            args[0],
-            args[1],
-            args[2],
-            args[3],
-            args[4],
-            args[5],
-            args[6],
-            args[7],
-            args[8],
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+            args[unsafe_offset=6],
+            args[unsafe_offset=7],
+            args[unsafe_offset=8],
         )
     except e:
         return _spec_unsupported(e)
@@ -1197,16 +1218,26 @@ def _ternary_bcast[
                 rest = rest // d2
                 var i1 = rest % d1
                 var i0 = rest // d1
-                var a = a_ptr[i0 * as0 + i1 * as1 + i2 * as2 + i3 * as3]
-                var b = b_ptr[i0 * bs0 + i1 * bs1 + i2 * bs2 + i3 * bs3]
-                var c = c_ptr[i0 * cs0 + i1 * cs1 + i2 * cs2 + i3 * cs3]
+                var a = a_ptr[
+                    unsafe_offset=i0 * as0 + i1 * as1 + i2 * as2 + i3 * as3
+                ]
+                var b = b_ptr[
+                    unsafe_offset=i0 * bs0 + i1 * bs1 + i2 * bs2 + i3 * bs3
+                ]
+                var c = c_ptr[
+                    unsafe_offset=i0 * cs0 + i1 * cs1 + i2 * cs2 + i3 * cs3
+                ]
                 var af = a.cast[DType.float32]()
                 var bf = b.cast[DType.float32]()
                 var cf = c.cast[DType.float32]()
                 comptime if op_code == TOP_ADDCMUL:
-                    out_ptr[i] = (af + value_f32 * (bf * cf)).cast[dtype]()
+                    out_ptr[unsafe_offset=i] = (
+                        af + value_f32 * (bf * cf)
+                    ).cast[dtype]()
                 else:
-                    out_ptr[i] = (af + value_f32 * (bf / cf)).cast[dtype]()
+                    out_ptr[unsafe_offset=i] = (
+                        af + value_f32 * (bf / cf)
+                    ).cast[dtype]()
 
             _parallel_for[func](total, ctx)
         else:
@@ -1223,17 +1254,23 @@ def _ternary_bcast[
                 rest = rest // d2
                 var i1 = rest % d1
                 var i0 = rest // d1
-                var a = a_ptr[i0 * as0 + i1 * as1 + i2 * as2 + i3 * as3]
-                var b = b_ptr[i0 * bs0 + i1 * bs1 + i2 * bs2 + i3 * bs3]
-                var c = c_ptr[i0 * cs0 + i1 * cs1 + i2 * cs2 + i3 * cs3]
+                var a = a_ptr[
+                    unsafe_offset=i0 * as0 + i1 * as1 + i2 * as2 + i3 * as3
+                ]
+                var b = b_ptr[
+                    unsafe_offset=i0 * bs0 + i1 * bs1 + i2 * bs2 + i3 * bs3
+                ]
+                var c = c_ptr[
+                    unsafe_offset=i0 * cs0 + i1 * cs1 + i2 * cs2 + i3 * cs3
+                ]
                 comptime if dtype.is_floating_point():
                     comptime if op_code == TOP_ADDCMUL:
-                        out_ptr[i] = a + value_dt * (b * c)
+                        out_ptr[unsafe_offset=i] = a + value_dt * (b * c)
                     else:
-                        out_ptr[i] = a + value_dt * (b / c)
+                        out_ptr[unsafe_offset=i] = a + value_dt * (b / c)
                 else:
                     # Integer addcmul: value is an exact integer scalar.
-                    out_ptr[i] = a + value_dt * (b * c)
+                    out_ptr[unsafe_offset=i] = a + value_dt * (b * c)
 
             _parallel_for[func2](total, ctx)
 
@@ -1329,17 +1366,17 @@ def _ternary_bcast_dispatcher[
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         _ternary_bcast_go[op_code](
-            args[0],
-            args[1],
-            args[2],
-            args[3],
-            args[4],
-            args[5],
-            args[6],
-            args[7],
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+            args[unsafe_offset=6],
+            args[unsafe_offset=7],
         )
     except e:
         return _spec_unsupported(e)
@@ -1448,8 +1485,8 @@ def _addr_bcast[
         var i_flat = Int(idx[0].value())
         var i = i_flat // m
         var j = i_flat % m
-        var bv = b_ptr[i * bs0]
-        var cv = c_ptr[j * cs0]
+        var bv = b_ptr[unsafe_offset=i * bs0]
+        var cv = c_ptr[unsafe_offset=j * cs0]
         # Multiply in float32, then explicitly round down to `dtype` and
         # back up before the next op -- one rounding per op, matching
         # CPU's Half/BFloat16 operator overloads (convert to float, do ONE
@@ -1468,13 +1505,15 @@ def _addr_bcast[
         # `self` is masked to 0 rather than branched around: beta==0 must
         # not propagate nan/inf from `self` (matches CPU), and a select on
         # an already-loaded value keeps this branch-free per element.
-        var av = Scalar[dtype](0) if beta_is_zero else a_ptr[i * as0 + j * as1]
+        var av = Scalar[dtype](0) if beta_is_zero else a_ptr[
+            unsafe_offset=i * as0 + j * as1
+        ]
         var t1 = (
             (beta_f32 * av.cast[DType.float32]())
             .cast[dtype]()
             .cast[DType.float32]()
         )
-        out_ptr[i_flat] = (t1 + t3).cast[dtype]()
+        out_ptr[unsafe_offset=i_flat] = (t1 + t3).cast[dtype]()
 
     # Not `_parallel_for` on CPU -- see the module comment above.
     if ctx.api() == "cpu":
@@ -1544,18 +1583,18 @@ def _addr_bcast_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         _addr_bcast_go(
-            args[0],
-            args[1],
-            args[2],
-            args[3],
-            args[4],
-            args[5],
-            args[6],
-            args[7],
-            args[8],
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+            args[unsafe_offset=6],
+            args[unsafe_offset=7],
+            args[unsafe_offset=8],
         )
     except e:
         return _spec_unsupported(e)
@@ -1619,12 +1658,10 @@ def _add_f32_bf16_spec_into_go(
     if a.numel > 0:
         _add_f32_bf16_contig(
             _make_ptr[DType.float32](out.ptr).as_unsafe_any_origin(),
-            _make_ptr[DType.float32](fp32_addr)
-            .as_unsafe_any_origin()
-            .as_immutable(),
+            _make_ptr[DType.float32](fp32_addr).as_unsafe_any_origin().as_imm(),
             _make_ptr[DType.bfloat16](bf16_addr)
             .as_unsafe_any_origin()
-            .as_immutable(),
+            .as_imm(),
             a.numel,
             ctx,
         )

--- a/torch_mojo_backend/eager_kernels/loss_ops/loss_ops.mojo
+++ b/torch_mojo_backend/eager_kernels/loss_ops/loss_ops.mojo
@@ -72,10 +72,10 @@ comptime _VEC_MIN_CLASSES = 4 * _BWD_BLOCK
 
 @__name("nll_forward_none")
 def _nll_forward_none(
-    output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    total_weight: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    log_probs: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    target: UnsafePointer[Scalar[DType.int64], MutAnyOrigin],
+    output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    total_weight: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    log_probs: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    target: Pointer[Scalar[DType.int64], MutAnyOrigin],
     rows_arg: Int64,
     classes_arg: Int64,
     ignore_index_arg: Int64,
@@ -87,23 +87,23 @@ def _nll_forward_none(
     var ignore_index = Int(ignore_index_arg)
     var row = Int(block_idx.x) * _NONE_BLOCK + Int(thread_idx.x)
     if row == 0:
-        total_weight[0] = 0.0
+        total_weight[unsafe_offset=0] = 0.0
     var stride = Int(grid_dim.x) * _NONE_BLOCK
     while row < rows:
-        var t = Int(target[row])
+        var t = Int(target[unsafe_offset=row])
         var loss = Float32(0.0)
         if t != ignore_index and t >= 0 and t < classes:
-            loss = -log_probs[row * classes + t]
-        output[row] = loss
+            loss = -log_probs[unsafe_offset=row * classes + t]
+        output[unsafe_offset=row] = loss
         row += stride
 
 
 @__name("nll_forward_mean")
 def _nll_forward_mean(
-    output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    total_weight: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    log_probs: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    target: UnsafePointer[Scalar[DType.int64], MutAnyOrigin],
+    output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    total_weight: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    log_probs: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    target: Pointer[Scalar[DType.int64], MutAnyOrigin],
     rows_arg: Int64,
     classes_arg: Int64,
     ignore_index_arg: Int64,
@@ -123,18 +123,18 @@ def _nll_forward_mean(
     var base = 0
     while base + _MEAN_CHUNK <= rows:
         var r = base + tid * _MEAN_ILP
-        var tv = target.load[width=_MEAN_ILP, alignment=8](r)
+        var tv = target.unsafe_load[width=_MEAN_ILP, alignment=8](r)
         comptime for lane in range(_MEAN_ILP):
             var t = Int(tv[lane])
             if t != ignore_index and t >= 0 and t < classes:
-                acc[lane] += log_probs[(r + lane) * classes + t]
+                acc[lane] += log_probs[unsafe_offset=(r + lane) * classes + t]
                 count[lane] += 1.0
         base += _MEAN_CHUNK
     var row = base + tid
     while row < rows:
-        var t = Int(target[row])
+        var t = Int(target[unsafe_offset=row])
         if t != ignore_index and t >= 0 and t < classes:
-            acc[0] += log_probs[row * classes + t]
+            acc[0] += log_probs[unsafe_offset=row * classes + t]
             count[0] += 1.0
         row += _MEAN_BLOCK
     var total = block.sum[block_size=_MEAN_BLOCK, broadcast=False](
@@ -144,15 +144,15 @@ def _nll_forward_mean(
         count.reduce_add()
     )
     if tid == 0:
-        output[0] = -total / valid
-        total_weight[0] = valid
+        output[unsafe_offset=0] = -total / valid
+        total_weight[unsafe_offset=0] = valid
 
 
 @__name("nll_forward_mean_partial")
 def _nll_forward_mean_partial(
-    scratch: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    log_probs: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    target: UnsafePointer[Scalar[DType.int64], MutAnyOrigin],
+    scratch: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    log_probs: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    target: Pointer[Scalar[DType.int64], MutAnyOrigin],
     rows_arg: Int64,
     classes_arg: Int64,
     ignore_index_arg: Int64,
@@ -167,24 +167,24 @@ def _nll_forward_mean_partial(
     var row = Int(block_idx.x) * _PARTIAL_BLOCK + Int(thread_idx.x)
     var stride = Int(grid_dim.x) * _PARTIAL_BLOCK
     while row < rows:
-        var t = Int(target[row])
+        var t = Int(target[unsafe_offset=row])
         if t != ignore_index and t >= 0 and t < classes:
-            acc += log_probs[row * classes + t]
+            acc += log_probs[unsafe_offset=row * classes + t]
             count += 1.0
         row += stride
     var total = block.sum[block_size=_PARTIAL_BLOCK, broadcast=False](acc)
     var valid = block.sum[block_size=_PARTIAL_BLOCK, broadcast=False](count)
     if thread_idx.x == 0:
         var b = Int(block_idx.x)
-        scratch[2 * b] = total
-        scratch[2 * b + 1] = valid
+        scratch[unsafe_offset=2 * b] = total
+        scratch[unsafe_offset=2 * b + 1] = valid
 
 
 @__name("nll_forward_mean_final")
 def _nll_forward_mean_final(
-    output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    total_weight: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    scratch: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    total_weight: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    scratch: Pointer[Scalar[DType.float32], MutAnyOrigin],
     partials_arg: Int64,
 ):
     # Int is not device-passable (host/device width mismatch); scalars cross
@@ -194,22 +194,22 @@ def _nll_forward_mean_final(
     var count = Float32(0.0)
     var i = Int(thread_idx.x)
     while i < partials:
-        acc += scratch[2 * i]
-        count += scratch[2 * i + 1]
+        acc += scratch[unsafe_offset=2 * i]
+        count += scratch[unsafe_offset=2 * i + 1]
         i += _PARTIAL_BLOCK
     var total = block.sum[block_size=_PARTIAL_BLOCK, broadcast=False](acc)
     var valid = block.sum[block_size=_PARTIAL_BLOCK, broadcast=False](count)
     if thread_idx.x == 0:
-        output[0] = -total / valid
-        total_weight[0] = valid
+        output[unsafe_offset=0] = -total / valid
+        total_weight[unsafe_offset=0] = valid
 
 
 @__name("nll_forward_sum")
 def _nll_forward_sum(
-    output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    total_weight: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    log_probs: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    target: UnsafePointer[Scalar[DType.int64], MutAnyOrigin],
+    output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    total_weight: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    log_probs: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    target: Pointer[Scalar[DType.int64], MutAnyOrigin],
     rows_arg: Int64,
     classes_arg: Int64,
     ignore_index_arg: Int64,
@@ -230,11 +230,11 @@ def _nll_forward_sum(
         var row = base + tid
         var loss = Float32(0.0)
         if row < rows:
-            var t = Int(target[row])
+            var t = Int(target[unsafe_offset=row])
             if t != ignore_index and t >= 0 and t < classes:
-                loss = -log_probs[row * classes + t]
+                loss = -log_probs[unsafe_offset=row * classes + t]
                 count += 1.0
-        losses[tid] = loss
+        losses[unsafe_offset=tid] = loss
         barrier()
         if tid == 0:
             # Serial fp32 accumulation in row order; ignored rows contribute
@@ -242,21 +242,21 @@ def _nll_forward_sum(
             # skips them.
             var limit = min(_SUM_BLOCK, rows - base)
             for i in range(limit):
-                acc += losses[i]
+                acc += losses[unsafe_offset=i]
         barrier()
         base += _SUM_BLOCK
     var valid = block.sum[block_size=_SUM_BLOCK, broadcast=False](count)
     if tid == 0:
-        output[0] = acc
-        total_weight[0] = valid
+        output[unsafe_offset=0] = acc
+        total_weight[unsafe_offset=0] = valid
 
 
 @__name("nll_backward_vec4")
 def _nll_backward_vec4(
-    grad_input: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    target: UnsafePointer[Scalar[DType.int64], MutAnyOrigin],
-    total_weight: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_input: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    target: Pointer[Scalar[DType.int64], MutAnyOrigin],
+    total_weight: Pointer[Scalar[DType.float32], MutAnyOrigin],
     rows_arg: Int64,
     classes_arg: Int64,
     reduction_arg: Int64,
@@ -278,16 +278,18 @@ def _nll_backward_vec4(
     var strip = Int(block_idx.x) * (_BWD_BLOCK * _VEC_UNROLL)
     var scale = Float32(0.0)
     if reduction == 1:
-        scale = grad_output[0] / total_weight[0]
+        scale = grad_output[unsafe_offset=0] / total_weight[unsafe_offset=0]
     elif reduction == 2:
-        scale = grad_output[0]
+        scale = grad_output[unsafe_offset=0]
     var row = Int(block_idx.y)
     while row < rows:
-        var t = Int(target[row])
+        var t = Int(target[unsafe_offset=row])
         var valid = t != ignore_index and t >= 0 and t < classes
         var grad = Float32(0.0)
         if valid:
-            grad = -(grad_output[row] if reduction == 0 else scale)
+            grad = -(
+                grad_output[unsafe_offset=row] if reduction == 0 else scale
+            )
         var base = row * classes
         comptime for u in range(_VEC_UNROLL):
             var v = strip + u * _BWD_BLOCK + tid
@@ -299,16 +301,18 @@ def _nll_backward_vec4(
                 comptime for lane in range(4):
                     if valid and t == col + lane:
                         chunk[lane] = grad
-                grad_input.store[width=4, alignment=16](base + col, chunk)
+                grad_input.unsafe_store[width=4, alignment=16](
+                    base + col, chunk
+                )
         row += Int(grid_dim.y)
 
 
 @__name("nll_backward_scalar")
 def _nll_backward_scalar(
-    grad_input: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    target: UnsafePointer[Scalar[DType.int64], MutAnyOrigin],
-    total_weight: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_input: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    target: Pointer[Scalar[DType.int64], MutAnyOrigin],
+    total_weight: Pointer[Scalar[DType.float32], MutAnyOrigin],
     rows_arg: Int64,
     classes_arg: Int64,
     reduction_arg: Int64,
@@ -324,29 +328,33 @@ def _nll_backward_scalar(
     var warp_stride = Int(grid_dim.x) * (_BWD_BLOCK // WARP_SIZE)
     var scale = Float32(0.0)
     if reduction == 1:
-        scale = grad_output[0] / total_weight[0]
+        scale = grad_output[unsafe_offset=0] / total_weight[unsafe_offset=0]
     elif reduction == 2:
-        scale = grad_output[0]
+        scale = grad_output[unsafe_offset=0]
     var row = Int(block_idx.x) * (_BWD_BLOCK // WARP_SIZE) + Int(warp_id())
     while row < rows:
-        var t = Int(target[row])
+        var t = Int(target[unsafe_offset=row])
         var valid = t != ignore_index and t >= 0 and t < classes
         var grad = Float32(0.0)
         if valid:
-            grad = -(grad_output[row] if reduction == 0 else scale)
+            grad = -(
+                grad_output[unsafe_offset=row] if reduction == 0 else scale
+            )
         var base = row * classes
         var col = lane
         while col < classes:
-            grad_input[base + col] = grad if (valid and col == t) else 0.0
+            grad_input[unsafe_offset=base + col] = grad if (
+                valid and col == t
+            ) else 0.0
             col += WARP_SIZE
         row += warp_stride
 
 
 def enqueue_nll_forward_f32(
-    output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    total_weight: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    log_probs: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    target: UnsafePointer[Scalar[DType.int64], MutAnyOrigin],
+    output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    total_weight: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    log_probs: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    target: Pointer[Scalar[DType.int64], MutAnyOrigin],
     rows: Int,
     classes: Int,
     reduction: Int,
@@ -444,10 +452,10 @@ def enqueue_nll_forward_f32(
 
 
 def enqueue_nll_backward_f32(
-    grad_input: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    target: UnsafePointer[Scalar[DType.int64], MutAnyOrigin],
-    total_weight: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_input: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    target: Pointer[Scalar[DType.int64], MutAnyOrigin],
+    total_weight: Pointer[Scalar[DType.float32], MutAnyOrigin],
     rows: Int,
     classes: Int,
     reduction: Int,
@@ -585,18 +593,18 @@ def _nll_forward_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         _nll_forward_go(
-            args[0],
-            args[1],
-            args[2],
-            args[3],
-            args[4],
-            args[5],
-            args[6],
-            args[7],
-            args[8],
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+            args[unsafe_offset=6],
+            args[unsafe_offset=7],
+            args[unsafe_offset=8],
         )
     except e:
         return _spec_unsupported(e)
@@ -608,18 +616,18 @@ def _nll_backward_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         _nll_backward_go(
-            args[0],
-            args[1],
-            args[2],
-            args[3],
-            args[4],
-            args[5],
-            args[6],
-            args[7],
-            args[8],
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+            args[unsafe_offset=6],
+            args[unsafe_offset=7],
+            args[unsafe_offset=8],
         )
     except e:
         return _spec_unsupported(e)

--- a/torch_mojo_backend/eager_kernels/matmul_ops/apple_gemm_nn_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/matmul_ops/apple_gemm_nn_kernels.mojo
@@ -82,8 +82,8 @@ def _nn_mma8x8(
 
 
 def _nn_ksplit_reduce_kernel(
-    out_ptr: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    ws_ptr: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    ws_ptr: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
     mn_arg: Int64,
     ksplits_arg: Int64,
     total_arg: Int64,
@@ -104,8 +104,8 @@ def _nn_ksplit_reduce_kernel(
         var base = bz * ksplits * mn + off
         var acc = SIMD[DType.float32, 4](0)
         for st in range(ksplits):
-            acc += ws_ptr.load[width=4](base + st * mn)
-        out_ptr.store(i, acc)
+            acc += ws_ptr.unsafe_load[width=4](base + st * mn)
+        out_ptr.unsafe_store(i, acc)
     else:
         for u in range(4):
             var iu = i + u
@@ -116,8 +116,8 @@ def _nn_ksplit_reduce_kernel(
             var baseu = bzu * ksplits * mn + offu
             var accu = Scalar[DType.float32](0)
             for st in range(ksplits):
-                accu += ws_ptr[baseu + st * mn]
-            out_ptr[iu] = accu
+                accu += ws_ptr[unsafe_offset=baseu + st * mn]
+            out_ptr[unsafe_offset=iu] = accu
 
 
 # ---------------------------------------------------------------------------
@@ -144,9 +144,9 @@ def _apple8_nn_smem_kernel[
     DOUBLE: Bool = True,
     SWIZZLE: Int = 0,
 ](
-    c_base: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    a_base: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
-    b_base: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
+    c_base: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    a_base: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
+    b_base: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
     m_arg: Int64,
     n_arg: Int64,
     k_arg: Int64,
@@ -188,9 +188,9 @@ def _apple8_nn_smem_kernel[
 
     # With ksplits > 1, C is a [batch * ksplits, m, n] workspace and each
     # split writes its own slice. a_bstride is 0 when A is batch-shared.
-    var c_ptr = c_base + Int(block_idx.z) * m * n
-    var a_ptr = a_base + bz * a_bstride
-    var b_ptr = b_base + bz * k * n
+    var c_ptr = c_base.unsafe_offset(Int(block_idx.z) * m * n)
+    var a_ptr = a_base.unsafe_offset(bz * a_bstride)
+    var b_ptr = b_base.unsafe_offset(bz * k * n)
 
     # SWIZZLE > 0: the MN grid is launched flattened into grid.x and
     # rasterized in supertiles of SWIZZLE block-rows — consecutive blocks
@@ -251,13 +251,15 @@ def _apple8_nn_smem_kernel[
             var row = bm + mm
             var col = kt + kq
             if row < m and col + 4 <= k_end:
-                a_regs[q] = (a_ptr + row * k + col).load[width=4]()
+                a_regs[q] = (a_ptr.unsafe_offset(row * k + col)).unsafe_load[
+                    width=4
+                ]()
             else:
                 var v = SIMD[DType.float32, 4](0)
                 if row < m:
                     comptime for j in range(4):
                         if col + j < k_end:
-                            v[j] = a_ptr[row * k + col + j]
+                            v[j] = a_ptr[unsafe_offset=row * k + col + j]
                 a_regs[q] = v
         comptime for q in range(BV):
             var fid = q * THREADS + tid
@@ -266,13 +268,15 @@ def _apple8_nn_smem_kernel[
             var row = kt + kk
             var col = bn + nq
             if row < k_end and col + 4 <= n:
-                b_regs[q] = (b_ptr + row * n + col).load[width=4]()
+                b_regs[q] = (b_ptr.unsafe_offset(row * n + col)).unsafe_load[
+                    width=4
+                ]()
             else:
                 var v = SIMD[DType.float32, 4](0)
                 if row < k_end:
                     comptime for j in range(4):
                         if col + j < n:
-                            v[j] = b_ptr[row * n + col + j]
+                            v[j] = b_ptr[unsafe_offset=row * n + col + j]
                 b_regs[q] = v
 
     # Register -> threadgroup store for buffer `buf`.
@@ -283,18 +287,18 @@ def _apple8_nn_smem_kernel[
         a_regs: InlineArray[SIMD[DType.float32, 4], AV],
         b_regs: InlineArray[SIMD[DType.float32, 4], BV],
     ):
-        var a_dst = a_smem + buf * BM * LDA
-        var b_dst = b_smem + buf * BK * LDB
+        var a_dst = a_smem.unsafe_offset(buf * BM * LDA)
+        var b_dst = b_smem.unsafe_offset(buf * BK * LDB)
         comptime for q in range(AV):
             var fid = q * THREADS + tid
             var mm = fid // KV
             var kq = (fid % KV) * 4
-            a_dst.store(mm * LDA + kq, a_regs[q])
+            a_dst.unsafe_store(mm * LDA + kq, a_regs[q])
         comptime for q in range(BV):
             var fid = q * THREADS + tid
             var kk = fid // NV
             var nq = (fid % NV) * 4
-            b_dst.store(kk * LDB + nq, b_regs[q])
+            b_dst.unsafe_store(kk * LDB + nq, b_regs[q])
 
     # BK/8 8-slab mma sweeps over threadgroup buffer `buf`.
     @always_inline
@@ -303,23 +307,31 @@ def _apple8_nn_smem_kernel[
         buf: Int,
         mut acc: InlineArray[SIMD[DType.float32, NN_FRAG8], NT_M * NT_N],
     ):
-        var a_src = a_smem + buf * BM * LDA + (sgm + frow) * LDA + fcol
-        var b_src = b_smem + buf * BK * LDB + frow * LDB + sgn + fcol
+        var a_src = a_smem.unsafe_offset(
+            buf * BM * LDA + (sgm + frow) * LDA + fcol
+        )
+        var b_src = b_smem.unsafe_offset(
+            buf * BK * LDB + frow * LDB + sgn + fcol
+        )
         comptime for kc in range(BK // NN_MMA8_DIM):
             var afrag = InlineArray[SIMD[DType.float32, NN_FRAG8], NT_M](
                 uninitialized=True
             )
             comptime for mi in range(NT_M):
                 afrag[mi] = (
-                    a_src + mi * NN_MMA8_DIM * LDA + kc * NN_MMA8_DIM
-                ).load[width=NN_FRAG8]()
+                    a_src.unsafe_offset(
+                        mi * NN_MMA8_DIM * LDA + kc * NN_MMA8_DIM
+                    )
+                ).unsafe_load[width=NN_FRAG8]()
             var bfrag = InlineArray[SIMD[DType.float32, NN_FRAG8], NT_N](
                 uninitialized=True
             )
             comptime for ni in range(NT_N):
                 bfrag[ni] = (
-                    b_src + kc * NN_MMA8_DIM * LDB + ni * NN_MMA8_DIM
-                ).load[width=NN_FRAG8]()
+                    b_src.unsafe_offset(
+                        kc * NN_MMA8_DIM * LDB + ni * NN_MMA8_DIM
+                    )
+                ).unsafe_load[width=NN_FRAG8]()
             comptime for mi in range(NT_M):
                 comptime for ni in range(NT_N):
                     acc[mi * NT_N + ni] = _nn_mma8x8(
@@ -362,9 +374,9 @@ def _apple8_nn_smem_kernel[
                 var gcol = bn + sgn + ni * NN_MMA8_DIM + fcol
                 var frag = accum[mi * NT_N + ni]
                 if gcol + NN_FRAG8 <= n:
-                    c_ptr.store(grow * n + gcol, frag)
+                    c_ptr.unsafe_store(grow * n + gcol, frag)
                 elif gcol < n:
-                    c_ptr[grow * n + gcol] = frag[0]
+                    c_ptr[unsafe_offset=grow * n + gcol] = frag[0]
 
 
 @always_inline
@@ -403,12 +415,8 @@ def apple_nn_smem_enqueue[
     var ksplits = 1
     if blocks < NN_TARGET_BLOCKS // 2:
         ksplits = min(min(ceildiv(NN_TARGET_BLOCKS, blocks), slabs), 8)
-    var a = (
-        _make_ptr[DType.float32](a_addr).as_unsafe_any_origin().as_immutable()
-    )
-    var b = (
-        _make_ptr[DType.float32](b_addr).as_unsafe_any_origin().as_immutable()
-    )
+    var a = _make_ptr[DType.float32](a_addr).as_unsafe_any_origin().as_imm()
+    var b = _make_ptr[DType.float32](b_addr).as_unsafe_any_origin().as_imm()
     if ksplits == 1:
         var c = _make_ptr[DType.float32](c_addr).as_unsafe_any_origin()
         _enqueue_cached[
@@ -436,7 +444,7 @@ def apple_nn_smem_enqueue[
         )
         return
     var ws = ctx.enqueue_create_buffer[DType.float32](batch * ksplits * m * n)
-    var ws_mut = UnsafePointer[Scalar[DType.float32], MutUntrackedOrigin](
+    var ws_mut = Pointer[Scalar[DType.float32], MutUntrackedOrigin](
         unsafe_from_address=Int(ws.unsafe_ptr())
     ).as_unsafe_any_origin()
     _enqueue_cached[
@@ -470,7 +478,7 @@ def apple_nn_smem_enqueue[
         1,
         256,
         c_out,
-        ws_mut.as_immutable(),
+        ws_mut.as_imm(),
         Int64(m * n),
         Int64(ksplits),
         Int64(total),
@@ -497,9 +505,9 @@ def _apple8_nn_direct_kernel[
     SGC: Int = 2,
     SWIZZLE: Int = 0,
 ](
-    c_base: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    a_base: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
-    b_base: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
+    c_base: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    a_base: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
+    b_base: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
     m_arg: Int64,
     n_arg: Int64,
     k_arg: Int64,
@@ -526,9 +534,9 @@ def _apple8_nn_direct_kernel[
     var k_start = min(k, ks * kchunk)
     var k_end = min(k, k_start + kchunk)
 
-    var c_ptr = c_base + Int(block_idx.z) * m * n
-    var a_ptr = a_base + bz * a_bstride
-    var b_ptr = b_base + bz * k * n
+    var c_ptr = c_base.unsafe_offset(Int(block_idx.z) * m * n)
+    var a_ptr = a_base.unsafe_offset(bz * a_bstride)
+    var b_ptr = b_base.unsafe_offset(bz * k * n)
 
     var bx: Int
     var by: Int
@@ -576,7 +584,7 @@ def _apple8_nn_direct_kernel[
             if grow < m:
                 comptime for s in range(NN_FRAG8):
                     if kk + fcol + s < k_end:
-                        af[s] = a_ptr[grow * k + kk + fcol + s]
+                        af[s] = a_ptr[unsafe_offset=grow * k + kk + fcol + s]
             afrag[mi] = af
         var bfrag = InlineArray[SIMD[DType.float32, NN_FRAG8], NT_N](
             uninitialized=True
@@ -587,7 +595,7 @@ def _apple8_nn_direct_kernel[
                 comptime for s in range(NN_FRAG8):
                     var gj = col_base + ni * NN_MMA8_DIM + fcol + s
                     if gj < n:
-                        bf[s] = b_ptr[(kk + frow) * n + gj]
+                        bf[s] = b_ptr[unsafe_offset=(kk + frow) * n + gj]
             bfrag[ni] = bf
         comptime for mi in range(NT_M):
             comptime for ni in range(NT_N):
@@ -600,25 +608,29 @@ def _apple8_nn_direct_kernel[
     @always_inline
     @parameter
     def _load_a_fast(
-        ap0: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
+        ap0: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
     ) -> InlineArray[SIMD[DType.float32, NN_FRAG8], NT_M]:
         var afrag = InlineArray[SIMD[DType.float32, NN_FRAG8], NT_M](
             uninitialized=True
         )
         comptime for mi in range(NT_M):
-            afrag[mi] = (ap0 + mi * NN_MMA8_DIM * k).load[width=NN_FRAG8]()
+            afrag[mi] = (ap0.unsafe_offset(mi * NN_MMA8_DIM * k)).unsafe_load[
+                width=NN_FRAG8
+            ]()
         return afrag^
 
     @always_inline
     @parameter
     def _load_b_fast(
-        bp0: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
+        bp0: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
     ) -> InlineArray[SIMD[DType.float32, NN_FRAG8], NT_N]:
         var bfrag = InlineArray[SIMD[DType.float32, NN_FRAG8], NT_N](
             uninitialized=True
         )
         comptime for ni in range(NT_N):
-            bfrag[ni] = (bp0 + ni * NN_MMA8_DIM).load[width=NN_FRAG8]()
+            bfrag[ni] = (bp0.unsafe_offset(ni * NN_MMA8_DIM)).unsafe_load[
+                width=NN_FRAG8
+            ]()
         return bfrag^
 
     @always_inline
@@ -638,15 +650,15 @@ def _apple8_nn_direct_kernel[
     if interior:
         # Software-pipelined pointer-increment loop: the next slab's
         # fragments are in flight while the current slab's mmas issue.
-        var ap = a_ptr + (row_base + frow) * k + fcol + k_start
-        var bp = b_ptr + (k_start + frow) * n + col_base + fcol
+        var ap = a_ptr.unsafe_offset((row_base + frow) * k + fcol + k_start)
+        var bp = b_ptr.unsafe_offset((k_start + frow) * n + col_base + fcol)
         var nslabs = (k_end - k_start) // NN_MMA8_DIM
         if nslabs > 0:
             var cura = _load_a_fast(ap)
             var curb = _load_b_fast(bp)
             for _ in range(nslabs - 1):
-                ap += NN_MMA8_DIM
-                bp += NN_MMA8_DIM * n
+                ap = ap.unsafe_offset(NN_MMA8_DIM)
+                bp = bp.unsafe_offset(NN_MMA8_DIM * n)
                 var nxta = _load_a_fast(ap)
                 var nxtb = _load_b_fast(bp)
                 _mma_block(cura, curb, accum)
@@ -668,9 +680,9 @@ def _apple8_nn_direct_kernel[
                 var gcol = col_base + ni * NN_MMA8_DIM + fcol
                 var frag = accum[mi * NT_N + ni]
                 if gcol + NN_FRAG8 <= n:
-                    c_ptr.store(grow * n + gcol, frag)
+                    c_ptr.unsafe_store(grow * n + gcol, frag)
                 elif gcol < n:
-                    c_ptr[grow * n + gcol] = frag[0]
+                    c_ptr[unsafe_offset=grow * n + gcol] = frag[0]
 
 
 @always_inline
@@ -704,12 +716,8 @@ def apple_nn_direct_enqueue[
     var ksplits = 1
     if blocks < NN_TARGET_BLOCKS // 2:
         ksplits = min(min(ceildiv(NN_TARGET_BLOCKS, blocks), slabs), 8)
-    var a = (
-        _make_ptr[DType.float32](a_addr).as_unsafe_any_origin().as_immutable()
-    )
-    var b = (
-        _make_ptr[DType.float32](b_addr).as_unsafe_any_origin().as_immutable()
-    )
+    var a = _make_ptr[DType.float32](a_addr).as_unsafe_any_origin().as_imm()
+    var b = _make_ptr[DType.float32](b_addr).as_unsafe_any_origin().as_imm()
     if ksplits == 1:
         var c = _make_ptr[DType.float32](c_addr).as_unsafe_any_origin()
         _enqueue_cached[
@@ -732,7 +740,7 @@ def apple_nn_direct_enqueue[
         )
         return
     var ws = ctx.enqueue_create_buffer[DType.float32](batch * ksplits * m * n)
-    var ws_mut = UnsafePointer[Scalar[DType.float32], MutUntrackedOrigin](
+    var ws_mut = Pointer[Scalar[DType.float32], MutUntrackedOrigin](
         unsafe_from_address=Int(ws.unsafe_ptr())
     ).as_unsafe_any_origin()
     _enqueue_cached[_apple8_nn_direct_kernel[True, BM, BN, SGR, SGC, SWIZZLE]](
@@ -761,7 +769,7 @@ def apple_nn_direct_enqueue[
         1,
         256,
         c_out,
-        ws_mut.as_immutable(),
+        ws_mut.as_imm(),
         Int64(m * n),
         Int64(ksplits),
         Int64(total),

--- a/torch_mojo_backend/eager_kernels/matmul_ops/apple_gemm_nt_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/matmul_ops/apple_gemm_nt_kernels.mojo
@@ -96,8 +96,8 @@ def _nt_mma8x8(
 
 
 def _nt_ksplit_reduce_kernel(
-    out_ptr: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    ws_ptr: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    ws_ptr: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
     mn_arg: Int64,
     ksplits_arg: Int64,
     total_arg: Int64,
@@ -118,8 +118,8 @@ def _nt_ksplit_reduce_kernel(
         var base = bz * ksplits * mn + off
         var acc = SIMD[DType.float32, 4](0)
         for st in range(ksplits):
-            acc += ws_ptr.load[width=4](base + st * mn)
-        out_ptr.store(i, acc)
+            acc += ws_ptr.unsafe_load[width=4](base + st * mn)
+        out_ptr.unsafe_store(i, acc)
     else:
         for u in range(4):
             var iu = i + u
@@ -130,8 +130,8 @@ def _nt_ksplit_reduce_kernel(
             var baseu = bzu * ksplits * mn + offu
             var accu = Scalar[DType.float32](0)
             for st in range(ksplits):
-                accu += ws_ptr[baseu + st * mn]
-            out_ptr[iu] = accu
+                accu += ws_ptr[unsafe_offset=baseu + st * mn]
+            out_ptr[unsafe_offset=iu] = accu
 
 
 # ---------------------------------------------------------------------------
@@ -159,9 +159,9 @@ def _apple8_nt_smem_kernel[
     DOUBLE: Bool = True,
     SWIZZLE: Int = 0,
 ](
-    c_base: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    a_base: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
-    b_base: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
+    c_base: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    a_base: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
+    b_base: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
     m_arg: Int64,
     n_arg: Int64,
     k_arg: Int64,
@@ -201,9 +201,9 @@ def _apple8_nt_smem_kernel[
 
     # With ksplits > 1, C is a [batch * ksplits, m, n] workspace and each
     # split writes its own slice. a_bstride is 0 when A is batch-shared.
-    var c_ptr = c_base + Int(block_idx.z) * m * n
-    var a_ptr = a_base + bz * a_bstride
-    var b_ptr = b_base + bz * k * n
+    var c_ptr = c_base.unsafe_offset(Int(block_idx.z) * m * n)
+    var a_ptr = a_base.unsafe_offset(bz * a_bstride)
+    var b_ptr = b_base.unsafe_offset(bz * k * n)
 
     # SWIZZLE > 0: the MN grid is launched flattened into grid.x and
     # rasterized in supertiles of SWIZZLE block-rows — consecutive blocks
@@ -266,13 +266,15 @@ def _apple8_nt_smem_kernel[
             var row = bm + mm
             var col = kt + kq
             if row < m and col + 4 <= k_end:
-                a_regs[q] = (a_ptr + row * k + col).load[width=4]()
+                a_regs[q] = (a_ptr.unsafe_offset(row * k + col)).unsafe_load[
+                    width=4
+                ]()
             else:
                 var v = SIMD[DType.float32, 4](0)
                 if row < m:
                     comptime for j in range(4):
                         if col + j < k_end:
-                            v[j] = a_ptr[row * k + col + j]
+                            v[j] = a_ptr[unsafe_offset=row * k + col + j]
                 a_regs[q] = v
         comptime for q in range(BV):
             var fid = q * THREADS + tid
@@ -281,13 +283,15 @@ def _apple8_nt_smem_kernel[
             var row = bn + nn
             var col = kt + kq
             if row < n and col + 4 <= k_end:
-                b_regs[q] = (b_ptr + row * k + col).load[width=4]()
+                b_regs[q] = (b_ptr.unsafe_offset(row * k + col)).unsafe_load[
+                    width=4
+                ]()
             else:
                 var v = SIMD[DType.float32, 4](0)
                 if row < n:
                     comptime for j in range(4):
                         if col + j < k_end:
-                            v[j] = b_ptr[row * k + col + j]
+                            v[j] = b_ptr[unsafe_offset=row * k + col + j]
                 b_regs[q] = v
 
     # Register -> threadgroup store for buffer `buf`. B lands transposed:
@@ -299,19 +303,19 @@ def _apple8_nt_smem_kernel[
         a_regs: InlineArray[SIMD[DType.float32, 4], AV],
         b_regs: InlineArray[SIMD[DType.float32, 4], BV],
     ):
-        var a_dst = a_smem + buf * BM * LDA
-        var b_dst = b_smem + buf * BK * LDB
+        var a_dst = a_smem.unsafe_offset(buf * BM * LDA)
+        var b_dst = b_smem.unsafe_offset(buf * BK * LDB)
         comptime for q in range(AV):
             var fid = q * THREADS + tid
             var mm = fid // KV
             var kq = (fid % KV) * 4
-            a_dst.store(mm * LDA + kq, a_regs[q])
+            a_dst.unsafe_store(mm * LDA + kq, a_regs[q])
         comptime for q in range(BV):
             var fid = q * THREADS + tid
             var nn = fid // KV
             var kq = (fid % KV) * 4
             comptime for j in range(4):
-                b_dst[(kq + j) * LDB + nn] = b_regs[q][j]
+                b_dst[unsafe_offset=(kq + j) * LDB + nn] = b_regs[q][j]
 
     # BK/8 8-slab mma sweeps over threadgroup buffer `buf`.
     @always_inline
@@ -320,23 +324,31 @@ def _apple8_nt_smem_kernel[
         buf: Int,
         mut acc: InlineArray[SIMD[DType.float32, NT_FRAG8], NT_M * NT_N],
     ):
-        var a_src = a_smem + buf * BM * LDA + (sgm + frow) * LDA + fcol
-        var b_src = b_smem + buf * BK * LDB + frow * LDB + sgn + fcol
+        var a_src = a_smem.unsafe_offset(
+            buf * BM * LDA + (sgm + frow) * LDA + fcol
+        )
+        var b_src = b_smem.unsafe_offset(
+            buf * BK * LDB + frow * LDB + sgn + fcol
+        )
         comptime for kc in range(BK // NT_MMA8_DIM):
             var afrag = InlineArray[SIMD[DType.float32, NT_FRAG8], NT_M](
                 uninitialized=True
             )
             comptime for mi in range(NT_M):
                 afrag[mi] = (
-                    a_src + mi * NT_MMA8_DIM * LDA + kc * NT_MMA8_DIM
-                ).load[width=NT_FRAG8]()
+                    a_src.unsafe_offset(
+                        mi * NT_MMA8_DIM * LDA + kc * NT_MMA8_DIM
+                    )
+                ).unsafe_load[width=NT_FRAG8]()
             var bfrag = InlineArray[SIMD[DType.float32, NT_FRAG8], NT_N](
                 uninitialized=True
             )
             comptime for ni in range(NT_N):
                 bfrag[ni] = (
-                    b_src + kc * NT_MMA8_DIM * LDB + ni * NT_MMA8_DIM
-                ).load[width=NT_FRAG8]()
+                    b_src.unsafe_offset(
+                        kc * NT_MMA8_DIM * LDB + ni * NT_MMA8_DIM
+                    )
+                ).unsafe_load[width=NT_FRAG8]()
             comptime for mi in range(NT_M):
                 comptime for ni in range(NT_N):
                     acc[mi * NT_N + ni] = _nt_mma8x8(
@@ -378,9 +390,9 @@ def _apple8_nt_smem_kernel[
                 var gcol = bn + sgn + ni * NT_MMA8_DIM + fcol
                 var frag = accum[mi * NT_N + ni]
                 if gcol + NT_FRAG8 <= n:
-                    c_ptr.store(grow * n + gcol, frag)
+                    c_ptr.unsafe_store(grow * n + gcol, frag)
                 elif gcol < n:
-                    c_ptr[grow * n + gcol] = frag[0]
+                    c_ptr[unsafe_offset=grow * n + gcol] = frag[0]
 
 
 @always_inline
@@ -419,12 +431,8 @@ def apple_nt_smem_enqueue[
     var ksplits = 1
     if blocks < NT_TARGET_BLOCKS // 2:
         ksplits = min(min(ceildiv(NT_TARGET_BLOCKS, blocks), slabs), 8)
-    var a = (
-        _make_ptr[DType.float32](a_addr).as_unsafe_any_origin().as_immutable()
-    )
-    var b = (
-        _make_ptr[DType.float32](b_addr).as_unsafe_any_origin().as_immutable()
-    )
+    var a = _make_ptr[DType.float32](a_addr).as_unsafe_any_origin().as_imm()
+    var b = _make_ptr[DType.float32](b_addr).as_unsafe_any_origin().as_imm()
     if ksplits == 1:
         var c = _make_ptr[DType.float32](c_addr).as_unsafe_any_origin()
         _enqueue_cached[
@@ -452,7 +460,7 @@ def apple_nt_smem_enqueue[
         )
         return
     var ws = ctx.enqueue_create_buffer[DType.float32](batch * ksplits * m * n)
-    var ws_mut = UnsafePointer[Scalar[DType.float32], MutUntrackedOrigin](
+    var ws_mut = Pointer[Scalar[DType.float32], MutUntrackedOrigin](
         unsafe_from_address=Int(ws.unsafe_ptr())
     ).as_unsafe_any_origin()
     _enqueue_cached[
@@ -486,7 +494,7 @@ def apple_nt_smem_enqueue[
         1,
         256,
         c_out,
-        ws_mut.as_immutable(),
+        ws_mut.as_imm(),
         Int64(m * n),
         Int64(ksplits),
         Int64(total),
@@ -513,9 +521,9 @@ def _apple8_nt_direct_kernel[
     SGC: Int = 2,
     SWIZZLE: Int = 0,
 ](
-    c_base: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    a_base: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
-    b_base: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
+    c_base: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    a_base: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
+    b_base: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
     m_arg: Int64,
     n_arg: Int64,
     k_arg: Int64,
@@ -542,9 +550,9 @@ def _apple8_nt_direct_kernel[
     var k_start = min(k, ks * kchunk)
     var k_end = min(k, k_start + kchunk)
 
-    var c_ptr = c_base + Int(block_idx.z) * m * n
-    var a_ptr = a_base + bz * a_bstride
-    var b_ptr = b_base + bz * k * n
+    var c_ptr = c_base.unsafe_offset(Int(block_idx.z) * m * n)
+    var a_ptr = a_base.unsafe_offset(bz * a_bstride)
+    var b_ptr = b_base.unsafe_offset(bz * k * n)
 
     var bx: Int
     var by: Int
@@ -592,7 +600,7 @@ def _apple8_nt_direct_kernel[
             if grow < m:
                 comptime for s in range(NT_FRAG8):
                     if kk + fcol + s < k_end:
-                        af[s] = a_ptr[grow * k + kk + fcol + s]
+                        af[s] = a_ptr[unsafe_offset=grow * k + kk + fcol + s]
             afrag[mi] = af
         var bfrag = InlineArray[SIMD[DType.float32, NT_FRAG8], NT_N](
             uninitialized=True
@@ -603,7 +611,7 @@ def _apple8_nt_direct_kernel[
                 comptime for s in range(NT_FRAG8):
                     var gj = col_base + ni * NT_MMA8_DIM + fcol + s
                     if gj < n:
-                        bf[s] = b_ptr[gj * k + kk + frow]
+                        bf[s] = b_ptr[unsafe_offset=gj * k + kk + frow]
             bfrag[ni] = bf
         comptime for mi in range(NT_M):
             comptime for ni in range(NT_N):
@@ -616,29 +624,31 @@ def _apple8_nt_direct_kernel[
     @always_inline
     @parameter
     def _load_a_fast(
-        ap0: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
+        ap0: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
     ) -> InlineArray[SIMD[DType.float32, NT_FRAG8], NT_M]:
         var afrag = InlineArray[SIMD[DType.float32, NT_FRAG8], NT_M](
             uninitialized=True
         )
         comptime for mi in range(NT_M):
-            afrag[mi] = (ap0 + mi * NT_MMA8_DIM * k).load[width=NT_FRAG8]()
+            afrag[mi] = (ap0.unsafe_offset(mi * NT_MMA8_DIM * k)).unsafe_load[
+                width=NT_FRAG8
+            ]()
         return afrag^
 
     @always_inline
     @parameter
     def _load_b_fast(
-        bp0: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
+        bp0: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
     ) -> InlineArray[SIMD[DType.float32, NT_FRAG8], NT_N]:
         var bfrag = InlineArray[SIMD[DType.float32, NT_FRAG8], NT_N](
             uninitialized=True
         )
         comptime for ni in range(NT_N):
             # B is (N, K): the fragment's two slots differ in n-row.
-            var p = bp0 + ni * NT_MMA8_DIM * k
+            var p = bp0.unsafe_offset(ni * NT_MMA8_DIM * k)
             var bf = SIMD[DType.float32, NT_FRAG8](0)
-            bf[0] = p[0]
-            bf[1] = p[k]
+            bf[0] = p[unsafe_offset=0]
+            bf[1] = p[unsafe_offset=k]
             bfrag[ni] = bf
         return bfrag^
 
@@ -659,15 +669,15 @@ def _apple8_nt_direct_kernel[
     if interior:
         # Software-pipelined pointer-increment loop: the next slab's
         # fragments are in flight while the current slab's mmas issue.
-        var ap = a_ptr + (row_base + frow) * k + fcol + k_start
-        var bp = b_ptr + (col_base + fcol) * k + frow + k_start
+        var ap = a_ptr.unsafe_offset((row_base + frow) * k + fcol + k_start)
+        var bp = b_ptr.unsafe_offset((col_base + fcol) * k + frow + k_start)
         var nslabs = (k_end - k_start) // NT_MMA8_DIM
         if nslabs > 0:
             var cura = _load_a_fast(ap)
             var curb = _load_b_fast(bp)
             for _ in range(nslabs - 1):
-                ap += NT_MMA8_DIM
-                bp += NT_MMA8_DIM
+                ap = ap.unsafe_offset(NT_MMA8_DIM)
+                bp = bp.unsafe_offset(NT_MMA8_DIM)
                 var nxta = _load_a_fast(ap)
                 var nxtb = _load_b_fast(bp)
                 _mma_block(cura, curb, accum)
@@ -689,9 +699,9 @@ def _apple8_nt_direct_kernel[
                 var gcol = col_base + ni * NT_MMA8_DIM + fcol
                 var frag = accum[mi * NT_N + ni]
                 if gcol + NT_FRAG8 <= n:
-                    c_ptr.store(grow * n + gcol, frag)
+                    c_ptr.unsafe_store(grow * n + gcol, frag)
                 elif gcol < n:
-                    c_ptr[grow * n + gcol] = frag[0]
+                    c_ptr[unsafe_offset=grow * n + gcol] = frag[0]
 
 
 @always_inline
@@ -725,12 +735,8 @@ def apple_nt_direct_enqueue[
     var ksplits = 1
     if blocks < NT_TARGET_BLOCKS // 2:
         ksplits = min(min(ceildiv(NT_TARGET_BLOCKS, blocks), slabs), 8)
-    var a = (
-        _make_ptr[DType.float32](a_addr).as_unsafe_any_origin().as_immutable()
-    )
-    var b = (
-        _make_ptr[DType.float32](b_addr).as_unsafe_any_origin().as_immutable()
-    )
+    var a = _make_ptr[DType.float32](a_addr).as_unsafe_any_origin().as_imm()
+    var b = _make_ptr[DType.float32](b_addr).as_unsafe_any_origin().as_imm()
     if ksplits == 1:
         var c = _make_ptr[DType.float32](c_addr).as_unsafe_any_origin()
         _enqueue_cached[
@@ -753,7 +759,7 @@ def apple_nt_direct_enqueue[
         )
         return
     var ws = ctx.enqueue_create_buffer[DType.float32](batch * ksplits * m * n)
-    var ws_mut = UnsafePointer[Scalar[DType.float32], MutUntrackedOrigin](
+    var ws_mut = Pointer[Scalar[DType.float32], MutUntrackedOrigin](
         unsafe_from_address=Int(ws.unsafe_ptr())
     ).as_unsafe_any_origin()
     _enqueue_cached[_apple8_nt_direct_kernel[True, BM, BN, SGR, SGC, SWIZZLE]](
@@ -782,7 +788,7 @@ def apple_nt_direct_enqueue[
         1,
         256,
         c_out,
-        ws_mut.as_immutable(),
+        ws_mut.as_imm(),
         Int64(m * n),
         Int64(ksplits),
         Int64(total),

--- a/torch_mojo_backend/eager_kernels/matmul_ops/apple_gemm_tn_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/matmul_ops/apple_gemm_tn_kernels.mojo
@@ -109,8 +109,8 @@ def _tn_mma8x8(
 
 
 def _tn_ksplit_reduce_kernel(
-    out_ptr: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    ws_ptr: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    ws_ptr: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
     mn_arg: Int64,
     ksplits_arg: Int64,
     total_arg: Int64,
@@ -131,8 +131,8 @@ def _tn_ksplit_reduce_kernel(
         var base = bz * ksplits * mn + off
         var acc = SIMD[DType.float32, 4](0)
         for st in range(ksplits):
-            acc += ws_ptr.load[width=4](base + st * mn)
-        out_ptr.store(i, acc)
+            acc += ws_ptr.unsafe_load[width=4](base + st * mn)
+        out_ptr.unsafe_store(i, acc)
     else:
         for u in range(4):
             var iu = i + u
@@ -143,8 +143,8 @@ def _tn_ksplit_reduce_kernel(
             var baseu = bzu * ksplits * mn + offu
             var accu = Scalar[DType.float32](0)
             for st in range(ksplits):
-                accu += ws_ptr[baseu + st * mn]
-            out_ptr[iu] = accu
+                accu += ws_ptr[unsafe_offset=baseu + st * mn]
+            out_ptr[unsafe_offset=iu] = accu
 
 
 def _apple8_tn_kernel[
@@ -154,9 +154,9 @@ def _apple8_tn_kernel[
     SGR: Int = 2,
     SGC: Int = 2,
 ](
-    c_base: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    a_base: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
-    b_base: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
+    c_base: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    a_base: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
+    b_base: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
     m_arg: Int64,
     n_arg: Int64,
     k_arg: Int64,
@@ -185,9 +185,9 @@ def _apple8_tn_kernel[
 
     # With ksplits > 1, C is a [batch * ksplits, m, n] workspace and each
     # split writes its own slice. a_bstride is 0 when A is batch-shared.
-    var c_ptr = c_base + Int(block_idx.z) * m * n
-    var a_ptr = a_base + bz * a_bstride
-    var b_ptr = b_base + bz * k * n
+    var c_ptr = c_base.unsafe_offset(Int(block_idx.z) * m * n)
+    var a_ptr = a_base.unsafe_offset(bz * a_bstride)
+    var b_ptr = b_base.unsafe_offset(bz * k * n)
 
     var lane = Int(lane_id())
     var fl = _tn_frag8_layout(lane)
@@ -220,7 +220,7 @@ def _apple8_tn_kernel[
                 comptime for s in range(TN_FRAG8):
                     if kk + fcol + s < k_end:
                         # A is (K, M): logical row = stored column.
-                        af[s] = a_ptr[(kk + fcol + s) * m + grow]
+                        af[s] = a_ptr[unsafe_offset=(kk + fcol + s) * m + grow]
             afrag[mi] = af
         var bfrag = InlineArray[SIMD[DType.float32, TN_FRAG8], NT_N](
             uninitialized=True
@@ -231,7 +231,7 @@ def _apple8_tn_kernel[
                 comptime for s in range(TN_FRAG8):
                     var gj = col_base + ni * TN_MMA8_DIM + fcol + s
                     if gj < n:
-                        bf[s] = b_ptr[(kk + frow) * n + gj]
+                        bf[s] = b_ptr[unsafe_offset=(kk + frow) * n + gj]
             bfrag[ni] = bf
         comptime for mi in range(NT_M):
             comptime for ni in range(NT_N):
@@ -245,29 +245,31 @@ def _apple8_tn_kernel[
     @always_inline
     @parameter
     def _load_a_fast(
-        ap0: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
+        ap0: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
     ) -> InlineArray[SIMD[DType.float32, TN_FRAG8], NT_M]:
         var afrag = InlineArray[SIMD[DType.float32, TN_FRAG8], NT_M](
             uninitialized=True
         )
         comptime for mi in range(NT_M):
-            var p = ap0 + mi * TN_MMA8_DIM
+            var p = ap0.unsafe_offset(mi * TN_MMA8_DIM)
             var af = SIMD[DType.float32, TN_FRAG8](0)
-            af[0] = p[0]
-            af[1] = p[m]
+            af[0] = p[unsafe_offset=0]
+            af[1] = p[unsafe_offset=m]
             afrag[mi] = af
         return afrag^
 
     @always_inline
     @parameter
     def _load_b_fast(
-        bp0: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
+        bp0: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
     ) -> InlineArray[SIMD[DType.float32, TN_FRAG8], NT_N]:
         var bfrag = InlineArray[SIMD[DType.float32, TN_FRAG8], NT_N](
             uninitialized=True
         )
         comptime for ni in range(NT_N):
-            bfrag[ni] = (bp0 + ni * TN_MMA8_DIM).load[width=TN_FRAG8]()
+            bfrag[ni] = (bp0.unsafe_offset(ni * TN_MMA8_DIM)).unsafe_load[
+                width=TN_FRAG8
+            ]()
         return bfrag^
 
     @always_inline
@@ -288,15 +290,15 @@ def _apple8_tn_kernel[
         # Software-pipelined pointer-increment loop: the next slab's
         # fragments are in flight while the current slab's mmas issue, so a
         # single simdgroup hides most of the device-load latency itself.
-        var ap = a_ptr + (k_start + fcol) * m + row_base + frow
-        var bp = b_ptr + (k_start + frow) * n + col_base + fcol
+        var ap = a_ptr.unsafe_offset((k_start + fcol) * m + row_base + frow)
+        var bp = b_ptr.unsafe_offset((k_start + frow) * n + col_base + fcol)
         var nslabs = (k_end - k_start) // TN_MMA8_DIM
         if nslabs > 0:
             var cura = _load_a_fast(ap)
             var curb = _load_b_fast(bp)
             for _ in range(nslabs - 1):
-                ap += TN_MMA8_DIM * m
-                bp += TN_MMA8_DIM * n
+                ap = ap.unsafe_offset(TN_MMA8_DIM * m)
+                bp = bp.unsafe_offset(TN_MMA8_DIM * n)
                 var nxta = _load_a_fast(ap)
                 var nxtb = _load_b_fast(bp)
                 _mma_block(cura, curb, accum)
@@ -318,9 +320,9 @@ def _apple8_tn_kernel[
                 var gcol = col_base + ni * TN_MMA8_DIM + fcol
                 var frag = accum[mi * NT_N + ni]
                 if gcol + TN_FRAG8 <= n:
-                    c_ptr.store(grow * n + gcol, frag)
+                    c_ptr.unsafe_store(grow * n + gcol, frag)
                 elif gcol < n:
-                    c_ptr[grow * n + gcol] = frag[0]
+                    c_ptr[unsafe_offset=grow * n + gcol] = frag[0]
 
 
 @always_inline
@@ -351,12 +353,8 @@ def apple_tn_enqueue[
     # Each shard costs an m*n partials round-trip plus a reduce launch.
     if blocks < TN_TARGET_BLOCKS // 2:
         ksplits = min(min(ceildiv(TN_TARGET_BLOCKS, blocks), slabs), 8)
-    var a = (
-        _make_ptr[DType.float32](a_addr).as_unsafe_any_origin().as_immutable()
-    )
-    var b = (
-        _make_ptr[DType.float32](b_addr).as_unsafe_any_origin().as_immutable()
-    )
+    var a = _make_ptr[DType.float32](a_addr).as_unsafe_any_origin().as_imm()
+    var b = _make_ptr[DType.float32](b_addr).as_unsafe_any_origin().as_imm()
     if ksplits == 1:
         var c = _make_ptr[DType.float32](c_addr).as_unsafe_any_origin()
         _enqueue_cached[_apple8_tn_kernel[False, BM, BN, SGR, SGC]](
@@ -377,7 +375,7 @@ def apple_tn_enqueue[
         )
         return
     var ws = ctx.enqueue_create_buffer[DType.float32](batch * ksplits * m * n)
-    var ws_mut = UnsafePointer[Scalar[DType.float32], MutUntrackedOrigin](
+    var ws_mut = Pointer[Scalar[DType.float32], MutUntrackedOrigin](
         unsafe_from_address=Int(ws.unsafe_ptr())
     ).as_unsafe_any_origin()
     _enqueue_cached[_apple8_tn_kernel[True, BM, BN, SGR, SGC]](
@@ -406,7 +404,7 @@ def apple_tn_enqueue[
         1,
         256,
         c_out,
-        ws_mut.as_immutable(),
+        ws_mut.as_imm(),
         Int64(m * n),
         Int64(ksplits),
         Int64(total),

--- a/torch_mojo_backend/eager_kernels/matmul_ops/gemm_splitk_common.mojo
+++ b/torch_mojo_backend/eager_kernels/matmul_ops/gemm_splitk_common.mojo
@@ -22,8 +22,8 @@ comptime TARGET_BLOCKS = 80 if has_apple_gpu_accelerator() else 342
 
 @__name("pure_ksplit_reduce")
 def _ksplit_reduce_kernel(
-    out_ptr: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    ws_ptr: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    ws_ptr: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
     mn_arg: Int64,
     ksplits_arg: Int64,
     total_arg: Int64,
@@ -44,8 +44,8 @@ def _ksplit_reduce_kernel(
         var base = bz * ksplits * mn + off
         var acc = SIMD[DType.float32, 4](0)
         for st in range(ksplits):
-            acc += ws_ptr.load[width=4](base + st * mn)
-        out_ptr.store(i, acc)
+            acc += ws_ptr.unsafe_load[width=4](base + st * mn)
+        out_ptr.unsafe_store(i, acc)
     else:
         for u in range(4):
             var iu = i + u
@@ -56,5 +56,5 @@ def _ksplit_reduce_kernel(
             var baseu = bzu * ksplits * mn + offu
             var accu = Scalar[DType.float32](0)
             for st in range(ksplits):
-                accu += ws_ptr[baseu + st * mn]
-            out_ptr[iu] = accu
+                accu += ws_ptr[unsafe_offset=baseu + st * mn]
+            out_ptr[unsafe_offset=iu] = accu

--- a/torch_mojo_backend/eager_kernels/matmul_ops/matmul_ops.mojo
+++ b/torch_mojo_backend/eager_kernels/matmul_ops/matmul_ops.mojo
@@ -12,7 +12,8 @@
 # ===----------------------------------------------------------------------=== #
 
 from std.math import ceildiv
-from std.memory import alloc, stack_allocation
+from std.memory import stack_allocation
+from std.memory.alloc import unsafe_alloc
 from std.os import abort
 from max.gpu.sync import barrier
 from std.gpu import (
@@ -175,9 +176,9 @@ def _gemm_tiled_kernel[
     TN: Int,
     transpose_b: Bool,
 ](
-    c_base: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    a_base: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    b_base: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    c_base: Pointer[Scalar[dtype], MutAnyOrigin],
+    a_base: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    b_base: Pointer[Scalar[dtype], ImmutAnyOrigin],
     m_arg: Int64,
     n_arg: Int64,
     k_arg: Int64,
@@ -209,9 +210,9 @@ def _gemm_tiled_kernel[
     # With ksplits > 1, C is a [batch * ksplits, m, n] workspace and each
     # split writes its own slice; a reduce kernel sums them afterwards.
     # a_bstride is 0 when A is shared across the batch (conv weights).
-    var c_ptr = c_base + block_idx.z * m * n
-    var a_ptr = a_base + bz * a_bstride
-    var b_ptr = b_base + bz * k * n
+    var c_ptr = c_base.unsafe_offset(block_idx.z * m * n)
+    var a_ptr = a_base.unsafe_offset(bz * a_bstride)
+    var b_ptr = b_base.unsafe_offset(bz * k * n)
 
     var bm = block_idx.y * BM
     var bn = block_idx.x * BN
@@ -243,8 +244,8 @@ def _gemm_tiled_kernel[
             var col = kt + kk
             var val = Scalar[dtype](0)
             if row < m and col < k_end:
-                val = a_ptr[row * k + col]
-            a_smem[kk * BM + mm] = val
+                val = a_ptr[unsafe_offset=row * k + col]
+            a_smem[unsafe_offset=kk * BM + mm] = val
 
         comptime for t in range(LB):
             var i = t * THREADS + tid
@@ -256,26 +257,26 @@ def _gemm_tiled_kernel[
                 var row = bn + nn  # row of B (n, k)
                 var col = kt + kk
                 if row < n and col < k_end:
-                    val = b_ptr[row * k + col]
-                b_smem[kk * BN + nn] = val
+                    val = b_ptr[unsafe_offset=row * k + col]
+                b_smem[unsafe_offset=kk * BN + nn] = val
             else:
                 var kk = i // BN
                 var nn = i % BN
                 var row = kt + kk  # row of B (k, n)
                 var col = bn + nn
                 if row < k_end and col < n:
-                    val = b_ptr[row * n + col]
-                b_smem[kk * BN + nn] = val
+                    val = b_ptr[unsafe_offset=row * n + col]
+                b_smem[unsafe_offset=kk * BN + nn] = val
 
         barrier()
 
         # Runtime loop on kk: full comptime unrolling of the slab kept ~190
         # live registers (1 block/SM); this stays ~2x lower.
         for kk in range(BK):
-            var a_frag = a_smem.load[width=TM](kk * BM + tm0).cast[
+            var a_frag = a_smem.unsafe_load[width=TM](kk * BM + tm0).cast[
                 DType.float32
             ]()
-            var b_frag = b_smem.load[width=TN](kk * BN + tn0).cast[
+            var b_frag = b_smem.unsafe_load[width=TN](kk * BN + tn0).cast[
                 DType.float32
             ]()
             comptime for i in range(TM):
@@ -288,12 +289,12 @@ def _gemm_tiled_kernel[
         if row < m:
             var out = acc[i].cast[dtype]()
             if bn + tn0 + TN <= n:
-                c_ptr.store(row * n + bn + tn0, out)
+                c_ptr.unsafe_store(row * n + bn + tn0, out)
             else:
                 comptime for j in range(TN):
                     var col = bn + tn0 + j
                     if col < n:
-                        c_ptr[row * n + col] = out[j]
+                        c_ptr[unsafe_offset=row * n + col] = out[j]
 
 
 # ---------------------------------------------------------------------------
@@ -322,9 +323,9 @@ def _gemm_pipe_kernel[
     VEC_B: Int,
     transpose_b: Bool,
 ](
-    c_base: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    a_base: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
-    b_base: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
+    c_base: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    a_base: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
+    b_base: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
     m_arg: Int64,
     n_arg: Int64,
     k_arg: Int64,
@@ -359,9 +360,9 @@ def _gemm_pipe_kernel[
     # With ksplits > 1, C is a [batch * ksplits, m, n] workspace and each
     # split writes its own slice; a reduce kernel sums them afterwards.
     # a_bstride is 0 when A is shared across the batch (conv weights).
-    var c_ptr = c_base + block_idx.z * m * n
-    var a_ptr = a_base + bz * a_bstride
-    var b_ptr = b_base + bz * k * n
+    var c_ptr = c_base.unsafe_offset(block_idx.z * m * n)
+    var a_ptr = a_base.unsafe_offset(bz * a_bstride)
+    var b_ptr = b_base.unsafe_offset(bz * k * n)
 
     var bm = block_idx.y * BM
     var bn = block_idx.x * BN
@@ -401,30 +402,30 @@ def _gemm_pipe_kernel[
             var vec = SIMD[F32, VEC_A](0)
             if row < m:
                 if col + VEC_A <= k_end:
-                    vec = a_ptr.load[width=VEC_A](row * k + col)
+                    vec = a_ptr.unsafe_load[width=VEC_A](row * k + col)
                 elif col < k_end:
                     for u in range(k_end - col):
-                        vec[u] = a_ptr[row * k + col + u]
+                        vec[u] = a_ptr[unsafe_offset=row * k + col + u]
             regs[t] = vec
 
     @always_inline
     @parameter
     @__copy_capture(a_smem, tid)
     def _store_a_smem(buf: Int, regs: InlineArray[SIMD[F32, VEC_A], NA]):
-        var base = a_smem + buf * BK * BM
+        var base = a_smem.unsafe_offset(buf * BK * BM)
         comptime for t in range(NA):
             var ci = t * THREADS + tid
             var mm = ci // (BK // VEC_A)
             var ck = (ci % (BK // VEC_A)) * VEC_A
             comptime for u in range(VEC_A):
-                base[(ck + u) * BM + mm] = regs[t][u]
+                base[unsafe_offset=(ck + u) * BM + mm] = regs[t][u]
 
     @always_inline
     @parameter
     @__copy_capture(b_ptr, bn, n, k, k_end)
     def _cpasync_b(kt: Int, buf: Int):
         # B (k, n) row-major: chunks along n, straight into Bs[kk][nn].
-        var base = b_smem + buf * BK * BN
+        var base = b_smem.unsafe_offset(buf * BK * BN)
         comptime for t in range(NB):
             var ci = t * THREADS + tid
             var kk = ci // (BN // VEC_B)
@@ -436,8 +437,12 @@ def _gemm_pipe_kernel[
                 bytes = Int32(max(0, min(VEC_B, n - col)) * 4)
             var src_off = (row * n + col) if bytes > 0 else 0
             async_copy[VEC_B * 4, fill=Scalar[F32](0)](
-                (b_ptr + src_off).address_space_cast[AddressSpace.GLOBAL](),
-                (base + kk * BN + cn).address_space_cast[AddressSpace.SHARED](),
+                (b_ptr.unsafe_offset(src_off)).unsafe_address_space_cast[
+                    AddressSpace.GLOBAL
+                ](),
+                (base.unsafe_offset(kk * BN + cn)).unsafe_address_space_cast[
+                    AddressSpace.SHARED
+                ](),
                 src_size=bytes,
             )
 
@@ -455,23 +460,23 @@ def _gemm_pipe_kernel[
             var vec = SIMD[F32, VEC_B](0)
             if row < n:
                 if col + VEC_B <= k_end:
-                    vec = b_ptr.load[width=VEC_B](row * k + col)
+                    vec = b_ptr.unsafe_load[width=VEC_B](row * k + col)
                 elif col < k_end:
                     for u in range(k_end - col):
-                        vec[u] = b_ptr[row * k + col + u]
+                        vec[u] = b_ptr[unsafe_offset=row * k + col + u]
             regs[t] = vec
 
     @always_inline
     @parameter
     @__copy_capture(b_smem, tid)
     def _store_b_smem(buf: Int, regs: InlineArray[SIMD[F32, VEC_B], NB]):
-        var base = b_smem + buf * BK * BN
+        var base = b_smem.unsafe_offset(buf * BK * BN)
         comptime for t in range(NB):
             var ci = t * THREADS + tid
             var nn = ci // (BK // VEC_B)
             var ck = (ci % (BK // VEC_B)) * VEC_B
             comptime for u in range(VEC_B):
-                base[(ck + u) * BN + nn] = regs[t][u]
+                base[unsafe_offset=(ck + u) * BN + nn] = regs[t][u]
 
     @always_inline
     @parameter
@@ -512,11 +517,11 @@ def _gemm_pipe_kernel[
             comptime if transpose_b:
                 _load_b_regs(k_start + (s + 1) * BK, b_regs)
 
-        var a_base_s = a_smem + cur * BK * BM
-        var b_base_s = b_smem + cur * BK * BN
+        var a_base_s = a_smem.unsafe_offset(cur * BK * BM)
+        var b_base_s = b_smem.unsafe_offset(cur * BK * BN)
         for kk in range(BK):
-            var a_frag = a_base_s.load[width=TM](kk * BM + tm0)
-            var b_frag = b_base_s.load[width=TN](kk * BN + tn0)
+            var a_frag = a_base_s.unsafe_load[width=TM](kk * BM + tm0)
+            var b_frag = b_base_s.unsafe_load[width=TN](kk * BN + tn0)
             comptime for i in range(TM):
                 acc[i] = b_frag.fma(SIMD[F32, TN](a_frag[i]), acc[i])
 
@@ -535,12 +540,12 @@ def _gemm_pipe_kernel[
         var row = bm + tm0 + i
         if row < m:
             if bn + tn0 + TN <= n:
-                c_ptr.store(row * n + bn + tn0, acc[i])
+                c_ptr.unsafe_store(row * n + bn + tn0, acc[i])
             else:
                 comptime for j in range(TN):
                     var col = bn + tn0 + j
                     if col < n:
-                        c_ptr[row * n + col] = acc[i][j]
+                        c_ptr[unsafe_offset=row * n + col] = acc[i][j]
 
 
 # ---------------------------------------------------------------------------
@@ -560,8 +565,8 @@ comptime PIPE3_STAGES = 4
 # (96 KB for a GPT-2 decode step; ~1 µs).
 @__name("pure_transpose_small")
 def _transpose_small_kernel(
-    out_ptr: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
     m_arg: Int64,
     k_arg: Int64,
 ):
@@ -575,7 +580,7 @@ def _transpose_small_kernel(
         return
     var mm = i // k
     var kk = i % k
-    out_ptr[kk * m + mm] = in_ptr[i]
+    out_ptr[unsafe_offset=kk * m + mm] = in_ptr[unsafe_offset=i]
 
 
 @__llvm_metadata(
@@ -605,15 +610,15 @@ def _gemm_pipe3_kernel[
     # -1 keeps the historical default (2 for BM >= 128 else 3).
     # BIAS: fuse `c[row, col] += bias[col]` into the epilogue (the ks == 0
     # split only, so split-K partial sums receive the bias exactly once).
-    c_base: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    a_base: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
-    b_base: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
+    c_base: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    a_base: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
+    b_base: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
     m_arg: Int64,
     n_arg: Int64,
     k_arg: Int64,
     a_bstride_arg: Int64,
     ksplits_arg: Int64,
-    bias_ptr: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
+    bias_ptr: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
 ):
     # Int is not device-passable (host/device width mismatch); scalars cross
     # the launch ABI as Int64 and index math stays in Int.
@@ -642,9 +647,9 @@ def _gemm_pipe3_kernel[
     # With ksplits > 1, C is a [batch * ksplits, m, n] workspace and each
     # split writes its own slice; a reduce kernel sums them afterwards.
     # a_bstride is 0 when A is shared across the batch (conv weights).
-    var c_ptr = c_base + block_idx.z * m * n
-    var a_ptr = a_base + bz * a_bstride
-    var b_ptr = b_base + bz * k * n
+    var c_ptr = c_base.unsafe_offset(block_idx.z * m * n)
+    var a_ptr = a_base.unsafe_offset(bz * a_bstride)
+    var b_ptr = b_base.unsafe_offset(bz * k * n)
 
     var bm = block_idx.y * BM
     var bn = block_idx.x * BN
@@ -671,8 +676,8 @@ def _gemm_pipe3_kernel[
     def _fetch(s: Int):
         var buf = s % STAGES
         var kt = k_start + s * BK
-        var a_dst = a_smem + buf * BM * BK
-        var b_dst = b_smem + buf * BK * BN
+        var a_dst = a_smem.unsafe_offset(buf * BM * BK)
+        var b_dst = b_smem.unsafe_offset(buf * BK * BN)
 
         comptime if AT:
             # A^T (k, m) row-major: chunks along m into As[kk][mm], so the
@@ -689,10 +694,12 @@ def _gemm_pipe3_kernel[
                     bytes = Int32(max(0, min(VEC_A, m - col)) * 4)
                 var src_off = (row * m + col) if bytes > 0 else 0
                 async_copy[VEC_A * 4, fill=Scalar[F32](0)](
-                    (a_ptr + src_off).address_space_cast[AddressSpace.GLOBAL](),
-                    (a_dst + kk * BM + cm).address_space_cast[
-                        AddressSpace.SHARED
+                    (a_ptr.unsafe_offset(src_off)).unsafe_address_space_cast[
+                        AddressSpace.GLOBAL
                     ](),
+                    (
+                        a_dst.unsafe_offset(kk * BM + cm)
+                    ).unsafe_address_space_cast[AddressSpace.SHARED](),
                     src_size=bytes,
                 )
         else:
@@ -708,10 +715,12 @@ def _gemm_pipe3_kernel[
                     bytes = Int32(max(0, min(VEC_A, k_end - col)) * 4)
                 var src_off = (row * k + col) if bytes > 0 else 0
                 async_copy[VEC_A * 4, fill=Scalar[F32](0)](
-                    (a_ptr + src_off).address_space_cast[AddressSpace.GLOBAL](),
-                    (a_dst + mm * BK + ck).address_space_cast[
-                        AddressSpace.SHARED
+                    (a_ptr.unsafe_offset(src_off)).unsafe_address_space_cast[
+                        AddressSpace.GLOBAL
                     ](),
+                    (
+                        a_dst.unsafe_offset(mm * BK + ck)
+                    ).unsafe_address_space_cast[AddressSpace.SHARED](),
                     src_size=bytes,
                 )
 
@@ -727,8 +736,10 @@ def _gemm_pipe3_kernel[
                 bytes = Int32(max(0, min(VEC_B, n - col)) * 4)
             var src_off = (row * n + col) if bytes > 0 else 0
             async_copy[VEC_B * 4, fill=Scalar[F32](0)](
-                (b_ptr + src_off).address_space_cast[AddressSpace.GLOBAL](),
-                (b_dst + kk * BN + cn).address_space_cast[
+                (b_ptr.unsafe_offset(src_off)).unsafe_address_space_cast[
+                    AddressSpace.GLOBAL
+                ](),
+                (b_dst.unsafe_offset(kk * BN + cn)).unsafe_address_space_cast[
                     AddressSpace.SHARED
                 ](),
                 src_size=bytes,
@@ -747,8 +758,8 @@ def _gemm_pipe3_kernel[
         barrier()
 
         var buf = s % STAGES
-        var a_base_s = a_smem + buf * BM * BK
-        var b_base_s = b_smem + buf * BK * BN
+        var a_base_s = a_smem.unsafe_offset(buf * BM * BK)
+        var b_base_s = b_smem.unsafe_offset(buf * BK * BN)
 
         # Fully unrolled with register-double-buffered fragments: the
         # loads for slab column kk + 1 issue before the FMAs of column
@@ -756,21 +767,21 @@ def _gemm_pipe3_kernel[
         # instead of stalling every iteration.
         var a_cur: SIMD[F32, TM]
         comptime if AT:
-            a_cur = a_base_s.load[width=TM](tm0)
+            a_cur = a_base_s.unsafe_load[width=TM](tm0)
         else:
             a_cur = SIMD[F32, TM](0)
             comptime for i in range(TM):
-                a_cur[i] = a_base_s[(tm0 + i) * BK]
-        var b_cur = b_base_s.load[width=TN](tn0)
+                a_cur[i] = a_base_s[unsafe_offset=(tm0 + i) * BK]
+        var b_cur = b_base_s.unsafe_load[width=TN](tn0)
         comptime for kk in range(BK - 1):
             var a_nxt: SIMD[F32, TM]
             comptime if AT:
-                a_nxt = a_base_s.load[width=TM]((kk + 1) * BM + tm0)
+                a_nxt = a_base_s.unsafe_load[width=TM]((kk + 1) * BM + tm0)
             else:
                 a_nxt = SIMD[F32, TM](0)
                 comptime for i in range(TM):
-                    a_nxt[i] = a_base_s[(tm0 + i) * BK + kk + 1]
-            var b_nxt = b_base_s.load[width=TN]((kk + 1) * BN + tn0)
+                    a_nxt[i] = a_base_s[unsafe_offset=(tm0 + i) * BK + kk + 1]
+            var b_nxt = b_base_s.unsafe_load[width=TN]((kk + 1) * BN + tn0)
             comptime for i in range(TM):
                 acc[i] = b_cur.fma(SIMD[F32, TN](a_cur[i]), acc[i])
             a_cur = a_nxt
@@ -797,33 +808,33 @@ def _gemm_pipe3_kernel[
                 comptime for i in range(TM):
                     out[i] = acc[i][j]
                 if row0 + TM <= m:
-                    c_ptr.store(col * m + row0, out)
+                    c_ptr.unsafe_store(col * m + row0, out)
                 else:
                     comptime for i in range(TM):
                         if row0 + i < m:
-                            c_ptr[col * m + row0 + i] = out[i]
+                            c_ptr[unsafe_offset=col * m + row0 + i] = out[i]
     else:
         comptime if BIAS:
             var bias_frag = SIMD[F32, TN](0)
             if ks == 0:
                 if bn + tn0 + TN <= n:
-                    bias_frag = bias_ptr.load[width=TN](bn + tn0)
+                    bias_frag = bias_ptr.unsafe_load[width=TN](bn + tn0)
                 else:
                     comptime for j in range(TN):
                         if bn + tn0 + j < n:
-                            bias_frag[j] = bias_ptr[bn + tn0 + j]
+                            bias_frag[j] = bias_ptr[unsafe_offset=bn + tn0 + j]
             comptime for i in range(TM):
                 acc[i] = acc[i] + bias_frag
         comptime for i in range(TM):
             var row = bm + tm0 + i
             if row < m:
                 if bn + tn0 + TN <= n:
-                    c_ptr.store(row * n + bn + tn0, acc[i])
+                    c_ptr.unsafe_store(row * n + bn + tn0, acc[i])
                 else:
                     comptime for j in range(TN):
                         var col = bn + tn0 + j
                         if col < n:
-                            c_ptr[row * n + col] = acc[i][j]
+                            c_ptr[unsafe_offset=row * n + col] = acc[i][j]
 
 
 # ---------------------------------------------------------------------------
@@ -845,9 +856,9 @@ def _gemm_smallm_kernel[
     dtype: DType,
     transpose_b: Bool,
 ](
-    c_base: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    a_base: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    b_base: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    c_base: Pointer[Scalar[dtype], MutAnyOrigin],
+    a_base: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    b_base: Pointer[Scalar[dtype], ImmutAnyOrigin],
     m_arg: Int64,
     n_arg: Int64,
     k_arg: Int64,
@@ -875,9 +886,9 @@ def _gemm_smallm_kernel[
     # With ksplits > 1, C is a [batch * ksplits, m, n] workspace and each
     # split writes its own slice; a reduce kernel sums them afterwards.
     # a_bstride is 0 when A is shared across the batch (conv weights).
-    var c_ptr = c_base + block_idx.z * m * n
-    var a_ptr = a_base + bz * a_bstride
-    var b_ptr = b_base + bz * k * n
+    var c_ptr = c_base.unsafe_offset(block_idx.z * m * n)
+    var a_ptr = a_base.unsafe_offset(bz * a_bstride)
+    var b_ptr = b_base.unsafe_offset(bz * k * n)
 
     var acc = InlineArray[Scalar[DType.float32], SMALLM_MR](
         fill=Scalar[DType.float32](0)
@@ -892,9 +903,9 @@ def _gemm_smallm_kernel[
     @parameter
     def _load_b(kk: Int) -> Scalar[DType.float32]:
         comptime if transpose_b:
-            return b_ptr[col * k + kk].cast[DType.float32]()
+            return b_ptr[unsafe_offset=col * k + kk].cast[DType.float32]()
         else:
-            return b_ptr[kk * n + col].cast[DType.float32]()
+            return b_ptr[unsafe_offset=kk * n + col].cast[DType.float32]()
 
     for kt in range(k_start, k4, KU):
         var bv = InlineArray[Scalar[DType.float32], KU](uninitialized=True)
@@ -904,7 +915,7 @@ def _gemm_smallm_kernel[
             comptime for r in range(SMALLM_MR):
                 if r < m:
                     acc[r] = (
-                        a_ptr[r * k + kt + u]
+                        a_ptr[unsafe_offset=r * k + kt + u]
                         .cast[DType.float32]()
                         .fma(bv[u], acc[r])
                     )
@@ -913,11 +924,15 @@ def _gemm_smallm_kernel[
         var bv = _load_b(kk)
         comptime for r in range(SMALLM_MR):
             if r < m:
-                acc[r] = a_ptr[r * k + kk].cast[DType.float32]().fma(bv, acc[r])
+                acc[r] = (
+                    a_ptr[unsafe_offset=r * k + kk]
+                    .cast[DType.float32]()
+                    .fma(bv, acc[r])
+                )
 
     comptime for r in range(SMALLM_MR):
         if r < m:
-            c_ptr[r * n + col] = acc[r].cast[dtype]()
+            c_ptr[unsafe_offset=r * n + col] = acc[r].cast[dtype]()
 
 
 # ---------------------------------------------------------------------------
@@ -938,10 +953,10 @@ def _gemm_smallm_kernel[
 def _amd_dynamic_mfma_edge_kernel[
     dtype: DType, transpose_b: Bool, fuse_bias: Bool
 ](
-    c: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    a: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    b: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    bias: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    c: Pointer[Scalar[dtype], MutAnyOrigin],
+    a: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    b: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    bias: Pointer[Scalar[dtype], ImmutAnyOrigin],
     n_arg: Int64,
     k_arg: Int64,
     row_start_arg: Int64,
@@ -972,24 +987,26 @@ def _amd_dynamic_mfma_edge_kernel[
     var k4 = (k // 4) * 4
     for kk in range(0, k4, 4):
         comptime for u in range(4):
-            var bv = b[col * k + kk + u] if transpose_b else b[
-                (kk + u) * n + col
+            var bv = b[unsafe_offset=col * k + kk + u] if transpose_b else b[
+                unsafe_offset=(kk + u) * n + col
             ]
             acc = (
-                a[row * k + kk + u]
+                a[unsafe_offset=row * k + kk + u]
                 .cast[DType.float32]()
                 .fma(bv.cast[DType.float32](), acc)
             )
     for kk in range(k4, k):
-        var bv = b[col * k + kk] if transpose_b else b[kk * n + col]
+        var bv = b[unsafe_offset=col * k + kk] if transpose_b else b[
+            unsafe_offset=kk * n + col
+        ]
         acc = (
-            a[row * k + kk]
+            a[unsafe_offset=row * k + kk]
             .cast[DType.float32]()
             .fma(bv.cast[DType.float32](), acc)
         )
     comptime if fuse_bias:
-        acc += bias[col].cast[DType.float32]()
-    c[row * n + col] = acc.cast[dtype]()
+        acc += bias[unsafe_offset=col].cast[DType.float32]()
+    c[unsafe_offset=row * n + col] = acc.cast[dtype]()
 
 
 @always_inline
@@ -1056,7 +1073,7 @@ def _amd_dynamic_mfma_gemm[
     var c_ptr = _make_ptr[dtype](c_addr)
     var c = TileTensor(c_ptr, row_major(Coord(m, n)))
     var a = TileTensor(
-        _make_ptr[dtype](a_addr).as_immutable(), row_major(Coord(m, k))
+        _make_ptr[dtype](a_addr).as_imm(), row_major(Coord(m, k))
     )
 
     @always_inline
@@ -1069,15 +1086,17 @@ def _amd_dynamic_mfma_gemm[
         var col = Int(coords[1])
         var off = row * n + col
         if col + width <= n:
-            c_ptr.store[width=width, alignment=4](off, value.cast[dtype]())
+            c_ptr.unsafe_store[width=width, alignment=4](
+                off, value.cast[dtype]()
+            )
         else:
             comptime for i in range(width):
                 if col + i < n:
-                    c_ptr[off + i] = value[i].cast[dtype]()
+                    c_ptr[unsafe_offset=off + i] = value[i].cast[dtype]()
 
     comptime edge_epilogue = Optional[elementwise_epilogue_type](_edge_store)
 
-    var bias_ptr = _make_ptr[dtype](bias_addr).as_immutable()
+    var bias_ptr = _make_ptr[dtype](bias_addr).as_imm()
 
     @always_inline
     @parameter
@@ -1090,14 +1109,18 @@ def _amd_dynamic_mfma_gemm[
         var off = row * n + col
         if col + width <= n:
             var result = (
-                value.cast[F32]() + bias_ptr.load[width=width](col).cast[F32]()
+                value.cast[F32]()
+                + bias_ptr.unsafe_load[width=width](col).cast[F32]()
             )
-            c_ptr.store[width=width, alignment=4](off, result.cast[dtype]())
+            c_ptr.unsafe_store[width=width, alignment=4](
+                off, result.cast[dtype]()
+            )
         else:
             comptime for i in range(width):
                 if col + i < n:
-                    c_ptr[off + i] = (
-                        value[i].cast[F32]() + bias_ptr[col + i].cast[F32]()
+                    c_ptr[unsafe_offset=off + i] = (
+                        value[i].cast[F32]()
+                        + bias_ptr[unsafe_offset=col + i].cast[F32]()
                     ).cast[dtype]()
 
     comptime bias_epilogue = Optional[elementwise_epilogue_type](_bias_store)
@@ -1111,7 +1134,7 @@ def _amd_dynamic_mfma_gemm[
         k_group_size=K_GROUP_SIZE,
     )
     var b = TileTensor(
-        _make_ptr[dtype](b_addr).as_immutable(),
+        _make_ptr[dtype](b_addr).as_imm(),
         row_major(Coord(n, k)) if transpose_b else row_major(Coord(k, n)),
     )
 
@@ -1139,8 +1162,8 @@ def _amd_dynamic_mfma_gemm[
             ),
         )
     var c_raw = c_ptr.as_unsafe_any_origin()
-    var a_raw = _make_ptr[dtype](a_addr).as_unsafe_any_origin().as_immutable()
-    var b_raw = _make_ptr[dtype](b_addr).as_unsafe_any_origin().as_immutable()
+    var a_raw = _make_ptr[dtype](a_addr).as_unsafe_any_origin().as_imm()
+    var b_raw = _make_ptr[dtype](b_addr).as_unsafe_any_origin().as_imm()
     if n_full < n:
         var col_count = n - n_full
         _enqueue_cached[
@@ -1205,9 +1228,9 @@ def _amd_splitk_mfma_kernel[
     BLOCK_K: Int,
     config: MatmulConfig[dtype, dtype, DType.float32, False],
 ](
-    ws_base: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    a_base: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    b_base: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    ws_base: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    a_base: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    b_base: Pointer[Scalar[dtype], ImmutAnyOrigin],
     m_arg: Int64,
     n_arg: Int64,
     k_arg: Int64,
@@ -1228,20 +1251,22 @@ def _amd_splitk_mfma_kernel[
 
     var z = Int(block_idx.z)
     var k_off = z * k_per
-    var ws_ptr = ws_base + z * m * n
+    var ws_ptr = ws_base.unsafe_offset(z * m * n)
     var c = TileTensor(ws_ptr, row_major(Coord(m, n)))
     # A keeps its true row stride `k` and is merely offset along the contraction
     # axis; B's slab is `k_per` whole rows, so its extent carries the slab length
     # and the core's K loop follows it.
-    var a = TileTensor(a_base + k_off, row_major(Coord(m, k)))
-    var b = TileTensor(b_base + k_off * n, row_major(Coord(k_per, n)))
+    var a = TileTensor(a_base.unsafe_offset(k_off), row_major(Coord(m, k)))
+    var b = TileTensor(
+        b_base.unsafe_offset(k_off * n), row_major(Coord(k_per, n))
+    )
 
     @always_inline
     @parameter
     def _store[
         value_dtype: DType, width: SIMDLength, *, alignment: Int = 1
     ](coords: IndexList[2], value: SIMD[value_dtype, width]):
-        ws_ptr.store[width=width, alignment=size_of[DType.float32]()](
+        ws_ptr.unsafe_store[width=width, alignment=size_of[DType.float32]()](
             Int(coords[0]) * n + Int(coords[1]),
             value.cast[DType.float32](),
         )
@@ -1256,8 +1281,8 @@ def _amd_splitk_mfma_kernel[
 def _splitk_reduce_kernel[
     dtype: DType, VEC: Int
 ](
-    c_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    ws_ptr: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
+    c_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    ws_ptr: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
     total_arg: Int64,
     parts_arg: Int64,
     vec_count_arg: Int64,
@@ -1276,10 +1301,10 @@ def _splitk_reduce_kernel[
     while j < vec_count:
         var acc = SIMD[DType.float32, VEC](0)
         for p in range(parts):
-            acc += ws_ptr.load[width=VEC, alignment=VEC * 4](
+            acc += ws_ptr.unsafe_load[width=VEC, alignment=VEC * 4](
                 p * total + j * VEC
             )
-        c_ptr.store[width=VEC, alignment=VEC * size_of[dtype]()](
+        c_ptr.unsafe_store[width=VEC, alignment=VEC * size_of[dtype]()](
             j * VEC, acc.cast[dtype]()
         )
         j += gstride
@@ -1287,8 +1312,8 @@ def _splitk_reduce_kernel[
     while tail < total:
         var acc = Scalar[DType.float32](0)
         for p in range(parts):
-            acc += ws_ptr[p * total + tail]
-        c_ptr[tail] = acc.cast[dtype]()
+            acc += ws_ptr[unsafe_offset=p * total + tail]
+        c_ptr[unsafe_offset=tail] = acc.cast[dtype]()
         tail += gstride
 
 
@@ -1327,8 +1352,8 @@ def _amd_splitk_mfma_gemm[
         _amd_splitk_mfma_kernel[dtype, BM, BN, BLOCK_K, config]
     ](
         ws.unsafe_ptr().as_unsafe_any_origin(),
-        _make_ptr[dtype](a_addr).as_unsafe_any_origin().as_immutable(),
-        _make_ptr[dtype](b_addr).as_unsafe_any_origin().as_immutable(),
+        _make_ptr[dtype](a_addr).as_unsafe_any_origin().as_imm(),
+        _make_ptr[dtype](b_addr).as_unsafe_any_origin().as_imm(),
         Int64(m),
         Int64(n),
         Int64(k),
@@ -1352,7 +1377,7 @@ def _amd_splitk_mfma_gemm[
         1,
         256,
         _make_ptr[dtype](c_addr).as_unsafe_any_origin(),
-        ws.unsafe_ptr().as_unsafe_any_origin().as_immutable(),
+        ws.unsafe_ptr().as_unsafe_any_origin().as_imm(),
         Int64(total),
         Int64(parts),
         Int64(total // VEC),
@@ -1473,9 +1498,9 @@ def _amd_batched_mfma_kernel[
     CAUSAL: Int,
     config: MatmulConfig[dtype, dtype, dtype, transpose_b],
 ](
-    c_base: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    a_base: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    b_base: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    c_base: Pointer[Scalar[dtype], MutAnyOrigin],
+    a_base: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    b_base: Pointer[Scalar[dtype], ImmutAnyOrigin],
     m_arg: Int64,
     n_arg: Int64,
     k_arg: Int64,
@@ -1499,7 +1524,7 @@ def _amd_batched_mfma_kernel[
     var z = Int(block_idx.z)
     var row_block = Int(block_idx.y)
     var col_block = Int(block_idx.x)
-    var c_ptr = c_base + z * c_bstride
+    var c_ptr = c_base.unsafe_offset(z * c_bstride)
 
     # A shortened or late-starting K range, in elements.  BM and BN are multiples
     # of BLOCK_K and the dispatch guarantees `k % 32 == 0`, so every bound below
@@ -1523,11 +1548,11 @@ def _amd_batched_mfma_kernel[
     # shortened K only has to be expressed in B's extent; A keeps its true row
     # stride and is merely offset along the contraction axis.
     var a = TileTensor(
-        a_base + z * a_bstride + (k_off if not transpose_b else 0),
+        a_base.unsafe_offset(z * a_bstride + (k_off if not transpose_b else 0)),
         row_major(Coord(m, k)),
     )
     var b = TileTensor(
-        b_base + z * b_bstride + k_off * n,
+        b_base.unsafe_offset(z * b_bstride + k_off * n),
         row_major(Coord(n, k)) if transpose_b else row_major(Coord(k_live, n)),
     )
 
@@ -1540,7 +1565,7 @@ def _amd_batched_mfma_kernel[
     def _store[
         value_dtype: DType, width: SIMDLength, *, alignment: Int = 1
     ](coords: IndexList[2], value: SIMD[value_dtype, width]):
-        c_ptr.store[width=width, alignment=size_of[dtype]()](
+        c_ptr.unsafe_store[width=width, alignment=size_of[dtype]()](
             Int(coords[0]) * n + Int(coords[1]), value.cast[dtype]()
         )
 
@@ -1559,7 +1584,7 @@ def _amd_batched_mfma_kernel[
                 var row = row_block * BM + index // BN
                 var col = col_block * BN + index % BN
                 if row < row_end and col < col_end:
-                    c_ptr[row * n + col] = Scalar[dtype](0)
+                    c_ptr[unsafe_offset=row * n + col] = Scalar[dtype](0)
                 index += threads
             return
 
@@ -1576,9 +1601,9 @@ def _amd_batched_mfma_kernel[
 def _amd_batched_mfma_edge_kernel[
     dtype: DType, transpose_b: Bool, CAUSAL: Int
 ](
-    c_base: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    a_base: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    b_base: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    c_base: Pointer[Scalar[dtype], MutAnyOrigin],
+    a_base: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    b_base: Pointer[Scalar[dtype], ImmutAnyOrigin],
     m_arg: Int64,
     n_arg: Int64,
     k_arg: Int64,
@@ -1610,13 +1635,15 @@ def _amd_batched_mfma_edge_kernel[
     var z = Int(block_idx.y)
     var row = idx // col_count
     var col = col_start + idx % col_count
-    var a = a_base + z * a_bstride
-    var b = b_base + z * b_bstride
+    var a = a_base.unsafe_offset(z * a_bstride)
+    var b = b_base.unsafe_offset(z * b_bstride)
     var k_begin = 0
     var k_end = k
     comptime if CAUSAL == CAUSAL_OUT:
         if col > row:
-            (c_base + z * c_bstride)[row * n + col] = Scalar[dtype](0)
+            (c_base.unsafe_offset(z * c_bstride))[
+                unsafe_offset=row * n + col
+            ] = Scalar[dtype](0)
             return
     comptime if CAUSAL == CAUSAL_A_ROWS:
         k_end = min(k, row + 1)
@@ -1624,13 +1651,17 @@ def _amd_batched_mfma_edge_kernel[
         k_begin = min(k, col)
     var acc = Scalar[DType.float32](0)
     for kk in range(k_begin, k_end):
-        var bv = b[col * k + kk] if transpose_b else b[kk * n + col]
+        var bv = b[unsafe_offset=col * k + kk] if transpose_b else b[
+            unsafe_offset=kk * n + col
+        ]
         acc = (
-            a[row * k + kk]
+            a[unsafe_offset=row * k + kk]
             .cast[DType.float32]()
             .fma(bv.cast[DType.float32](), acc)
         )
-    (c_base + z * c_bstride)[row * n + col] = acc.cast[dtype]()
+    (c_base.unsafe_offset(z * c_bstride))[
+        unsafe_offset=row * n + col
+    ] = acc.cast[dtype]()
 
 
 @always_inline
@@ -1680,8 +1711,8 @@ def _amd_batched_mfma_gemm[
         num_warp_k_partitions=WARP_K_PARTITIONS,
     )
     var c_ptr = _make_ptr[dtype](c_addr).as_unsafe_any_origin()
-    var a_ptr = _make_ptr[dtype](a_addr).as_unsafe_any_origin().as_immutable()
-    var b_ptr = _make_ptr[dtype](b_addr).as_unsafe_any_origin().as_immutable()
+    var a_ptr = _make_ptr[dtype](a_addr).as_unsafe_any_origin().as_imm()
+    var b_ptr = _make_ptr[dtype](b_addr).as_unsafe_any_origin().as_imm()
     var n_full = (n // BN) * BN
     if n_full > 0:
         ctx.enqueue_function[
@@ -2031,9 +2062,9 @@ def _nt_mfma_kernel[
     FILL_AT: Int = 0,
     WBODY: Bool = False,
 ](
-    c: UnsafePointer[Scalar[otype], MutAnyOrigin],
-    a: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    b: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    c: Pointer[Scalar[otype], MutAnyOrigin],
+    a: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    b: Pointer[Scalar[dtype], ImmutAnyOrigin],
     m_arg: Int64,
     n_arg: Int64,
     k_arg: Int64,
@@ -2272,14 +2303,14 @@ def _nt_mfma_kernel[
         var bkr = tid // XPB
         var bxc = (tid % XPB) * NT_HVEC
         var k0 = slab * k_per
-        var a_ptr = a + (
+        var a_ptr = a.unsafe_offset(
             (m0 + trow) * k
             + tcol
             + k0 if A_KMAJOR else (k0 + NROWS * akr) * m
             + m0
             + axc
         )
-        var b_ptr = b + (
+        var b_ptr = b.unsafe_offset(
             (n0 + trow) * k
             + tcol
             + k0 if B_KMAJOR else (k0 + NROWS * bkr) * n
@@ -2303,7 +2334,7 @@ def _nt_mfma_kernel[
 
         var acc = stack_allocation[MT * NTL * 16, DType.float32]()
         comptime for i in range(MT * NTL):
-            acc.store(i * 16, SIMD[DType.float32, 16](0))
+            acc.unsafe_store(i * 16, SIMD[DType.float32, 16](0))
 
         var areg = stack_allocation[APASS * NT_VEC, dtype]()
         var breg = stack_allocation[BPASS * NT_VEC, dtype]()
@@ -2330,8 +2361,8 @@ def _nt_mfma_kernel[
                         live = live and m0 + trow + p * ROWS < m
                     var v = SIMD[dtype, NT_VEC](0)
                     if live:
-                        v = a_ptr.load[width=NT_VEC](p * pass_step)
-                    areg.store(p * NT_VEC, v)
+                        v = a_ptr.unsafe_load[width=NT_VEC](p * pass_step)
+                    areg.unsafe_store(p * NT_VEC, v)
             else:
                 comptime for p in range(APASS):
                     var live = True
@@ -2356,14 +2387,16 @@ def _nt_mfma_kernel[
                         )
                     var v0 = SIMD[dtype, NT_HVEC](0)
                     if live:
-                        v0 = a_ptr.load[width=NT_HVEC](p * a_pass)
+                        v0 = a_ptr.unsafe_load[width=NT_HVEC](p * a_pass)
                     comptime if PAIR:
                         var v1 = SIMD[dtype, NT_HVEC](0)
                         if live:
-                            v1 = a_ptr.load[width=NT_HVEC](p * a_pass + m)
-                        areg.store(p * NT_VEC, v0.interleave(v1))
+                            v1 = a_ptr.unsafe_load[width=NT_HVEC](
+                                p * a_pass + m
+                            )
+                        areg.unsafe_store(p * NT_VEC, v0.interleave(v1))
                     else:
-                        areg.store(p * NT_VEC, v0)
+                        areg.unsafe_store(p * NT_VEC, v0)
             comptime if B_KMAJOR:
                 comptime for p in range(BPASS):
                     var live = kok
@@ -2373,8 +2406,8 @@ def _nt_mfma_kernel[
                         live = live and n0 + trow + p * ROWS < n
                     var v = SIMD[dtype, NT_VEC](0)
                     if live:
-                        v = b_ptr.load[width=NT_VEC](p * pass_step)
-                    breg.store(p * NT_VEC, v)
+                        v = b_ptr.unsafe_load[width=NT_VEC](p * pass_step)
+                    breg.unsafe_store(p * NT_VEC, v)
             else:
                 comptime for p in range(BPASS):
                     var live = True
@@ -2393,16 +2426,18 @@ def _nt_mfma_kernel[
                         )
                     var v0 = SIMD[dtype, NT_HVEC](0)
                     if live:
-                        v0 = b_ptr.load[width=NT_HVEC](p * b_pass)
+                        v0 = b_ptr.unsafe_load[width=NT_HVEC](p * b_pass)
                     comptime if PAIR:
                         var v1 = SIMD[dtype, NT_HVEC](0)
                         if live:
-                            v1 = b_ptr.load[width=NT_HVEC](p * b_pass + n)
-                        breg.store(p * NT_VEC, v0.interleave(v1))
+                            v1 = b_ptr.unsafe_load[width=NT_HVEC](
+                                p * b_pass + n
+                            )
+                        breg.unsafe_store(p * NT_VEC, v0.interleave(v1))
                     else:
-                        breg.store(p * NT_VEC, v0)
-            a_ptr += a_step
-            b_ptr += b_step
+                        breg.unsafe_store(p * NT_VEC, v0)
+            a_ptr = a_ptr.unsafe_offset(a_step)
+            b_ptr = b_ptr.unsafe_offset(b_step)
 
         @always_inline
         @parameter
@@ -2414,12 +2449,14 @@ def _nt_mfma_kernel[
         ):
             comptime if SWIZZLE:
                 comptime for h in range(NT_VEC // 4):
-                    dst.store(
+                    dst.unsafe_store(
                         row_base + 4 * ((chunk0 + h) ^ sw_w),
-                        regs.load[width=4](reg_off + 4 * h),
+                        regs.unsafe_load[width=4](reg_off + 4 * h),
                     )
             else:
-                dst.store(row_base + tcol, regs.load[width=NT_VEC](reg_off))
+                dst.unsafe_store(
+                    row_base + tcol, regs.unsafe_load[width=NT_VEC](reg_off)
+                )
 
         # The interleaved k pair lands contiguously at `2 * x` of pair row `p`,
         # so the whole NT_VEC is still one `ds_write_b128`.
@@ -2434,8 +2471,9 @@ def _nt_mfma_kernel[
             reg_off: Int,
         ):
             comptime if PAIR:
-                dst.store(
-                    pair * 2 * w + 2 * xcol, regs.load[width=NT_VEC](reg_off)
+                dst.unsafe_store(
+                    pair * 2 * w + 2 * xcol,
+                    regs.unsafe_load[width=NT_VEC](reg_off),
                 )
             else:
                 # Unpaired, the fragment's four elements are `BX` apart and
@@ -2443,9 +2481,9 @@ def _nt_mfma_kernel[
                 # would land on the banks the `lo` half already holds.  Permuting
                 # the row by `x ^ (32 * ((k >> 2) & 1))` costs no LDS and makes
                 # them disjoint, and `(k >> 2) & 1` is exactly the reader's `hi`.
-                dst.store(
+                dst.unsafe_store(
                     pair * w + (xcol ^ (32 * ((pair >> 2) & 1))),
-                    regs.load[width=NT_VEC](reg_off),
+                    regs.unsafe_load[width=NT_VEC](reg_off),
                 )
 
         @always_inline
@@ -2532,9 +2570,11 @@ def _nt_mfma_kernel[
                     kof = 4 * ((2 * s) ^ t0)
                 comptime for i in range(MT):
                     comptime if A_KMAJOR:
-                        af.store(
+                        af.unsafe_store(
                             (s * MT + i) * 4,
-                            pa.load[width=4](abase + i * NT_MMA * PAD + kof),
+                            pa.unsafe_load[width=4](
+                                abase + i * NT_MMA * PAD + kof
+                            ),
                         )
                     else:
                         var base = (
@@ -2548,22 +2588,24 @@ def _nt_mfma_kernel[
                             )
                         )
                         comptime if PAIR:
-                            af.store(
+                            af.unsafe_store(
                                 (s * MT + i) * 4,
-                                pa.load[width=2](base).join(
-                                    pa.load[width=2](base + 2 * BM)
+                                pa.unsafe_load[width=2](base).join(
+                                    pa.unsafe_load[width=2](base + 2 * BM)
                                 ),
                             )
                         else:
                             var v = SIMD[dtype, 4]()
                             comptime for e in range(4):
-                                v[e] = pa[base + e * BM]
-                            af.store((s * MT + i) * 4, v)
+                                v[e] = pa[unsafe_offset=base + e * BM]
+                            af.unsafe_store((s * MT + i) * 4, v)
                 comptime for j in range(NTL):
                     comptime if B_KMAJOR:
-                        bf.store(
+                        bf.unsafe_store(
                             (s * NTL + j) * 4,
-                            pb.load[width=4](bbase + j * NT_MMA * PAD + kof),
+                            pb.unsafe_load[width=4](
+                                bbase + j * NT_MMA * PAD + kof
+                            ),
                         )
                     else:
                         var base = (
@@ -2577,17 +2619,17 @@ def _nt_mfma_kernel[
                             )
                         )
                         comptime if PAIR:
-                            bf.store(
+                            bf.unsafe_store(
                                 (s * NTL + j) * 4,
-                                pb.load[width=2](base).join(
-                                    pb.load[width=2](base + 2 * BN)
+                                pb.unsafe_load[width=2](base).join(
+                                    pb.unsafe_load[width=2](base + 2 * BN)
                                 ),
                             )
                         else:
                             var v = SIMD[dtype, 4]()
                             comptime for e in range(4):
-                                v[e] = pb[base + e * BN]
-                            bf.store((s * NTL + j) * 4, v)
+                                v[e] = pb[unsafe_offset=base + e * BN]
+                            bf.unsafe_store((s * NTL + j) * 4, v)
 
         @always_inline
         @parameter
@@ -2595,19 +2637,19 @@ def _nt_mfma_kernel[
             comptime for s in range(S0, S1):
                 comptime for i in range(MT):
                     comptime for j in range(NTL):
-                        var d = acc.load[width=16]((i * NTL + j) * 16)
+                        var d = acc.unsafe_load[width=16]((i * NTL + j) * 16)
                         mma(
                             d,
-                            af.load[width=4]((s * MT + i) * 4),
-                            bf.load[width=4]((s * NTL + j) * 4),
+                            af.unsafe_load[width=4]((s * MT + i) * 4),
+                            bf.unsafe_load[width=4]((s * NTL + j) * 4),
                             d,
                         )
-                        acc.store((i * NTL + j) * 16, d)
+                        acc.unsafe_store((i * NTL + j) * 16, d)
 
         var ca = smem
-        var cb = smem + SA
-        var na = smem + (SA + SB if STAGES == 2 else 0)
-        var nb = na + SA
+        var cb = smem.unsafe_offset(SA)
+        var na = smem.unsafe_offset(SA + SB if STAGES == 2 else 0)
+        var nb = na.unsafe_offset(SA)
 
         # k tiles THIS workgroup runs.  Under `SPLITK` the slab length `k_per` is a
         # whole number of k tiles but need NOT divide the tile count: the last slab
@@ -2765,7 +2807,9 @@ def _nt_mfma_kernel[
         var out = stack_allocation[(MT * NTL if OUT_ALL else 1) * 16, otype]()
         comptime if OUT_ALL:
             comptime for i in range(MT * NTL):
-                out.store(i * 16, acc.load[width=16](i * 16).cast[otype]())
+                out.unsafe_store(
+                    i * 16, acc.unsafe_load[width=16](i * 16).cast[otype]()
+                )
         llvm_intrinsic["llvm.amdgcn.sched.barrier", NoneType](Int32(0))
 
         # Register p of accumulator (i, j) is row
@@ -2775,7 +2819,7 @@ def _nt_mfma_kernel[
         # Under SPLITK each slab owns its own FP32 plane of the workspace; the
         # only rounding to the output dtype is the one the reduction performs,
         # exactly as in the unsplit path.
-        var cp = c + (slab * m * n if SPLITK else 0)
+        var cp = c.unsafe_offset(slab * m * n if SPLITK else 0)
         var cbase = (m0 + wm0 + 4 * hi) * n + n0 + wn0 + lo
         # Distance to the edge, so each guard is one compare against a
         # compile-time offset instead of a recomputed address.
@@ -2786,8 +2830,11 @@ def _nt_mfma_kernel[
                 comptime dc = j * NT_MMA
                 comptime if not OUT_ALL:
                     _nt_sched_fence()
-                    out.store(
-                        0, acc.load[width=16]((i * NTL + j) * 16).cast[otype]()
+                    out.unsafe_store(
+                        0,
+                        acc.unsafe_load[width=16]((i * NTL + j) * 16).cast[
+                            otype
+                        ](),
                     )
                     llvm_intrinsic["llvm.amdgcn.sched.barrier", NoneType](
                         Int32(0)
@@ -2796,13 +2843,17 @@ def _nt_mfma_kernel[
                 comptime if not MASK_STORE:
                     comptime for p in range(16):
                         comptime dr = i * NT_MMA + 8 * (p // 4) + (p % 4)
-                        cp[cbase + dr * n + dc] = out[OFF + p]
+                        cp[unsafe_offset=cbase + dr * n + dc] = out[
+                            unsafe_offset=OFF + p
+                        ]
                 else:
                     if dc < cmax:
                         comptime for p in range(16):
                             comptime dr = i * NT_MMA + 8 * (p // 4) + (p % 4)
                             if dr < rmax:
-                                cp[cbase + dr * n + dc] = out[OFF + p]
+                                cp[unsafe_offset=cbase + dr * n + dc] = out[
+                                    unsafe_offset=OFF + p
+                                ]
 
 
 # Bytes per CU cycle the epilogue and the split-K workspace move.  Fitted from
@@ -3049,8 +3100,8 @@ def _nt_mfma_gemm[
             ]
         ](
             _make_ptr[otype](c_addr),
-            _make_ptr[dtype](a_addr).as_immutable(),
-            _make_ptr[dtype](b_addr).as_immutable(),
+            _make_ptr[dtype](a_addr).as_imm(),
+            _make_ptr[dtype](b_addr).as_imm(),
             Int64(m),
             Int64(n),
             Int64(k),
@@ -3381,7 +3432,7 @@ def _dense_mfma_route[
             1,
             256,
             _make_ptr[dtype](c_addr).as_unsafe_any_origin(),
-            ws.unsafe_ptr().as_unsafe_any_origin().as_immutable(),
+            ws.unsafe_ptr().as_unsafe_any_origin().as_imm(),
             Int64(m * n),
             Int64(b_parts),
             Int64(m * n // VEC),
@@ -3856,12 +3907,8 @@ def _enqueue_pipe[
 ) raises:
     comptime THREADS = (BM // TM) * (BN // TN)
     var c = _make_ptr[DType.float32](c_addr).as_unsafe_any_origin()
-    var a = (
-        _make_ptr[DType.float32](a_addr).as_unsafe_any_origin().as_immutable()
-    )
-    var b = (
-        _make_ptr[DType.float32](b_addr).as_unsafe_any_origin().as_immutable()
-    )
+    var a = _make_ptr[DType.float32](a_addr).as_unsafe_any_origin().as_imm()
+    var b = _make_ptr[DType.float32](b_addr).as_unsafe_any_origin().as_imm()
     var va4 = k % 4 == 0  # A (and B when transposed) is loaded along k
 
     comptime if transpose_b:
@@ -4096,8 +4143,8 @@ def _gemm_enqueue[
             ):
                 return
 
-        var a = _make_ptr[dtype](a_addr).as_unsafe_any_origin().as_immutable()
-        var b = _make_ptr[dtype](b_addr).as_unsafe_any_origin().as_immutable()
+        var a = _make_ptr[dtype](a_addr).as_unsafe_any_origin().as_imm()
+        var b = _make_ptr[dtype](b_addr).as_unsafe_any_origin().as_imm()
 
         # Skinny-M float32 paths (decode-step GEMMs: m = batch <= 32). The
         # BM=64 tiles waste half of every block there; the BM=32 pipe3 tile
@@ -4444,7 +4491,7 @@ def _gemm_enqueue[
             var ws_ptr = (
                 _make_ptr[DType.float32](c_target)
                 .as_unsafe_any_origin()
-                .as_immutable()
+                .as_imm()
             )
             _enqueue_cached[_ksplit_reduce_kernel](
                 ctx,
@@ -4517,12 +4564,8 @@ def _gemv_enqueue[
 ) raises:
     comptime if has_accelerator():
         var c_ptr = _make_ptr[dtype](c_addr).as_unsafe_any_origin()
-        var a_ptr = (
-            _make_ptr[dtype](a_addr).as_unsafe_any_origin().as_immutable()
-        )
-        var b_ptr = (
-            _make_ptr[dtype](b_addr).as_unsafe_any_origin().as_immutable()
-        )
+        var a_ptr = _make_ptr[dtype](a_addr).as_unsafe_any_origin().as_imm()
+        var b_ptr = _make_ptr[dtype](b_addr).as_unsafe_any_origin().as_imm()
         var c = TileTensor(c_ptr, row_major(m, n))
         var a = TileTensor(a_ptr, row_major(m, k))
         comptime if transpose_b:
@@ -4609,10 +4652,10 @@ def _gemv_dtype_dispatch(
 def _apple8_gemm_kernel[
     HAS_BIAS: Bool, SPLIT: Bool, TRANSPOSE_B: Bool
 ](
-    c_ptr: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    a_ptr: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
-    b_ptr: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
-    bias_ptr: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
+    c_ptr: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    a_ptr: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
+    b_ptr: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
+    bias_ptr: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
     m_arg: Int64,
     n_arg: Int64,
     k_arg: Int64,
@@ -4659,7 +4702,9 @@ def _apple8_gemm_kernel[
         comptime for mi in range(NT_M):
             var grow = row_base + mi * MMA8_DIM + frow
             if interior or grow < m:
-                afrag[mi] = (a_ptr + grow * k + kk + fcol).load[width=FRAG8]()
+                afrag[mi] = (
+                    a_ptr.unsafe_offset(grow * k + kk + fcol)
+                ).unsafe_load[width=FRAG8]()
             else:
                 afrag[mi] = SIMD[DType.float32, FRAG8](0)
         var bfrag = InlineArray[SIMD[DType.float32, FRAG8], NT_N](
@@ -4671,17 +4716,19 @@ def _apple8_gemm_kernel[
                 comptime for s in range(FRAG8):
                     var gj = col_base + ni * MMA8_DIM + fcol + s
                     if interior or gj < n:
-                        bf[s] = b_ptr[gj * k + kk + frow]
+                        bf[s] = b_ptr[unsafe_offset=gj * k + kk + frow]
                 bfrag[ni] = bf
             else:
                 var krow = kk + frow
                 var gj = col_base + ni * MMA8_DIM + fcol
                 if interior or gj + 1 < n:
-                    bfrag[ni] = (b_ptr + krow * n + gj).load[width=FRAG8]()
+                    bfrag[ni] = (
+                        b_ptr.unsafe_offset(krow * n + gj)
+                    ).unsafe_load[width=FRAG8]()
                 else:
                     var bf = SIMD[DType.float32, FRAG8](0)
                     if gj < n:
-                        bf[0] = b_ptr[krow * n + gj]
+                        bf[0] = b_ptr[unsafe_offset=krow * n + gj]
                     bfrag[ni] = bf
         comptime for mi in range(NT_M):
             comptime for ni in range(NT_N):
@@ -4699,19 +4746,19 @@ def _apple8_gemm_kernel[
                 if grow < m and gcol < n:
                     var v = frag[s]
                     comptime if SPLIT:
-                        c_ptr[out_base + grow * n + gcol] = v
+                        c_ptr[unsafe_offset=out_base + grow * n + gcol] = v
                     else:
                         comptime if HAS_BIAS:
-                            v += bias_ptr[gcol]
-                        c_ptr[grow * n + gcol] = v
+                            v += bias_ptr[unsafe_offset=gcol]
+                        c_ptr[unsafe_offset=grow * n + gcol] = v
 
 
 def _apple8_reduce_kernel[
     HAS_BIAS: Bool
 ](
-    c_ptr: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    ws_ptr: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
-    bias_ptr: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
+    c_ptr: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    ws_ptr: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
+    bias_ptr: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
     mn_arg: Int64,
     n_arg: Int64,
     ksplits_arg: Int64,
@@ -4727,10 +4774,10 @@ def _apple8_reduce_kernel[
     while i < mn:
         var acc = Float32(0)
         for z in range(ksplits):
-            acc += ws_ptr[z * mn + i]
+            acc += ws_ptr[unsafe_offset=z * mn + i]
         comptime if HAS_BIAS:
-            acc += bias_ptr[i % n]
-        c_ptr[i] = acc
+            acc += bias_ptr[unsafe_offset=i % n]
+        c_ptr[unsafe_offset=i] = acc
         i += gstride
 
 
@@ -4750,16 +4797,12 @@ def _apple8_enqueue[
     var gx = ceildiv(n, 64)
     var gy = ceildiv(m, 32)
     var c = _make_ptr[DType.float32](c_addr).as_unsafe_any_origin()
-    var a = (
-        _make_ptr[DType.float32](a_addr).as_unsafe_any_origin().as_immutable()
-    )
-    var b = (
-        _make_ptr[DType.float32](b_addr).as_unsafe_any_origin().as_immutable()
-    )
+    var a = _make_ptr[DType.float32](a_addr).as_unsafe_any_origin().as_imm()
+    var b = _make_ptr[DType.float32](b_addr).as_unsafe_any_origin().as_imm()
     var bias = (
         _make_ptr[DType.float32](bias_addr if bias_addr != 0 else a_addr)
         .as_unsafe_any_origin()
-        .as_immutable()
+        .as_imm()
     )
     var slabs = k // MMA8_DIM
     var ksplits = 1
@@ -4787,7 +4830,7 @@ def _apple8_enqueue[
         )
         return
     var ws = ctx.enqueue_create_buffer[DType.float32](ksplits * m * n)
-    var ws_mut = UnsafePointer[Scalar[DType.float32], MutUntrackedOrigin](
+    var ws_mut = Pointer[Scalar[DType.float32], MutUntrackedOrigin](
         unsafe_from_address=Int(ws.unsafe_ptr())
     ).as_unsafe_any_origin()
     _enqueue_cached[_apple8_gemm_kernel[False, True, TRANSPOSE_B]](
@@ -4815,7 +4858,7 @@ def _apple8_enqueue[
         1,
         256,
         c,
-        ws_mut.as_immutable(),
+        ws_mut.as_imm(),
         bias,
         Int64(mn),
         Int64(n),
@@ -4853,9 +4896,9 @@ def _apple8_fat_kernel[
     CAUSAL: Int = 0,
     TRANSPOSE_A: Bool = False,
 ](
-    c_base: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    a_base: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
-    b_base: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
+    c_base: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    a_base: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
+    b_base: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
     m_arg: Int64,
     n_arg: Int64,
     k_arg: Int64,
@@ -4884,9 +4927,9 @@ def _apple8_fat_kernel[
 
     # With ksplits > 1, C is a [batch * ksplits, m, n] workspace and each
     # split writes its own slice. a_bstride is 0 when A is batch-shared.
-    var c_ptr = c_base + Int(block_idx.z) * m * n
-    var a_ptr = a_base + bz * a_bstride
-    var b_ptr = b_base + bz * k * n
+    var c_ptr = c_base.unsafe_offset(Int(block_idx.z) * m * n)
+    var a_ptr = a_base.unsafe_offset(bz * a_bstride)
+    var b_ptr = b_base.unsafe_offset(bz * k * n)
 
     var lane = Int(lane_id())
     var fl = _frag8_layout(lane)
@@ -4935,9 +4978,13 @@ def _apple8_fat_kernel[
                     if kk + fcol + s < k_end:
                         comptime if TRANSPOSE_A:
                             # A (K, M): logical row = stored column.
-                            af[s] = a_ptr[(kk + fcol + s) * m + grow]
+                            af[s] = a_ptr[
+                                unsafe_offset=(kk + fcol + s) * m + grow
+                            ]
                         else:
-                            af[s] = a_ptr[grow * k + kk + fcol + s]
+                            af[s] = a_ptr[
+                                unsafe_offset=grow * k + kk + fcol + s
+                            ]
             afrag[mi] = af
         var bfrag = InlineArray[SIMD[DType.float32, FRAG8], NT_N](
             uninitialized=True
@@ -4949,13 +4996,13 @@ def _apple8_fat_kernel[
                     comptime for s in range(FRAG8):
                         var gj = col_base + ni * MMA8_DIM + fcol + s
                         if gj < n:
-                            bf[s] = b_ptr[gj * k + kk + frow]
+                            bf[s] = b_ptr[unsafe_offset=gj * k + kk + frow]
             else:
                 if kk + frow < k_end:
                     comptime for s in range(FRAG8):
                         var gj = col_base + ni * MMA8_DIM + fcol + s
                         if gj < n:
-                            bf[s] = b_ptr[(kk + frow) * n + gj]
+                            bf[s] = b_ptr[unsafe_offset=(kk + frow) * n + gj]
             bfrag[ni] = bf
         comptime for mi in range(NT_M):
             comptime for ni in range(NT_N):
@@ -4968,7 +5015,7 @@ def _apple8_fat_kernel[
     @always_inline
     @parameter
     def _load_a_fast(
-        ap0: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
+        ap0: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
     ) -> InlineArray[SIMD[DType.float32, FRAG8], NT_M]:
         var afrag = InlineArray[SIMD[DType.float32, FRAG8], NT_M](
             uninitialized=True
@@ -4977,19 +5024,21 @@ def _apple8_fat_kernel[
             comptime if TRANSPOSE_A:
                 # A (K, M): the fragment's two slots differ by one stored
                 # row (stride m) — per-lane scalar pairs, like transposed B.
-                var p = ap0 + mi * MMA8_DIM
+                var p = ap0.unsafe_offset(mi * MMA8_DIM)
                 var af = SIMD[DType.float32, FRAG8](0)
                 comptime for s in range(FRAG8):
-                    af[s] = p[s * m]
+                    af[s] = p[unsafe_offset=s * m]
                 afrag[mi] = af
             else:
-                afrag[mi] = (ap0 + mi * MMA8_DIM * k).load[width=FRAG8]()
+                afrag[mi] = (ap0.unsafe_offset(mi * MMA8_DIM * k)).unsafe_load[
+                    width=FRAG8
+                ]()
         return afrag^
 
     @always_inline
     @parameter
     def _load_b_fast(
-        bp0: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
+        bp0: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
     ) -> InlineArray[SIMD[DType.float32, FRAG8], NT_N]:
         var bfrag = InlineArray[SIMD[DType.float32, FRAG8], NT_N](
             uninitialized=True
@@ -4997,13 +5046,15 @@ def _apple8_fat_kernel[
         comptime for ni in range(NT_N):
             comptime if TRANSPOSE_B:
                 # B is (N, K): the fragment's two slots differ in n-row.
-                var p = bp0 + ni * MMA8_DIM * k
+                var p = bp0.unsafe_offset(ni * MMA8_DIM * k)
                 var bf = SIMD[DType.float32, FRAG8](0)
-                bf[0] = p[0]
-                bf[1] = p[k]
+                bf[0] = p[unsafe_offset=0]
+                bf[1] = p[unsafe_offset=k]
                 bfrag[ni] = bf
             else:
-                bfrag[ni] = (bp0 + ni * MMA8_DIM).load[width=FRAG8]()
+                bfrag[ni] = (bp0.unsafe_offset(ni * MMA8_DIM)).unsafe_load[
+                    width=FRAG8
+                ]()
         return bfrag^
 
     @always_inline
@@ -5024,29 +5075,29 @@ def _apple8_fat_kernel[
         # Software-pipelined pointer-increment loop: the next slab's
         # fragments are in flight while the current slab's mmas issue, so a
         # single simdgroup hides most of the device-load latency itself.
-        var ap: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin]
+        var ap: Pointer[Scalar[DType.float32], ImmutAnyOrigin]
         var astep: Int
         comptime if TRANSPOSE_A:
-            ap = a_ptr + (k_start + fcol) * m + row_base + frow
+            ap = a_ptr.unsafe_offset((k_start + fcol) * m + row_base + frow)
             astep = MMA8_DIM * m
         else:
-            ap = a_ptr + (row_base + frow) * k + fcol + k_start
+            ap = a_ptr.unsafe_offset((row_base + frow) * k + fcol + k_start)
             astep = MMA8_DIM
-        var bp: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin]
+        var bp: Pointer[Scalar[DType.float32], ImmutAnyOrigin]
         var bstep: Int
         comptime if TRANSPOSE_B:
-            bp = b_ptr + (col_base + fcol) * k + frow + k_start
+            bp = b_ptr.unsafe_offset((col_base + fcol) * k + frow + k_start)
             bstep = MMA8_DIM
         else:
-            bp = b_ptr + (k_start + frow) * n + col_base + fcol
+            bp = b_ptr.unsafe_offset((k_start + frow) * n + col_base + fcol)
             bstep = MMA8_DIM * n
         var nslabs = (k_end - k_start) // MMA8_DIM
         if nslabs > 0:
             var cura = _load_a_fast(ap)
             var curb = _load_b_fast(bp)
             for _ in range(nslabs - 1):
-                ap += astep
-                bp += bstep
+                ap = ap.unsafe_offset(astep)
+                bp = bp.unsafe_offset(bstep)
                 var nxta = _load_a_fast(ap)
                 var nxtb = _load_b_fast(bp)
                 _mma_block(cura, curb, accum)
@@ -5068,9 +5119,9 @@ def _apple8_fat_kernel[
                 var gcol = col_base + ni * MMA8_DIM + fcol
                 var frag = accum[mi * NT_N + ni]
                 if gcol + FRAG8 <= n:
-                    c_ptr.store(grow * n + gcol, frag)
+                    c_ptr.unsafe_store(grow * n + gcol, frag)
                 elif gcol < n:
-                    c_ptr[grow * n + gcol] = frag[0]
+                    c_ptr[unsafe_offset=grow * n + gcol] = frag[0]
 
 
 @always_inline
@@ -5118,12 +5169,8 @@ def _apple8_fat_enqueue[
     # core busy; each shard costs an m*n partials round-trip.
     if blocks < TARGET_BLOCKS // 2:
         ksplits = min(min(ceildiv(TARGET_BLOCKS, blocks), slabs), 8)
-    var a = (
-        _make_ptr[DType.float32](a_addr).as_unsafe_any_origin().as_immutable()
-    )
-    var b = (
-        _make_ptr[DType.float32](b_addr).as_unsafe_any_origin().as_immutable()
-    )
+    var a = _make_ptr[DType.float32](a_addr).as_unsafe_any_origin().as_imm()
+    var b = _make_ptr[DType.float32](b_addr).as_unsafe_any_origin().as_imm()
     if ksplits == 1:
         var c = _make_ptr[DType.float32](c_addr).as_unsafe_any_origin()
         comptime if STAGED:
@@ -5178,7 +5225,7 @@ def _apple8_fat_enqueue[
             )
         return
     var ws = ctx.enqueue_create_buffer[DType.float32](batch * ksplits * m * n)
-    var ws_mut = UnsafePointer[Scalar[DType.float32], MutUntrackedOrigin](
+    var ws_mut = Pointer[Scalar[DType.float32], MutUntrackedOrigin](
         unsafe_from_address=Int(ws.unsafe_ptr())
     ).as_unsafe_any_origin()
     comptime if STAGED:
@@ -5239,7 +5286,7 @@ def _apple8_fat_enqueue[
         1,
         256,
         c_out,
-        ws_mut.as_immutable(),
+        ws_mut.as_imm(),
         Int64(m * n),
         Int64(ksplits),
         Int64(total),
@@ -5268,9 +5315,9 @@ def _apple8_fat_enqueue[
 def _apple8_smem_kernel[
     SPLIT: Bool, TRANSPOSE_B: Bool, TRANSPOSE_A: Bool = False
 ](
-    c_base: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    a_base: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
-    b_base: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
+    c_base: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    a_base: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
+    b_base: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
     m_arg: Int64,
     n_arg: Int64,
     k_arg: Int64,
@@ -5306,9 +5353,9 @@ def _apple8_smem_kernel[
     var k_start = min(k, ks * kchunk)
     var k_end = min(k, k_start + kchunk)
 
-    var c_ptr = c_base + Int(block_idx.z) * m * n
-    var a_ptr = a_base + bz * a_bstride
-    var b_ptr = b_base + bz * k * n
+    var c_ptr = c_base.unsafe_offset(Int(block_idx.z) * m * n)
+    var a_ptr = a_base.unsafe_offset(bz * a_bstride)
+    var b_ptr = b_base.unsafe_offset(bz * k * n)
 
     var bm = Int(block_idx.y) * BLOCK_M
     var bn = Int(block_idx.x) * BLOCK_N
@@ -5351,13 +5398,15 @@ def _apple8_smem_kernel[
                 var row = kt + kk
                 var col = bm + mq
                 if row < k_end and col + 4 <= m:
-                    a_regs[q] = (a_ptr + row * m + col).load[width=4]()
+                    a_regs[q] = (
+                        a_ptr.unsafe_offset(row * m + col)
+                    ).unsafe_load[width=4]()
                 else:
                     var v = SIMD[DType.float32, 4](0)
                     if row < k_end:
                         comptime for j in range(4):
                             if col + j < m:
-                                v[j] = a_ptr[row * m + col + j]
+                                v[j] = a_ptr[unsafe_offset=row * m + col + j]
                     a_regs[q] = v
             else:
                 var mm = fid >> 2
@@ -5365,13 +5414,15 @@ def _apple8_smem_kernel[
                 var row = bm + mm
                 var col = kt + kq
                 if row < m and col + 4 <= k_end:
-                    a_regs[q] = (a_ptr + row * k + col).load[width=4]()
+                    a_regs[q] = (
+                        a_ptr.unsafe_offset(row * k + col)
+                    ).unsafe_load[width=4]()
                 else:
                     var v = SIMD[DType.float32, 4](0)
                     if row < m:
                         comptime for j in range(4):
                             if col + j < k_end:
-                                v[j] = a_ptr[row * k + col + j]
+                                v[j] = a_ptr[unsafe_offset=row * k + col + j]
                     a_regs[q] = v
         comptime for q in range(BV):
             var fid = q * THREADS + tid
@@ -5382,13 +5433,15 @@ def _apple8_smem_kernel[
                 var row = bn + nn
                 var col = kt + kq
                 if row < n and col + 4 <= k_end:
-                    b_regs[q] = (b_ptr + row * k + col).load[width=4]()
+                    b_regs[q] = (
+                        b_ptr.unsafe_offset(row * k + col)
+                    ).unsafe_load[width=4]()
                 else:
                     var v = SIMD[DType.float32, 4](0)
                     if row < n:
                         comptime for j in range(4):
                             if col + j < k_end:
-                                v[j] = b_ptr[row * k + col + j]
+                                v[j] = b_ptr[unsafe_offset=row * k + col + j]
                     b_regs[q] = v
             else:
                 # B (K, N): a straight row-segment copy.
@@ -5397,13 +5450,15 @@ def _apple8_smem_kernel[
                 var row = kt + kk
                 var col = bn + nq
                 if row < k_end and col + 4 <= n:
-                    b_regs[q] = (b_ptr + row * n + col).load[width=4]()
+                    b_regs[q] = (
+                        b_ptr.unsafe_offset(row * n + col)
+                    ).unsafe_load[width=4]()
                 else:
                     var v = SIMD[DType.float32, 4](0)
                     if row < k_end:
                         comptime for j in range(4):
                             if col + j < n:
-                                v[j] = b_ptr[row * n + col + j]
+                                v[j] = b_ptr[unsafe_offset=row * n + col + j]
                     b_regs[q] = v
 
     # Register -> threadgroup store for buffer `buf`.
@@ -5414,30 +5469,30 @@ def _apple8_smem_kernel[
         a_regs: InlineArray[SIMD[DType.float32, 4], AV],
         b_regs: InlineArray[SIMD[DType.float32, 4], BV],
     ):
-        var a_dst = a_smem + buf * BLOCK_M * LDA
-        var b_dst = b_smem + buf * BK * LDB
+        var a_dst = a_smem.unsafe_offset(buf * BLOCK_M * LDA)
+        var b_dst = b_smem.unsafe_offset(buf * BK * LDB)
         comptime for q in range(AV):
             var fid = q * THREADS + tid
             comptime if TRANSPOSE_A:
                 var kk = fid >> 4
                 var mq = (fid & 15) * 4
                 comptime for j in range(4):
-                    a_dst[(mq + j) * LDA + kk] = a_regs[q][j]
+                    a_dst[unsafe_offset=(mq + j) * LDA + kk] = a_regs[q][j]
             else:
                 var mm = fid >> 2
                 var kq = (fid & 3) * 4
-                a_dst.store(mm * LDA + kq, a_regs[q])
+                a_dst.unsafe_store(mm * LDA + kq, a_regs[q])
         comptime for q in range(BV):
             var fid = q * THREADS + tid
             comptime if TRANSPOSE_B:
                 var nn = fid >> 2
                 var kq = (fid & 3) * 4
                 comptime for j in range(4):
-                    b_dst[(kq + j) * LDB + nn] = b_regs[q][j]
+                    b_dst[unsafe_offset=(kq + j) * LDB + nn] = b_regs[q][j]
             else:
                 var kk = fid >> 4
                 var nq = (fid & 15) * 4
-                b_dst.store(kk * LDB + nq, b_regs[q])
+                b_dst.unsafe_store(kk * LDB + nq, b_regs[q])
 
     # Two 8-slab mma sweeps over threadgroup buffer `buf`.
     @always_inline
@@ -5446,23 +5501,27 @@ def _apple8_smem_kernel[
         buf: Int,
         mut acc: InlineArray[SIMD[DType.float32, FRAG8], NT_M * NT_N],
     ):
-        var a_src = a_smem + buf * BLOCK_M * LDA + (sgm + frow) * LDA + fcol
-        var b_src = b_smem + buf * BK * LDB + frow * LDB + sgn + fcol
+        var a_src = a_smem.unsafe_offset(
+            buf * BLOCK_M * LDA + (sgm + frow) * LDA + fcol
+        )
+        var b_src = b_smem.unsafe_offset(
+            buf * BK * LDB + frow * LDB + sgn + fcol
+        )
         comptime for kc in range(BK // MMA8_DIM):
             var afrag = InlineArray[SIMD[DType.float32, FRAG8], NT_M](
                 uninitialized=True
             )
             comptime for mi in range(NT_M):
-                afrag[mi] = (a_src + mi * MMA8_DIM * LDA + kc * MMA8_DIM).load[
-                    width=FRAG8
-                ]()
+                afrag[mi] = (
+                    a_src.unsafe_offset(mi * MMA8_DIM * LDA + kc * MMA8_DIM)
+                ).unsafe_load[width=FRAG8]()
             var bfrag = InlineArray[SIMD[DType.float32, FRAG8], NT_N](
                 uninitialized=True
             )
             comptime for ni in range(NT_N):
-                bfrag[ni] = (b_src + kc * MMA8_DIM * LDB + ni * MMA8_DIM).load[
-                    width=FRAG8
-                ]()
+                bfrag[ni] = (
+                    b_src.unsafe_offset(kc * MMA8_DIM * LDB + ni * MMA8_DIM)
+                ).unsafe_load[width=FRAG8]()
             comptime for mi in range(NT_M):
                 comptime for ni in range(NT_N):
                     acc[mi * NT_N + ni] = _mma8x8(
@@ -5490,9 +5549,9 @@ def _apple8_smem_kernel[
                 var gcol = bn + sgn + ni * MMA8_DIM + fcol
                 var frag = accum[mi * NT_N + ni]
                 if gcol + FRAG8 <= n:
-                    c_ptr.store(grow * n + gcol, frag)
+                    c_ptr.unsafe_store(grow * n + gcol, frag)
                 elif gcol < n:
-                    c_ptr[grow * n + gcol] = frag[0]
+                    c_ptr[unsafe_offset=grow * n + gcol] = frag[0]
 
 
 def _tune_enqueue[
@@ -5536,23 +5595,15 @@ def _tune_enqueue[
             )
             c_target = Int(ws.value().unsafe_ptr())
         var c = _make_ptr[DType.float32](c_target).as_unsafe_any_origin()
-        var a = (
-            _make_ptr[DType.float32](a_addr)
-            .as_unsafe_any_origin()
-            .as_immutable()
-        )
-        var b = (
-            _make_ptr[DType.float32](b_addr)
-            .as_unsafe_any_origin()
-            .as_immutable()
-        )
+        var a = _make_ptr[DType.float32](a_addr).as_unsafe_any_origin().as_imm()
+        var b = _make_ptr[DType.float32](b_addr).as_unsafe_any_origin().as_imm()
         comptime if pipe3:
             var bias = (
                 _make_ptr[DType.float32](
                     bias_addr if bias_addr != 0 else a_addr
                 )
                 .as_unsafe_any_origin()
-                .as_immutable()
+                .as_imm()
             )
             _enqueue_cached[
                 _gemm_pipe3_kernel[
@@ -5602,7 +5653,7 @@ def _tune_enqueue[
             var ws_ptr = (
                 _make_ptr[DType.float32](c_target)
                 .as_unsafe_any_origin()
-                .as_immutable()
+                .as_imm()
             )
             _enqueue_cached[_ksplit_reduce_kernel](
                 ctx,
@@ -5649,9 +5700,7 @@ def _ct_enqueue[
         var at_buf = ctx.enqueue_create_buffer[DType.float32](m * k)
         var at_addr = Int(at_buf.unsafe_ptr())
         var a_in = (
-            _make_ptr[DType.float32](a_addr)
-            .as_unsafe_any_origin()
-            .as_immutable()
+            _make_ptr[DType.float32](a_addr).as_unsafe_any_origin().as_imm()
         )
         var at_out = _make_ptr[DType.float32](at_addr).as_unsafe_any_origin()
         _enqueue_cached[_transpose_small_kernel](
@@ -5668,14 +5717,10 @@ def _ct_enqueue[
         )
         var c = _make_ptr[DType.float32](c_addr).as_unsafe_any_origin()
         var wa = (
-            _make_ptr[DType.float32](b_addr)
-            .as_unsafe_any_origin()
-            .as_immutable()
+            _make_ptr[DType.float32](b_addr).as_unsafe_any_origin().as_imm()
         )
         var at = (
-            _make_ptr[DType.float32](at_addr)
-            .as_unsafe_any_origin()
-            .as_immutable()
+            _make_ptr[DType.float32](at_addr).as_unsafe_any_origin().as_imm()
         )
         # Swapped roles: kernel-m = n (weight rows), kernel-n = m.
         _enqueue_cached[
@@ -5725,9 +5770,7 @@ def _pipe3t_enqueue[
         var at_buf = ctx.enqueue_create_buffer[DType.float32](m * k)
         var at_addr = Int(at_buf.unsafe_ptr())
         var a_in = (
-            _make_ptr[DType.float32](a_addr)
-            .as_unsafe_any_origin()
-            .as_immutable()
+            _make_ptr[DType.float32](a_addr).as_unsafe_any_origin().as_imm()
         )
         var at_out = _make_ptr[DType.float32](at_addr).as_unsafe_any_origin()
         _enqueue_cached[_transpose_small_kernel](
@@ -5756,15 +5799,9 @@ def _pipe3t_enqueue[
             c_target = Int(ws.value().unsafe_ptr())
         var c = _make_ptr[DType.float32](c_target).as_unsafe_any_origin()
         var at = (
-            _make_ptr[DType.float32](at_addr)
-            .as_unsafe_any_origin()
-            .as_immutable()
+            _make_ptr[DType.float32](at_addr).as_unsafe_any_origin().as_imm()
         )
-        var b = (
-            _make_ptr[DType.float32](b_addr)
-            .as_unsafe_any_origin()
-            .as_immutable()
-        )
+        var b = _make_ptr[DType.float32](b_addr).as_unsafe_any_origin().as_imm()
         _enqueue_cached[
             _gemm_pipe3_kernel[
                 BM, BN, BK, TM, TN, 4, 4, False, STAGES, True, MINB
@@ -5792,7 +5829,7 @@ def _pipe3t_enqueue[
             var ws_ptr = (
                 _make_ptr[DType.float32](c_target)
                 .as_unsafe_any_origin()
-                .as_immutable()
+                .as_imm()
             )
             _enqueue_cached[_ksplit_reduce_kernel](
                 ctx,
@@ -6011,9 +6048,9 @@ def _gemm_dtype_dispatch(
 def _cpu_gemm_naive[
     dtype: DType
 ](
-    c_ptr: UnsafePointer[Scalar[dtype], MutUntrackedOrigin],
-    a_ptr: UnsafePointer[Scalar[dtype], MutUntrackedOrigin],
-    b_ptr: UnsafePointer[Scalar[dtype], MutUntrackedOrigin],
+    c_ptr: Pointer[Scalar[dtype], MutUntrackedOrigin],
+    a_ptr: Pointer[Scalar[dtype], MutUntrackedOrigin],
+    b_ptr: Pointer[Scalar[dtype], MutUntrackedOrigin],
     batch: Int,
     m: Int,
     n: Int,
@@ -6035,27 +6072,27 @@ def _cpu_gemm_naive[
     def row_func(row: Int):
         var bz = row // m
         var mm = row % m
-        var a_row = a_ptr + bz * a_bstride + mm * k
-        var c_row = c_ptr + row * n
-        var b_base = b_ptr + bz * b_batch_stride
+        var a_row = a_ptr.unsafe_offset(bz * a_bstride + mm * k)
+        var c_row = c_ptr.unsafe_offset(row * n)
+        var b_base = b_ptr.unsafe_offset(bz * b_batch_stride)
         for j in range(n):
             var acc = Float32(0)
             if transpose_b:
-                var b_row = b_base + j * k
+                var b_row = b_base.unsafe_offset(j * k)
                 for kk in range(k):
                     acc += (
-                        a_row[kk].cast[DType.float32]()
-                        * b_row[kk].cast[DType.float32]()
+                        a_row[unsafe_offset=kk].cast[DType.float32]()
+                        * b_row[unsafe_offset=kk].cast[DType.float32]()
                     )
             else:
                 for kk in range(k):
                     acc += (
-                        a_row[kk].cast[DType.float32]()
-                        * b_base[kk * n + j].cast[DType.float32]()
+                        a_row[unsafe_offset=kk].cast[DType.float32]()
+                        * b_base[unsafe_offset=kk * n + j].cast[DType.float32]()
                     )
             if has_bias:
-                acc += bias_ptr[j].cast[DType.float32]()
-            c_row[j] = acc.cast[dtype]()
+                acc += bias_ptr[unsafe_offset=j].cast[DType.float32]()
+            c_row[unsafe_offset=j] = acc.cast[dtype]()
 
     parallelize[row_func](batch * m, ctx)
 
@@ -6064,9 +6101,9 @@ def _cpu_gemm_naive[
 def _cpu_matmul_one[
     ab_dtype: DType, c_dtype: DType, transpose_b: Bool
 ](
-    c_ptr: UnsafePointer[Scalar[c_dtype], MutUntrackedOrigin],
-    a_ptr: UnsafePointer[Scalar[ab_dtype], MutUntrackedOrigin],
-    b_ptr: UnsafePointer[Scalar[ab_dtype], MutUntrackedOrigin],
+    c_ptr: Pointer[Scalar[c_dtype], MutUntrackedOrigin],
+    a_ptr: Pointer[Scalar[ab_dtype], MutUntrackedOrigin],
+    b_ptr: Pointer[Scalar[ab_dtype], MutUntrackedOrigin],
     m: Int,
     n: Int,
     k: Int,
@@ -6106,9 +6143,9 @@ def _cpu_gemm[
     bias_addr: Int,  # 0 means no bias
     ctx: DeviceContext,
 ) raises:
-    var c_base = _make_ptr[dtype](c_addr) + c_off
-    var a_base = _make_ptr[dtype](a_addr) + a_off
-    var b_base = _make_ptr[dtype](b_addr) + b_off
+    var c_base = _make_ptr[dtype](c_addr).unsafe_offset(c_off)
+    var a_base = _make_ptr[dtype](a_addr).unsafe_offset(a_off)
+    var b_base = _make_ptr[dtype](b_addr).unsafe_offset(b_off)
     var has_bias = bias_addr != 0
 
     # Shapes the library CPU matmul mishandles (see the section comment):
@@ -6140,9 +6177,9 @@ def _cpu_gemm[
         # fp32: matmul each batch straight into C, then optional fp32 bias
         # (broadcast over all batch * m rows).
         for bz in range(batch):
-            var c_ptr = c_base + bz * (m * n)
-            var a_ptr = a_base + bz * a_bstride
-            var b_ptr = b_base + bz * b_batch_stride
+            var c_ptr = c_base.unsafe_offset(bz * (m * n))
+            var a_ptr = a_base.unsafe_offset(bz * a_bstride)
+            var b_ptr = b_base.unsafe_offset(bz * b_batch_stride)
             if transpose_b:
                 _cpu_matmul_one[dtype, dtype, True](
                     c_ptr, a_ptr, b_ptr, m, n, k, ctx
@@ -6165,7 +6202,7 @@ def _cpu_gemm[
             # Accumulate A@B in an fp32 scratch, then add bias in fp32 and
             # cast to the output dtype exactly once.
             var total = batch * m * n
-            var scratch = alloc[Scalar[DType.float32]](total)
+            var scratch = unsafe_alloc[Scalar[DType.float32]](total)
             var bias_ptr = _make_ptr[dtype](bias_addr)
 
             @always_inline
@@ -6173,14 +6210,17 @@ def _cpu_gemm[
             @__copy_capture(scratch, c_base, bias_ptr)
             def add_cast_func[width: Int, alignment: Int = 1](idx: StdCoord):
                 var i = Int(idx[0].value())
-                var acc = scratch[i] + bias_ptr[i % n].cast[DType.float32]()
-                c_base[i] = acc.cast[dtype]()
+                var acc = (
+                    scratch[unsafe_offset=i]
+                    + bias_ptr[unsafe_offset=i % n].cast[DType.float32]()
+                )
+                c_base[unsafe_offset=i] = acc.cast[dtype]()
 
             try:
                 for bz in range(batch):
-                    var s_ptr = scratch + bz * (m * n)
-                    var a_ptr = a_base + bz * a_bstride
-                    var b_ptr = b_base + bz * b_batch_stride
+                    var s_ptr = scratch.unsafe_offset(bz * (m * n))
+                    var a_ptr = a_base.unsafe_offset(bz * a_bstride)
+                    var b_ptr = b_base.unsafe_offset(bz * b_batch_stride)
                     if transpose_b:
                         _cpu_matmul_one[dtype, DType.float32, True](
                             s_ptr, a_ptr, b_ptr, m, n, k, ctx
@@ -6191,12 +6231,12 @@ def _cpu_gemm[
                         )
                 elementwise[add_cast_func, simd_width=1](StdCoord(total), ctx)
             finally:
-                scratch.free()
+                scratch.unsafe_free()
         else:
             for bz in range(batch):
-                var c_ptr = c_base + bz * (m * n)
-                var a_ptr = a_base + bz * a_bstride
-                var b_ptr = b_base + bz * b_batch_stride
+                var c_ptr = c_base.unsafe_offset(bz * (m * n))
+                var a_ptr = a_base.unsafe_offset(bz * a_bstride)
+                var b_ptr = b_base.unsafe_offset(bz * b_batch_stride)
                 if transpose_b:
                     _cpu_matmul_one[dtype, dtype, True](
                         c_ptr, a_ptr, b_ptr, m, n, k, ctx
@@ -6463,9 +6503,16 @@ def _bmm_causal_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
-        _bmm_causal_go(args[0], args[1], args[2], args[3], args[4], args[5])
+        _bmm_causal_go(
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+        )
     except e:
         return _spec_unsupported(e)
     return _raw_ret_none()
@@ -6491,7 +6538,9 @@ def _bias_add_row[
     @__copy_capture(out_ptr, bias_ptr)
     def func[width: Int, alignment: Int = 1](idx: StdCoord):
         var i = Int(idx[0].value())
-        out_ptr[i] = out_ptr[i] + bias_ptr[i % cols]
+        out_ptr[unsafe_offset=i] = (
+            out_ptr[unsafe_offset=i] + bias_ptr[unsafe_offset=i % cols]
+        )
 
     if ctx.api() == "cpu":
         elementwise[func, simd_width=1](StdCoord(total), ctx)
@@ -6665,9 +6714,16 @@ def _matmul_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
-        _matmul_go(args[0], args[1], args[2], args[3], args[4], args[5])
+        _matmul_go(
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+        )
     except e:
         return _spec_unsupported(e)
     return _raw_ret_none()
@@ -6678,9 +6734,16 @@ def _bmm_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
-        _bmm_go(args[0], args[1], args[2], args[3], args[4], args[5])
+        _bmm_go(
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+        )
     except e:
         return _spec_unsupported(e)
     return _raw_ret_none()

--- a/torch_mojo_backend/eager_kernels/matmul_ops/tn_f32_gemm_core.mojo
+++ b/torch_mojo_backend/eager_kernels/matmul_ops/tn_f32_gemm_core.mojo
@@ -120,9 +120,9 @@ def _tn_core_kernel[
     MINB: Int,
     PUMP: Int = 1,  # slabs per barrier (1 or 2; 2 needs STAGES >= 6 even)
 ](
-    c_base: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    a_base: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
-    b_base: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
+    c_base: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    a_base: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
+    b_base: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
     m_arg: Int64,
     n_arg: Int64,
     k_arg: Int64,
@@ -167,7 +167,7 @@ def _tn_core_kernel[
 
     # With ksplits > 1, C is a [ksplits, m, n] workspace; a reduce kernel
     # sums the slices afterwards. Batch is always 1 here (TN wgrad).
-    var c_ptr = c_base + block_idx.z * m * n
+    var c_ptr = c_base.unsafe_offset(block_idx.z * m * n)
 
     var bm = block_idx.y * BM
     var bn = block_idx.x * BN
@@ -195,7 +195,7 @@ def _tn_core_kernel[
         Scalar[F32], address_space=AddressSpace.SHARED, alignment=16
     ]()
     var a_smem = smem_base
-    var b_smem = smem_base + STAGES * BM * BK
+    var b_smem = smem_base.unsafe_offset(STAGES * BM * BK)
 
     # Fragment base columns within a smem row.
     var am0 = wr * WM + tr * TM
@@ -254,7 +254,7 @@ def _tn_core_kernel[
         # A^T (k, m) row-major: chunks along m into As[kk][mm] (coalesced
         # along m — the physical TN layout IS the slab layout; no
         # transpose, no copy).
-        var a_dst = a_smem + (buf * BM * BK + a_bkk * BM + a_cm)
+        var a_dst = a_smem.unsafe_offset(buf * BM * BK + a_bkk * BM + a_cm)
         var a_src = a_srcs
         comptime for t in range(NA):
             var bytes = a_bytes
@@ -262,17 +262,17 @@ def _tn_core_kernel[
                 if kt + a_bkk + t * ROWS_A_STEP >= k_end:
                     bytes = 0
             async_copy[VEC_A * 4, fill=Scalar[F32](0)](
-                (a_base + (a_src + t * a_rstep)).address_space_cast[
-                    AddressSpace.GLOBAL
-                ](),
-                (a_dst + t * (ROWS_A_STEP * BM)).address_space_cast[
-                    AddressSpace.SHARED
-                ](),
+                (
+                    a_base.unsafe_offset(a_src + t * a_rstep)
+                ).unsafe_address_space_cast[AddressSpace.GLOBAL](),
+                (
+                    a_dst.unsafe_offset(t * (ROWS_A_STEP * BM))
+                ).unsafe_address_space_cast[AddressSpace.SHARED](),
                 src_size=bytes,
             )
 
         # B (k, n) row-major: chunks along n into Bs[kk][nn].
-        var b_dst = b_smem + (buf * BK * BN + b_bkk * BN + b_cn)
+        var b_dst = b_smem.unsafe_offset(buf * BK * BN + b_bkk * BN + b_cn)
         var b_src = b_srcs
         comptime for t in range(NB):
             var bytes = b_bytes
@@ -280,12 +280,12 @@ def _tn_core_kernel[
                 if kt + b_bkk + t * ROWS_B_STEP >= k_end:
                     bytes = 0
             async_copy[VEC_B * 4, fill=Scalar[F32](0)](
-                (b_base + (b_src + t * b_rstep)).address_space_cast[
-                    AddressSpace.GLOBAL
-                ](),
-                (b_dst + t * (ROWS_B_STEP * BN)).address_space_cast[
-                    AddressSpace.SHARED
-                ](),
+                (
+                    b_base.unsafe_offset(b_src + t * b_rstep)
+                ).unsafe_address_space_cast[AddressSpace.GLOBAL](),
+                (
+                    b_dst.unsafe_offset(t * (ROWS_B_STEP * BN))
+                ).unsafe_address_space_cast[AddressSpace.SHARED](),
                 src_size=bytes,
             )
 
@@ -308,19 +308,21 @@ def _tn_core_kernel[
         # without it Mojo emits align-4 vector loads, which reach PTX as
         # scalar ld.shared.b32 and ptxas only partially re-fuses them
         # (that alone cost ~18% FMA pipe on 4096^3).
-        var a_base_s = a_smem + aoff
-        var b_base_s = b_smem + boff
-        var a_cur = a_base_s.load[width=TM, alignment=16](am0)
+        var a_base_s = a_smem.unsafe_offset(aoff)
+        var b_base_s = b_smem.unsafe_offset(boff)
+        var a_cur = a_base_s.unsafe_load[width=TM, alignment=16](am0)
         var b_cur = InlineArray[SIMD[F32, 4], QN](uninitialized=True)
         comptime for q in range(QN):
-            b_cur[q] = b_base_s.load[width=4, alignment=16](bn0 + q * (LC * 4))
+            b_cur[q] = b_base_s.unsafe_load[width=4, alignment=16](
+                bn0 + q * (LC * 4)
+            )
         comptime for kk in range(BK - 1):
-            var a_nxt = a_base_s.load[width=TM, alignment=16](
+            var a_nxt = a_base_s.unsafe_load[width=TM, alignment=16](
                 (kk + 1) * BM + am0
             )
             var b_nxt = InlineArray[SIMD[F32, 4], QN](uninitialized=True)
             comptime for q in range(QN):
-                b_nxt[q] = b_base_s.load[width=4, alignment=16](
+                b_nxt[q] = b_base_s.unsafe_load[width=4, alignment=16](
                     (kk + 1) * BN + bn0 + q * (LC * 4)
                 )
             comptime for i in range(TM):
@@ -413,11 +415,11 @@ def _tn_core_kernel[
                 var col = bn + wc * WN + qn * (LC * 4) + tc * 4
                 var v = acc[i * QN + qn]
                 if col + 4 <= n:
-                    c_ptr.store[alignment=CALIGN](row * n + col, v)
+                    c_ptr.unsafe_store[alignment=CALIGN](row * n + col, v)
                 else:
                     comptime for j in range(4):
                         if col + j < n:
-                            c_ptr[row * n + col + j] = v[j]
+                            c_ptr[unsafe_offset=row * n + col + j] = v[j]
 
 
 @__llvm_metadata(
@@ -435,9 +437,9 @@ def _tn_split_kernel[
     LR: Int = 8,  # lane-grid rows within a warp (8 -> 8x16, 4 -> 16x8)
     SERP: Bool = False,  # serpentine quadrant order (operand-reuse aid)
 ](
-    c_base: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    a_base: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
-    b_base: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
+    c_base: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    a_base: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
+    b_base: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
     m_arg: Int64,
     n_arg: Int64,
     k_arg: Int64,
@@ -474,7 +476,7 @@ def _tn_split_kernel[
     if ns <= 0:
         return
 
-    var c_ptr = c_base + block_idx.z * m * n
+    var c_ptr = c_base.unsafe_offset(block_idx.z * m * n)
 
     var bm = block_idx.y * BM
     var bn = block_idx.x * BN
@@ -510,9 +512,9 @@ def _tn_split_kernel[
     var smem = external_memory[
         Scalar[F32], address_space=AddressSpace.SHARED, alignment=16
     ]()
-    var a_smem = smem + gid * GROUP_F
-    var b_smem = a_smem + STAGES * BK * BM
-    var ex_smem = smem + GROUP_F
+    var a_smem = smem.unsafe_offset(gid * GROUP_F)
+    var b_smem = a_smem.unsafe_offset(STAGES * BK * BM)
+    var ex_smem = smem.unsafe_offset(GROUP_F)
 
     var am0 = wr * WM + tr * TM
     var bn0 = wc * WN + tc * 4
@@ -553,7 +555,7 @@ def _tn_split_kernel[
         # buffer `buf`.
         var kt = k_start + s * BK
 
-        var a_dst = a_smem + (buf * BM * BK + a_bkk * BM + a_cm)
+        var a_dst = a_smem.unsafe_offset(buf * BM * BK + a_bkk * BM + a_cm)
         var a_src = a_srcs
         comptime for t in range(NA):
             var bytes = a_bytes
@@ -561,16 +563,16 @@ def _tn_split_kernel[
                 if kt + a_bkk + t * ROWS_A_STEP >= k_end:
                     bytes = 0
             async_copy[VEC_A * 4, fill=Scalar[F32](0)](
-                (a_base + (a_src + t * a_rstep)).address_space_cast[
-                    AddressSpace.GLOBAL
-                ](),
-                (a_dst + t * (ROWS_A_STEP * BM)).address_space_cast[
-                    AddressSpace.SHARED
-                ](),
+                (
+                    a_base.unsafe_offset(a_src + t * a_rstep)
+                ).unsafe_address_space_cast[AddressSpace.GLOBAL](),
+                (
+                    a_dst.unsafe_offset(t * (ROWS_A_STEP * BM))
+                ).unsafe_address_space_cast[AddressSpace.SHARED](),
                 src_size=bytes,
             )
 
-        var b_dst = b_smem + (buf * BK * BN + b_bkk * BN + b_cn)
+        var b_dst = b_smem.unsafe_offset(buf * BK * BN + b_bkk * BN + b_cn)
         var b_src = b_srcs
         comptime for t in range(NB):
             var bytes = b_bytes
@@ -578,12 +580,12 @@ def _tn_split_kernel[
                 if kt + b_bkk + t * ROWS_B_STEP >= k_end:
                     bytes = 0
             async_copy[VEC_B * 4, fill=Scalar[F32](0)](
-                (b_base + (b_src + t * b_rstep)).address_space_cast[
-                    AddressSpace.GLOBAL
-                ](),
-                (b_dst + t * (ROWS_B_STEP * BN)).address_space_cast[
-                    AddressSpace.SHARED
-                ](),
+                (
+                    b_base.unsafe_offset(b_src + t * b_rstep)
+                ).unsafe_address_space_cast[AddressSpace.GLOBAL](),
+                (
+                    b_dst.unsafe_offset(t * (ROWS_B_STEP * BN))
+                ).unsafe_address_space_cast[AddressSpace.SHARED](),
                 src_size=bytes,
             )
 
@@ -602,19 +604,21 @@ def _tn_split_kernel[
     @always_inline
     @parameter
     def _compute(aoff: Int, boff: Int):
-        var a_base_s = a_smem + aoff
-        var b_base_s = b_smem + boff
-        var a_cur = a_base_s.load[width=TM, alignment=16](am0)
+        var a_base_s = a_smem.unsafe_offset(aoff)
+        var b_base_s = b_smem.unsafe_offset(boff)
+        var a_cur = a_base_s.unsafe_load[width=TM, alignment=16](am0)
         var b_cur = InlineArray[SIMD[F32, 4], QN](uninitialized=True)
         comptime for q in range(QN):
-            b_cur[q] = b_base_s.load[width=4, alignment=16](bn0 + q * (LC * 4))
+            b_cur[q] = b_base_s.unsafe_load[width=4, alignment=16](
+                bn0 + q * (LC * 4)
+            )
         comptime for kk in range(BK - 1):
-            var a_nxt = a_base_s.load[width=TM, alignment=16](
+            var a_nxt = a_base_s.unsafe_load[width=TM, alignment=16](
                 (kk + 1) * BM + am0
             )
             var b_nxt = InlineArray[SIMD[F32, 4], QN](uninitialized=True)
             comptime for q in range(QN):
-                b_nxt[q] = b_base_s.load[width=4, alignment=16](
+                b_nxt[q] = b_base_s.unsafe_load[width=4, alignment=16](
                     (kk + 1) * BN + bn0 + q * (LC * 4)
                 )
             comptime for i in range(TM):
@@ -662,7 +666,7 @@ def _tn_split_kernel[
             comptime for j in range(EX_CHUNK):
                 comptime idx = r * EX_CHUNK + j
                 comptime if idx < TM * QN:
-                    ex_smem.store[alignment=16](
+                    ex_smem.unsafe_store[alignment=16](
                         ltid * (EX_CHUNK * 4) + j * 4, acc[idx]
                     )
         barrier()
@@ -670,7 +674,7 @@ def _tn_split_kernel[
             comptime for j in range(EX_CHUNK):
                 comptime idx = r * EX_CHUNK + j
                 comptime if idx < TM * QN:
-                    acc[idx] += ex_smem.load[width=4, alignment=16](
+                    acc[idx] += ex_smem.unsafe_load[width=4, alignment=16](
                         ltid * (EX_CHUNK * 4) + j * 4
                     )
         comptime if r != EX_ROUNDS - 1:
@@ -688,8 +692,8 @@ def _tn_split_kernel[
                 var col = bn + wc * WN + qn * (LC * 4) + tc * 4
                 var v = acc[i * QN + qn]
                 if col + 4 <= n:
-                    c_ptr.store[alignment=CALIGN](row * n + col, v)
+                    c_ptr.unsafe_store[alignment=CALIGN](row * n + col, v)
                 else:
                     comptime for j in range(4):
                         if col + j < n:
-                            c_ptr[row * n + col + j] = v[j]
+                            c_ptr[unsafe_offset=row * n + col + j] = v[j]

--- a/torch_mojo_backend/eager_kernels/matmul_ops/tn_f32_gemm_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/matmul_ops/tn_f32_gemm_kernels.mojo
@@ -62,7 +62,8 @@ from max.gpu.host import (
 )
 from std.memory import AddressSpace
 from std.math import ceildiv
-from std.memory import alloc, stack_allocation
+from std.memory import stack_allocation
+from std.memory.alloc import unsafe_alloc
 from std.sys.info import _has_sm_9x
 
 from gemm_splitk_common import TARGET_BLOCKS, _ksplit_reduce_kernel
@@ -112,8 +113,8 @@ comptime DEEPK_MAX_BASE = 7
 # slabs per thread; not latency-bound there).
 @__name("tn_ksplit_reduce_wide")
 def _tn_ksplit_reduce_wide_kernel(
-    c_ptr: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    ws_ptr: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
+    c_ptr: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    ws_ptr: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
     mn_arg: Int64,
     ksplits_arg: Int64,
 ):
@@ -133,27 +134,29 @@ def _tn_ksplit_reduce_wide_kernel(
     if o + 4 <= mn:
         var st = j
         while st < ksplits:
-            acc += ws_ptr.load[width=4](st * mn + o)
+            acc += ws_ptr.unsafe_load[width=4](st * mn + o)
             st += 8
     elif o < mn:
         var st = j
         while st < ksplits:
             comptime for u in range(4):
                 if o + u < mn:
-                    acc[u] += ws_ptr[st * mn + o + u]
+                    acc[u] += ws_ptr[unsafe_offset=st * mn + o + u]
             st += 8
-    smem.store[alignment=16](tid * 4, acc)
+    smem.unsafe_store[alignment=16](tid * 4, acc)
     barrier()
     if j == 0:
         var total = SIMD[DType.float32, 4](0)
         comptime for g in range(8):
-            total += smem.load[width=4, alignment=16]((g * 32 + lane) * 4)
+            total += smem.unsafe_load[width=4, alignment=16](
+                (g * 32 + lane) * 4
+            )
         if o + 4 <= mn:
-            c_ptr.store(o, total)
+            c_ptr.unsafe_store(o, total)
         elif o < mn:
             comptime for u in range(4):
                 if o + u < mn:
-                    c_ptr[o + u] = total[u]
+                    c_ptr[unsafe_offset=o + u] = total[u]
 
 
 @always_inline
@@ -188,8 +191,10 @@ def _enqueue_cached_smem3d[
     var name = String(t"TMB_KERNEL_{key}_{ctx.id()}")
     comptime FuncT = type_of(ctx.compile_function[func]())
 
-    if global_ptr := _get_global_or_null(name):
-        var fptr = global_ptr.value().bitcast[FuncT]()
+    var global_ptr = _get_global_or_null(name)
+
+    if global_ptr:
+        var fptr = global_ptr.value().unsafe_bitcast[FuncT]()
         ctx.enqueue_function(
             fptr[],
             *args,
@@ -204,11 +209,11 @@ def _enqueue_cached_smem3d[
             UInt32(smem_bytes)
         )
     )
-    var fptr = alloc[FuncT](1)
-    fptr.init_pointee_move(compiled^)
+    var fptr = unsafe_alloc[FuncT](1)
+    fptr.unsafe_write(compiled^)
     external_call["KGEN_CompilerRT_InsertGlobal", NoneType](
         StringSlice(name),
-        fptr.bitcast[NoneType](),
+        fptr.unsafe_bitcast[NoneType](),
     )
     ctx.enqueue_function(
         fptr[],
@@ -258,12 +263,8 @@ def _tn_core_launch[
     # tn_f32_gemm_core.mojo).
     comptime SMEM_BYTES = _tn_core_smem_bytes[BM, BN, BK, STAGES]()
     var c = _make_ptr[DType.float32](c_addr).as_unsafe_any_origin()
-    var a = (
-        _make_ptr[DType.float32](a_addr).as_unsafe_any_origin().as_immutable()
-    )
-    var b = (
-        _make_ptr[DType.float32](b_addr).as_unsafe_any_origin().as_immutable()
-    )
+    var a = _make_ptr[DType.float32](a_addr).as_unsafe_any_origin().as_imm()
+    var b = _make_ptr[DType.float32](b_addr).as_unsafe_any_origin().as_imm()
 
     if va4 and vb4:
         _enqueue_cached_smem3d[
@@ -372,12 +373,8 @@ def _tn_split_launch[
     # from the dynamic shared window -- see tn_f32_gemm_core.mojo.
     comptime SMEM_BYTES = _tn_split_smem_bytes[BM, BN, BK, STAGES]()
     var c = _make_ptr[DType.float32](c_addr).as_unsafe_any_origin()
-    var a = (
-        _make_ptr[DType.float32](a_addr).as_unsafe_any_origin().as_immutable()
-    )
-    var b = (
-        _make_ptr[DType.float32](b_addr).as_unsafe_any_origin().as_immutable()
-    )
+    var a = _make_ptr[DType.float32](a_addr).as_unsafe_any_origin().as_imm()
+    var b = _make_ptr[DType.float32](b_addr).as_unsafe_any_origin().as_imm()
 
     if va4 and vb4:
         _enqueue_cached_smem3d[
@@ -671,9 +668,7 @@ def try_enqueue_tn_f32_gemm(
         var gxr = ceildiv(total, 1024)
         var c_out = _make_ptr[DType.float32](c_addr).as_unsafe_any_origin()
         var ws_ptr = (
-            _make_ptr[DType.float32](c_target)
-            .as_unsafe_any_origin()
-            .as_immutable()
+            _make_ptr[DType.float32](c_target).as_unsafe_any_origin().as_imm()
         )
         # Deep splits: one-pass wide reduce (see _tn_ksplit_reduce_wide);
         # shallow splits keep the stock reduce (its 4-elems/thread grid is

--- a/torch_mojo_backend/eager_kernels/native_dropout_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/native_dropout_kernels.mojo
@@ -89,9 +89,9 @@ def _philox4x32_10(counter: UInt64, seed: UInt64) -> SIMD[DType.uint32, 4]:
 
 @__name("native_dropout_forward_philox_vec4")
 def _forward_vec4(
-    output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    mask: UnsafePointer[Scalar[DType.bool], MutAnyOrigin],
-    input: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    mask: Pointer[Scalar[DType.bool], MutAnyOrigin],
+    input: Pointer[Scalar[DType.float32], MutAnyOrigin],
     elements_arg: Int64,
     seed: UInt64,
     base_offset: UInt64,
@@ -110,10 +110,10 @@ def _forward_vec4(
         var keep_bits = (
             rnd.cast[DType.uint64]() - SIMD[DType.uint64, 4](threshold)
         ) >> 63
-        var x = input.load[width=4, alignment=16](base)
+        var x = input.unsafe_load[width=4, alignment=16](base)
         var result = x * keep_bits.cast[DType.float32]() * scale
-        output.store[alignment=16](base, result)
-        mask.bitcast[Scalar[DType.uint8]]().store[alignment=4](
+        output.unsafe_store[alignment=16](base, result)
+        mask.unsafe_bitcast[Scalar[DType.uint8]]().unsafe_store[alignment=4](
             base, keep_bits.cast[DType.uint8]()
         )
     else:
@@ -123,17 +123,19 @@ def _forward_vec4(
                 var keep_bit = (
                     rnd[lane].cast[DType.uint64]() - threshold
                 ) >> 63
-                output[idx] = (
-                    input[idx] * keep_bit.cast[DType.float32]() * scale
+                output[unsafe_offset=idx] = (
+                    input[unsafe_offset=idx]
+                    * keep_bit.cast[DType.float32]()
+                    * scale
                 )
-                mask[idx] = Scalar[DType.bool](keep_bit != 0)
+                mask[unsafe_offset=idx] = Scalar[DType.bool](keep_bit != 0)
 
 
 @__name("native_dropout_forward_philox_generic")
 def _forward_generic(
-    output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    mask: UnsafePointer[Scalar[DType.bool], MutAnyOrigin],
-    input: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    mask: Pointer[Scalar[DType.bool], MutAnyOrigin],
+    input: Pointer[Scalar[DType.float32], MutAnyOrigin],
     elements_arg: Int64,
     seed: UInt64,
     base_offset: UInt64,
@@ -153,14 +155,18 @@ def _forward_generic(
         var idx = base + lane
         if idx < elements:
             var keep_bit = (rnd[lane].cast[DType.uint64]() - threshold) >> 63
-            output[idx] = input[idx] * keep_bit.cast[DType.float32]() * scale
-            mask[idx] = Scalar[DType.bool](keep_bit != 0)
+            output[unsafe_offset=idx] = (
+                input[unsafe_offset=idx]
+                * keep_bit.cast[DType.float32]()
+                * scale
+            )
+            mask[unsafe_offset=idx] = Scalar[DType.bool](keep_bit != 0)
 
 
 @__name("native_dropout_forward_zero_fill")
 def _forward_zero_fill(
-    output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    mask: UnsafePointer[Scalar[DType.bool], MutAnyOrigin],
+    output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    mask: Pointer[Scalar[DType.bool], MutAnyOrigin],
     elements_arg: Int64,
 ):
     # Int is not device-passable (host/device width mismatch); scalars cross
@@ -171,15 +177,15 @@ def _forward_zero_fill(
     comptime for lane in range(4):
         var idx = base + lane
         if idx < elements:
-            output[idx] = Float32(0.0)
-            mask[idx] = Scalar[DType.bool](False)
+            output[unsafe_offset=idx] = Float32(0.0)
+            mask[unsafe_offset=idx] = Scalar[DType.bool](False)
 
 
 @__name("native_dropout_backward_vec4")
 def _backward_vec4(
-    grad_input: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    mask: UnsafePointer[Scalar[DType.bool], MutAnyOrigin],
+    grad_input: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    mask: Pointer[Scalar[DType.bool], MutAnyOrigin],
     elements_arg: Int64,
     scale: Float32,
 ):
@@ -190,27 +196,29 @@ def _backward_vec4(
     if base >= elements:
         return
     if base + 4 <= elements:
-        var g = grad_output.load[width=4, alignment=16](base)
-        var mask_bytes = mask.bitcast[Scalar[DType.uint8]]().load[
+        var g = grad_output.unsafe_load[width=4, alignment=16](base)
+        var mask_bytes = mask.unsafe_bitcast[Scalar[DType.uint8]]().unsafe_load[
             width=4, alignment=4
         ](base)
         # Bool storage is 0/1 by contract, so the byte cast is Float32(mask).
         var m = mask_bytes.cast[DType.float32]()
-        grad_input.store[alignment=16](base, g * m * scale)
+        grad_input.unsafe_store[alignment=16](base, g * m * scale)
     else:
         comptime for lane in range(4):
             var idx = base + lane
             if idx < elements:
-                grad_input[idx] = (
-                    grad_output[idx] * mask[idx].cast[DType.float32]() * scale
+                grad_input[unsafe_offset=idx] = (
+                    grad_output[unsafe_offset=idx]
+                    * mask[unsafe_offset=idx].cast[DType.float32]()
+                    * scale
                 )
 
 
 @__name("native_dropout_backward_generic")
 def _backward_generic(
-    grad_input: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    mask: UnsafePointer[Scalar[DType.bool], MutAnyOrigin],
+    grad_input: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    mask: Pointer[Scalar[DType.bool], MutAnyOrigin],
     elements_arg: Int64,
     scale: Float32,
 ):
@@ -224,8 +232,10 @@ def _backward_generic(
     comptime for lane in range(4):
         var idx = base + lane
         if idx < elements:
-            grad_input[idx] = (
-                grad_output[idx] * mask[idx].cast[DType.float32]() * scale
+            grad_input[unsafe_offset=idx] = (
+                grad_output[unsafe_offset=idx]
+                * mask[unsafe_offset=idx].cast[DType.float32]()
+                * scale
             )
 
 
@@ -235,9 +245,9 @@ def _is_aligned(address: Int, alignment: Int) -> Bool:
 
 
 def enqueue_native_dropout_f32(
-    output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    mask: UnsafePointer[Scalar[DType.bool], MutAnyOrigin],
-    input: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    mask: Pointer[Scalar[DType.bool], MutAnyOrigin],
+    input: Pointer[Scalar[DType.float32], MutAnyOrigin],
     elements: Int,
     p: Float64,
     seed: UInt64,
@@ -306,9 +316,9 @@ def enqueue_native_dropout_f32(
 
 
 def enqueue_native_dropout_backward_f32(
-    grad_input: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    mask: UnsafePointer[Scalar[DType.bool], MutAnyOrigin],
+    grad_input: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    mask: Pointer[Scalar[DType.bool], MutAnyOrigin],
     elements: Int,
     scale: Float64,
     ctx: DeviceContext,

--- a/torch_mojo_backend/eager_kernels/nn_ops/cumsum_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/nn_ops/cumsum_kernels.mojo
@@ -146,8 +146,8 @@ def _acc_dtype[dtype: DType]() -> DType:
 def _inner_tile[
     dtype: DType, acc: DType, threads: Int, exclusive: Bool = False
 ](
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
     base: Int,
     n_valid: Int,
     carry: Scalar[acc],
@@ -165,7 +165,7 @@ def _inner_tile[
     var tid = Int(thread_idx.x)
     var val = Scalar[acc](0)
     if tid < n_valid:
-        val = in_ptr[base + tid].cast[acc]()
+        val = in_ptr[unsafe_offset=base + tid].cast[acc]()
     # Always scan exclusive internally: the inclusive value (needed for the
     # tile-total broadcast either way) is one add away, and the caller's
     # requested flavor is a comptime select, not a second scan.
@@ -174,10 +174,10 @@ def _inner_tile[
 
     comptime if exclusive:
         if tid < n_valid:
-            out_ptr[base + tid] = (carry + excl).cast[dtype]()
+            out_ptr[unsafe_offset=base + tid] = (carry + excl).cast[dtype]()
     else:
         if tid < n_valid:
-            out_ptr[base + tid] = (carry + incl).cast[dtype]()
+            out_ptr[unsafe_offset=base + tid] = (carry + incl).cast[dtype]()
 
     var last = n_valid - 1
     var tile_total = block.broadcast[block_size=threads](incl, src_thread=last)
@@ -191,8 +191,8 @@ def _inner_tile[
 def _cumsum_inner_lines_kernel[
     dtype: DType, threads: Int, exclusive: Bool = False
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     line_len_arg: Int64,
     num_lines_arg: Int64,
 ):
@@ -226,8 +226,8 @@ def _cumsum_inner_lines_kernel[
 def _cumsum_chunk_reduce_kernel[
     dtype: DType, threads: Int, tiles: Int
 ](
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    workspace_ptr: UnsafePointer[Scalar[_acc_dtype[dtype]()], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    workspace_ptr: Pointer[Scalar[_acc_dtype[dtype]()], MutAnyOrigin],
     line_len_arg: Int64,
     chunks_per_line_arg: Int64,
 ):
@@ -253,15 +253,14 @@ def _cumsum_chunk_reduce_kernel[
     var tid = Int(thread_idx.x)
     var partial = Scalar[acc](0)
 
-    @parameter
-    for t in range(tiles):
+    comptime for t in range(tiles):
         var local = t * threads + tid
         var global_idx = chunk_start + local
         if global_idx < line_len:
-            partial += in_ptr[row_base + global_idx].cast[acc]()
+            partial += in_ptr[unsafe_offset=row_base + global_idx].cast[acc]()
     var total = block.sum[block_size=threads](partial)
     if tid == 0:
-        workspace_ptr[flat] = total
+        workspace_ptr[unsafe_offset=flat] = total
 
 
 @__llvm_metadata(
@@ -271,9 +270,9 @@ def _cumsum_chunk_reduce_kernel[
 def _cumsum_chunk_finish_kernel[
     dtype: DType, threads: Int, tiles: Int
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    workspace_ptr: UnsafePointer[Scalar[_acc_dtype[dtype]()], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    workspace_ptr: Pointer[Scalar[_acc_dtype[dtype]()], ImmutAnyOrigin],
     line_len_arg: Int64,
     chunks_per_line_arg: Int64,
 ):
@@ -304,28 +303,28 @@ def _cumsum_chunk_finish_kernel[
     var chunk = flat % chunks_per_line
     var chunk_start = chunk * threads * tiles
     var row_base = line * line_len
-    var seed = workspace_ptr[flat]
+    var seed = workspace_ptr[unsafe_offset=flat]
     var tid = Int(thread_idx.x)
     var local_base = chunk_start + tid * tiles
 
     var local_scan = InlineArray[Scalar[acc], tiles](uninitialized=True)
     var running = Scalar[acc](0)
 
-    @parameter
-    for k in range(tiles):
+    comptime for k in range(tiles):
         var idx = local_base + k
         if idx < line_len:
-            running += in_ptr[row_base + idx].cast[acc]()
+            running += in_ptr[unsafe_offset=row_base + idx].cast[acc]()
         local_scan[k] = running
 
     var excl = block.prefix_sum[block_size=threads, exclusive=True](running)
     var base = seed + excl
 
-    @parameter
-    for k in range(tiles):
+    comptime for k in range(tiles):
         var idx = local_base + k
         if idx < line_len:
-            out_ptr[row_base + idx] = (base + local_scan[k]).cast[dtype]()
+            out_ptr[unsafe_offset=row_base + idx] = (base + local_scan[k]).cast[
+                dtype
+            ]()
 
 
 # ===========================================================================
@@ -345,8 +344,8 @@ def _cumsum_chunk_finish_kernel[
 def _cumsum_outer_kernel[
     dtype: DType, threads: Int
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     scan_len_arg: Int64,
     inner_arg: Int64,
     num_lines_arg: Int64,
@@ -366,8 +365,8 @@ def _cumsum_outer_kernel[
         var r = 0
         while r < scan_len:
             var addr = base + r * inner
-            acc_v += in_ptr[addr].cast[acc]()
-            out_ptr[addr] = acc_v.cast[dtype]()
+            acc_v += in_ptr[unsafe_offset=addr].cast[acc]()
+            out_ptr[unsafe_offset=addr] = acc_v.cast[dtype]()
             r += 1
         line += gstride
 
@@ -391,8 +390,8 @@ def enqueue_cumsum_rows[
     dtype: DType
 ](
     ctx: DeviceContext,
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     rows: Int,
     cols: Int,
 ) raises:
@@ -441,11 +440,11 @@ def enqueue_cumsum_rows_workspace[
     dtype: DType
 ](
     ctx: DeviceContext,
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     rows: Int,
     cols: Int,
-    workspace_ptr: UnsafePointer[Scalar[_acc_dtype[dtype]()], MutAnyOrigin],
+    workspace_ptr: Pointer[Scalar[_acc_dtype[dtype]()], MutAnyOrigin],
 ) raises:
     """INNER family, 'few very long lines' regime: 3-pass workspace scan.
     `workspace_ptr` must hold >= cumsum_workspace_lines[dtype](rows, cols)
@@ -457,7 +456,7 @@ def enqueue_cumsum_rows_workspace[
     comptime esize = size_of[dtype]()
     var chunks_per_line = ceildiv(cols, WS_THREADS * WS_CHUNK_TILES)
     var total_chunks = rows * chunks_per_line
-    var ws_immut = workspace_ptr.as_immutable()
+    var ws_immut = workspace_ptr.as_imm()
     var sm_blocks = min(rows, _device_sm_count(ctx) * 8)
 
     _enqueue_cached[
@@ -532,8 +531,8 @@ def enqueue_cumsum_cols[
     dtype: DType
 ](
     ctx: DeviceContext,
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     rows: Int,
     cols: Int,
 ) raises:

--- a/torch_mojo_backend/eager_kernels/nn_ops/nn_ops.mojo
+++ b/torch_mojo_backend/eager_kernels/nn_ops/nn_ops.mojo
@@ -34,7 +34,8 @@ from max.gpu.host import DeviceContext
 from max.gpu.primitives import block
 from std.gpu.primitives import warp
 from std.math import ceildiv, exp, floor
-from std.memory import alloc, stack_allocation
+from std.memory import stack_allocation
+from std.memory.alloc import unsafe_alloc
 from std.python import PythonObject
 from std.python.bindings import PythonModuleBuilder
 from std.sys.info import (
@@ -144,13 +145,13 @@ def _batch_norm[
     def func[width: Int, alignment: Int = 1](idx: Coord):
         var i = Int(idx[0].value())
         var c = (i // inner) % channels
-        var m = mean_ptr[c].cast[DType.float32]()
-        var v = var_ptr[c].cast[DType.float32]()
-        var g = gamma_ptr[c].cast[DType.float32]()
-        var b = beta_ptr[c].cast[DType.float32]()
+        var m = mean_ptr[unsafe_offset=c].cast[DType.float32]()
+        var v = var_ptr[unsafe_offset=c].cast[DType.float32]()
+        var g = gamma_ptr[unsafe_offset=c].cast[DType.float32]()
+        var b = beta_ptr[unsafe_offset=c].cast[DType.float32]()
         var scale = g / ieee_sqrt(v + eps)
-        var a = in_ptr[i].cast[DType.float32]()
-        out_ptr[i] = ((a - m) * scale + b).cast[dtype]()
+        var a = in_ptr[unsafe_offset=i].cast[DType.float32]()
+        out_ptr[unsafe_offset=i] = ((a - m) * scale + b).cast[dtype]()
 
     _parallel_for[func](total, ctx)
 
@@ -249,20 +250,24 @@ def _layer_norm[
             var base = r * cols
             var total = Float32(0)
             for j in range(cols):
-                total += in_ptr[base + j].cast[DType.float32]()
+                total += in_ptr[unsafe_offset=base + j].cast[DType.float32]()
             var mean = total / Float32(cols)
             var var_sum = Float32(0)
             for j in range(cols):
-                var d = in_ptr[base + j].cast[DType.float32]() - mean
+                var d = (
+                    in_ptr[unsafe_offset=base + j].cast[DType.float32]() - mean
+                )
                 var_sum += d * d
             var rstd = 1.0 / ieee_sqrt(var_sum / Float32(cols) + eps)
             for j in range(cols):
-                var x = in_ptr[base + j].cast[DType.float32]()
-                var g = gamma_ptr[j].cast[DType.float32]()
-                var b = beta_ptr[j].cast[DType.float32]()
-                out_ptr[base + j] = ((x - mean) * rstd * g + b).cast[dtype]()
-            mean_out_ptr[r] = mean
-            rstd_out_ptr[r] = rstd
+                var x = in_ptr[unsafe_offset=base + j].cast[DType.float32]()
+                var g = gamma_ptr[unsafe_offset=j].cast[DType.float32]()
+                var b = beta_ptr[unsafe_offset=j].cast[DType.float32]()
+                out_ptr[unsafe_offset=base + j] = (
+                    (x - mean) * rstd * g + b
+                ).cast[dtype]()
+            mean_out_ptr[unsafe_offset=r] = mean
+            rstd_out_ptr[unsafe_offset=r] = rstd
 
         _parallel_for[func](rows, ctx)
     else:
@@ -365,8 +370,8 @@ comptime _APPLE_SM_BIG_ROW_BYTES = 25_000  # 1024-thread blocks above this
 def _softmax_rows_warp_kernel[
     dtype: DType, V: Int
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     rows_arg: Int64,
     cols_arg: Int64,
     scale: Float32,
@@ -403,7 +408,7 @@ def _softmax_rows_warp_kernel[
             var x = SIMD[DType.float32, V](min_finite[DType.float32]())
             if j0 < allowed:  # implies j0 < cols, i.e. a full in-row vector
                 var raw = (
-                    in_ptr.load[width=V, alignment=V * size_of[dtype]()](
+                    in_ptr.unsafe_load[width=V, alignment=V * size_of[dtype]()](
                         base + j0
                     ).cast[DType.float32]()
                     * scale
@@ -437,7 +442,7 @@ def _softmax_rows_warp_kernel[
         comptime for k in range(_APPLE_SM_MAX_VPT):
             var v = lane + k * WARP_SIZE
             if v < n_vec:
-                out_ptr.store[width=V, alignment=V * size_of[dtype]()](
+                out_ptr.unsafe_store[width=V, alignment=V * size_of[dtype]()](
                     base + v * V, (vals[k] * inv).cast[dtype]()
                 )
         row += row_stride
@@ -450,8 +455,8 @@ def _softmax_rows_warp_kernel[
 def _softmax_rows_block_kernel[
     dtype: DType, threads: Int, vec: Bool
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     rows_arg: Int64,
     cols_arg: Int64,
     scale: Float32,
@@ -494,7 +499,7 @@ def _softmax_rows_block_kernel[
             var v = tid
             while v < n_vec_a:
                 var x = (
-                    in_ptr.load[width=V, alignment=16](
+                    in_ptr.unsafe_load[width=V, alignment=16](
                         base + head + v * V
                     ).cast[DType.float32]()
                     * scale
@@ -509,14 +514,20 @@ def _softmax_rows_block_kernel[
             # Scalar head plus the partial vector at the causal boundary.
             var jh = tid
             while jh < min(head, allowed):
-                var x = in_ptr[base + jh].cast[DType.float32]() * scale
+                var x = (
+                    in_ptr[unsafe_offset=base + jh].cast[DType.float32]()
+                    * scale
+                )
                 var nm = max(m_t, x)
                 s_t = s_t * exp(m_t - nm) + exp(x - nm)
                 m_t = nm
                 jh += threads
             var jt = head + n_vec_a * V + tid
             while jt < allowed:
-                var x = in_ptr[base + jt].cast[DType.float32]() * scale
+                var x = (
+                    in_ptr[unsafe_offset=base + jt].cast[DType.float32]()
+                    * scale
+                )
                 var nm = max(m_t, x)
                 s_t = s_t * exp(m_t - nm) + exp(x - nm)
                 m_t = nm
@@ -524,7 +535,9 @@ def _softmax_rows_block_kernel[
         else:
             var j = tid
             while j < allowed:
-                var x = in_ptr[base + j].cast[DType.float32]() * scale
+                var x = (
+                    in_ptr[unsafe_offset=base + j].cast[DType.float32]() * scale
+                )
                 var nm = max(m_t, x)
                 s_t = s_t * exp(m_t - nm) + exp(x - nm)
                 m_t = nm
@@ -547,9 +560,12 @@ def _softmax_rows_block_kernel[
             while jh < head:
                 var y = Scalar[dtype](0)
                 if jh < allowed:
-                    var x = in_ptr[base + jh].cast[DType.float32]() * scale
+                    var x = (
+                        in_ptr[unsafe_offset=base + jh].cast[DType.float32]()
+                        * scale
+                    )
                     y = (exp(x - block_m) * inv).cast[dtype]()
-                out_ptr[base + jh] = y
+                out_ptr[unsafe_offset=base + jh] = y
                 jh += threads
             var v = tid
             while v < n_vec_c:
@@ -557,9 +573,9 @@ def _softmax_rows_block_kernel[
                 var y = SIMD[dtype, V](0)
                 if j0 < allowed:
                     var x = (
-                        in_ptr.load[width=V, alignment=16](base + j0).cast[
-                            DType.float32
-                        ]()
+                        in_ptr.unsafe_load[width=V, alignment=16](
+                            base + j0
+                        ).cast[DType.float32]()
                         * scale
                     )
                     var e = exp(x - block_m) * inv
@@ -568,25 +584,32 @@ def _softmax_rows_block_kernel[
                             if j0 + li >= allowed:
                                 e[li] = 0
                     y = e.cast[dtype]()
-                out_ptr.store[width=V, alignment=16](base + j0, y)
+                out_ptr.unsafe_store[width=V, alignment=16](base + j0, y)
                 v += threads
             var jt = head + n_vec_c * V + tid
             while jt < cols:
                 var y = Scalar[dtype](0)
                 if jt < allowed:
-                    var x = in_ptr[base + jt].cast[DType.float32]() * scale
+                    var x = (
+                        in_ptr[unsafe_offset=base + jt].cast[DType.float32]()
+                        * scale
+                    )
                     y = (exp(x - block_m) * inv).cast[dtype]()
-                out_ptr[base + jt] = y
+                out_ptr[unsafe_offset=base + jt] = y
                 jt += threads
         else:
             var j = tid
             while j < allowed:
-                var x = in_ptr[base + j].cast[DType.float32]() * scale
-                out_ptr[base + j] = (exp(x - block_m) * inv).cast[dtype]()
+                var x = (
+                    in_ptr[unsafe_offset=base + j].cast[DType.float32]() * scale
+                )
+                out_ptr[unsafe_offset=base + j] = (exp(x - block_m) * inv).cast[
+                    dtype
+                ]()
                 j += threads
             var jz = allowed + tid
             while jz < cols:
-                out_ptr[base + jz] = Scalar[dtype](0)
+                out_ptr[unsafe_offset=base + jz] = Scalar[dtype](0)
                 jz += threads
 
         row += Int(grid_dim.x)
@@ -596,8 +619,8 @@ def _softmax_rows_block_kernel[
 def _softmax_rows_apple[
     dtype: DType
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutUntrackedOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], MutUntrackedOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutUntrackedOrigin],
+    in_ptr: Pointer[Scalar[dtype], MutUntrackedOrigin],
     rows: Int,
     cols: Int,
     scale: Float32,
@@ -608,7 +631,7 @@ def _softmax_rows_apple[
     """Regime dispatch for the Apple-GPU row-softmax kernels."""
     comptime V = 16 // size_of[dtype]()
     var mout = out_ptr.as_unsafe_any_origin()
-    var min_ = in_ptr.as_unsafe_any_origin().as_immutable()
+    var min_ = in_ptr.as_unsafe_any_origin().as_imm()
     var aligned = Int(out_ptr) % 16 == 0 and Int(in_ptr) % 16 == 0
     var warp_grid = min(
         (rows + _APPLE_SM_WARPS_PER_BLOCK - 1) // _APPLE_SM_WARPS_PER_BLOCK,
@@ -741,10 +764,10 @@ def _softmax_rows_apple[
 )
 @__name("softmax_rows_dropout_warp_f32")
 def _softmax_rows_dropout_warp_kernel(
-    probs_ptr: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    pdrop_ptr: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    mask_ptr: UnsafePointer[Scalar[DType.bool], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
+    probs_ptr: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    pdrop_ptr: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    mask_ptr: Pointer[Scalar[DType.bool], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
     rows_arg: Int64,
     cols_arg: Int64,
     scale: Float32,
@@ -779,7 +802,9 @@ def _softmax_rows_dropout_warp_kernel(
             var j0 = (lane + k * WARP_SIZE) * 4
             var x = SIMD[DType.float32, 4](min_finite[DType.float32]())
             if j0 < allowed:
-                var raw = in_ptr.load[width=4, alignment=16](base + j0) * scale
+                var raw = (
+                    in_ptr.unsafe_load[width=4, alignment=16](base + j0) * scale
+                )
                 if j0 + 4 > allowed:
                     comptime for li in range(4):
                         if j0 + li < allowed:
@@ -808,20 +833,20 @@ def _softmax_rows_dropout_warp_kernel(
             var v = lane + k * WARP_SIZE
             if v < n_vec:
                 var y = vals[k] * inv
-                probs_ptr.store[width=4, alignment=16](base + v * 4, y)
+                probs_ptr.unsafe_store[width=4, alignment=16](base + v * 4, y)
                 var rnd = _philox4x32_10(
                     base_offset + UInt64(base // 4 + v), seed
                 )
                 var keep_bits = (
                     rnd.cast[DType.uint64]() - SIMD[DType.uint64, 4](threshold)
                 ) >> 63
-                pdrop_ptr.store[width=4, alignment=16](
+                pdrop_ptr.unsafe_store[width=4, alignment=16](
                     base + v * 4,
                     y * keep_bits.cast[DType.float32]() * keep_scale,
                 )
-                mask_ptr.bitcast[Scalar[DType.uint8]]().store[alignment=4](
-                    base + v * 4, keep_bits.cast[DType.uint8]()
-                )
+                mask_ptr.unsafe_bitcast[Scalar[DType.uint8]]().unsafe_store[
+                    alignment=4
+                ](base + v * 4, keep_bits.cast[DType.uint8]())
         row += row_stride
 
 
@@ -926,9 +951,7 @@ def enqueue_softmax_rows_dropout_f32(
             _make_ptr[DType.float32](probs_addr).as_unsafe_any_origin(),
             _make_ptr[DType.float32](pdrop_addr).as_unsafe_any_origin(),
             _make_ptr[DType.bool](mask_addr).as_unsafe_any_origin(),
-            _make_ptr[DType.float32](in_addr)
-            .as_unsafe_any_origin()
-            .as_immutable(),
+            _make_ptr[DType.float32](in_addr).as_unsafe_any_origin().as_imm(),
             Int64(rows),
             Int64(cols),
             scale,
@@ -955,8 +978,8 @@ comptime _SM_VECTOR_BYTES = 16
 def _softmax_warp_rows[
     dtype: DType, causal: Bool, VEC: Int
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     rows: Int,
     cols: Int,
     scale: Float32,
@@ -994,7 +1017,9 @@ def _softmax_warp_rows[
         var col = lane * VEC
         while col < vec_limit:
             var x = (
-                in_ptr.load[width=VEC, alignment=ALIGN](base + col).cast[F32]()
+                in_ptr.unsafe_load[width=VEC, alignment=ALIGN](base + col).cast[
+                    F32
+                ]()
                 * scale
             )
             var new_max = max(run_max, x)
@@ -1006,7 +1031,7 @@ def _softmax_warp_rows[
         var tail_max = Float32.MIN_FINITE
         var tail_sum = Float32(0.0)
         if tail < limit:
-            tail_max = in_ptr[base + tail].cast[F32]() * scale
+            tail_max = in_ptr[unsafe_offset=base + tail].cast[F32]() * scale
             tail_sum = 1.0
 
         # Lane-local then warp-wide combination of the (max, sum) pairs.
@@ -1022,25 +1047,31 @@ def _softmax_warp_rows[
         col = lane * VEC
         while col < vec_limit:
             var x = (
-                in_ptr.load[width=VEC, alignment=ALIGN](base + col).cast[F32]()
+                in_ptr.unsafe_load[width=VEC, alignment=ALIGN](base + col).cast[
+                    F32
+                ]()
                 * scale
             )
-            out_ptr.store[width=VEC, alignment=ALIGN](
+            out_ptr.unsafe_store[width=VEC, alignment=ALIGN](
                 base + col, (exp(x - row_max) * inv).cast[dtype]()
             )
             col += WARP_SIZE * VEC
         if tail < limit:
-            out_ptr[base + tail] = (
-                exp(in_ptr[base + tail].cast[F32]() * scale - row_max) * inv
+            out_ptr[unsafe_offset=base + tail] = (
+                exp(
+                    in_ptr[unsafe_offset=base + tail].cast[F32]() * scale
+                    - row_max
+                )
+                * inv
             ).cast[dtype]()
 
         comptime if causal:
             var zero_head = min(cols, ceildiv(limit, VEC) * VEC)
             if limit + lane < zero_head:
-                out_ptr[base + limit + lane] = Scalar[dtype](0)
+                out_ptr[unsafe_offset=base + limit + lane] = Scalar[dtype](0)
             col = zero_head + lane * VEC
             while col + VEC <= cols:
-                out_ptr.store[width=VEC, alignment=ALIGN](
+                out_ptr.unsafe_store[width=VEC, alignment=ALIGN](
                     base + col, SIMD[dtype, VEC](Scalar[dtype](0))
                 )
                 col += WARP_SIZE * VEC
@@ -1053,8 +1084,8 @@ def _softmax_warp_rows[
 def _softmax_warp_kernel[
     dtype: DType, causal: Bool, VEC: Int
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     rows_arg: Int64,
     cols_arg: Int64,
     scale: Float32,
@@ -1074,8 +1105,8 @@ def _softmax_warp_kernel[
 def _enqueue_softmax_warp[
     dtype: DType, causal: Bool, VEC: Int
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     rows: Int,
     cols: Int,
     scale: Float32,
@@ -1127,19 +1158,28 @@ def _softmax_rows[
                 allowed = min(cols, r % q_len + 1)
             var m = Float32.MIN
             for j in range(allowed):
-                var x = in_ptr[base + j].cast[DType.float32]() * scale
+                var x = (
+                    in_ptr[unsafe_offset=base + j].cast[DType.float32]() * scale
+                )
                 if x > m:
                     m = x
             var denom = Float32(0)
             for j in range(allowed):
-                var x = in_ptr[base + j].cast[DType.float32]() * scale
+                var x = (
+                    in_ptr[unsafe_offset=base + j].cast[DType.float32]() * scale
+                )
                 denom += exp(x - m)
             for j in range(cols):
                 if j < allowed:
-                    var x = in_ptr[base + j].cast[DType.float32]() * scale
-                    out_ptr[base + j] = (exp(x - m) / denom).cast[dtype]()
+                    var x = (
+                        in_ptr[unsafe_offset=base + j].cast[DType.float32]()
+                        * scale
+                    )
+                    out_ptr[unsafe_offset=base + j] = (exp(x - m) / denom).cast[
+                        dtype
+                    ]()
                 else:
-                    out_ptr[base + j] = Scalar[dtype](0)
+                    out_ptr[unsafe_offset=base + j] = Scalar[dtype](0)
 
         _parallel_for[func](rows, ctx)
     else:
@@ -1164,7 +1204,7 @@ def _softmax_rows[
                 if wide_ok:
                     _enqueue_softmax_warp[dtype, True, WIDE](
                         out_ptr.as_unsafe_any_origin(),
-                        in_ptr.as_unsafe_any_origin().as_immutable(),
+                        in_ptr.as_unsafe_any_origin().as_imm(),
                         rows,
                         cols,
                         scale,
@@ -1174,7 +1214,7 @@ def _softmax_rows[
                 else:
                     _enqueue_softmax_warp[dtype, True, 1](
                         out_ptr.as_unsafe_any_origin(),
-                        in_ptr.as_unsafe_any_origin().as_immutable(),
+                        in_ptr.as_unsafe_any_origin().as_imm(),
                         rows,
                         cols,
                         scale,
@@ -1192,7 +1232,7 @@ def _softmax_rows[
                 var r = Int(coords[0].value())
                 var c = Int(coords[1].value())
                 var v = (
-                    in_ptr.load[width=_simd_width](r * cols + c).cast[
+                    in_ptr.unsafe_load[width=_simd_width](r * cols + c).cast[
                         DType.float32
                     ]()
                     * scale
@@ -1200,8 +1240,7 @@ def _softmax_rows[
                 if causal != 0:
                     var allowed = min(cols, r % q_len + 1)
 
-                    @parameter
-                    for lane in range(_simd_width):
+                    comptime for lane in range(_simd_width):
                         if c + lane >= allowed:
                             v[lane] = min_or_neg_inf[DType.float32]()
                 # Known trade-off: for float16 input with scale > 1 this
@@ -1290,10 +1329,10 @@ def _attn_decode_kernel[
     MAX_HD: Int = ATTN_MAX_HD,
     RED_STAGES: Int = 8,
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    q_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    k_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    v_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    q_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    k_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    v_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     kv_len_arg: Int64,
     head_dim_arg: Int64,
     scale: Float32,
@@ -1351,7 +1390,9 @@ def _attn_decode_kernel[
     ]()
 
     for d in range(tid, head_dim, THREADS):
-        q_smem[d] = q_ptr[q_base + d].cast[DType.float32]()
+        q_smem[unsafe_offset=d] = q_ptr[unsafe_offset=q_base + d].cast[
+            DType.float32
+        ]()
     barrier()
 
     var m = Float32.MIN
@@ -1359,46 +1400,46 @@ def _attn_decode_kernel[
         var krow = k_base + j * k_s_stride
         var acc = Float32(0)
         for d in range(0, head_dim, 4):
-            var k4 = k_ptr.load[width=4, alignment=vec_align](krow + d).cast[
-                DType.float32
-            ]()
-            var q4 = q_smem.load[width=4, alignment=16](d)
+            var k4 = k_ptr.unsafe_load[width=4, alignment=vec_align](
+                krow + d
+            ).cast[DType.float32]()
+            var q4 = q_smem.unsafe_load[width=4, alignment=16](d)
             acc += (q4 * k4).reduce_add()
         var s = acc * scale
-        s_smem[j] = s
+        s_smem[unsafe_offset=j] = s
         if s > m:
             m = s
-    red[tid] = m
+    red[unsafe_offset=tid] = m
     barrier()
     var stride = THREADS // 2
     for _ in range(RED_STAGES):
         if tid < stride:
-            if red[tid + stride] > red[tid]:
-                red[tid] = red[tid + stride]
+            if red[unsafe_offset=tid + stride] > red[unsafe_offset=tid]:
+                red[unsafe_offset=tid] = red[unsafe_offset=tid + stride]
         barrier()
         stride //= 2
     if tid == 0:
-        bcast[0] = red[0]
+        bcast[unsafe_offset=0] = red[unsafe_offset=0]
     barrier()
-    m = bcast[0]
+    m = bcast[unsafe_offset=0]
 
     var s = Float32(0)
     for j in range(tid, kv_len, THREADS):
-        var e = exp(s_smem[j] - m)
-        s_smem[j] = e
+        var e = exp(s_smem[unsafe_offset=j] - m)
+        s_smem[unsafe_offset=j] = e
         s += e
-    red[tid] = s
+    red[unsafe_offset=tid] = s
     barrier()
     stride = THREADS // 2
     for _ in range(RED_STAGES):
         if tid < stride:
-            red[tid] += red[tid + stride]
+            red[unsafe_offset=tid] += red[unsafe_offset=tid + stride]
         barrier()
         stride //= 2
     if tid == 0:
-        bcast[1] = red[0]
+        bcast[unsafe_offset=1] = red[unsafe_offset=0]
     barrier()
-    var inv_denom = 1.0 / bcast[1]
+    var inv_denom = 1.0 / bcast[unsafe_offset=1]
 
     # GPT-2's D=64 matches an AMD wavefront. Partition the V reduction over
     # all four wavefronts so the bandwidth-heavy pass uses the whole block,
@@ -1412,31 +1453,35 @@ def _attn_decode_kernel[
             var acc = Float32(0)
             for j in range(wave, kv_len, 4):
                 acc += (
-                    s_smem[j]
-                    * v_ptr[v_base + j * v_s_stride + lane].cast[
+                    s_smem[unsafe_offset=j]
+                    * v_ptr[unsafe_offset=v_base + j * v_s_stride + lane].cast[
                         DType.float32
                     ]()
                 )
-            red[tid] = acc
+            red[unsafe_offset=tid] = acc
             barrier()
             if wave == 0:
                 acc = (
-                    red[lane]
-                    + red[64 + lane]
-                    + red[128 + lane]
-                    + red[192 + lane]
+                    red[unsafe_offset=lane]
+                    + red[unsafe_offset=64 + lane]
+                    + red[unsafe_offset=128 + lane]
+                    + red[unsafe_offset=192 + lane]
                 )
-                out_ptr[out_base + lane] = (acc * inv_denom).cast[dtype]()
+                out_ptr[unsafe_offset=out_base + lane] = (acc * inv_denom).cast[
+                    dtype
+                ]()
             return
 
     for d in range(tid, head_dim, THREADS):
         var acc = Float32(0)
         for j in range(kv_len):
             acc += (
-                s_smem[j]
-                * v_ptr[v_base + j * v_s_stride + d].cast[DType.float32]()
+                s_smem[unsafe_offset=j]
+                * v_ptr[unsafe_offset=v_base + j * v_s_stride + d].cast[
+                    DType.float32
+                ]()
             )
-        out_ptr[out_base + d] = (acc * inv_denom).cast[dtype]()
+        out_ptr[unsafe_offset=out_base + d] = (acc * inv_denom).cast[dtype]()
 
 
 @always_inline
@@ -1492,35 +1537,39 @@ def _attn_decode_cpu[
             var dot = Float32(0)
             for d in range(head_dim):
                 dot += (
-                    q_ptr[q_base + d].cast[DType.float32]()
-                    * k_ptr[krow + d].cast[DType.float32]()
+                    q_ptr[unsafe_offset=q_base + d].cast[DType.float32]()
+                    * k_ptr[unsafe_offset=krow + d].cast[DType.float32]()
                 )
             var s = dot * scale
             if s > m:
                 m = s
 
-        var acc_out = alloc[Float32](head_dim)
+        var acc_out = unsafe_alloc[Float32](head_dim)
         for d in range(head_dim):
-            acc_out[d] = Float32(0)
+            acc_out[unsafe_offset=d] = Float32(0)
         var denom = Float32(0)
         for j in range(kv_len):
             var krow = k_base + j * k_s_stride
             var dot = Float32(0)
             for d in range(head_dim):
                 dot += (
-                    q_ptr[q_base + d].cast[DType.float32]()
-                    * k_ptr[krow + d].cast[DType.float32]()
+                    q_ptr[unsafe_offset=q_base + d].cast[DType.float32]()
+                    * k_ptr[unsafe_offset=krow + d].cast[DType.float32]()
                 )
             var s = dot * scale
             var p = exp(s - m)
             denom += p
             var vrow = v_base + j * v_s_stride
             for d in range(head_dim):
-                acc_out[d] += p * v_ptr[vrow + d].cast[DType.float32]()
+                acc_out[unsafe_offset=d] += (
+                    p * v_ptr[unsafe_offset=vrow + d].cast[DType.float32]()
+                )
 
         for d in range(head_dim):
-            out_ptr[out_base + d] = (acc_out[d] / denom).cast[dtype]()
-        acc_out.free()
+            out_ptr[unsafe_offset=out_base + d] = (
+                acc_out[unsafe_offset=d] / denom
+            ).cast[dtype]()
+        acc_out.unsafe_free()
 
     # CPU-only launch: `func` uses a host `alloc()`/`free()` for its per-row
     # scratch, and `_parallel_for` would also compile a `target="gpu"`
@@ -1596,15 +1645,9 @@ def _attn_decode[
                     1,
                     APPLE_ATTN_THREADS,
                     _make_ptr[dtype](out_addr).as_unsafe_any_origin(),
-                    _make_ptr[dtype](q_addr)
-                    .as_unsafe_any_origin()
-                    .as_immutable(),
-                    _make_ptr[dtype](k_addr)
-                    .as_unsafe_any_origin()
-                    .as_immutable(),
-                    _make_ptr[dtype](v_addr)
-                    .as_unsafe_any_origin()
-                    .as_immutable(),
+                    _make_ptr[dtype](q_addr).as_unsafe_any_origin().as_imm(),
+                    _make_ptr[dtype](k_addr).as_unsafe_any_origin().as_imm(),
+                    _make_ptr[dtype](v_addr).as_unsafe_any_origin().as_imm(),
                     Int64(kv_len),
                     Int64(head_dim),
                     scale,
@@ -1627,9 +1670,9 @@ def _attn_decode[
             1,
             ATTN_THREADS,
             _make_ptr[dtype](out_addr).as_unsafe_any_origin(),
-            _make_ptr[dtype](q_addr).as_unsafe_any_origin().as_immutable(),
-            _make_ptr[dtype](k_addr).as_unsafe_any_origin().as_immutable(),
-            _make_ptr[dtype](v_addr).as_unsafe_any_origin().as_immutable(),
+            _make_ptr[dtype](q_addr).as_unsafe_any_origin().as_imm(),
+            _make_ptr[dtype](k_addr).as_unsafe_any_origin().as_imm(),
+            _make_ptr[dtype](v_addr).as_unsafe_any_origin().as_imm(),
             Int64(kv_len),
             Int64(head_dim),
             scale,
@@ -1699,12 +1742,12 @@ def _max_pool2d[
                 var iw = ow * stride_w - pad_w + fw * dil_w
                 if iw < 0 or iw >= in_w:
                     continue
-                var v = in_ptr[in_base + ih * in_w + iw]
+                var v = in_ptr[unsafe_offset=in_base + ih * in_w + iw]
                 if v > best:
                     best = v
                     best_idx = ih * in_w + iw
-        out_ptr[i] = best
-        idx_ptr[i] = Int64(best_idx)
+        out_ptr[unsafe_offset=i] = best
+        idx_ptr[unsafe_offset=i] = Int64(best_idx)
 
     _parallel_for[func](planes * out_h * out_w, ctx)
 
@@ -1790,8 +1833,10 @@ def _gather0[
     @__copy_capture(out_ptr, weight_ptr, indices_ptr)
     def func[width: Int, alignment: Int = 1](idx: Coord):
         var i = Int(idx[0].value())
-        var row = Int(indices_ptr[i // row_len])
-        out_ptr[i] = weight_ptr[row * row_len + i % row_len]
+        var row = Int(indices_ptr[unsafe_offset=i // row_len])
+        out_ptr[unsafe_offset=i] = weight_ptr[
+            unsafe_offset=row * row_len + i % row_len
+        ]
 
     _parallel_for[func](num_indices * row_len, ctx)
 
@@ -1990,8 +2035,8 @@ def _cumsum_rows_portable[
         var base = r * cols
         var total = Scalar[acc](0)
         for j in range(cols):
-            total += in_ptr[base + j].cast[acc]()
-            out_ptr[base + j] = total.cast[dtype]()
+            total += in_ptr[unsafe_offset=base + j].cast[acc]()
+            out_ptr[unsafe_offset=base + j] = total.cast[dtype]()
 
     _parallel_for[func](rows, ctx)
 
@@ -2021,8 +2066,8 @@ def _cumsum_cols_portable[
         var i = 0
         while i < rows:
             var addr = i * cols + c
-            total += in_ptr[addr].cast[acc]()
-            out_ptr[addr] = total.cast[dtype]()
+            total += in_ptr[unsafe_offset=addr].cast[acc]()
+            out_ptr[unsafe_offset=addr] = total.cast[dtype]()
             i += 1
 
     _parallel_for[func](cols, ctx)
@@ -2044,9 +2089,7 @@ def _cumsum_inner_into[
     if ctx.api() == "cuda":
         comptime if has_accelerator():
             var gout = _make_ptr[dtype](out_addr).as_unsafe_any_origin()
-            var gin = (
-                _make_ptr[dtype](in_addr).as_unsafe_any_origin().as_immutable()
-            )
+            var gin = _make_ptr[dtype](in_addr).as_unsafe_any_origin().as_imm()
             # sm_count_floor: below this many independent lines, one block
             # per line cannot fill the device — see FILL_WAVES in
             # cumsum_kernels.mojo. Read at runtime (not the compile-time
@@ -2087,9 +2130,7 @@ def _cumsum_outer_into[
     if ctx.api() == "cuda":
         comptime if has_accelerator():
             var gout = _make_ptr[dtype](out_addr).as_unsafe_any_origin()
-            var gin = (
-                _make_ptr[dtype](in_addr).as_unsafe_any_origin().as_immutable()
-            )
+            var gin = _make_ptr[dtype](in_addr).as_unsafe_any_origin().as_imm()
             enqueue_cumsum_cols[dtype](ctx, gout, gin, rows, cols)
         else:
             raise Error("no GPU accelerator available at compile time")
@@ -2154,9 +2195,9 @@ def _avg_pool2d[
 
         if ih0 >= ih1 or iw0 >= iw1:
             # Window entirely in padding: torch leaves the output at 0.
-            out_ptr[i] = Scalar[dtype](0)
+            out_ptr[unsafe_offset=i] = Scalar[dtype](0)
         else:
-            var divide_factor = 0
+            var divide_factor: Int
             if divisor_override != 0:
                 divide_factor = divisor_override
             elif count_include_pad != 0:
@@ -2167,8 +2208,12 @@ def _avg_pool2d[
             for ih in range(ih0, ih1):
                 var row = in_base + ih * in_w
                 for iw in range(iw0, iw1):
-                    total += in_ptr[row + iw].cast[DType.float32]()
-            out_ptr[i] = (total / Float32(divide_factor)).cast[dtype]()
+                    total += in_ptr[unsafe_offset=row + iw].cast[
+                        DType.float32
+                    ]()
+            out_ptr[unsafe_offset=i] = (total / Float32(divide_factor)).cast[
+                dtype
+            ]()
 
     _parallel_for[func](planes * out_h * out_w, ctx)
 
@@ -2271,8 +2316,8 @@ def _adaptive_avg_pool2d[
         for ih in range(ih0, ih1):
             var row = in_base + ih * in_w
             for iw in range(iw0, iw1):
-                total += in_ptr[row + iw].cast[DType.float32]()
-        out_ptr[i] = (total / Float32(area)).cast[dtype]()
+                total += in_ptr[unsafe_offset=row + iw].cast[DType.float32]()
+        out_ptr[unsafe_offset=i] = (total / Float32(area)).cast[dtype]()
 
     _parallel_for[func](planes * out_h * out_w, ctx)
 
@@ -2353,21 +2398,25 @@ def _group_norm[
             var base = r * cols
             var total = Float32(0)
             for j in range(cols):
-                total += in_ptr[base + j].cast[DType.float32]()
+                total += in_ptr[unsafe_offset=base + j].cast[DType.float32]()
             var mean = total / Float32(cols)
             var var_sum = Float32(0)
             for j in range(cols):
-                var d = in_ptr[base + j].cast[DType.float32]() - mean
+                var d = (
+                    in_ptr[unsafe_offset=base + j].cast[DType.float32]() - mean
+                )
                 var_sum += d * d
             var rstd = 1.0 / ieee_sqrt(var_sum / Float32(cols) + eps)
             for j in range(cols):
                 var c = g * cpg + j // hxw
-                var x = in_ptr[base + j].cast[DType.float32]()
-                var gm = gamma_ptr[c].cast[DType.float32]()
-                var bt = beta_ptr[c].cast[DType.float32]()
-                out_ptr[base + j] = ((x - mean) * rstd * gm + bt).cast[dtype]()
-            mean_out_ptr[r] = mean
-            rstd_out_ptr[r] = rstd
+                var x = in_ptr[unsafe_offset=base + j].cast[DType.float32]()
+                var gm = gamma_ptr[unsafe_offset=c].cast[DType.float32]()
+                var bt = beta_ptr[unsafe_offset=c].cast[DType.float32]()
+                out_ptr[unsafe_offset=base + j] = (
+                    (x - mean) * rstd * gm + bt
+                ).cast[dtype]()
+            mean_out_ptr[unsafe_offset=r] = mean
+            rstd_out_ptr[unsafe_offset=r] = rstd
 
         _parallel_for[func](rows, ctx)
     else:
@@ -2510,12 +2559,12 @@ def _upsample_bilinear2d[
 
         var r0 = in_base + ih0 * in_w
         var r1 = in_base + ih1 * in_w
-        var v00 = in_ptr[r0 + iw0].cast[DType.float32]()
-        var v01 = in_ptr[r0 + iw1].cast[DType.float32]()
-        var v10 = in_ptr[r1 + iw0].cast[DType.float32]()
-        var v11 = in_ptr[r1 + iw1].cast[DType.float32]()
+        var v00 = in_ptr[unsafe_offset=r0 + iw0].cast[DType.float32]()
+        var v01 = in_ptr[unsafe_offset=r0 + iw1].cast[DType.float32]()
+        var v10 = in_ptr[unsafe_offset=r1 + iw0].cast[DType.float32]()
+        var v11 = in_ptr[unsafe_offset=r1 + iw1].cast[DType.float32]()
         var res = h0 * (w0 * v00 + w1 * v01) + h1 * (w0 * v10 + w1 * v11)
-        out_ptr[i] = res.cast[dtype]()
+        out_ptr[unsafe_offset=i] = res.cast[dtype]()
 
     _parallel_for[func](planes * out_h * out_w, ctx)
 
@@ -2576,18 +2625,18 @@ def _batch_norm_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         _batch_norm_go(
-            args[0],
-            args[1],
-            args[2],
-            args[3],
-            args[4],
-            args[5],
-            args[6],
-            args[7],
-            args[8],
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+            args[unsafe_offset=6],
+            args[unsafe_offset=7],
+            args[unsafe_offset=8],
         )
     except e:
         return _spec_unsupported(e)
@@ -2599,18 +2648,18 @@ def _layer_norm_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         _layer_norm_go(
-            args[0],
-            args[1],
-            args[2],
-            args[3],
-            args[4],
-            args[5],
-            args[6],
-            args[7],
-            args[8],
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+            args[unsafe_offset=6],
+            args[unsafe_offset=7],
+            args[unsafe_offset=8],
         )
     except e:
         return _spec_unsupported(e)
@@ -2622,18 +2671,18 @@ def _softmax_rows_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         _softmax_rows_go(
-            args[0],
-            args[1],
-            args[2],
-            args[3],
-            args[4],
-            args[5],
-            args[6],
-            args[7],
-            args[8],
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+            args[unsafe_offset=6],
+            args[unsafe_offset=7],
+            args[unsafe_offset=8],
         )
     except e:
         return _spec_unsupported(e)
@@ -2645,24 +2694,24 @@ def _softmax_rows_dropout_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         _softmax_rows_dropout_go(
-            args[0],
-            args[1],
-            args[2],
-            args[3],
-            args[4],
-            args[5],
-            args[6],
-            args[7],
-            args[8],
-            args[9],
-            args[10],
-            args[11],
-            args[12],
-            args[13],
-            args[14],
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+            args[unsafe_offset=6],
+            args[unsafe_offset=7],
+            args[unsafe_offset=8],
+            args[unsafe_offset=9],
+            args[unsafe_offset=10],
+            args[unsafe_offset=11],
+            args[unsafe_offset=12],
+            args[unsafe_offset=13],
+            args[unsafe_offset=14],
         )
     except e:
         return _spec_unsupported(e)
@@ -2674,9 +2723,16 @@ def _max_pool2d_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
-        _max_pool2d_go(args[0], args[1], args[2], args[3], args[4], args[5])
+        _max_pool2d_go(
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+        )
     except e:
         return _spec_unsupported(e)
     return _raw_ret_none()
@@ -2687,9 +2743,15 @@ def _avg_pool2d_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
-        _avg_pool2d_go(args[0], args[1], args[2], args[3], args[4])
+        _avg_pool2d_go(
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+        )
     except e:
         return _spec_unsupported(e)
     return _raw_ret_none()
@@ -2700,9 +2762,15 @@ def _adaptive_avg_pool2d_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
-        _adaptive_avg_pool2d_go(args[0], args[1], args[2], args[3], args[4])
+        _adaptive_avg_pool2d_go(
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+        )
     except e:
         return _spec_unsupported(e)
     return _raw_ret_none()
@@ -2713,18 +2781,18 @@ def _group_norm_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         _group_norm_go(
-            args[0],
-            args[1],
-            args[2],
-            args[3],
-            args[4],
-            args[5],
-            args[6],
-            args[7],
-            args[8],
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+            args[unsafe_offset=6],
+            args[unsafe_offset=7],
+            args[unsafe_offset=8],
         )
     except e:
         return _spec_unsupported(e)
@@ -2736,9 +2804,15 @@ def _upsample_bilinear2d_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
-        _upsample_bilinear2d_go(args[0], args[1], args[2], args[3], args[4])
+        _upsample_bilinear2d_go(
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+        )
     except e:
         return _spec_unsupported(e)
     return _raw_ret_none()
@@ -2749,17 +2823,17 @@ def _gather0_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         _gather0_go(
-            args[0],
-            args[1],
-            args[2],
-            args[3],
-            args[4],
-            args[5],
-            args[6],
-            args[7],
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+            args[unsafe_offset=6],
+            args[unsafe_offset=7],
         )
     except e:
         return _spec_unsupported(e)
@@ -2771,9 +2845,14 @@ def _all_bool_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
-        _all_bool_go(args[0], args[1], args[2], args[3])
+        _all_bool_go(
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+        )
     except e:
         return _spec_unsupported(e)
     return _raw_ret_none()
@@ -2784,9 +2863,14 @@ def _any_bool_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
-        _any_bool_go(args[0], args[1], args[2], args[3])
+        _any_bool_go(
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+        )
     except e:
         return _spec_unsupported(e)
     return _raw_ret_none()

--- a/torch_mojo_backend/eager_kernels/normalization_backward_ops/normalization_backward_dx.mojo
+++ b/torch_mojo_backend/eager_kernels/normalization_backward_ops/normalization_backward_dx.mojo
@@ -73,12 +73,12 @@ comptime _MAX_WARP_CHUNKS = 6 if has_apple_gpu_accelerator() else 8
 def _dx_warp_rows[
     chunks: Int
 ](
-    dx: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    input: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    mean: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    rstd: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    weight: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    dx: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    input: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    mean: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    rstd: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    weight: Pointer[Scalar[DType.float32], MutAnyOrigin],
     rows: Int,
     cols: Int,
     vec_cols: Int,
@@ -125,8 +125,8 @@ def _dx_warp_rows[
     var inv_cols = 1.0 / Float32(cols)
 
     while row < rows:
-        var m = mean[row]
-        var r = rstd[row]
+        var m = mean[unsafe_offset=row]
+        var r = rstd[unsafe_offset=row]
         var scale = r * inv_cols
         var base = row * cols
         var acc_q = SIMD[DType.float32, _VEC](0.0)
@@ -149,16 +149,18 @@ def _dx_warp_rows[
                         alignment=16,
                     ](input, offset)
                 else:
-                    q = grad_output.load[width=_VEC, alignment=16](offset)
-                    x = input.load[width=_VEC, alignment=16](offset)
+                    q = grad_output.unsafe_load[width=_VEC, alignment=16](
+                        offset
+                    )
+                    x = input.unsafe_load[width=_VEC, alignment=16](offset)
                 if has_weight != 0:
-                    q *= weight.load[width=_VEC, alignment=16](c * _VEC)
+                    q *= weight.unsafe_load[width=_VEC, alignment=16](c * _VEC)
                 var xh = (x - m) * r
-                q_shared.store[width=_VEC, alignment=16](
+                q_shared.unsafe_store[width=_VEC, alignment=16](
                     warp_slot + u * WARP_SIZE * _VEC, q
                 )
                 comptime if stage_xh:
-                    xh_shared.store[width=_VEC, alignment=16](
+                    xh_shared.unsafe_store[width=_VEC, alignment=16](
                         warp_slot + u * WARP_SIZE * _VEC, xh
                     )
                 acc_q += q
@@ -172,29 +174,31 @@ def _dx_warp_rows[
             var c = lane + u * WARP_SIZE
             if c < vec_cols:
                 var offset = base + c * _VEC
-                var q = q_shared.load[width=_VEC, alignment=16](
+                var q = q_shared.unsafe_load[width=_VEC, alignment=16](
                     warp_slot + u * WARP_SIZE * _VEC
                 )
                 var xh: SIMD[DType.float32, _VEC]
                 comptime if stage_xh:
-                    xh = xh_shared.load[width=_VEC, alignment=16](
+                    xh = xh_shared.unsafe_load[width=_VEC, alignment=16](
                         warp_slot + u * WARP_SIZE * _VEC
                     )
                 else:
-                    xh = (input.load[width=_VEC, alignment=16](offset) - m) * r
+                    xh = (
+                        input.unsafe_load[width=_VEC, alignment=16](offset) - m
+                    ) * r
                 var out = q.fma(r, xh.fma(-kc, -kb))
-                dx.store[width=_VEC, alignment=16](offset, out)
+                dx.unsafe_store[width=_VEC, alignment=16](offset, out)
         row += row_stride
 
 
 @__name("layer_norm_backward_dx_f32_c1")
 def _dx_c1(
-    dx: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    input: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    mean: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    rstd: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    weight: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    dx: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    input: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    mean: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    rstd: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    weight: Pointer[Scalar[DType.float32], MutAnyOrigin],
     rows_arg: Int64,
     cols_arg: Int64,
     vec_cols_arg: Int64,
@@ -222,12 +226,12 @@ def _dx_c1(
 
 @__name("layer_norm_backward_dx_f32_c2")
 def _dx_c2(
-    dx: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    input: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    mean: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    rstd: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    weight: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    dx: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    input: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    mean: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    rstd: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    weight: Pointer[Scalar[DType.float32], MutAnyOrigin],
     rows_arg: Int64,
     cols_arg: Int64,
     vec_cols_arg: Int64,
@@ -255,12 +259,12 @@ def _dx_c2(
 
 @__name("layer_norm_backward_dx_f32_c3")
 def _dx_c3(
-    dx: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    input: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    mean: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    rstd: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    weight: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    dx: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    input: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    mean: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    rstd: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    weight: Pointer[Scalar[DType.float32], MutAnyOrigin],
     rows_arg: Int64,
     cols_arg: Int64,
     vec_cols_arg: Int64,
@@ -288,12 +292,12 @@ def _dx_c3(
 
 @__name("layer_norm_backward_dx_f32_c4")
 def _dx_c4(
-    dx: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    input: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    mean: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    rstd: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    weight: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    dx: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    input: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    mean: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    rstd: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    weight: Pointer[Scalar[DType.float32], MutAnyOrigin],
     rows_arg: Int64,
     cols_arg: Int64,
     vec_cols_arg: Int64,
@@ -321,12 +325,12 @@ def _dx_c4(
 
 @__name("layer_norm_backward_dx_f32_c6")
 def _dx_c6(
-    dx: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    input: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    mean: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    rstd: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    weight: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    dx: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    input: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    mean: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    rstd: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    weight: Pointer[Scalar[DType.float32], MutAnyOrigin],
     rows_arg: Int64,
     cols_arg: Int64,
     vec_cols_arg: Int64,
@@ -354,12 +358,12 @@ def _dx_c6(
 
 @__name("layer_norm_backward_dx_f32_c8")
 def _dx_c8(
-    dx: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    input: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    mean: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    rstd: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    weight: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    dx: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    input: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    mean: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    rstd: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    weight: Pointer[Scalar[DType.float32], MutAnyOrigin],
     rows_arg: Int64,
     cols_arg: Int64,
     vec_cols_arg: Int64,
@@ -387,12 +391,12 @@ def _dx_c8(
 
 @__name("layer_norm_backward_dx_f32_generic")
 def _dx_generic(
-    dx: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    input: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    mean: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    rstd: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    weight: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    dx: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    input: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    mean: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    rstd: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    weight: Pointer[Scalar[DType.float32], MutAnyOrigin],
     rows_arg: Int64,
     cols_arg: Int64,
     has_weight_arg: Int64,
@@ -406,17 +410,17 @@ def _dx_generic(
     var row = Int(block_idx.x)
     var row_stride = Int(grid_dim.x)
     while row < rows:
-        var m = mean[row]
-        var r = rstd[row]
+        var m = mean[unsafe_offset=row]
+        var r = rstd[unsafe_offset=row]
         var base = row * cols
         var acc_q = Float32(0.0)
         var acc_qx = Float32(0.0)
         var col = tid
         while col < cols:
-            var q = grad_output[base + col]
+            var q = grad_output[unsafe_offset=base + col]
             if has_weight != 0:
-                q *= weight[col]
-            var xh = (input[base + col] - m) * r
+                q *= weight[unsafe_offset=col]
+            var xh = (input[unsafe_offset=base + col] - m) * r
             acc_q += q
             acc_qx += q * xh
             col += _GEN_BLOCK
@@ -434,22 +438,22 @@ def _dx_generic(
         )
         col = tid
         while col < cols:
-            var q = grad_output[base + col]
+            var q = grad_output[unsafe_offset=base + col]
             if has_weight != 0:
-                q *= weight[col]
-            var xh = (input[base + col] - m) * r
-            dx[base + col] = q * r - kb - xh * kc
+                q *= weight[unsafe_offset=col]
+            var xh = (input[unsafe_offset=base + col] - m) * r
+            dx[unsafe_offset=base + col] = q * r - kb - xh * kc
             col += _GEN_BLOCK
         row += row_stride
 
 
 def enqueue_layer_norm_backward_dx_f32(
-    dx: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    input: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    mean: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    rstd: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    weight: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    dx: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    input: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    mean: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    rstd: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    weight: Pointer[Scalar[DType.float32], MutAnyOrigin],
     rows: Int,
     cols: Int,
     has_weight: Bool,

--- a/torch_mojo_backend/eager_kernels/normalization_backward_ops/normalization_backward_ops.mojo
+++ b/torch_mojo_backend/eager_kernels/normalization_backward_ops/normalization_backward_ops.mojo
@@ -29,14 +29,14 @@ from variant_gates import _op_on, _register_call
 
 
 def enqueue_layer_norm_backward_f32(
-    grad_input: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_weight: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_bias: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    input: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    mean: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    rstd: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    weight: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_input: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_weight: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_bias: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    input: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    mean: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    rstd: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    weight: Pointer[Scalar[DType.float32], MutAnyOrigin],
     rows: Int,
     cols: Int,
     output_mask: Int,
@@ -139,21 +139,21 @@ def _layer_norm_backward_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         _layer_norm_backward_go(
-            args[0],
-            args[1],
-            args[2],
-            args[3],
-            args[4],
-            args[5],
-            args[6],
-            args[7],
-            args[8],
-            args[9],
-            args[10],
-            args[11],
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+            args[unsafe_offset=6],
+            args[unsafe_offset=7],
+            args[unsafe_offset=8],
+            args[unsafe_offset=9],
+            args[unsafe_offset=10],
+            args[unsafe_offset=11],
         )
     except e:
         return _spec_unsupported(e)

--- a/torch_mojo_backend/eager_kernels/normalization_backward_ops/normalization_backward_params.mojo
+++ b/torch_mojo_backend/eager_kernels/normalization_backward_ops/normalization_backward_params.mojo
@@ -40,12 +40,12 @@ comptime _FINAL_TY = 32
 
 @__name("layer_norm_backward_params_direct")
 def _direct_kernel(
-    grad_weight: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_bias: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    input: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    mean: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    rstd: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_weight: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_bias: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    input: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    mean: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    rstd: Pointer[Scalar[DType.float32], MutAnyOrigin],
     rows_arg: Int64,
     cols_arg: Int64,
     want_weight_arg: Int64,
@@ -65,28 +65,30 @@ def _direct_kernel(
     var index = col
     if want_weight != 0:
         for row in range(rows):
-            var dy = grad_output[index]
-            var xhat = (input[index] - mean[row]) * rstd[row]
+            var dy = grad_output[unsafe_offset=index]
+            var xhat = (
+                input[unsafe_offset=index] - mean[unsafe_offset=row]
+            ) * rstd[unsafe_offset=row]
             weight_acc += dy * xhat
             bias_acc += dy
             index += cols
-        grad_weight[col] = weight_acc
+        grad_weight[unsafe_offset=col] = weight_acc
     else:
         for _ in range(rows):
-            bias_acc += grad_output[index]
+            bias_acc += grad_output[unsafe_offset=index]
             index += cols
     if want_bias != 0:
-        grad_bias[col] = bias_acc
+        grad_bias[unsafe_offset=col] = bias_acc
 
 
 @__name("layer_norm_backward_params_partial")
 def _partial_kernel(
-    partial_weight: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    partial_bias: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    input: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    mean: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    rstd: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    partial_weight: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    partial_bias: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    input: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    mean: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    rstd: Pointer[Scalar[DType.float32], MutAnyOrigin],
     rows_arg: Int64,
     cols_arg: Int64,
     chunk_rows_arg: Int64,
@@ -113,39 +115,45 @@ def _partial_kernel(
     if want_weight != 0:
         while row + _UNROLL <= row_end:
             comptime for k in range(_UNROLL):
-                var dy = grad_output[index + k * cols]
-                var x = input[index + k * cols]
-                weight_acc += dy * ((x - mean[row + k]) * rstd[row + k])
+                var dy = grad_output[unsafe_offset=index + k * cols]
+                var x = input[unsafe_offset=index + k * cols]
+                weight_acc += dy * (
+                    (x - mean[unsafe_offset=row + k])
+                    * rstd[unsafe_offset=row + k]
+                )
                 bias_acc += dy
             row += _UNROLL
             index += _UNROLL * cols
         while row < row_end:
-            var dy = grad_output[index]
-            weight_acc += dy * ((input[index] - mean[row]) * rstd[row])
+            var dy = grad_output[unsafe_offset=index]
+            weight_acc += dy * (
+                (input[unsafe_offset=index] - mean[unsafe_offset=row])
+                * rstd[unsafe_offset=row]
+            )
             bias_acc += dy
             row += 1
             index += cols
-        partial_weight[chunk * cols + col] = weight_acc
+        partial_weight[unsafe_offset=chunk * cols + col] = weight_acc
     else:
         while row + _UNROLL <= row_end:
             comptime for k in range(_UNROLL):
-                bias_acc += grad_output[index + k * cols]
+                bias_acc += grad_output[unsafe_offset=index + k * cols]
             row += _UNROLL
             index += _UNROLL * cols
         while row < row_end:
-            bias_acc += grad_output[index]
+            bias_acc += grad_output[unsafe_offset=index]
             row += 1
             index += cols
     if want_bias != 0:
-        partial_bias[chunk * cols + col] = bias_acc
+        partial_bias[unsafe_offset=chunk * cols + col] = bias_acc
 
 
 @__name("layer_norm_backward_params_final")
 def _final_kernel(
-    grad_weight: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_bias: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    partial_weight: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    partial_bias: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_weight: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_bias: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    partial_weight: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    partial_bias: Pointer[Scalar[DType.float32], MutAnyOrigin],
     cols_arg: Int64,
     num_chunks_arg: Int64,
     want_weight_arg: Int64,
@@ -178,33 +186,33 @@ def _final_kernel(
         while chunk < num_chunks:
             var index = chunk * cols + col
             if want_weight != 0:
-                weight_acc += partial_weight[index]
+                weight_acc += partial_weight[unsafe_offset=index]
             if want_bias != 0:
-                bias_acc += partial_bias[index]
+                bias_acc += partial_bias[unsafe_offset=index]
             chunk += _FINAL_TY
-    shared_weight[ty * _FINAL_TX + tx] = weight_acc
-    shared_bias[ty * _FINAL_TX + tx] = bias_acc
+    shared_weight[unsafe_offset=ty * _FINAL_TX + tx] = weight_acc
+    shared_bias[unsafe_offset=ty * _FINAL_TX + tx] = bias_acc
     barrier()
     if ty == 0 and col < cols:
         if want_weight != 0:
             var total = Float32(0.0)
             comptime for lane in range(_FINAL_TY):
-                total += shared_weight[lane * _FINAL_TX + tx]
-            grad_weight[col] = total
+                total += shared_weight[unsafe_offset=lane * _FINAL_TX + tx]
+            grad_weight[unsafe_offset=col] = total
         if want_bias != 0:
             var total = Float32(0.0)
             comptime for lane in range(_FINAL_TY):
-                total += shared_bias[lane * _FINAL_TX + tx]
-            grad_bias[col] = total
+                total += shared_bias[unsafe_offset=lane * _FINAL_TX + tx]
+            grad_bias[unsafe_offset=col] = total
 
 
 def enqueue_layer_norm_backward_params_f32(
-    grad_weight: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_bias: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    input: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    mean: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    rstd: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_weight: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_bias: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    input: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    mean: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    rstd: Pointer[Scalar[DType.float32], MutAnyOrigin],
     rows: Int,
     cols: Int,
     want_weight: Bool,
@@ -275,7 +283,9 @@ def enqueue_layer_norm_backward_params_f32(
         var scratch = ctx.enqueue_create_buffer[DType.float32](lanes * lane)
         var scratch_base = scratch.unsafe_ptr().as_unsafe_any_origin()
         var partial_weight = scratch_base
-        var partial_bias = scratch_base + (lane if want_weight else 0)
+        var partial_bias = scratch_base.unsafe_offset(
+            lane if want_weight else 0
+        )
 
         _enqueue_cached[_partial_kernel](
             ctx,

--- a/torch_mojo_backend/eager_kernels/normalization_forward_ops/batch_norm_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/normalization_forward_ops/batch_norm_kernels.mojo
@@ -98,10 +98,10 @@ comptime BN_MIN_RUNS_PER_SPLIT = 2
 def _bn_scale_shift[
     pdtype: DType, sdtype: DType, //, from_invstd: Bool
 ](
-    mean_ptr: UnsafePointer[Scalar[sdtype], ImmutAnyOrigin],
-    var_ptr: UnsafePointer[Scalar[sdtype], ImmutAnyOrigin],
-    gamma_ptr: UnsafePointer[Scalar[pdtype], ImmutAnyOrigin],
-    beta_ptr: UnsafePointer[Scalar[pdtype], ImmutAnyOrigin],
+    mean_ptr: Pointer[Scalar[sdtype], ImmutAnyOrigin],
+    var_ptr: Pointer[Scalar[sdtype], ImmutAnyOrigin],
+    gamma_ptr: Pointer[Scalar[pdtype], ImmutAnyOrigin],
+    beta_ptr: Pointer[Scalar[pdtype], ImmutAnyOrigin],
     c: Int,
     eps: Float32,
     has_weight: Bool,
@@ -116,16 +116,18 @@ def _bn_scale_shift[
     `1/sqrt(var + eps)` (the training route, whose merge inverted it) rather
     than the variance (the inference route, reading a running variance).
     """
-    mean = mean_ptr[c].cast[DType.float32]()
+    mean = mean_ptr[unsafe_offset=c].cast[DType.float32]()
     comptime if from_invstd:
-        scale = var_ptr[c].cast[DType.float32]()
+        scale = var_ptr[unsafe_offset=c].cast[DType.float32]()
     else:
-        scale = 1.0 / ieee_sqrt(var_ptr[c].cast[DType.float32]() + eps)
+        scale = 1.0 / ieee_sqrt(
+            var_ptr[unsafe_offset=c].cast[DType.float32]() + eps
+        )
     if has_weight:
-        scale *= gamma_ptr[c].cast[DType.float32]()
+        scale *= gamma_ptr[unsafe_offset=c].cast[DType.float32]()
     shift = Float32(0)
     if has_bias:
-        shift = beta_ptr[c].cast[DType.float32]()
+        shift = beta_ptr[unsafe_offset=c].cast[DType.float32]()
 
 
 @__llvm_metadata(
@@ -139,14 +141,14 @@ def _bn_elementwise_kernel[
     V: Int,
     from_invstd: Bool,
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    mean_ptr: UnsafePointer[Scalar[sdtype], ImmutAnyOrigin],
-    var_ptr: UnsafePointer[Scalar[sdtype], ImmutAnyOrigin],
-    gamma_ptr: UnsafePointer[Scalar[pdtype], ImmutAnyOrigin],
-    beta_ptr: UnsafePointer[Scalar[pdtype], ImmutAnyOrigin],
-    save_mean_ptr: UnsafePointer[Scalar[sdtype], MutAnyOrigin],
-    save_invstd_ptr: UnsafePointer[Scalar[sdtype], MutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    mean_ptr: Pointer[Scalar[sdtype], ImmutAnyOrigin],
+    var_ptr: Pointer[Scalar[sdtype], ImmutAnyOrigin],
+    gamma_ptr: Pointer[Scalar[pdtype], ImmutAnyOrigin],
+    beta_ptr: Pointer[Scalar[pdtype], ImmutAnyOrigin],
+    save_mean_ptr: Pointer[Scalar[sdtype], MutAnyOrigin],
+    save_invstd_ptr: Pointer[Scalar[sdtype], MutAnyOrigin],
     eps: Float32,
     inner_slots_arg: Int64,
     channels_arg: Int64,
@@ -188,9 +190,12 @@ def _bn_elementwise_kernel[
         if slot == 0:
             var c = Int(block_idx.y)
             while c < channels:
-                save_mean_ptr[c] = mean_ptr[c]
-                save_invstd_ptr[c] = (
-                    1.0 / ieee_sqrt(var_ptr[c].cast[DType.float32]() + eps)
+                save_mean_ptr[unsafe_offset=c] = mean_ptr[unsafe_offset=c]
+                save_invstd_ptr[unsafe_offset=c] = (
+                    1.0
+                    / ieee_sqrt(
+                        var_ptr[unsafe_offset=c].cast[DType.float32]() + eps
+                    )
                 ).cast[sdtype]()
                 c += plane_stride
     while plane < planes:
@@ -211,8 +216,10 @@ def _bn_elementwise_kernel[
             shift,
         )
         var at = plane * inner_slots * V + slot * V
-        var x = in_ptr.load[width=V, alignment=align](at).cast[DType.float32]()
-        out_ptr.store[width=V, alignment=align](
+        var x = in_ptr.unsafe_load[width=V, alignment=align](at).cast[
+            DType.float32
+        ]()
+        out_ptr.unsafe_store[width=V, alignment=align](
             at, ((x - mean) * scale + shift).cast[dtype]()
         )
         plane += plane_stride
@@ -228,7 +235,7 @@ def _bn_run_base(n: Int, c: Int, channels: Int, hxw: Int) -> Int:
 def _bn_scan_shard[
     dtype: DType, //
 ](
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     c: Int,
     channels: Int,
     hxw: Int,
@@ -296,10 +303,10 @@ def _bn_scan_shard[
 def _bn_finalize[
     sdtype: DType, //
 ](
-    mean_out_ptr: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    invstd_out_ptr: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    run_mean_ptr: UnsafePointer[Scalar[sdtype], MutAnyOrigin],
-    run_var_ptr: UnsafePointer[Scalar[sdtype], MutAnyOrigin],
+    mean_out_ptr: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    invstd_out_ptr: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    run_mean_ptr: Pointer[Scalar[sdtype], MutAnyOrigin],
+    run_var_ptr: Pointer[Scalar[sdtype], MutAnyOrigin],
     c: Int,
     mean: Float32,
     m2_in: Float32,
@@ -315,18 +322,20 @@ def _bn_finalize[
         m2 = Float32(0)
     var nf = Float32(count)
     var biased = m2 / nf
-    mean_out_ptr[c] = mean
-    invstd_out_ptr[c] = 1.0 / ieee_sqrt(biased + eps)
+    mean_out_ptr[unsafe_offset=c] = mean
+    invstd_out_ptr[unsafe_offset=c] = 1.0 / ieee_sqrt(biased + eps)
     if has_running:
         var keep = 1.0 - momentum
-        run_mean_ptr[c] = (
-            keep * run_mean_ptr[c].cast[DType.float32]() + momentum * mean
+        run_mean_ptr[unsafe_offset=c] = (
+            keep * run_mean_ptr[unsafe_offset=c].cast[DType.float32]()
+            + momentum * mean
         ).cast[sdtype]()
         var unbiased = biased
         if count > 1:
             unbiased = m2 / (nf - 1.0)
-        run_var_ptr[c] = (
-            keep * run_var_ptr[c].cast[DType.float32]() + momentum * unbiased
+        run_var_ptr[unsafe_offset=c] = (
+            keep * run_var_ptr[unsafe_offset=c].cast[DType.float32]()
+            + momentum * unbiased
         ).cast[sdtype]()
 
 
@@ -337,11 +346,11 @@ def _bn_finalize[
 def _bn_moments_fused_kernel[
     dtype: DType, sdtype: DType
 ](
-    mean_out_ptr: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    invstd_out_ptr: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    run_mean_ptr: UnsafePointer[Scalar[sdtype], MutAnyOrigin],
-    run_var_ptr: UnsafePointer[Scalar[sdtype], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    mean_out_ptr: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    invstd_out_ptr: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    run_mean_ptr: Pointer[Scalar[sdtype], MutAnyOrigin],
+    run_var_ptr: Pointer[Scalar[sdtype], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     channels_arg: Int64,
     runs_arg: Int64,
     hxw_arg: Int64,
@@ -361,7 +370,7 @@ def _bn_moments_fused_kernel[
     var c = Int(block_idx.x)
     var tid = Int(thread_idx.x)
     var count = runs * hxw
-    var shift = in_ptr[c * hxw].cast[DType.float32]()
+    var shift = in_ptr[unsafe_offset=c * hxw].cast[DType.float32]()
 
     var s = Float32(0)
     var q = Float32(0)
@@ -400,8 +409,8 @@ def _bn_moments_fused_kernel[
 def _bn_moments_kernel[
     dtype: DType
 ](
-    ws_ptr: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    ws_ptr: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     channels_arg: Int64,
     runs_arg: Int64,
     hxw_arg: Int64,
@@ -436,13 +445,13 @@ def _bn_moments_kernel[
     # Assumed mean: the channel's very first element, identical in every shard
     # of this channel so the partial moment pairs merge by addition. On a
     # re-pass it is the accurate mean instead, which leaves no cancellation.
-    var shift = in_ptr[c * hxw].cast[DType.float32]()
+    var shift = in_ptr[unsafe_offset=c * hxw].cast[DType.float32]()
     if repass:
         # Uniform across the block: this early exit cannot desynchronize the
         # barriers inside `block.sum` below.
-        if ws_ptr[meta + channels + c] == 0:
+        if ws_ptr[unsafe_offset=meta + channels + c] == 0:
             return
-        shift = ws_ptr[meta + c]
+        shift = ws_ptr[unsafe_offset=meta + c]
 
     var chunk_n = ceildiv(runs, splits_n)
     var n0 = (k // splits_j) * chunk_n
@@ -461,8 +470,8 @@ def _bn_moments_kernel[
     var bs = block.sum[block_size=BN_THREADS](s_tot)
     var bq = block.sum[block_size=BN_THREADS](q_tot)
     if tid == 0:
-        ws_ptr[k * channels + c] = bs
-        ws_ptr[(splits + k) * channels + c] = bq
+        ws_ptr[unsafe_offset=k * channels + c] = bs
+        ws_ptr[unsafe_offset=(splits + k) * channels + c] = bq
 
 
 @__llvm_metadata(
@@ -472,12 +481,12 @@ def _bn_moments_kernel[
 def _bn_merge_kernel[
     dtype: DType, sdtype: DType
 ](
-    mean_out_ptr: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    invstd_out_ptr: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    run_mean_ptr: UnsafePointer[Scalar[sdtype], MutAnyOrigin],
-    run_var_ptr: UnsafePointer[Scalar[sdtype], MutAnyOrigin],
-    ws_ptr: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    mean_out_ptr: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    invstd_out_ptr: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    run_mean_ptr: Pointer[Scalar[sdtype], MutAnyOrigin],
+    run_var_ptr: Pointer[Scalar[sdtype], MutAnyOrigin],
+    ws_ptr: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     channels_arg: Int64,
     splits_arg: Int64,
     count_arg: Int64,
@@ -512,20 +521,20 @@ def _bn_merge_kernel[
     var s = Float32(0)
     var q = Float32(0)
     for k in range(splits):
-        s += ws_ptr[k * channels + c]
-        q += ws_ptr[(splits + k) * channels + c]
+        s += ws_ptr[unsafe_offset=k * channels + c]
+        q += ws_ptr[unsafe_offset=(splits + k) * channels + c]
     var nf = Float32(count)
-    var shift = in_ptr[c * Int(hxw_arg)].cast[DType.float32]()
-    if finalize and ws_ptr[meta + channels + c] != 0:
-        shift = ws_ptr[meta + c]
+    var shift = in_ptr[unsafe_offset=c * Int(hxw_arg)].cast[DType.float32]()
+    if finalize and ws_ptr[unsafe_offset=meta + channels + c] != 0:
+        shift = ws_ptr[unsafe_offset=meta + c]
     var mean = shift + s / nf
 
     if not finalize:
         if _moment_cancels(s, q, count):
-            ws_ptr[meta + c] = mean
-            ws_ptr[meta + channels + c] = Float32(1)
+            ws_ptr[unsafe_offset=meta + c] = mean
+            ws_ptr[unsafe_offset=meta + channels + c] = Float32(1)
         else:
-            ws_ptr[meta + channels + c] = Float32(0)
+            ws_ptr[unsafe_offset=meta + channels + c] = Float32(0)
         return
 
     _bn_finalize(
@@ -586,7 +595,7 @@ def enqueue_batch_norm_stats[
     elements, plus the ATen running-statistics update."""
     comptime if not has_accelerator():
         raise Error("no GPU accelerator available at compile time")
-    var in_ptr = _make_ptr[dtype](in_addr).as_unsafe_any_origin().as_immutable()
+    var in_ptr = _make_ptr[dtype](in_addr).as_unsafe_any_origin().as_imm()
     var mean_ptr = _make_ptr[DType.float32](mean_addr).as_unsafe_any_origin()
     var invstd_ptr = _make_ptr[DType.float32](
         invstd_addr
@@ -706,19 +715,13 @@ def enqueue_batch_norm_elementwise[
     comptime if not has_accelerator():
         raise Error("no GPU accelerator available at compile time")
     var out_ptr = _make_ptr[dtype](out_addr).as_unsafe_any_origin()
-    var in_ptr = _make_ptr[dtype](in_addr).as_unsafe_any_origin().as_immutable()
-    var mean_ptr = (
-        _make_ptr[sdtype](mean_addr).as_unsafe_any_origin().as_immutable()
-    )
-    var var_ptr = (
-        _make_ptr[sdtype](var_addr).as_unsafe_any_origin().as_immutable()
-    )
+    var in_ptr = _make_ptr[dtype](in_addr).as_unsafe_any_origin().as_imm()
+    var mean_ptr = _make_ptr[sdtype](mean_addr).as_unsafe_any_origin().as_imm()
+    var var_ptr = _make_ptr[sdtype](var_addr).as_unsafe_any_origin().as_imm()
     var gamma_ptr = (
-        _make_ptr[pdtype](gamma_addr).as_unsafe_any_origin().as_immutable()
+        _make_ptr[pdtype](gamma_addr).as_unsafe_any_origin().as_imm()
     )
-    var beta_ptr = (
-        _make_ptr[pdtype](beta_addr).as_unsafe_any_origin().as_immutable()
-    )
+    var beta_ptr = _make_ptr[pdtype](beta_addr).as_unsafe_any_origin().as_imm()
     var save_mean_ptr = _make_ptr[sdtype](save_mean_addr).as_unsafe_any_origin()
     var save_invstd_ptr = _make_ptr[sdtype](
         save_invstd_addr

--- a/torch_mojo_backend/eager_kernels/normalization_forward_ops/normalization_forward_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/normalization_forward_ops/normalization_forward_kernels.mojo
@@ -118,7 +118,7 @@ def _affine_vec_ok[
 def _affine_vec[
     dtype: DType, //, V: Int, affine: Int
 ](
-    p: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    p: Pointer[Scalar[dtype], ImmutAnyOrigin],
     col0: Int,
     gbase: Int,
     hxw: Int,
@@ -133,19 +133,21 @@ def _affine_vec[
     var out = SIMD[DType.float32, V](0)
     comptime if affine == AFFINE_COL:
         if vec_ok:
-            return p.load[width=V, alignment=V * size_of[dtype]()](col0).cast[
-                DType.float32
-            ]()
-        return p.load[width=V, alignment=size_of[dtype]()](col0).cast[
+            return p.unsafe_load[width=V, alignment=V * size_of[dtype]()](
+                col0
+            ).cast[DType.float32]()
+        return p.unsafe_load[width=V, alignment=size_of[dtype]()](col0).cast[
             DType.float32
         ]()
     else:
         if vec_ok:
             return SIMD[DType.float32, V](
-                p[gbase + col0 // hxw].cast[DType.float32]()
+                p[unsafe_offset=gbase + col0 // hxw].cast[DType.float32]()
             )
         comptime for k in range(V):
-            out[k] = p[gbase + (col0 + k) // hxw].cast[DType.float32]()
+            out[k] = p[unsafe_offset=gbase + (col0 + k) // hxw].cast[
+                DType.float32
+            ]()
         return out
 
 
@@ -153,16 +155,16 @@ def _affine_vec[
 def _affine_scalar[
     dtype: DType, //, affine: Int
 ](
-    p: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    p: Pointer[Scalar[dtype], ImmutAnyOrigin],
     col: Int,
     gbase: Int,
     hxw: Int,
 ) -> Float32:
     """One column's affine coefficient (the scalar head/tail of a row)."""
     comptime if affine == AFFINE_COL:
-        return p[col].cast[DType.float32]()
+        return p[unsafe_offset=col].cast[DType.float32]()
     else:
-        return p[gbase + col // hxw].cast[DType.float32]()
+        return p[unsafe_offset=gbase + col // hxw].cast[DType.float32]()
 
 
 @always_inline
@@ -181,12 +183,12 @@ def _affine_base[affine: Int](row: Int, group: Int, cpg: Int) -> Int:
 def _norm_rows_cached_kernel[
     dtype: DType, threads: Int, vecs: Int, affine: Int, ragged: Bool
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    mean_ptr: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    rstd_ptr: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    gamma_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    beta_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    mean_ptr: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    rstd_ptr: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    gamma_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    beta_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     rows_arg: Int64,
     cols_arg: Int64,
     eps: Float32,
@@ -254,16 +256,16 @@ def _norm_rows_cached_kernel[
         comptime for u in range(vecs):
             var v = tid + u * threads
             if v < n_vec:
-                x[u] = in_ptr.load[width=V, alignment=vec_align](
+                x[u] = in_ptr.unsafe_load[width=V, alignment=vec_align](
                     vec_start + v * V
                 )
                 acc += x[u].cast[DType.float32]()
         var thread_sum = acc.reduce_add()
         if has_head:
-            xh = in_ptr[base + head_col].cast[DType.float32]()
+            xh = in_ptr[unsafe_offset=base + head_col].cast[DType.float32]()
             thread_sum += xh
         if has_tail:
-            xt = in_ptr[base + tail_col].cast[DType.float32]()
+            xt = in_ptr[unsafe_offset=base + tail_col].cast[DType.float32]()
             thread_sum += xt
         # Row-uniform: every lane of the block reaches both reductions.
         var mean = block.sum[block_size=threads](thread_sum) * inv_cols
@@ -286,8 +288,8 @@ def _norm_rows_cached_kernel[
         if variance != variance:
             mean = variance
         if tid == 0:
-            mean_ptr[row] = mean
-            rstd_ptr[row] = rstd
+            mean_ptr[unsafe_offset=row] = mean
+            rstd_ptr[unsafe_offset=row] = rstd
 
         var gbase = _affine_base[affine](row, group, cpg)
         comptime for u in range(vecs):
@@ -306,7 +308,7 @@ def _norm_rows_cached_kernel[
                     r += _affine_vec[V=V, affine=affine](
                         beta_ptr, col0, gbase, hxw, aff_vec_ok
                     )
-                out_ptr.store[width=V, alignment=vec_align](
+                out_ptr.unsafe_store[width=V, alignment=vec_align](
                     vec_start + v * V, r.cast[dtype]()
                 )
         if has_head:
@@ -346,10 +348,10 @@ def _norm_rows_cached_kernel[
 def _norm_write_element[
     dtype: DType, //, affine: Int
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    gamma_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    beta_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    gamma_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    beta_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     base: Int,
     col: Int,
     gbase: Int,
@@ -360,12 +362,14 @@ def _norm_write_element[
     has_bias: Bool,
 ):
     """Normalize and store one element of a row (scalar head/tail)."""
-    var r = (in_ptr[base + col].cast[DType.float32]() - mean) * rstd
+    var r = (
+        in_ptr[unsafe_offset=base + col].cast[DType.float32]() - mean
+    ) * rstd
     if has_weight:
         r *= _affine_scalar[affine=affine](gamma_ptr, col, gbase, hxw)
     if has_bias:
         r += _affine_scalar[affine=affine](beta_ptr, col, gbase, hxw)
-    out_ptr[base + col] = r.cast[dtype]()
+    out_ptr[unsafe_offset=base + col] = r.cast[dtype]()
 
 
 @__llvm_metadata(
@@ -375,12 +379,12 @@ def _norm_write_element[
 def _norm_rows_moments_kernel[
     dtype: DType, affine: Int
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    mean_ptr: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    rstd_ptr: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    gamma_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    beta_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    mean_ptr: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    rstd_ptr: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    gamma_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    beta_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     rows_arg: Int64,
     cols_arg: Int64,
     eps: Float32,
@@ -432,7 +436,7 @@ def _norm_rows_moments_kernel[
         _moment_partition[dtype](
             Int(in_ptr), base, cols, head, n_vec, vec_start, tail_start
         )
-        var shift = in_ptr[base].cast[DType.float32]()
+        var shift = in_ptr[unsafe_offset=base].cast[DType.float32]()
         var s = Float32(0)
         var q = Float32(0)
         _moments_scan_contig[V=V, vec_align=vec_align, threads=NORM_THREADS](
@@ -484,8 +488,8 @@ def _norm_rows_moments_kernel[
         if variance != variance:
             mean = variance
         if tid == 0:
-            mean_ptr[row] = mean
-            rstd_ptr[row] = rstd
+            mean_ptr[unsafe_offset=row] = mean
+            rstd_ptr[unsafe_offset=row] = rstd
 
         var gbase = _affine_base[affine](row, group, cpg)
         if vec_io:
@@ -511,7 +515,7 @@ def _norm_rows_moments_kernel[
                 var off = vec_start + v * V
                 var col0 = off - base
                 var r = (
-                    in_ptr.load[width=V, alignment=vec_align](off).cast[
+                    in_ptr.unsafe_load[width=V, alignment=vec_align](off).cast[
                         DType.float32
                     ]()
                     - mean
@@ -531,7 +535,7 @@ def _norm_rows_moments_kernel[
                     r += _affine_vec[V=V, affine=affine](
                         beta_ptr, col0, gbase, hxw, aff_vec_ok
                     )
-                out_ptr.store[width=V, alignment=vec_align](
+                out_ptr.unsafe_store[width=V, alignment=vec_align](
                     off, r.cast[dtype]()
                 )
                 v += NORM_THREADS
@@ -577,12 +581,12 @@ def _norm_rows_moments_kernel[
 def _ln_fwd_warp_rows[
     dtype: DType, //, chunks: Int
 ](
-    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    mean: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    rstd: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    input: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    weight: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    bias: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    output: Pointer[Scalar[dtype], MutAnyOrigin],
+    mean: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    rstd: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    input: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    weight: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    bias: Pointer[Scalar[dtype], ImmutAnyOrigin],
     rows: Int,
     cols: Int,
     vec_cols: Int,
@@ -606,7 +610,9 @@ def _ln_fwd_warp_rows[
         comptime for u in range(chunks):
             var c = lane + u * WARP_SIZE
             if c < vec_cols:
-                x[u] = input.load[width=V, alignment=vec_align](base + c * V)
+                x[u] = input.unsafe_load[width=V, alignment=vec_align](
+                    base + c * V
+                )
                 acc += x[u].cast[DType.float32]()
         # Row condition is warp-uniform: every lane reaches the shuffles.
         var row_mean = warp.sum(acc.reduce_add()) * inv_cols
@@ -623,21 +629,21 @@ def _ln_fwd_warp_rows[
         if variance != variance:
             row_mean = variance
         if lane == 0:
-            mean[row] = row_mean
-            rstd[row] = row_rstd
+            mean[unsafe_offset=row] = row_mean
+            rstd[unsafe_offset=row] = row_rstd
         comptime for u in range(chunks):
             var c = lane + u * WARP_SIZE
             if c < vec_cols:
                 var result = (x[u].cast[DType.float32]() - row_mean) * row_rstd
                 if has_weight != 0:
-                    result *= weight.load[width=V, alignment=vec_align](
+                    result *= weight.unsafe_load[width=V, alignment=vec_align](
                         c * V
                     ).cast[DType.float32]()
                 if has_bias != 0:
-                    result += bias.load[width=V, alignment=vec_align](
+                    result += bias.unsafe_load[width=V, alignment=vec_align](
                         c * V
                     ).cast[DType.float32]()
-                output.store[width=V, alignment=vec_align](
+                output.unsafe_store[width=V, alignment=vec_align](
                     base + c * V, result.cast[dtype]()
                 )
         row += row_stride
@@ -647,12 +653,12 @@ def _ln_fwd_warp_rows[
 def _ln_fwd_warp_kernel[
     dtype: DType, chunks: Int
 ](
-    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    mean: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    rstd: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    input: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    weight: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    bias: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    output: Pointer[Scalar[dtype], MutAnyOrigin],
+    mean: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    rstd: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    input: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    weight: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    bias: Pointer[Scalar[dtype], ImmutAnyOrigin],
     rows_arg: Int64,
     cols_arg: Int64,
     vec_cols_arg: Int64,
@@ -682,12 +688,12 @@ def _ln_fwd_warp_kernel[
 def _enqueue_norm_cached[
     dtype: DType, threads: Int, vecs: Int, affine: Int, ragged: Bool
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    mean_ptr: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    rstd_ptr: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    gamma_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    beta_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    mean_ptr: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    rstd_ptr: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    gamma_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    beta_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     rows: Int,
     cols: Int,
     eps: Float32,
@@ -730,12 +736,12 @@ def _enqueue_norm_cached[
 def _enqueue_norm_warp[
     dtype: DType, chunks: Int
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    mean_ptr: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    rstd_ptr: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    gamma_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    beta_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    mean_ptr: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    rstd_ptr: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    gamma_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    beta_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     rows: Int,
     cols: Int,
     vec_cols: Int,
@@ -796,13 +802,9 @@ def enqueue_norm_rows[
     var out_ptr = _make_ptr[dtype](out_addr).as_unsafe_any_origin()
     var mean_ptr = _make_ptr[DType.float32](mean_addr).as_unsafe_any_origin()
     var rstd_ptr = _make_ptr[DType.float32](rstd_addr).as_unsafe_any_origin()
-    var in_ptr = _make_ptr[dtype](in_addr).as_unsafe_any_origin().as_immutable()
-    var gamma_ptr = (
-        _make_ptr[dtype](gamma_addr).as_unsafe_any_origin().as_immutable()
-    )
-    var beta_ptr = (
-        _make_ptr[dtype](beta_addr).as_unsafe_any_origin().as_immutable()
-    )
+    var in_ptr = _make_ptr[dtype](in_addr).as_unsafe_any_origin().as_imm()
+    var gamma_ptr = _make_ptr[dtype](gamma_addr).as_unsafe_any_origin().as_imm()
+    var beta_ptr = _make_ptr[dtype](beta_addr).as_unsafe_any_origin().as_imm()
     var hw = 1 if has_weight else 0
     var hb = 1 if has_bias else 0
 

--- a/torch_mojo_backend/eager_kernels/op_utils/__init__.mojo
+++ b/torch_mojo_backend/eager_kernels/op_utils/__init__.mojo
@@ -14,7 +14,8 @@ from std.gpu import block_dim, block_idx, grid_dim, thread_idx
 from max.gpu.host import DeviceAttribute, DeviceBuffer, DeviceContext
 from std.math import ceildiv, cos, floor, sin, sqrt, tan
 from std.math.polynomial import polynomial_evaluate
-from std.memory import OpaquePointer, alloc, bitcast, stack_allocation
+from std.memory import OpaquePointer, bitcast, stack_allocation
+from std.memory.alloc import unsafe_alloc
 from std.python import Python, PythonObject
 from std.python._cpython import PyObjectPtr, Py_ssize_t
 from std.sys import llvm_intrinsic
@@ -60,7 +61,7 @@ comptime FLOAT_DTYPES = [DType.float32, DType.float16, DType.bfloat16]
 # gfx942 assembly), and Apple uses `llvm.air.sqrt`.
 @always_inline
 def ieee_sqrt[
-    dtype: DType, width: SIMDSize, //
+    dtype: DType, width: SIMDLength, //
 ](x: SIMD[dtype, width]) -> SIMD[dtype, width]:
     """Elementwise square root that is correctly rounded on every backend.
 
@@ -106,7 +107,7 @@ def ieee_sqrt[
 # per-vendor accuracy claim.
 @always_inline
 def custom_tan[
-    dtype: DType, width: SIMDSize, //, *, exact: Bool = True
+    dtype: DType, width: SIMDLength, //, *, exact: Bool = True
 ](x: SIMD[dtype, width]) -> SIMD[dtype, width] where dtype.is_floating_point():
     """Elementwise tangent that keeps its relative accuracy on every backend.
 
@@ -314,7 +315,7 @@ def _fmod_narrow_float_exact_scalar(
 
 @always_inline
 def custom_remainder[
-    dtype: DType, width: SIMDSize, //
+    dtype: DType, width: SIMDLength, //
 ](a: SIMD[dtype, width], b: SIMD[dtype, width]) -> SIMD[dtype, width]:
     """Elementwise `a % b` with Python/torch semantics -- the result takes the
     DIVISOR's sign -- exact for every dtype.
@@ -396,19 +397,21 @@ def _enqueue_cached[
     var name = String(t"TMB_KERNEL_{key}_{ctx.id()}")
     comptime FuncT = type_of(ctx.compile_function[func]())
 
-    if global_ptr := _get_global_or_null(name):
-        var fptr = global_ptr.value().bitcast[FuncT]()
+    var global_ptr = _get_global_or_null(name)
+
+    if global_ptr:
+        var fptr = global_ptr.value().unsafe_bitcast[FuncT]()
         ctx.enqueue_function(
             fptr[], *args, grid_dim=(gx, gy, gz), block_dim=(threads,)
         )
         return
 
     var compiled = ctx.compile_function[func]()
-    var fptr = alloc[FuncT](1)
-    fptr.init_pointee_move(compiled^)
+    var fptr = unsafe_alloc[FuncT](1)
+    fptr.unsafe_write(compiled^)
     external_call["KGEN_CompilerRT_InsertGlobal", NoneType](
         StringSlice(name),
-        fptr.bitcast[NoneType](),
+        fptr.unsafe_bitcast[NoneType](),
     )
     ctx.enqueue_function(
         fptr[], *args, grid_dim=(gx, gy, gz), block_dim=(threads,)
@@ -435,8 +438,10 @@ def _enqueue_cached_2d[
     var name = String(t"TMB_KERNEL_2D_{key}_{ctx.id()}")
     comptime FuncT = type_of(ctx.compile_function[func]())
 
-    if global_ptr := _get_global_or_null(name):
-        var fptr = global_ptr.value().bitcast[FuncT]()
+    var global_ptr = _get_global_or_null(name)
+
+    if global_ptr:
+        var fptr = global_ptr.value().unsafe_bitcast[FuncT]()
         ctx.enqueue_function(
             fptr[],
             *args,
@@ -446,11 +451,11 @@ def _enqueue_cached_2d[
         return
 
     var compiled = ctx.compile_function[func]()
-    var fptr = alloc[FuncT](1)
-    fptr.init_pointee_move(compiled^)
+    var fptr = unsafe_alloc[FuncT](1)
+    fptr.unsafe_write(compiled^)
     external_call["KGEN_CompilerRT_InsertGlobal", NoneType](
         StringSlice(name),
-        fptr.bitcast[NoneType](),
+        fptr.unsafe_bitcast[NoneType](),
     )
     ctx.enqueue_function(
         fptr[],
@@ -565,7 +570,7 @@ def _device_attr_cached(
         var name = String(t"TMB_DEVATTR_{key}_{ctx.id()}")
         var cached = _get_global_or_null(name)
         if cached:
-            return cached.value().bitcast[Int]()[]
+            return cached.value().unsafe_bitcast[Int]()[]
         var value = fallback
         try:
             var queried = ctx.get_attribute(attr)
@@ -575,10 +580,10 @@ def _device_attr_cached(
             # A backend that does not answer this query caches the fallback
             # too, so it is asked exactly once rather than on every launch.
             value = fallback
-        var slot = alloc[Int](1)
-        slot.init_pointee_move(value)
+        var slot = unsafe_alloc[Int](1)
+        slot.unsafe_write(value)
         external_call["KGEN_CompilerRT_InsertGlobal", NoneType](
-            StringSlice(name), slot.bitcast[NoneType]()
+            StringSlice(name), slot.unsafe_bitcast[NoneType]()
         )
         return value
     except:
@@ -796,7 +801,7 @@ def _moment_partition[
 def _moments_scan_contig[
     dtype: DType, //, V: Int, vec_align: Int, threads: Int
 ](
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     start: Int,
     n: Int,
     head: Int,
@@ -824,9 +829,9 @@ def _moments_scan_contig[
     var v = tid
     while v < n_vec:
         var d = (
-            in_ptr.load[width=V, alignment=vec_align](vec_start + v * V).cast[
-                DType.float32
-            ]()
+            in_ptr.unsafe_load[width=V, alignment=vec_align](
+                vec_start + v * V
+            ).cast[DType.float32]()
             - shift
         )
         s_vec += d
@@ -837,13 +842,13 @@ def _moments_scan_contig[
 
     var jh = tid
     while jh < head:
-        var d = in_ptr[start + jh].cast[DType.float32]() - shift
+        var d = in_ptr[unsafe_offset=start + jh].cast[DType.float32]() - shift
         s_t += d
         q_t += d * d
         jh += threads
     var jt = tail_start + tid
     while jt < n:
-        var d = in_ptr[start + jt].cast[DType.float32]() - shift
+        var d = in_ptr[unsafe_offset=start + jt].cast[DType.float32]() - shift
         s_t += d
         q_t += d * d
         jt += threads
@@ -852,11 +857,9 @@ def _moments_scan_contig[
 @always_inline
 def _make_ptr[
     dtype: DType
-](addr: Int) -> UnsafePointer[Scalar[dtype], MutUntrackedOrigin]:
+](addr: Int) -> Pointer[Scalar[dtype], MutUntrackedOrigin]:
     """Create a typed pointer from a raw integer address."""
-    return UnsafePointer[Scalar[dtype], MutUntrackedOrigin](
-        unsafe_from_address=addr
-    )
+    return Pointer[Scalar[dtype], MutUntrackedOrigin](unsafe_from_address=addr)
 
 
 def _get_ctx(device_context_ptr: PythonObject) raises -> DeviceContext:
@@ -1100,7 +1103,7 @@ def _check_into(a: TensorSpec, dst: TensorSpec, expected_dtype: DType) raises:
 
 
 @always_inline
-def _spec_ptr(o: PyObjectPtr) -> UnsafePointer[TensorSpec, MutAnyOrigin]:
+def _spec_ptr(o: PyObjectPtr) -> Pointer[TensorSpec, MutAnyOrigin]:
     """The TensorSpec behind a borrowed spec argument — a pure pointer cast.
 
     Callers are internal and guarantee the type (never consults the type
@@ -1145,11 +1148,11 @@ def _spec_dispatcher2[
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         if nargs != 2:
             raise Error(what, " expects exactly 2 arguments")
-        go(args[0], args[1])
+        go(args[unsafe_offset=0], args[unsafe_offset=1])
         return _raw_ret_none()
     except e:
         return _spec_unsupported(e)
@@ -1163,11 +1166,11 @@ def _spec_dispatcher3[
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         if nargs != 3:
             raise Error(what, " expects exactly 3 arguments")
-        go(args[0], args[1], args[2])
+        go(args[unsafe_offset=0], args[unsafe_offset=1], args[unsafe_offset=2])
         return _raw_ret_none()
     except e:
         return _spec_unsupported(e)
@@ -1183,11 +1186,16 @@ def _spec_dispatcher4[
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         if nargs != 4:
             raise Error(what, " expects exactly 4 arguments")
-        go(args[0], args[1], args[2], args[3])
+        go(
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+        )
         return _raw_ret_none()
     except e:
         return _spec_unsupported(e)
@@ -1203,11 +1211,17 @@ def _spec_dispatcher5[
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         if nargs != 5:
             raise Error(what, " expects exactly 5 arguments")
-        go(args[0], args[1], args[2], args[3], args[4])
+        go(
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+        )
         return _raw_ret_none()
     except e:
         return _spec_unsupported(e)
@@ -1228,11 +1242,18 @@ def _spec_dispatcher6[
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         if nargs != 6:
             raise Error(what, " expects exactly 6 arguments")
-        go(args[0], args[1], args[2], args[3], args[4], args[5])
+        go(
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+        )
         return _raw_ret_none()
     except e:
         return _spec_unsupported(e)
@@ -1254,11 +1275,19 @@ def _spec_dispatcher7[
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         if nargs != 7:
             raise Error(what, " expects exactly 7 arguments")
-        go(args[0], args[1], args[2], args[3], args[4], args[5], args[6])
+        go(
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+            args[unsafe_offset=6],
+        )
         return _raw_ret_none()
     except e:
         return _spec_unsupported(e)
@@ -1281,19 +1310,19 @@ def _spec_dispatcher8[
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         if nargs != 8:
             raise Error(what, " expects exactly 8 arguments")
         go(
-            args[0],
-            args[1],
-            args[2],
-            args[3],
-            args[4],
-            args[5],
-            args[6],
-            args[7],
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+            args[unsafe_offset=6],
+            args[unsafe_offset=7],
         )
         return _raw_ret_none()
     except e:
@@ -1318,20 +1347,20 @@ def _spec_dispatcher9[
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         if nargs != 9:
             raise Error(what, " expects exactly 9 arguments")
         go(
-            args[0],
-            args[1],
-            args[2],
-            args[3],
-            args[4],
-            args[5],
-            args[6],
-            args[7],
-            args[8],
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+            args[unsafe_offset=6],
+            args[unsafe_offset=7],
+            args[unsafe_offset=8],
         )
         return _raw_ret_none()
     except e:
@@ -1357,21 +1386,21 @@ def _spec_dispatcher10[
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         if nargs != 10:
             raise Error(what, " expects exactly 10 arguments")
         go(
-            args[0],
-            args[1],
-            args[2],
-            args[3],
-            args[4],
-            args[5],
-            args[6],
-            args[7],
-            args[8],
-            args[9],
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+            args[unsafe_offset=6],
+            args[unsafe_offset=7],
+            args[unsafe_offset=8],
+            args[unsafe_offset=9],
         )
         return _raw_ret_none()
     except e:
@@ -1398,22 +1427,22 @@ def _spec_dispatcher11[
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         if nargs != 11:
             raise Error(what, " expects exactly 11 arguments")
         go(
-            args[0],
-            args[1],
-            args[2],
-            args[3],
-            args[4],
-            args[5],
-            args[6],
-            args[7],
-            args[8],
-            args[9],
-            args[10],
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+            args[unsafe_offset=6],
+            args[unsafe_offset=7],
+            args[unsafe_offset=8],
+            args[unsafe_offset=9],
+            args[unsafe_offset=10],
         )
         return _raw_ret_none()
     except e:
@@ -1441,23 +1470,23 @@ def _spec_dispatcher12[
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         if nargs != 12:
             raise Error(what, " expects exactly 12 arguments")
         go(
-            args[0],
-            args[1],
-            args[2],
-            args[3],
-            args[4],
-            args[5],
-            args[6],
-            args[7],
-            args[8],
-            args[9],
-            args[10],
-            args[11],
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+            args[unsafe_offset=6],
+            args[unsafe_offset=7],
+            args[unsafe_offset=8],
+            args[unsafe_offset=9],
+            args[unsafe_offset=10],
+            args[unsafe_offset=11],
         )
         return _raw_ret_none()
     except e:
@@ -1486,24 +1515,24 @@ def _spec_dispatcher13[
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         if nargs != 13:
             raise Error(what, " expects exactly 13 arguments")
         go(
-            args[0],
-            args[1],
-            args[2],
-            args[3],
-            args[4],
-            args[5],
-            args[6],
-            args[7],
-            args[8],
-            args[9],
-            args[10],
-            args[11],
-            args[12],
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+            args[unsafe_offset=6],
+            args[unsafe_offset=7],
+            args[unsafe_offset=8],
+            args[unsafe_offset=9],
+            args[unsafe_offset=10],
+            args[unsafe_offset=11],
+            args[unsafe_offset=12],
         )
         return _raw_ret_none()
     except e:
@@ -1534,26 +1563,26 @@ def _spec_dispatcher15[
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         if nargs != 15:
             raise Error(what, " expects exactly 15 arguments")
         go(
-            args[0],
-            args[1],
-            args[2],
-            args[3],
-            args[4],
-            args[5],
-            args[6],
-            args[7],
-            args[8],
-            args[9],
-            args[10],
-            args[11],
-            args[12],
-            args[13],
-            args[14],
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+            args[unsafe_offset=6],
+            args[unsafe_offset=7],
+            args[unsafe_offset=8],
+            args[unsafe_offset=9],
+            args[unsafe_offset=10],
+            args[unsafe_offset=11],
+            args[unsafe_offset=12],
+            args[unsafe_offset=13],
+            args[unsafe_offset=14],
         )
         return _raw_ret_none()
     except e:
@@ -1600,8 +1629,8 @@ def _flat_vec_unary_kernel[
     op: def[w: Int](SIMD[dtype, w]) thin -> SIMD[out_dtype, w],
     name: StaticString,
 ](
-    out_ptr: UnsafePointer[Scalar[out_dtype], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[out_dtype], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     total_arg: Int64,
 ):
     """One 16-byte load and one (possibly narrower) store per thread, plus a
@@ -1619,14 +1648,14 @@ def _flat_vec_unary_kernel[
     var c = tid
     while c < nvec:
         var i = c * VW
-        out_ptr.store[width=VW, alignment=out_align](
-            i, op[VW](in_ptr.load[width=VW, alignment=vec_align](i))
+        out_ptr.unsafe_store[width=VW, alignment=out_align](
+            i, op[VW](in_ptr.unsafe_load[width=VW, alignment=vec_align](i))
         )
         c += gstride
     var tail = total - nvec * VW
     if tid < tail:
         var i = nvec * VW + tid
-        out_ptr[i] = op[1](in_ptr[i])[0]
+        out_ptr[unsafe_offset=i] = op[1](in_ptr[unsafe_offset=i])[0]
 
 
 @always_inline
@@ -1663,7 +1692,7 @@ def _flat_vec_unary[
             1,
             GS_THREADS,
             _make_ptr[out_dtype](out_addr).as_unsafe_any_origin(),
-            _make_ptr[dtype](in_addr).as_unsafe_any_origin().as_immutable(),
+            _make_ptr[dtype](in_addr).as_unsafe_any_origin().as_imm(),
             Int64(total),
         )
         return True
@@ -1699,8 +1728,8 @@ def _parallel_for_dt[
 def _copy_strided_kernel[
     dtype: DType
 ](
-    dst_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    src_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    dst_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    src_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     shape: IndexList[MAX_RANK],
     dst_strides: IndexList[MAX_RANK],
     src_strides: IndexList[MAX_RANK],
@@ -1723,7 +1752,7 @@ def _copy_strided_kernel[
             src_off += coord * src_strides[d]
         dst_off += rest * dst_strides[0]
         src_off += rest * src_strides[0]
-        dst_ptr[dst_off] = src_ptr[src_off]
+        dst_ptr[unsafe_offset=dst_off] = src_ptr[unsafe_offset=src_off]
         i += gstride
 
 
@@ -1775,8 +1804,8 @@ def _t2dv_vec[dtype: DType]() -> Int:
 def _transpose2d_vec_kernel[
     dtype: DType
 ](
-    dst_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    src_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    dst_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    src_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     rows_arg: Int64,
     cols_arg: Int64,
     src_ld_arg: Int64,
@@ -1833,17 +1862,17 @@ def _transpose2d_vec_kernel[
             var r0 = ((q // cb) * LR + lane // LC) * VEC
             if c0 < cols and r0 < rows:
                 comptime for j in range(VEC):
-                    vals.store(
+                    vals.unsafe_store(
                         j * VEC,
-                        src_ptr.load[width=VEC](
+                        src_ptr.unsafe_load[width=VEC](
                             src_base + (c0 + j) * src_ld + r0
                         ),
                     )
                 comptime for i in range(VEC):
                     var o = SIMD[dtype, VEC]()
                     comptime for j in range(VEC):
-                        o[j] = vals[j * VEC + i]
-                    dst_ptr.store(dst_base + (r0 + i) * cols + c0, o)
+                        o[j] = vals[unsafe_offset=j * VEC + i]
+                    dst_ptr.unsafe_store(dst_base + (r0 + i) * cols + c0, o)
             q += gstride
         b += Int(grid_dim.z)
 
@@ -1851,8 +1880,8 @@ def _transpose2d_vec_kernel[
 def _transpose2d_kernel[
     dtype: DType
 ](
-    dst_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    src_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    dst_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    src_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     rows_arg: Int64,
     cols_arg: Int64,
     src_ld_arg: Int64,
@@ -1907,8 +1936,8 @@ def _transpose2d_kernel[
                 while y < TILE:
                     var c = c0 + y
                     if c < cols:
-                        tile[y * (TILE + 1) + tx] = src_ptr[
-                            src_base + c * src_ld + r
+                        tile[unsafe_offset=y * (TILE + 1) + tx] = src_ptr[
+                            unsafe_offset=src_base + c * src_ld + r
                         ]
                     y += _T2D_ROWS
             barrier()
@@ -1920,8 +1949,8 @@ def _transpose2d_kernel[
                 while y < TILE:
                     var row = r0 + y
                     if row < rows:
-                        dst_ptr[dst_base + row * cols + c] = tile[
-                            tx * (TILE + 1) + y
+                        dst_ptr[unsafe_offset=dst_base + row * cols + c] = tile[
+                            unsafe_offset=tx * (TILE + 1) + y
                         ]
                     y += _T2D_ROWS
             # Every lane must finish reading the LDS tile before the next row
@@ -1970,7 +1999,7 @@ def _copy_strided[
                 src_off += coord * src_strides[d]
             dst_off += rest * dst_strides[0]
             src_off += rest * src_strides[0]
-            dst_ptr[dst_off] = src_ptr[src_off]
+            dst_ptr[unsafe_offset=dst_off] = src_ptr[unsafe_offset=src_off]
 
         elementwise[func, simd_width=1](Coord(total), ctx)
     else:
@@ -2050,7 +2079,7 @@ def _copy_strided[
                         min(batch, _MAX_GRID_Y),
                         _T2DV_THREADS,
                         dst_ptr.as_unsafe_any_origin(),
-                        src_ptr.as_unsafe_any_origin().as_immutable(),
+                        src_ptr.as_unsafe_any_origin().as_imm(),
                         Int64(rows),
                         Int64(cols),
                         Int64(src_strides[MAX_RANK - 1]),
@@ -2070,7 +2099,7 @@ def _copy_strided[
                     min(batch, _MAX_GRID_Y),
                     TILE * _T2D_ROWS,
                     dst_ptr.as_unsafe_any_origin(),
-                    src_ptr.as_unsafe_any_origin().as_immutable(),
+                    src_ptr.as_unsafe_any_origin().as_imm(),
                     Int64(rows),
                     Int64(cols),
                     Int64(src_strides[MAX_RANK - 1]),
@@ -2087,7 +2116,7 @@ def _copy_strided[
                 1,
                 GS_THREADS,
                 dst_ptr.as_unsafe_any_origin(),
-                src_ptr.as_unsafe_any_origin().as_immutable(),
+                src_ptr.as_unsafe_any_origin().as_imm(),
                 shape,
                 dst_strides,
                 src_strides,
@@ -2267,7 +2296,7 @@ def _fill_blocks(slots: Int) -> Int:
 def _fill_vec_kernel[
     dtype: DType, VEC: Int
 ](
-    dst_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    dst_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
     value: Scalar[dtype],
     nvec_arg: Int64,
     size_arg: Int64,
@@ -2283,20 +2312,20 @@ def _fill_vec_kernel[
     var wide = SIMD[dtype, VEC](value)
     var j = tid
     while j < nvec:
-        dst_ptr.store[width=VEC, alignment=ALIGN](j * VEC, wide)
+        dst_ptr.unsafe_store[width=VEC, alignment=ALIGN](j * VEC, wide)
         j += gstride
     # The tail is at most VEC-1 elements and the grid is never narrower than
     # one FILL_THREADS-wide block, so the leading threads cover all of it.
     var t = nvec * VEC + tid
     if t < size:
-        dst_ptr[t] = value
+        dst_ptr[unsafe_offset=t] = value
 
 
 @__name(t"fill_strided_{8 * size_of[dtype]()}bit_r{RANK}_v{VEC}")
 def _fill_strided_kernel[
     dtype: DType, RANK: Int, VEC: Int
 ](
-    dst_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    dst_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
     value: Scalar[dtype],
     shape: IndexList[MAX_RANK],
     strides: IndexList[MAX_RANK],
@@ -2322,7 +2351,7 @@ def _fill_strided_kernel[
             off += (rest % shape[d]) * strides[d]
             rest = rest // shape[d]
         off += rest * strides[0]
-        dst_ptr.store[width=VEC, alignment=ALIGN](off * VEC, wide)
+        dst_ptr.unsafe_store[width=VEC, alignment=ALIGN](off * VEC, wide)
         i += gstride
 
 
@@ -2358,7 +2387,7 @@ def _fill_contig[
         @parameter
         @__copy_capture(dst_ptr, value)
         def func[width: Int, alignment: Int = 1](idx: Coord):
-            dst_ptr.store[width=width](
+            dst_ptr.unsafe_store[width=width](
                 Int(idx[0].value()), SIMD[dtype, width](value)
             )
 
@@ -2426,7 +2455,7 @@ def _fill_strided[
                 off += (rest % shape[d]) * strides[d]
                 rest = rest // shape[d]
             off += rest * strides[0]
-            dst_ptr.store[width=VEC](off * VEC, SIMD[dtype, VEC](value))
+            dst_ptr.unsafe_store[width=VEC](off * VEC, SIMD[dtype, VEC](value))
 
         elementwise[func, simd_width=1](Coord(total), ctx)
         return

--- a/torch_mojo_backend/eager_kernels/optimizer_ops/optimizer_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/optimizer_ops/optimizer_kernels.mojo
@@ -11,7 +11,7 @@ from std.ffi import _get_global_or_null, external_call
 from std.gpu import block_idx, thread_idx
 from max.gpu.host import DeviceContext
 from std.math import min, pow
-from std.memory import alloc
+from std.memory.alloc import unsafe_alloc
 from std.sys.info import has_apple_gpu_accelerator
 
 from op_utils import _enqueue_cached, ieee_sqrt
@@ -27,8 +27,8 @@ comptime _VEC = 4
 
 
 @always_inline
-def _ptr(addr: Int) -> UnsafePointer[Scalar[DType.float32], MutUntrackedOrigin]:
-    return UnsafePointer[Scalar[DType.float32], MutUntrackedOrigin](
+def _ptr(addr: Int) -> Pointer[Scalar[DType.float32], MutUntrackedOrigin]:
+    return Pointer[Scalar[DType.float32], MutUntrackedOrigin](
         unsafe_from_address=addr
     )
 
@@ -98,7 +98,10 @@ def _fused_adamw_f32(
     var grad_scale_ptr_addr = Int(grad_scale_ptr_addr_arg)
     var found_inf_ptr_addr = Int(found_inf_ptr_addr_arg)
     # found_inf must gate every mutation, including gradient writeback.
-    if found_inf_ptr_addr != 0 and _ptr(found_inf_ptr_addr)[0] == 1.0:
+    if (
+        found_inf_ptr_addr != 0
+        and _ptr(found_inf_ptr_addr)[unsafe_offset=0] == 1.0
+    ):
         return
 
     var chunk = Int(block_idx.x)
@@ -122,12 +125,12 @@ def _fused_adamw_f32(
 
     var lr = lr_scalar
     if lr_ptr_addr != 0:
-        lr = _ptr(lr_ptr_addr)[0]
+        lr = _ptr(lr_ptr_addr)[unsafe_offset=0]
     var inv_grad_scale = Float32(1.0)
     if grad_scale_ptr_addr != 0:
-        inv_grad_scale /= _ptr(grad_scale_ptr_addr)[0]
+        inv_grad_scale /= _ptr(grad_scale_ptr_addr)[unsafe_offset=0]
     var grad_sign = Float32(-1.0) if maximize_int != 0 else Float32(1.0)
-    var step = steps[0]
+    var step = steps[unsafe_offset=0]
     var bias1 = Float32(1.0) - pow(beta1, step)
     var sqrt_bias2 = ieee_sqrt(Float32(1.0) - pow(beta2, step))
     var amsgrad = amsgrad_int != 0
@@ -135,17 +138,17 @@ def _fused_adamw_f32(
     var index = begin + Int(thread_idx.x) * _VEC
     var stride = ADAMW_THREADS * _VEC
     while index + _VEC <= end:
-        var p = params.load[width=_VEC, alignment=4](index)
-        var g = grads.load[width=_VEC, alignment=4](index)
+        var p = params.unsafe_load[width=_VEC, alignment=4](index)
+        var g = grads.unsafe_load[width=_VEC, alignment=4](index)
         if grad_scale_ptr_addr != 0:
             g *= inv_grad_scale
-            grads.store[width=_VEC, alignment=4](index, g)
+            grads.unsafe_store[width=_VEC, alignment=4](index, g)
         g *= grad_sign
-        var m = exp_avgs.load[width=_VEC, alignment=4](index)
-        var v = exp_avg_sqs.load[width=_VEC, alignment=4](index)
+        var m = exp_avgs.unsafe_load[width=_VEC, alignment=4](index)
+        var v = exp_avg_sqs.unsafe_load[width=_VEC, alignment=4](index)
         var max_v = v
         if amsgrad:
-            max_v = max_exp_avg_sqs.load[width=_VEC, alignment=4](index)
+            max_v = max_exp_avg_sqs.unsafe_load[width=_VEC, alignment=4](index)
         var new_p, new_m, new_v, new_max = _adamw_update[_VEC](
             p,
             g,
@@ -161,28 +164,30 @@ def _fused_adamw_f32(
             sqrt_bias2,
             amsgrad,
         )
-        params.store[width=_VEC, alignment=4](index, new_p)
-        exp_avgs.store[width=_VEC, alignment=4](index, new_m)
-        exp_avg_sqs.store[width=_VEC, alignment=4](index, new_v)
+        params.unsafe_store[width=_VEC, alignment=4](index, new_p)
+        exp_avgs.unsafe_store[width=_VEC, alignment=4](index, new_m)
+        exp_avg_sqs.unsafe_store[width=_VEC, alignment=4](index, new_v)
         if amsgrad:
-            max_exp_avg_sqs.store[width=_VEC, alignment=4](index, new_max)
+            max_exp_avg_sqs.unsafe_store[width=_VEC, alignment=4](
+                index, new_max
+            )
         index += stride
 
     # Only the final chunk of a tensor can have a scalar tail. Starting it at
     # the first lane after the vector region keeps stores disjoint.
     index = begin + ((end - begin) // _VEC) * _VEC + Int(thread_idx.x)
     while index < end:
-        var p = params[index]
-        var g = grads[index]
+        var p = params[unsafe_offset=index]
+        var g = grads[unsafe_offset=index]
         if grad_scale_ptr_addr != 0:
             g *= inv_grad_scale
-            grads[index] = g
+            grads[unsafe_offset=index] = g
         g *= grad_sign
-        var m = exp_avgs[index]
-        var v = exp_avg_sqs[index]
+        var m = exp_avgs[unsafe_offset=index]
+        var v = exp_avg_sqs[unsafe_offset=index]
         var max_v = v
         if amsgrad:
-            max_v = max_exp_avg_sqs[index]
+            max_v = max_exp_avg_sqs[unsafe_offset=index]
         var new_p, new_m, new_v, new_max = _adamw_update[1](
             p,
             g,
@@ -198,11 +203,11 @@ def _fused_adamw_f32(
             sqrt_bias2,
             amsgrad,
         )
-        params[index] = new_p[0]
-        exp_avgs[index] = new_m[0]
-        exp_avg_sqs[index] = new_v[0]
+        params[unsafe_offset=index] = new_p[0]
+        exp_avgs[unsafe_offset=index] = new_m[0]
+        exp_avg_sqs[unsafe_offset=index] = new_v[0]
         if amsgrad:
-            max_exp_avg_sqs[index] = new_max[0]
+            max_exp_avg_sqs[unsafe_offset=index] = new_max[0]
         index += ADAMW_THREADS
 
 
@@ -214,15 +219,15 @@ def _fused_adamw_f32(
 # are passed as a valid dummy plus a has_* flag, never as null.
 @__name("fused_adamw_f32_tensor_apple_v1")
 def _fused_adamw_f32_tensor_apple(
-    params: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grads: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    exp_avgs: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    exp_avg_sqs: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    max_exp_avg_sqs: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    steps: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
-    lr_ptr: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
-    grad_scale_ptr: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
-    found_inf_ptr: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
+    params: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grads: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    exp_avgs: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    exp_avg_sqs: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    max_exp_avg_sqs: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    steps: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
+    lr_ptr: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
+    grad_scale_ptr: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
+    found_inf_ptr: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
     numel_arg: Int64,
     lr_scalar: Float32,
     has_lr_ptr_arg: Int64,
@@ -244,7 +249,7 @@ def _fused_adamw_f32_tensor_apple(
     var has_grad_scale = Int(has_grad_scale_arg)
     var has_found_inf = Int(has_found_inf_arg)
     # found_inf must gate every mutation, including gradient writeback.
-    if has_found_inf != 0 and found_inf_ptr[0] == 1.0:
+    if has_found_inf != 0 and found_inf_ptr[unsafe_offset=0] == 1.0:
         return
 
     var begin = Int(block_idx.x) * ADAMW_CHUNK_ELEMENTS
@@ -252,12 +257,12 @@ def _fused_adamw_f32_tensor_apple(
 
     var lr = lr_scalar
     if has_lr_ptr != 0:
-        lr = lr_ptr[0]
+        lr = lr_ptr[unsafe_offset=0]
     var inv_grad_scale = Float32(1.0)
     if has_grad_scale != 0:
-        inv_grad_scale /= grad_scale_ptr[0]
+        inv_grad_scale /= grad_scale_ptr[unsafe_offset=0]
     var grad_sign = Float32(-1.0) if maximize_int != 0 else Float32(1.0)
-    var step = steps[0]
+    var step = steps[unsafe_offset=0]
     var bias1 = Float32(1.0) - pow(beta1, step)
     var sqrt_bias2 = ieee_sqrt(Float32(1.0) - pow(beta2, step))
     var amsgrad = amsgrad_int != 0
@@ -265,17 +270,17 @@ def _fused_adamw_f32_tensor_apple(
     var index = begin + Int(thread_idx.x) * _VEC
     var stride = ADAMW_THREADS * _VEC
     while index + _VEC <= end:
-        var p = params.load[width=_VEC, alignment=4](index)
-        var g = grads.load[width=_VEC, alignment=4](index)
+        var p = params.unsafe_load[width=_VEC, alignment=4](index)
+        var g = grads.unsafe_load[width=_VEC, alignment=4](index)
         if has_grad_scale != 0:
             g *= inv_grad_scale
-            grads.store[width=_VEC, alignment=4](index, g)
+            grads.unsafe_store[width=_VEC, alignment=4](index, g)
         g *= grad_sign
-        var m = exp_avgs.load[width=_VEC, alignment=4](index)
-        var v = exp_avg_sqs.load[width=_VEC, alignment=4](index)
+        var m = exp_avgs.unsafe_load[width=_VEC, alignment=4](index)
+        var v = exp_avg_sqs.unsafe_load[width=_VEC, alignment=4](index)
         var max_v = v
         if amsgrad:
-            max_v = max_exp_avg_sqs.load[width=_VEC, alignment=4](index)
+            max_v = max_exp_avg_sqs.unsafe_load[width=_VEC, alignment=4](index)
         var new_p, new_m, new_v, new_max = _adamw_update[_VEC](
             p,
             g,
@@ -291,28 +296,30 @@ def _fused_adamw_f32_tensor_apple(
             sqrt_bias2,
             amsgrad,
         )
-        params.store[width=_VEC, alignment=4](index, new_p)
-        exp_avgs.store[width=_VEC, alignment=4](index, new_m)
-        exp_avg_sqs.store[width=_VEC, alignment=4](index, new_v)
+        params.unsafe_store[width=_VEC, alignment=4](index, new_p)
+        exp_avgs.unsafe_store[width=_VEC, alignment=4](index, new_m)
+        exp_avg_sqs.unsafe_store[width=_VEC, alignment=4](index, new_v)
         if amsgrad:
-            max_exp_avg_sqs.store[width=_VEC, alignment=4](index, new_max)
+            max_exp_avg_sqs.unsafe_store[width=_VEC, alignment=4](
+                index, new_max
+            )
         index += stride
 
     # Only the final chunk of a tensor can have a scalar tail. Starting it at
     # the first lane after the vector region keeps stores disjoint.
     index = begin + ((end - begin) // _VEC) * _VEC + Int(thread_idx.x)
     while index < end:
-        var p = params[index]
-        var g = grads[index]
+        var p = params[unsafe_offset=index]
+        var g = grads[unsafe_offset=index]
         if has_grad_scale != 0:
             g *= inv_grad_scale
-            grads[index] = g
+            grads[unsafe_offset=index] = g
         g *= grad_sign
-        var m = exp_avgs[index]
-        var v = exp_avg_sqs[index]
+        var m = exp_avgs[unsafe_offset=index]
+        var v = exp_avg_sqs[unsafe_offset=index]
         var max_v = v
         if amsgrad:
-            max_v = max_exp_avg_sqs[index]
+            max_v = max_exp_avg_sqs[unsafe_offset=index]
         var new_p, new_m, new_v, new_max = _adamw_update[1](
             p,
             g,
@@ -328,11 +335,11 @@ def _fused_adamw_f32_tensor_apple(
             sqrt_bias2,
             amsgrad,
         )
-        params[index] = new_p[0]
-        exp_avgs[index] = new_m[0]
-        exp_avg_sqs[index] = new_v[0]
+        params[unsafe_offset=index] = new_p[0]
+        exp_avgs[unsafe_offset=index] = new_m[0]
+        exp_avg_sqs[unsafe_offset=index] = new_v[0]
         if amsgrad:
-            max_exp_avg_sqs[index] = new_max[0]
+            max_exp_avg_sqs[unsafe_offset=index] = new_max[0]
         index += ADAMW_THREADS
 
 
@@ -384,10 +391,10 @@ def enqueue_fused_adamw_f32(
                 _ptr(desc.exp_avg_addr).as_unsafe_any_origin(),
                 _ptr(desc.exp_avg_sq_addr).as_unsafe_any_origin(),
                 _ptr(max_addr).as_unsafe_any_origin(),
-                _ptr(desc.step_addr).as_unsafe_any_origin().as_immutable(),
-                _ptr(lr_addr).as_unsafe_any_origin().as_immutable(),
-                _ptr(gs_addr).as_unsafe_any_origin().as_immutable(),
-                _ptr(fi_addr).as_unsafe_any_origin().as_immutable(),
+                _ptr(desc.step_addr).as_unsafe_any_origin().as_imm(),
+                _ptr(lr_addr).as_unsafe_any_origin().as_imm(),
+                _ptr(gs_addr).as_unsafe_any_origin().as_imm(),
+                _ptr(fi_addr).as_unsafe_any_origin().as_imm(),
                 Int64(desc.numel),
                 lr_scalar,
                 Int64(1 if lr_ptr_addr != 0 else 0),
@@ -407,8 +414,9 @@ def enqueue_fused_adamw_f32(
     # key, so dynamic input sizes never trigger recompilation.
     var cache_name = String(t"FUSED_ADAMW_F32_V5_ABI1_{ctx.id()}")
     comptime FuncT = type_of(ctx.compile_function[_fused_adamw_f32]())
-    if global_ptr := _get_global_or_null(cache_name):
-        var cached = global_ptr.value().bitcast[FuncT]()
+    var global_ptr = _get_global_or_null(cache_name)
+    if global_ptr:
+        var cached = global_ptr.value().unsafe_bitcast[FuncT]()
         ctx.enqueue_function(
             cached[],
             descs,
@@ -429,11 +437,11 @@ def enqueue_fused_adamw_f32(
         return
 
     var compiled = ctx.compile_function[_fused_adamw_f32]()
-    var cached = alloc[FuncT](1)
-    cached.init_pointee_move(compiled^)
+    var cached = unsafe_alloc[FuncT](1)
+    cached.unsafe_write(compiled^)
     external_call["KGEN_CompilerRT_InsertGlobal", NoneType](
         StringSlice(cache_name),
-        cached.bitcast[NoneType](),
+        cached.unsafe_bitcast[NoneType](),
     )
     ctx.enqueue_function(
         cached[],

--- a/torch_mojo_backend/eager_kernels/random_ops/uniform_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/random_ops/uniform_kernels.mojo
@@ -179,7 +179,7 @@ def _uniform_draw[
 def _uniform_kernel[
     dtype: DType, WIDE: Bool
 ](
-    dst_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
+    dst_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
     from_out: Scalar[dtype],
     to_out: Scalar[dtype],
     from_math: Scalar[_uniform_math_dtype[dtype]()],
@@ -216,11 +216,11 @@ def _uniform_kernel[
         )
         var base = group * GROUP
         comptime if WIDE:
-            dst_ptr.store[alignment=ALIGN](base, values)
+            dst_ptr.unsafe_store[alignment=ALIGN](base, values)
         else:
             comptime for lane in range(GROUP):
                 if base + lane < size:
-                    dst_ptr[base + lane] = values[lane]
+                    dst_ptr[unsafe_offset=base + lane] = values[lane]
         group += gstride
 
 
@@ -286,7 +286,7 @@ def enqueue_uniform[
 
             comptime for lane in range(GROUP):
                 if base + lane < size:
-                    dst_ptr[base + lane] = values[lane]
+                    dst_ptr[unsafe_offset=base + lane] = values[lane]
 
         elementwise[cpu_group, simd_width=1](Coord(groups), ctx)
         return

--- a/torch_mojo_backend/eager_kernels/reduce_skeleton.mojo
+++ b/torch_mojo_backend/eager_kernels/reduce_skeleton.mojo
@@ -644,14 +644,12 @@ def _block_fold[
             n_warps, acc, address_space=AddressSpace.SHARED
         ]()
         if tid % WARP_SIZE == 0:
-            smem[tid // WARP_SIZE] = lane_total
+            smem[unsafe_offset=tid // WARP_SIZE] = lane_total
         barrier()
         var total = Op.identity[acc, 1]()[0]
         if tid == 0:
-
-            @parameter
-            for k in range(n_warps):
-                total = Op.combine(total, smem[k])
+            comptime for k in range(n_warps):
+                total = Op.combine(total, smem[unsafe_offset=k])
         return total
 
 
@@ -659,7 +657,7 @@ def _block_fold[
 def _scan_contig[
     Op: ReduceOp, dtype: DType, acc: DType, V: Int, vec_align: Int, lanes: Int
 ](
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     start: Int,
     n: Int,
     head: Int,
@@ -681,7 +679,9 @@ def _scan_contig[
         acc_vec = Op.combine(
             acc_vec,
             Op.map[acc=acc](
-                in_ptr.load[width=V, alignment=vec_align](vec_start + v * V)
+                in_ptr.unsafe_load[width=V, alignment=vec_align](
+                    vec_start + v * V
+                )
             ),
         )
         v += lanes
@@ -689,11 +689,15 @@ def _scan_contig[
 
     var jh = lane
     while jh < head:
-        total = Op.combine(total, Op.map[acc=acc](in_ptr[start + jh]))
+        total = Op.combine(
+            total, Op.map[acc=acc](in_ptr[unsafe_offset=start + jh])
+        )
         jh += lanes
     var jt = tail_start + lane
     while jt < n:
-        total = Op.combine(total, Op.map[acc=acc](in_ptr[start + jt]))
+        total = Op.combine(
+            total, Op.map[acc=acc](in_ptr[unsafe_offset=start + jt])
+        )
         jt += lanes
     return total
 
@@ -710,9 +714,9 @@ def _scan_contig[
 def _reduce_contig_kernel[
     Op: ReduceOp, dtype: DType, lanes: Int
 ](
-    out_ptr: UnsafePointer[Scalar[Op.out_dtype[dtype]()], MutAnyOrigin],
-    ws_ptr: UnsafePointer[Scalar[Op.acc_dtype[dtype]()], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[Op.out_dtype[dtype]()], MutAnyOrigin],
+    ws_ptr: Pointer[Scalar[Op.acc_dtype[dtype]()], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     cols_arg: Int64,
     outputs_arg: Int64,
     splits_arg: Int64,
@@ -783,11 +787,11 @@ def _reduce_contig_kernel[
     var group_total = _block_fold[Op, acc, lanes](lane, total)
     if lane == 0:
         if splits == 1:
-            out_ptr[row] = Op.finish[out_dt=Op.out_dtype[dtype]()](
-                group_total, cols
-            )
+            out_ptr[unsafe_offset=row] = Op.finish[
+                out_dt=Op.out_dtype[dtype]()
+            ](group_total, cols)
         else:
-            ws_ptr[split * outputs + row] = group_total
+            ws_ptr[unsafe_offset=split * outputs + row] = group_total
 
 
 # ---------------------------------------------------------------------------
@@ -802,9 +806,9 @@ def _reduce_contig_kernel[
 def _reduce_strided_kernel[
     Op: ReduceOp, dtype: DType
 ](
-    out_ptr: UnsafePointer[Scalar[Op.out_dtype[dtype]()], MutAnyOrigin],
-    ws_ptr: UnsafePointer[Scalar[Op.acc_dtype[dtype]()], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[Op.out_dtype[dtype]()], MutAnyOrigin],
+    ws_ptr: Pointer[Scalar[Op.acc_dtype[dtype]()], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     reduce_arg: Int64,
     inner_arg: Int64,
     outputs_arg: Int64,
@@ -841,14 +845,16 @@ def _reduce_strided_kernel[
 
     var total = Op.identity[acc, 1]()[0]
     for r in range(r0, r1):
-        total = Op.combine(total, Op.map[acc=acc](in_ptr[base + r * inner]))
+        total = Op.combine(
+            total, Op.map[acc=acc](in_ptr[unsafe_offset=base + r * inner])
+        )
 
     if splits == 1:
-        out_ptr[out_index] = Op.finish[out_dt=Op.out_dtype[dtype]()](
-            total, reduce_n
-        )
+        out_ptr[unsafe_offset=out_index] = Op.finish[
+            out_dt=Op.out_dtype[dtype]()
+        ](total, reduce_n)
     else:
-        ws_ptr[split * outputs + out_index] = total
+        ws_ptr[unsafe_offset=split * outputs + out_index] = total
 
 
 # ---------------------------------------------------------------------------
@@ -863,8 +869,8 @@ def _reduce_strided_kernel[
 def _reduce_merge_thread_kernel[
     Op: ReduceOp, dtype: DType
 ](
-    out_ptr: UnsafePointer[Scalar[Op.out_dtype[dtype]()], MutAnyOrigin],
-    ws_ptr: UnsafePointer[Scalar[Op.acc_dtype[dtype]()], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[Op.out_dtype[dtype]()], MutAnyOrigin],
+    ws_ptr: Pointer[Scalar[Op.acc_dtype[dtype]()], ImmutAnyOrigin],
     outputs_arg: Int64,
     splits_arg: Int64,
     reduce_arg: Int64,
@@ -879,8 +885,10 @@ def _reduce_merge_thread_kernel[
         return
     var total = Op.identity[acc, 1]()[0]
     for k in range(splits):
-        total = Op.combine(total, ws_ptr[k * outputs + o])
-    out_ptr[o] = Op.finish[out_dt=Op.out_dtype[dtype]()](total, Int(reduce_arg))
+        total = Op.combine(total, ws_ptr[unsafe_offset=k * outputs + o])
+    out_ptr[unsafe_offset=o] = Op.finish[out_dt=Op.out_dtype[dtype]()](
+        total, Int(reduce_arg)
+    )
 
 
 @__llvm_metadata(
@@ -890,8 +898,8 @@ def _reduce_merge_thread_kernel[
 def _reduce_merge_block_kernel[
     Op: ReduceOp, dtype: DType
 ](
-    out_ptr: UnsafePointer[Scalar[Op.out_dtype[dtype]()], MutAnyOrigin],
-    ws_ptr: UnsafePointer[Scalar[Op.acc_dtype[dtype]()], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[Op.out_dtype[dtype]()], MutAnyOrigin],
+    ws_ptr: Pointer[Scalar[Op.acc_dtype[dtype]()], ImmutAnyOrigin],
     outputs_arg: Int64,
     splits_arg: Int64,
     reduce_arg: Int64,
@@ -906,10 +914,10 @@ def _reduce_merge_block_kernel[
     var tid = Int(thread_idx.x)
     var total = Op.identity[acc, 1]()[0]
     for k in range(tid, splits, RED_THREADS):
-        total = Op.combine(total, ws_ptr[k * outputs + o])
+        total = Op.combine(total, ws_ptr[unsafe_offset=k * outputs + o])
     var block_total = _block_fold[Op, acc, RED_THREADS](tid, total)
     if tid == 0:
-        out_ptr[o] = Op.finish[out_dt=Op.out_dtype[dtype]()](
+        out_ptr[unsafe_offset=o] = Op.finish[out_dt=Op.out_dtype[dtype]()](
             block_total, Int(reduce_arg)
         )
 
@@ -974,9 +982,10 @@ def _reduce_generic[
             var total = Op.identity[acc, 1]()[0]
             for r in range(reduce_n):
                 total = Op.combine(
-                    total, Op.map[acc=acc](in_ptr[base + r * inner])
+                    total,
+                    Op.map[acc=acc](in_ptr[unsafe_offset=base + r * inner]),
                 )
-            out_ptr[o] = Op.finish[out_dt=out_dt](total, reduce_n)
+            out_ptr[unsafe_offset=o] = Op.finish[out_dt=out_dt](total, reduce_n)
 
         _parallel_for[func](outputs, ctx)
         return
@@ -986,7 +995,7 @@ def _reduce_generic[
     else:
         var target = RED_BLOCKS_PER_SM * _device_sm_count(ctx)
         var mout = out_ptr.as_unsafe_any_origin()
-        var min_ = in_ptr.as_unsafe_any_origin().as_immutable()
+        var min_ = in_ptr.as_unsafe_any_origin().as_imm()
 
         var base_blocks = outputs
         # The contiguous kernel wants a whole 16-byte vector per thread before
@@ -1114,7 +1123,7 @@ def _reduce_generic[
                 1,
                 RED_THREADS,
                 mout,
-                ws_ptr.as_immutable(),
+                ws_ptr.as_imm(),
                 Int64(outputs),
                 Int64(splits),
                 Int64(reduce_n),
@@ -1128,7 +1137,7 @@ def _reduce_generic[
                 1,
                 RED_THREADS,
                 mout,
-                ws_ptr.as_immutable(),
+                ws_ptr.as_imm(),
                 Int64(outputs),
                 Int64(splits),
                 Int64(reduce_n),

--- a/torch_mojo_backend/eager_kernels/reduction_ops/reduction_ops.mojo
+++ b/torch_mojo_backend/eager_kernels/reduction_ops/reduction_ops.mojo
@@ -215,8 +215,8 @@ def _moment_finish[
 def _moment_flag_repass[
     dtype: DType
 ](
-    ws_ptr: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    ws_ptr: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     o: Int,
     outputs: Int,
     meta: Int,
@@ -235,12 +235,12 @@ def _moment_flag_repass[
     """
     if _moment_cancels(s, q, reduce_n):
         var base = _moment_slice_base(o, reduce_n, inner)
-        ws_ptr[meta + o] = in_ptr[base].cast[DType.float32]() + s / Float32(
-            reduce_n
-        )
-        ws_ptr[meta + outputs + o] = Float32(1)
+        ws_ptr[unsafe_offset=meta + o] = in_ptr[unsafe_offset=base].cast[
+            DType.float32
+        ]() + s / Float32(reduce_n)
+        ws_ptr[unsafe_offset=meta + outputs + o] = Float32(1)
     else:
-        ws_ptr[meta + outputs + o] = Float32(0)
+        ws_ptr[unsafe_offset=meta + outputs + o] = Float32(0)
 
 
 @always_inline
@@ -259,9 +259,9 @@ def _moment_slice_base(o: Int, reduce_n: Int, inner: Int) -> Int:
 def _moments_contig_kernel[
     dtype: DType
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    ws_ptr: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    ws_ptr: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     cols_arg: Int64,
     outputs_arg: Int64,
     splits_arg: Int64,
@@ -297,13 +297,13 @@ def _moments_contig_kernel[
     # Assumed mean: the row's first element, identical in every split of this
     # row so the partial moment pairs merge by addition. On a re-pass it is
     # the accurate mean instead, which leaves no cancellation to correct.
-    var shift = in_ptr[base].cast[DType.float32]()
+    var shift = in_ptr[unsafe_offset=base].cast[DType.float32]()
     if repass:
         # Uniform across the block: an early exit here cannot desynchronize
         # the barriers inside `block.sum` below.
-        if ws_ptr[2 * splits * outputs + outputs + row] == 0:
+        if ws_ptr[unsafe_offset=2 * splits * outputs + outputs + row] == 0:
             return
-        shift = ws_ptr[2 * splits * outputs + row]
+        shift = ws_ptr[unsafe_offset=2 * splits * outputs + row]
 
     # This split's shard of the row. The last shard may be empty (splits does
     # not divide cols); an empty shard contributes (0, 0), the identity.
@@ -368,10 +368,12 @@ def _moments_contig_kernel[
 
     if tid == 0:
         if fused:
-            out_ptr[row] = _moment_finish[dtype](bs, bq, cols, correction)
+            out_ptr[unsafe_offset=row] = _moment_finish[dtype](
+                bs, bq, cols, correction
+            )
         else:
-            ws_ptr[split * outputs + row] = bs
-            ws_ptr[(splits + split) * outputs + row] = bq
+            ws_ptr[unsafe_offset=split * outputs + row] = bs
+            ws_ptr[unsafe_offset=(splits + split) * outputs + row] = bq
 
 
 @__llvm_metadata(
@@ -381,9 +383,9 @@ def _moments_contig_kernel[
 def _moments_strided_kernel[
     dtype: DType
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    ws_ptr: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    ws_ptr: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     reduce_arg: Int64,
     inner_arg: Int64,
     outputs_arg: Int64,
@@ -424,17 +426,22 @@ def _moments_strided_kernel[
 
     var base = outer_index * reduce_n * inner + i
     var out_index = outer_index * inner + i
-    var shift = in_ptr[base].cast[DType.float32]()
+    var shift = in_ptr[unsafe_offset=base].cast[DType.float32]()
     if repass:
-        if ws_ptr[2 * splits * outputs + outputs + out_index] == 0:
+        if (
+            ws_ptr[unsafe_offset=2 * splits * outputs + outputs + out_index]
+            == 0
+        ):
             return
-        shift = ws_ptr[2 * splits * outputs + out_index]
+        shift = ws_ptr[unsafe_offset=2 * splits * outputs + out_index]
     var fused = splits == 1 and not repass
 
     var s = Float32(0)
     var q = Float32(0)
     for r in range(r0, r1):
-        var d = in_ptr[base + r * inner].cast[DType.float32]() - shift
+        var d = (
+            in_ptr[unsafe_offset=base + r * inner].cast[DType.float32]() - shift
+        )
         s += d
         q += d * d
 
@@ -445,15 +452,20 @@ def _moments_strided_kernel[
         s = Float32(0)
         q = Float32(0)
         for r in range(r0, r1):
-            var d = in_ptr[base + r * inner].cast[DType.float32]() - shift
+            var d = (
+                in_ptr[unsafe_offset=base + r * inner].cast[DType.float32]()
+                - shift
+            )
             s += d
             q += d * d
 
     if fused:
-        out_ptr[out_index] = _moment_finish[dtype](s, q, reduce_n, correction)
+        out_ptr[unsafe_offset=out_index] = _moment_finish[dtype](
+            s, q, reduce_n, correction
+        )
     else:
-        ws_ptr[split * outputs + out_index] = s
-        ws_ptr[(splits + split) * outputs + out_index] = q
+        ws_ptr[unsafe_offset=split * outputs + out_index] = s
+        ws_ptr[unsafe_offset=(splits + split) * outputs + out_index] = q
 
 
 @__llvm_metadata(
@@ -463,9 +475,9 @@ def _moments_strided_kernel[
 def _moments_merge_thread_kernel[
     dtype: DType
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    ws_ptr: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    ws_ptr: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     outputs_arg: Int64,
     splits_arg: Int64,
     reduce_arg: Int64,
@@ -492,14 +504,14 @@ def _moments_merge_thread_kernel[
     var o = Int(block_idx.x) * MOMENT_THREADS + Int(thread_idx.x)
     if o >= outputs:
         return
-    if Int(repass_arg) != 0 and ws_ptr[meta + outputs + o] == 0:
+    if Int(repass_arg) != 0 and ws_ptr[unsafe_offset=meta + outputs + o] == 0:
         return
     var s = Float32(0)
     var q = Float32(0)
     for k in range(splits):
-        s += ws_ptr[k * outputs + o]
-        q += ws_ptr[(splits + k) * outputs + o]
-    out_ptr[o] = _moment_finish[dtype](s, q, reduce_n, correction)
+        s += ws_ptr[unsafe_offset=k * outputs + o]
+        q += ws_ptr[unsafe_offset=(splits + k) * outputs + o]
+    out_ptr[unsafe_offset=o] = _moment_finish[dtype](s, q, reduce_n, correction)
     if Int(repass_arg) == 0:
         _moment_flag_repass[dtype](
             ws_ptr, in_ptr, o, outputs, meta, reduce_n, Int(inner_arg), s, q
@@ -513,9 +525,9 @@ def _moments_merge_thread_kernel[
 def _moments_merge_block_kernel[
     dtype: DType
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    ws_ptr: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    ws_ptr: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     outputs_arg: Int64,
     splits_arg: Int64,
     reduce_arg: Int64,
@@ -537,17 +549,19 @@ def _moments_merge_block_kernel[
     var tid = Int(thread_idx.x)
     # Uniform across the block (every thread reads the same flag), so this
     # early exit cannot desynchronize the barriers inside `block.sum`.
-    if Int(repass_arg) != 0 and ws_ptr[meta + outputs + o] == 0:
+    if Int(repass_arg) != 0 and ws_ptr[unsafe_offset=meta + outputs + o] == 0:
         return
     var s = Float32(0)
     var q = Float32(0)
     for k in range(tid, splits, MOMENT_THREADS):
-        s += ws_ptr[k * outputs + o]
-        q += ws_ptr[(splits + k) * outputs + o]
+        s += ws_ptr[unsafe_offset=k * outputs + o]
+        q += ws_ptr[unsafe_offset=(splits + k) * outputs + o]
     var bs = block.sum[block_size=MOMENT_THREADS](s)
     var bq = block.sum[block_size=MOMENT_THREADS](q)
     if tid == 0:
-        out_ptr[o] = _moment_finish[dtype](bs, bq, reduce_n, correction)
+        out_ptr[unsafe_offset=o] = _moment_finish[dtype](
+            bs, bq, reduce_n, correction
+        )
         if Int(repass_arg) == 0:
             _moment_flag_repass[dtype](
                 ws_ptr,
@@ -609,7 +623,7 @@ def _var_moments[
         def func[width: Int, alignment: Int = 1](idx: Coord):
             var o = Int(idx[0].value())
             var base = _moment_slice_base(o, reduce_n, inner)
-            var shift = in_ptr[base].cast[DType.float32]()
+            var shift = in_ptr[unsafe_offset=base].cast[DType.float32]()
             var s = Float32(0)
             var q = Float32(0)
             # Same adaptive re-pass as the GPU path: a second read only when
@@ -619,14 +633,19 @@ def _var_moments[
                 q = Float32(0)
                 for r in range(reduce_n):
                     var d = (
-                        in_ptr[base + r * inner].cast[DType.float32]() - shift
+                        in_ptr[unsafe_offset=base + r * inner].cast[
+                            DType.float32
+                        ]()
+                        - shift
                     )
                     s += d
                     q += d * d
                 if not _moment_cancels(s, q, reduce_n):
                     break
                 shift += s / Float32(reduce_n)
-            out_ptr[o] = _moment_finish[dtype](s, q, reduce_n, correction)
+            out_ptr[unsafe_offset=o] = _moment_finish[dtype](
+                s, q, reduce_n, correction
+            )
 
         _parallel_for[func](outputs, ctx)
         return
@@ -635,7 +654,7 @@ def _var_moments[
         comptime sm_count = ctx.default_device_info.sm_count
         var target = MOMENT_BLOCKS_PER_SM * sm_count
         var mout = out_ptr.as_unsafe_any_origin()
-        var min_ = in_ptr.as_unsafe_any_origin().as_immutable()
+        var min_ = in_ptr.as_unsafe_any_origin().as_imm()
 
         var base_blocks = outputs
         # The contiguous kernel wants a whole 16-byte vector per thread before
@@ -820,7 +839,7 @@ comptime LSM_BLOCKS_PER_CU = 4
 @always_inline
 def _lsm_store_out_16B[
     dtype: DType, width: Int, //, vec_align: Int
-](ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin], val: SIMD[dtype, width]):
+](ptr: Pointer[Scalar[dtype], MutAnyOrigin], val: SIMD[dtype, width]):
     """128-bit output store. On NVIDIA use a streaming (evict-first)
     `st.global.cs` store so the writes do not evict the input rows we re-read in
     pass 2; elsewhere fall back to a normal vectorized store."""
@@ -833,7 +852,7 @@ def _lsm_store_out_16B[
             has_side_effect=True,
         ](ptr, u[0], u[1], u[2], u[3])
     else:
-        ptr.store[width=width, alignment=vec_align](val)
+        ptr.unsafe_store[width=width, alignment=vec_align](val)
 
 
 # Fused online (single-read) log-softmax. The reduction reads each row ONCE
@@ -853,8 +872,8 @@ def _lsm_store_out_16B[
 def _log_softmax_rows_block_kernel[
     dtype: DType, threads: Int
 ](
-    out_ptr: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    in_ptr: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], ImmutAnyOrigin],
     cols_arg: Int64,
     rows_arg: Int64,
 ):
@@ -927,7 +946,7 @@ def _log_softmax_rows_block_kernel[
         var s_vec = SIMD[DType.float32, V](0.0)
         var v = tid
         while v < n_vec:
-            var x = in_ptr.load[width=V, alignment=vec_align](
+            var x = in_ptr.unsafe_load[width=V, alignment=vec_align](
                 vec_start + v * V
             ).cast[DType.float32]()
             var new_m = max(m_vec, x)
@@ -943,14 +962,14 @@ def _log_softmax_rows_block_kernel[
         # per element; no-ops when head == tail == 0).
         var jh = tid
         while jh < head:
-            var x = in_ptr[base + jh].cast[DType.float32]()
+            var x = in_ptr[unsafe_offset=base + jh].cast[DType.float32]()
             var nm = max(m_t, x)
             s_t = s_t * exp(m_t - nm) + exp(x - nm)
             m_t = nm
             jh += threads
         var jt = tail_start + tid
         while jt < cols:
-            var x = in_ptr[base + jt].cast[DType.float32]()
+            var x = in_ptr[unsafe_offset=base + jt].cast[DType.float32]()
             var nm = max(m_t, x)
             s_t = s_t * exp(m_t - nm) + exp(x - nm)
             m_t = nm
@@ -969,12 +988,12 @@ def _log_softmax_rows_block_kernel[
             # names a 16-byte boundary in each.
             var vo = tid
             while vo < n_vec_o:
-                var x = in_ptr.load[width=V, alignment=vec_align](
+                var x = in_ptr.unsafe_load[width=V, alignment=vec_align](
                     vec_start_o + vo * V
                 ).cast[DType.float32]()
                 var y = (x - block_m - log_denom).cast[dtype]()
                 _lsm_store_out_16B[vec_align=vec_align](
-                    out_ptr + (vec_start_o + vo * V), y
+                    out_ptr.unsafe_offset(vec_start_o + vo * V), y
                 )
                 vo += threads
         else:
@@ -986,21 +1005,26 @@ def _log_softmax_rows_block_kernel[
                 var off = vec_start_o + vo * V
                 var x = SIMD[DType.float32, V](0.0)
 
-                @parameter
-                for k in range(V):
-                    x[k] = in_ptr[off + k].cast[DType.float32]()
+                comptime for k in range(V):
+                    x[k] = in_ptr[unsafe_offset=off + k].cast[DType.float32]()
                 var y = (x - block_m - log_denom).cast[dtype]()
-                _lsm_store_out_16B[vec_align=vec_align](out_ptr + off, y)
+                _lsm_store_out_16B[vec_align=vec_align](
+                    out_ptr.unsafe_offset(off), y
+                )
                 vo += threads
         var jho = tid
         while jho < head_o:
-            var x = in_ptr[base + jho].cast[DType.float32]()
-            out_ptr[base + jho] = (x - block_m - log_denom).cast[dtype]()
+            var x = in_ptr[unsafe_offset=base + jho].cast[DType.float32]()
+            out_ptr[unsafe_offset=base + jho] = (x - block_m - log_denom).cast[
+                dtype
+            ]()
             jho += threads
         var jto = tail_start_o + tid
         while jto < cols:
-            var x = in_ptr[base + jto].cast[DType.float32]()
-            out_ptr[base + jto] = (x - block_m - log_denom).cast[dtype]()
+            var x = in_ptr[unsafe_offset=base + jto].cast[DType.float32]()
+            out_ptr[unsafe_offset=base + jto] = (x - block_m - log_denom).cast[
+                dtype
+            ]()
             jto += threads
 
         row += Int(grid_dim.x)
@@ -1023,16 +1047,20 @@ def _log_softmax_rows[
             var base = r * cols
             var m = Float32.MIN
             for j in range(cols):
-                var x = in_ptr[base + j].cast[DType.float32]()
+                var x = in_ptr[unsafe_offset=base + j].cast[DType.float32]()
                 if x > m:
                     m = x
             var denom = Float32(0)
             for j in range(cols):
-                denom += exp(in_ptr[base + j].cast[DType.float32]() - m)
+                denom += exp(
+                    in_ptr[unsafe_offset=base + j].cast[DType.float32]() - m
+                )
             var log_denom = log(denom)
             for j in range(cols):
-                var x = in_ptr[base + j].cast[DType.float32]()
-                out_ptr[base + j] = (x - m - log_denom).cast[dtype]()
+                var x = in_ptr[unsafe_offset=base + j].cast[DType.float32]()
+                out_ptr[unsafe_offset=base + j] = (x - m - log_denom).cast[
+                    dtype
+                ]()
 
         _parallel_for[func](rows, ctx)
     else:
@@ -1043,7 +1071,7 @@ def _log_softmax_rows[
             var esize = size_of[dtype]()
             var blocks = min(rows, max(1, LSM_L2_BUDGET // (cols * esize)))
             var mout = out_ptr.as_unsafe_any_origin()
-            var min_ = in_ptr.as_unsafe_any_origin().as_immutable()
+            var min_ = in_ptr.as_unsafe_any_origin().as_imm()
             # Big rows: 1024-thread blocks so the small (L2-capped) grid still
             # saturates memory. Small rows: 256 threads keep every thread busy.
             if cols * esize > LSM_BIG_ROW_BYTES:

--- a/torch_mojo_backend/eager_kernels/sdpa_backward_ops/sdpa_backward_gemm_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/sdpa_backward_ops/sdpa_backward_gemm_kernels.mojo
@@ -94,10 +94,10 @@ comptime _THREADS = 128
 def _sdpa_ta_gemm_kernel[
     MASKED: Bool, CAUSAL: Bool
 ](
-    c_base: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    a_base: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
-    b_base: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
-    mask_base: UnsafePointer[Scalar[DType.bool], ImmutAnyOrigin],
+    c_base: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    a_base: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
+    b_base: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
+    mask_base: Pointer[Scalar[DType.bool], ImmutAnyOrigin],
     m_arg: Int64,
     n_arg: Int64,
     k_arg: Int64,
@@ -111,10 +111,10 @@ def _sdpa_ta_gemm_kernel[
     comptime F32 = DType.float32
 
     var bz = Int(block_idx.z)
-    var c_ptr = c_base + bz * m * n
-    var a_ptr = a_base + bz * k * m
-    var b_ptr = b_base + bz * k * n
-    var mask_ptr = mask_base + bz * k * m
+    var c_ptr = c_base.unsafe_offset(bz * m * n)
+    var a_ptr = a_base.unsafe_offset(bz * k * m)
+    var b_ptr = b_base.unsafe_offset(bz * k * n)
+    var mask_ptr = mask_base.unsafe_offset(bz * k * m)
 
     var lane = Int(lane_id())
     var fl = _frag8_layout(lane)
@@ -152,11 +152,13 @@ def _sdpa_ta_gemm_kernel[
                 comptime for s in range(FRAG8):
                     var kl = kk + fcol + s
                     if kl < k:
-                        var av = a_ptr[kl * m + grow]
+                        var av = a_ptr[unsafe_offset=kl * m + grow]
                         comptime if MASKED:
                             av = (
                                 av
-                                * mask_ptr[kl * m + grow].cast[F32]()
+                                * mask_ptr[unsafe_offset=kl * m + grow].cast[
+                                    F32
+                                ]()
                                 * drop_scale
                             )
                         af[s] = av
@@ -168,7 +170,7 @@ def _sdpa_ta_gemm_kernel[
                 comptime for s in range(FRAG8):
                     var gj = col_base + ni * MMA8_DIM + fcol + s
                     if gj < n:
-                        bf[s] = b_ptr[(kk + frow) * n + gj]
+                        bf[s] = b_ptr[unsafe_offset=(kk + frow) * n + gj]
             bfrag[ni] = bf
         comptime for mi in range(_NT_M):
             comptime for ni in range(_NT_N):
@@ -182,30 +184,34 @@ def _sdpa_ta_gemm_kernel[
     @always_inline
     @parameter
     def _load_a_fast(
-        ap0: UnsafePointer[Scalar[F32], ImmutAnyOrigin],
-        mp0: UnsafePointer[Scalar[DType.bool], ImmutAnyOrigin],
+        ap0: Pointer[Scalar[F32], ImmutAnyOrigin],
+        mp0: Pointer[Scalar[DType.bool], ImmutAnyOrigin],
     ) -> InlineArray[SIMD[F32, FRAG8], _NT_M]:
         var afrag = InlineArray[SIMD[F32, FRAG8], _NT_M](uninitialized=True)
         comptime for mi in range(_NT_M):
-            var p = ap0 + mi * MMA8_DIM
+            var p = ap0.unsafe_offset(mi * MMA8_DIM)
             var af = SIMD[F32, FRAG8](0)
             comptime for s in range(FRAG8):
-                af[s] = p[s * m]
+                af[s] = p[unsafe_offset=s * m]
             comptime if MASKED:
-                var mp = mp0 + mi * MMA8_DIM
+                var mp = mp0.unsafe_offset(mi * MMA8_DIM)
                 comptime for s in range(FRAG8):
-                    af[s] = af[s] * mp[s * m].cast[F32]() * drop_scale
+                    af[s] = (
+                        af[s] * mp[unsafe_offset=s * m].cast[F32]() * drop_scale
+                    )
             afrag[mi] = af
         return afrag^
 
     @always_inline
     @parameter
     def _load_b_fast(
-        bp0: UnsafePointer[Scalar[F32], ImmutAnyOrigin],
+        bp0: Pointer[Scalar[F32], ImmutAnyOrigin],
     ) -> InlineArray[SIMD[F32, FRAG8], _NT_N]:
         var bfrag = InlineArray[SIMD[F32, FRAG8], _NT_N](uninitialized=True)
         comptime for ni in range(_NT_N):
-            bfrag[ni] = (bp0 + ni * MMA8_DIM).load[width=FRAG8]()
+            bfrag[ni] = (bp0.unsafe_offset(ni * MMA8_DIM)).unsafe_load[
+                width=FRAG8
+            ]()
         return bfrag^
 
     @always_inline
@@ -225,17 +231,17 @@ def _sdpa_ta_gemm_kernel[
     if interior:
         # Software-pipelined pointer-increment loop: the next slab's
         # fragments are in flight while the current slab's mmas issue.
-        var ap = a_ptr + (k_start + fcol) * m + row_base + frow
-        var mp = mask_ptr + (k_start + fcol) * m + row_base + frow
-        var bp = b_ptr + (k_start + frow) * n + col_base + fcol
+        var ap = a_ptr.unsafe_offset((k_start + fcol) * m + row_base + frow)
+        var mp = mask_ptr.unsafe_offset((k_start + fcol) * m + row_base + frow)
+        var bp = b_ptr.unsafe_offset((k_start + frow) * n + col_base + fcol)
         var nslabs = (k - k_start) // MMA8_DIM
         if nslabs > 0:
             var cura = _load_a_fast(ap, mp)
             var curb = _load_b_fast(bp)
             for _ in range(nslabs - 1):
-                ap += MMA8_DIM * m
-                mp += MMA8_DIM * m
-                bp += MMA8_DIM * n
+                ap = ap.unsafe_offset(MMA8_DIM * m)
+                mp = mp.unsafe_offset(MMA8_DIM * m)
+                bp = bp.unsafe_offset(MMA8_DIM * n)
                 var nxta = _load_a_fast(ap, mp)
                 var nxtb = _load_b_fast(bp)
                 _mma_block(cura, curb, accum)
@@ -257,16 +263,16 @@ def _sdpa_ta_gemm_kernel[
                 var gcol = col_base + ni * MMA8_DIM + fcol
                 var frag = accum[mi * _NT_N + ni]
                 if gcol + FRAG8 <= n:
-                    c_ptr.store(grow * n + gcol, frag)
+                    c_ptr.unsafe_store(grow * n + gcol, frag)
                 elif gcol < n:
-                    c_ptr[grow * n + gcol] = frag[0]
+                    c_ptr[unsafe_offset=grow * n + gcol] = frag[0]
 
 
 def enqueue_sdpa_ta_gemm_f32(
-    c_ptr: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    a_ptr: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
-    b_ptr: UnsafePointer[Scalar[DType.float32], ImmutAnyOrigin],
-    mask: Optional[UnsafePointer[Scalar[DType.bool], ImmutAnyOrigin]],
+    c_ptr: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    a_ptr: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
+    b_ptr: Pointer[Scalar[DType.float32], ImmutAnyOrigin],
+    mask: Optional[Pointer[Scalar[DType.bool], ImmutAnyOrigin]],
     batch: Int,
     m: Int,
     n: Int,
@@ -292,7 +298,7 @@ def enqueue_sdpa_ta_gemm_f32(
         var scale_f32 = Float32(drop_scale)
         # The unmasked kernels never dereference the mask pointer; alias A
         # so the argument stays a valid translated device pointer.
-        var mask_arg = a_ptr.bitcast[Scalar[DType.bool]]()
+        var mask_arg = a_ptr.unsafe_bitcast[Scalar[DType.bool]]()
         if mask:
             mask_arg = mask.value()
         if mask:

--- a/torch_mojo_backend/eager_kernels/sdpa_backward_ops/sdpa_backward_ops.mojo
+++ b/torch_mojo_backend/eager_kernels/sdpa_backward_ops/sdpa_backward_ops.mojo
@@ -77,9 +77,7 @@ def _sdpa_dropout_softmax_backward_go(
     var handled = False
     comptime for dt in FLOAT_DTYPES:
         if dtype == dt:
-            var mask: Optional[
-                UnsafePointer[Scalar[DType.bool], MutAnyOrigin]
-            ] = None
+            var mask: Optional[Pointer[Scalar[DType.bool], MutAnyOrigin]] = None
             if has_mask:
                 mask = _make_ptr[DType.bool](
                     mask_address
@@ -131,7 +129,7 @@ def _sdpa_dsb_f32_go(
     ).as_unsafe_any_origin()
     var mask_address = _raw_int(mask_ptr_obj)
     var has_mask = _raw_int(has_mask_obj) != 0
-    var mask: Optional[UnsafePointer[Scalar[DType.bool], MutAnyOrigin]] = None
+    var mask: Optional[Pointer[Scalar[DType.bool], MutAnyOrigin]] = None
     if has_mask:
         if mask_address == 0:
             raise Error(
@@ -176,16 +174,16 @@ def _sdpa_ta_gemm_go(
     var a = (
         _make_ptr[DType.float32](_raw_int(a_ptr_obj))
         .as_unsafe_any_origin()
-        .as_immutable()
+        .as_imm()
     )
     var b = (
         _make_ptr[DType.float32](_raw_int(b_ptr_obj))
         .as_unsafe_any_origin()
-        .as_immutable()
+        .as_imm()
     )
     var mask_address = _raw_int(mask_ptr_obj)
     var has_mask = _raw_tuple_int(params, 4) != 0
-    var mask: Optional[UnsafePointer[Scalar[DType.bool], ImmutAnyOrigin]] = None
+    var mask: Optional[Pointer[Scalar[DType.bool], ImmutAnyOrigin]] = None
     if has_mask:
         if mask_address == 0:
             raise Error(
@@ -193,9 +191,7 @@ def _sdpa_ta_gemm_go(
                 " is true"
             )
         mask = (
-            _make_ptr[DType.bool](mask_address)
-            .as_unsafe_any_origin()
-            .as_immutable()
+            _make_ptr[DType.bool](mask_address).as_unsafe_any_origin().as_imm()
         )
     elif mask_address != 0:
         raise Error(

--- a/torch_mojo_backend/eager_kernels/sdpa_backward_ops/sdpa_dropout_softmax_backward_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/sdpa_backward_ops/sdpa_dropout_softmax_backward_kernels.mojo
@@ -52,10 +52,10 @@ comptime _VECTOR_BYTES = 16
 def _fused_rows[
     dtype: DType, has_mask: Bool, causal: Bool, VEC: Int
 ](
-    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    probabilities: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    grad_after_dropout: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    mask: UnsafePointer[Scalar[DType.bool], MutAnyOrigin],
+    output: Pointer[Scalar[dtype], MutAnyOrigin],
+    probabilities: Pointer[Scalar[dtype], MutAnyOrigin],
+    grad_after_dropout: Pointer[Scalar[dtype], MutAnyOrigin],
+    mask: Pointer[Scalar[DType.bool], MutAnyOrigin],
     rows: Int,
     cols: Int,
     q_len: Int,
@@ -73,22 +73,26 @@ def _fused_rows[
     @always_inline
     @parameter
     def _grad_vec(index: Int) -> SIMD[F32, VEC]:
-        var d_p = grad_after_dropout.load[width=VEC, alignment=ALIGN](
+        var d_p = grad_after_dropout.unsafe_load[width=VEC, alignment=ALIGN](
             index
         ).cast[F32]()
         comptime if has_mask:
             # Preserve the pinned IEEE operation order.  A false mask is
             # multiplied rather than used as a selection, so non-finite
             # gradients still propagate as specified.
-            d_p = d_p * mask.load[width=VEC](index).cast[F32]() * dropout_scale
+            d_p = (
+                d_p
+                * mask.unsafe_load[width=VEC](index).cast[F32]()
+                * dropout_scale
+            )
         return d_p
 
     @always_inline
     @parameter
     def _grad_one(index: Int) -> Float32:
-        var d_p = grad_after_dropout[index].cast[F32]()
+        var d_p = grad_after_dropout[unsafe_offset=index].cast[F32]()
         comptime if has_mask:
-            d_p = d_p * mask[index].cast[F32]() * dropout_scale
+            d_p = d_p * mask[unsafe_offset=index].cast[F32]() * dropout_scale
         return d_p
 
     while row < rows:
@@ -104,7 +108,7 @@ def _fused_rows[
         while col < vec_limit:
             var index = base + col
             acc = (
-                probabilities.load[width=VEC, alignment=ALIGN](index)
+                probabilities.unsafe_load[width=VEC, alignment=ALIGN](index)
                 .cast[F32]()
                 .fma(_grad_vec(index), acc)
             )
@@ -113,9 +117,9 @@ def _fused_rows[
         var tail = vec_limit + lane
         var tail_sum = Float32(0.0)
         if tail < limit:
-            tail_sum = probabilities[base + tail].cast[F32]() * _grad_one(
-                base + tail
-            )
+            tail_sum = probabilities[unsafe_offset=base + tail].cast[
+                F32
+            ]() * _grad_one(base + tail)
 
         # The row bound is warp-uniform, so every lane reaches the shuffles.
         var row_sum = warp.sum(acc.reduce_add() + tail_sum)
@@ -125,17 +129,19 @@ def _fused_rows[
         while col < vec_limit:
             var index = base + col
             var value = (
-                probabilities.load[width=VEC, alignment=ALIGN](index).cast[
-                    F32
-                ]()
+                probabilities.unsafe_load[width=VEC, alignment=ALIGN](
+                    index
+                ).cast[F32]()
                 * (_grad_vec(index) - row_sum)
                 * score_scale
             )
-            output.store[width=VEC, alignment=ALIGN](index, value.cast[dtype]())
+            output.unsafe_store[width=VEC, alignment=ALIGN](
+                index, value.cast[dtype]()
+            )
             col += WARP_SIZE * VEC
         if tail < limit:
-            output[base + tail] = (
-                probabilities[base + tail].cast[F32]()
+            output[unsafe_offset=base + tail] = (
+                probabilities[unsafe_offset=base + tail].cast[F32]()
                 * (_grad_one(base + tail) - row_sum)
                 * score_scale
             ).cast[dtype]()
@@ -145,10 +151,10 @@ def _fused_rows[
         comptime if causal:
             var zero_head = min(cols, ceildiv(limit, VEC) * VEC)
             if limit + lane < zero_head:
-                output[base + limit + lane] = Scalar[dtype](0)
+                output[unsafe_offset=base + limit + lane] = Scalar[dtype](0)
             col = zero_head + lane * VEC
             while col + VEC <= cols:
-                output.store[width=VEC, alignment=ALIGN](
+                output.unsafe_store[width=VEC, alignment=ALIGN](
                     base + col, SIMD[dtype, VEC](Scalar[dtype](0))
                 )
                 col += WARP_SIZE * VEC
@@ -162,10 +168,10 @@ def _fused_rows[
 def _fused_kernel[
     dtype: DType, has_mask: Bool, causal: Bool, VEC: Int
 ](
-    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    probabilities: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    grad_after_dropout: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    mask: UnsafePointer[Scalar[DType.bool], MutAnyOrigin],
+    output: Pointer[Scalar[dtype], MutAnyOrigin],
+    probabilities: Pointer[Scalar[dtype], MutAnyOrigin],
+    grad_after_dropout: Pointer[Scalar[dtype], MutAnyOrigin],
+    mask: Pointer[Scalar[DType.bool], MutAnyOrigin],
     rows_arg: Int64,
     cols_arg: Int64,
     q_len_arg: Int64,
@@ -194,10 +200,10 @@ def _fused_kernel[
 def _enqueue_one[
     dtype: DType, has_mask: Bool, causal: Bool, VEC: Int
 ](
-    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    probabilities: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    grad_after_dropout: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    mask: UnsafePointer[Scalar[DType.bool], MutAnyOrigin],
+    output: Pointer[Scalar[dtype], MutAnyOrigin],
+    probabilities: Pointer[Scalar[dtype], MutAnyOrigin],
+    grad_after_dropout: Pointer[Scalar[dtype], MutAnyOrigin],
+    mask: Pointer[Scalar[DType.bool], MutAnyOrigin],
     rows: Int,
     cols: Int,
     q_len: Int,
@@ -230,10 +236,10 @@ def _enqueue_one[
 def _enqueue_regime[
     dtype: DType, causal: Bool
 ](
-    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    probabilities: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    grad_after_dropout: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    mask: UnsafePointer[Scalar[DType.bool], MutAnyOrigin],
+    output: Pointer[Scalar[dtype], MutAnyOrigin],
+    probabilities: Pointer[Scalar[dtype], MutAnyOrigin],
+    grad_after_dropout: Pointer[Scalar[dtype], MutAnyOrigin],
+    mask: Pointer[Scalar[DType.bool], MutAnyOrigin],
     rows: Int,
     cols: Int,
     q_len: Int,
@@ -311,10 +317,10 @@ def _enqueue_regime[
 def enqueue_sdpa_dropout_softmax_backward[
     dtype: DType
 ](
-    output: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    probabilities: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    grad_after_dropout: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    mask: Optional[UnsafePointer[Scalar[DType.bool], MutAnyOrigin]],
+    output: Pointer[Scalar[dtype], MutAnyOrigin],
+    probabilities: Pointer[Scalar[dtype], MutAnyOrigin],
+    grad_after_dropout: Pointer[Scalar[dtype], MutAnyOrigin],
+    mask: Optional[Pointer[Scalar[DType.bool], MutAnyOrigin]],
     rows: Int,
     cols: Int,
     q_len: Int,
@@ -349,9 +355,11 @@ def enqueue_sdpa_dropout_softmax_backward[
         # compile-time parameter, so the no-mask instantiation never emits a
         # single mask access.  Pass an aliased operand pointer as the unused
         # argument rather than model nullability all the way into the kernel.
-        var mask_ptr = mask.value() if has_mask else probabilities.bitcast[
-            Scalar[DType.bool]
-        ]()
+        var mask_ptr = (
+            mask.value() if has_mask else probabilities.unsafe_bitcast[
+                Scalar[DType.bool]
+            ]()
+        )
         if causal:
             _enqueue_regime[dtype, True](
                 output,
@@ -413,10 +421,10 @@ comptime _CVEC = 4  # float4 loads; requires 16B-aligned rows
 
 @__name("sdpa_dropout_softmax_backward_masked_f32")
 def _masked_f32(
-    output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    probabilities: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_after_dropout: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    mask: UnsafePointer[Scalar[DType.bool], MutAnyOrigin],
+    output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    probabilities: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_after_dropout: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    mask: Pointer[Scalar[DType.bool], MutAnyOrigin],
     rows_arg: Int64,
     cols_arg: Int64,
     dropout_scale: Float32,
@@ -439,11 +447,11 @@ def _masked_f32(
             # false mask is multiplied rather than used as a selection, so
             # non-finite gradients still propagate as specified.
             var masked_d_p = (
-                grad_after_dropout[index]
-                * mask[index].cast[DType.float32]()
+                grad_after_dropout[unsafe_offset=index]
+                * mask[unsafe_offset=index].cast[DType.float32]()
                 * dropout_scale
             )
-            partial_sum += probabilities[index] * masked_d_p
+            partial_sum += probabilities[unsafe_offset=index] * masked_d_p
             col += _APPLE_BLOCK
 
         # Every thread in the block reaches this row reduction. Broadcasting
@@ -455,12 +463,14 @@ def _masked_f32(
         while col < cols:
             var index = base + col
             var masked_d_p = (
-                grad_after_dropout[index]
-                * mask[index].cast[DType.float32]()
+                grad_after_dropout[unsafe_offset=index]
+                * mask[unsafe_offset=index].cast[DType.float32]()
                 * dropout_scale
             )
-            output[index] = (
-                probabilities[index] * (masked_d_p - row_sum) * score_scale
+            output[unsafe_offset=index] = (
+                probabilities[unsafe_offset=index]
+                * (masked_d_p - row_sum)
+                * score_scale
             )
             col += _APPLE_BLOCK
         row += row_stride
@@ -468,9 +478,9 @@ def _masked_f32(
 
 @__name("sdpa_dropout_softmax_backward_unmasked_f32")
 def _unmasked_f32(
-    output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    probabilities: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_after_dropout: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    probabilities: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_after_dropout: Pointer[Scalar[DType.float32], MutAnyOrigin],
     rows_arg: Int64,
     cols_arg: Int64,
     score_scale: Float32,
@@ -488,7 +498,10 @@ def _unmasked_f32(
         var col = tid
         while col < cols:
             var index = base + col
-            partial_sum += probabilities[index] * grad_after_dropout[index]
+            partial_sum += (
+                probabilities[unsafe_offset=index]
+                * grad_after_dropout[unsafe_offset=index]
+            )
             col += _APPLE_BLOCK
 
         var row_sum = block.sum[block_size=_APPLE_BLOCK, broadcast=True](
@@ -497,9 +510,9 @@ def _unmasked_f32(
         col = tid
         while col < cols:
             var index = base + col
-            output[index] = (
-                probabilities[index]
-                * (grad_after_dropout[index] - row_sum)
+            output[unsafe_offset=index] = (
+                probabilities[unsafe_offset=index]
+                * (grad_after_dropout[unsafe_offset=index] - row_sum)
                 * score_scale
             )
             col += _APPLE_BLOCK
@@ -523,10 +536,10 @@ def _unmasked_f32(
 def _masked_causal_warp_f32[
     V: Int, VPT: Int
 ](
-    output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    probabilities: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_after_dropout: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    mask: UnsafePointer[Scalar[DType.bool], MutAnyOrigin],
+    output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    probabilities: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_after_dropout: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    mask: Pointer[Scalar[DType.bool], MutAnyOrigin],
     rows_arg: Int64,
     cols_arg: Int64,
     q_len_arg: Int64,
@@ -558,11 +571,15 @@ def _masked_causal_warp_f32[
             var p = SIMD[DType.float32, V](0)
             var masked_d_p = SIMD[DType.float32, V](0)
             if j0 < allowed:
-                p = probabilities.load[width=V, alignment=V * 4](base + j0)
+                p = probabilities.unsafe_load[width=V, alignment=V * 4](
+                    base + j0
+                )
                 # Preserve the pinned IEEE operation order (`_masked_f32`).
                 masked_d_p = (
-                    grad_after_dropout.load[width=V, alignment=V * 4](base + j0)
-                    * mask.load[width=V](base + j0).cast[DType.float32]()
+                    grad_after_dropout.unsafe_load[width=V, alignment=V * 4](
+                        base + j0
+                    )
+                    * mask.unsafe_load[width=V](base + j0).cast[DType.float32]()
                     * dropout_scale
                 )
                 if j0 + V > allowed:
@@ -587,7 +604,7 @@ def _masked_causal_warp_f32[
                     comptime for li in range(V):
                         if j0 + li >= allowed:
                             value[li] = 0
-                output.store[width=V, alignment=V * 4](base + j0, value)
+                output.unsafe_store[width=V, alignment=V * 4](base + j0, value)
         row += row_stride
 
 
@@ -595,9 +612,9 @@ def _masked_causal_warp_f32[
 def _unmasked_causal_warp_f32[
     V: Int, VPT: Int
 ](
-    output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    probabilities: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_after_dropout: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    probabilities: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_after_dropout: Pointer[Scalar[DType.float32], MutAnyOrigin],
     rows_arg: Int64,
     cols_arg: Int64,
     q_len_arg: Int64,
@@ -624,8 +641,12 @@ def _unmasked_causal_warp_f32[
             var p = SIMD[DType.float32, V](0)
             var d = SIMD[DType.float32, V](0)
             if j0 < allowed:
-                p = probabilities.load[width=V, alignment=V * 4](base + j0)
-                d = grad_after_dropout.load[width=V, alignment=V * 4](base + j0)
+                p = probabilities.unsafe_load[width=V, alignment=V * 4](
+                    base + j0
+                )
+                d = grad_after_dropout.unsafe_load[width=V, alignment=V * 4](
+                    base + j0
+                )
                 if j0 + V > allowed:
                     comptime for li in range(V):
                         if j0 + li >= allowed:
@@ -646,16 +667,16 @@ def _unmasked_causal_warp_f32[
                     comptime for li in range(V):
                         if j0 + li >= allowed:
                             value[li] = 0
-                output.store[width=V, alignment=V * 4](base + j0, value)
+                output.unsafe_store[width=V, alignment=V * 4](base + j0, value)
         row += row_stride
 
 
 @__name("sdpa_dropout_softmax_backward_masked_causal_f32")
 def _masked_causal_f32(
-    output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    probabilities: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_after_dropout: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    mask: UnsafePointer[Scalar[DType.bool], MutAnyOrigin],
+    output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    probabilities: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_after_dropout: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    mask: Pointer[Scalar[DType.bool], MutAnyOrigin],
     rows_arg: Int64,
     cols_arg: Int64,
     q_len_arg: Int64,
@@ -680,11 +701,11 @@ def _masked_causal_f32(
             var index = base + col
             # Preserve the pinned IEEE operation order (see `_masked_f32`).
             var masked_d_p = (
-                grad_after_dropout[index]
-                * mask[index].cast[DType.float32]()
+                grad_after_dropout[unsafe_offset=index]
+                * mask[unsafe_offset=index].cast[DType.float32]()
                 * dropout_scale
             )
-            partial_sum += probabilities[index] * masked_d_p
+            partial_sum += probabilities[unsafe_offset=index] * masked_d_p
             col += _APPLE_BLOCK
 
         var row_sum = block.sum[block_size=_APPLE_BLOCK, broadcast=True](
@@ -696,23 +717,25 @@ def _masked_causal_f32(
             var value = Float32(0.0)
             if col < boundary:
                 var masked_d_p = (
-                    grad_after_dropout[index]
-                    * mask[index].cast[DType.float32]()
+                    grad_after_dropout[unsafe_offset=index]
+                    * mask[unsafe_offset=index].cast[DType.float32]()
                     * dropout_scale
                 )
                 value = (
-                    probabilities[index] * (masked_d_p - row_sum) * score_scale
+                    probabilities[unsafe_offset=index]
+                    * (masked_d_p - row_sum)
+                    * score_scale
                 )
-            output[index] = value
+            output[unsafe_offset=index] = value
             col += _APPLE_BLOCK
         row += row_stride
 
 
 @__name("sdpa_dropout_softmax_backward_unmasked_causal_f32")
 def _unmasked_causal_f32(
-    output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    probabilities: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_after_dropout: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    probabilities: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_after_dropout: Pointer[Scalar[DType.float32], MutAnyOrigin],
     rows_arg: Int64,
     cols_arg: Int64,
     q_len_arg: Int64,
@@ -734,7 +757,10 @@ def _unmasked_causal_f32(
         var col = tid
         while col < boundary:
             var index = base + col
-            partial_sum += probabilities[index] * grad_after_dropout[index]
+            partial_sum += (
+                probabilities[unsafe_offset=index]
+                * grad_after_dropout[unsafe_offset=index]
+            )
             col += _APPLE_BLOCK
 
         var row_sum = block.sum[block_size=_APPLE_BLOCK, broadcast=True](
@@ -746,20 +772,20 @@ def _unmasked_causal_f32(
             var value = Float32(0.0)
             if col < boundary:
                 value = (
-                    probabilities[index]
-                    * (grad_after_dropout[index] - row_sum)
+                    probabilities[unsafe_offset=index]
+                    * (grad_after_dropout[unsafe_offset=index] - row_sum)
                     * score_scale
                 )
-            output[index] = value
+            output[unsafe_offset=index] = value
             col += _APPLE_BLOCK
         row += row_stride
 
 
 def enqueue_sdpa_dropout_softmax_backward_f32(
-    output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    probabilities: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    grad_after_dropout: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    mask: Optional[UnsafePointer[Scalar[DType.bool], MutAnyOrigin]],
+    output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    probabilities: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    grad_after_dropout: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    mask: Optional[Pointer[Scalar[DType.bool], MutAnyOrigin]],
     rows: Int,
     cols: Int,
     has_mask: Bool,

--- a/torch_mojo_backend/eager_kernels/searchsorted_ops/searchsorted_ops.mojo
+++ b/torch_mojo_backend/eager_kernels/searchsorted_ops/searchsorted_ops.mojo
@@ -73,9 +73,9 @@ def _binary_search_position[
     has_sorter: Bool,
     right: Bool,
 ](
-    boundaries: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    values: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    sorter: UnsafePointer[Scalar[DType.int64], ImmutAnyOrigin],
+    boundaries: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    values: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    sorter: Pointer[Scalar[DType.int64], ImmutAnyOrigin],
     value_index: Int,
     boundary_size: Int,
     values_per_batch: Int,
@@ -84,16 +84,16 @@ def _binary_search_position[
     comptime if not boundaries_are_1d:
         boundary_base = (value_index // values_per_batch) * boundary_size
 
-    var value = SIMD[dtype, 1](values[value_index])
+    var value = SIMD[dtype, 1](values[unsafe_offset=value_index])
     var low = 0
     var high = boundary_size
     while low < high:
         var mid = low + ((high - low) >> 1)
         var boundary_index = mid
         comptime if has_sorter:
-            boundary_index = Int(sorter[boundary_base + mid])
+            boundary_index = Int(sorter[unsafe_offset=boundary_base + mid])
         var boundary = SIMD[dtype, 1](
-            boundaries[boundary_base + boundary_index]
+            boundaries[unsafe_offset=boundary_base + boundary_index]
         )
         var advance = _should_advance[dtype, right](boundary, value)
         # Conditional expressions lower to selects: the data-dependent update
@@ -116,10 +116,10 @@ def _binary_search_kernel[
     has_sorter: Bool,
     right: Bool,
 ](
-    out_ptr: UnsafePointer[Scalar[out_dtype], MutAnyOrigin],
-    boundaries: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    values: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    sorter: UnsafePointer[Scalar[DType.int64], ImmutAnyOrigin],
+    out_ptr: Pointer[Scalar[out_dtype], MutAnyOrigin],
+    boundaries: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    values: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    sorter: Pointer[Scalar[DType.int64], ImmutAnyOrigin],
     num_values_arg: Int64,
     boundary_size_arg: Int64,
     values_per_batch_arg: Int64,
@@ -130,7 +130,7 @@ def _binary_search_kernel[
     var i = Int(block_idx.x) * Int(block_dim.x) + Int(thread_idx.x)
     var stride = Int(grid_dim.x) * Int(block_dim.x)
     while i < num_values:
-        out_ptr[i] = _binary_search_position[
+        out_ptr[unsafe_offset=i] = _binary_search_position[
             dtype, boundaries_are_1d, has_sorter, right
         ](
             boundaries,
@@ -164,15 +164,11 @@ def _searchsorted[
 ) raises:
     var out = _make_ptr[out_dtype](out_addr).as_unsafe_any_origin()
     var boundaries = (
-        _make_ptr[dtype](boundaries_addr).as_unsafe_any_origin().as_immutable()
+        _make_ptr[dtype](boundaries_addr).as_unsafe_any_origin().as_imm()
     )
-    var values = (
-        _make_ptr[dtype](values_addr).as_unsafe_any_origin().as_immutable()
-    )
+    var values = _make_ptr[dtype](values_addr).as_unsafe_any_origin().as_imm()
     var sorter = (
-        _make_ptr[DType.int64](sorter_addr)
-        .as_unsafe_any_origin()
-        .as_immutable()
+        _make_ptr[DType.int64](sorter_addr).as_unsafe_any_origin().as_imm()
     )
 
     if ctx.api() == "cpu":
@@ -189,7 +185,7 @@ def _searchsorted[
         )
         def func[width: Int, alignment: Int = 1](idx: Coord):
             var i = Int(idx[0].value())
-            out[i] = _binary_search_position[
+            out[unsafe_offset=i] = _binary_search_position[
                 dtype, boundaries_are_1d, has_sorter, right
             ](
                 boundaries,

--- a/torch_mojo_backend/eager_kernels/softmax_backward_ops/softmax_backward_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/softmax_backward_ops/softmax_backward_kernels.mojo
@@ -42,7 +42,7 @@ from max.gpu.memory import external_memory
 from std.memory import AddressSpace
 from max.gpu.primitives import block
 from std.math import ceildiv, exp
-from std.memory import alloc
+from std.memory.alloc import unsafe_alloc
 from std.sys.info import has_accelerator, size_of
 from std.utils.static_tuple import StaticTuple
 
@@ -77,9 +77,9 @@ comptime _REG_MAX_SLOTS = 8
 def _log_softmax_bwd_smem_kernel[
     dtype: DType, threads: Int
 ](
-    gi: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    g: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    o: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    gi: Pointer[Scalar[dtype], MutAnyOrigin],
+    g: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    o: Pointer[Scalar[dtype], ImmutAnyOrigin],
     rows_arg: Int64,
     cols_arg: Int64,
 ):
@@ -111,16 +111,16 @@ def _log_softmax_bwd_smem_kernel[
     var vsum = SIMD[DType.float32, VEC](0)
     var ssum = Float32(0)
     if tid < head:
-        ssum += g[base + tid].cast[DType.float32]()
+        ssum += g[unsafe_offset=base + tid].cast[DType.float32]()
     var v = tid
     while v < nvec:
-        var gv = g.load[width=VEC, alignment=16](base + head + v * VEC)
-        smem_g.store[width=VEC, alignment=16](v * VEC, gv)
+        var gv = g.unsafe_load[width=VEC, alignment=16](base + head + v * VEC)
+        smem_g.unsafe_store[width=VEC, alignment=16](v * VEC, gv)
         vsum += gv.cast[DType.float32]()
         v += threads
     var j = tail_start + tid
     while j < cols:
-        ssum += g[base + j].cast[DType.float32]()
+        ssum += g[unsafe_offset=base + j].cast[DType.float32]()
         j += threads
     var srow = block.sum[block_size=threads, broadcast=True](
         vsum.reduce_add() + ssum
@@ -128,27 +128,29 @@ def _log_softmax_bwd_smem_kernel[
 
     if tid < head:
         var idx = base + tid
-        gi[idx] = (
-            g[idx].cast[DType.float32]()
-            - exp(o[idx].cast[DType.float32]()) * srow
+        gi[unsafe_offset=idx] = (
+            g[unsafe_offset=idx].cast[DType.float32]()
+            - exp(o[unsafe_offset=idx].cast[DType.float32]()) * srow
         ).cast[dtype]()
     v = tid
     while v < nvec:
         var idx = base + head + v * VEC
-        var gv = smem_g.load[width=VEC, alignment=16](v * VEC).cast[
+        var gv = smem_g.unsafe_load[width=VEC, alignment=16](v * VEC).cast[
             DType.float32
         ]()
-        var ov = o.load[width=VEC, alignment=16](idx).cast[DType.float32]()
-        gi.store[width=VEC, alignment=16](
+        var ov = o.unsafe_load[width=VEC, alignment=16](idx).cast[
+            DType.float32
+        ]()
+        gi.unsafe_store[width=VEC, alignment=16](
             idx, (gv - exp(ov) * srow).cast[dtype]()
         )
         v += threads
     j = tail_start + tid
     while j < cols:
         var idx = base + j
-        gi[idx] = (
-            g[idx].cast[DType.float32]()
-            - exp(o[idx].cast[DType.float32]()) * srow
+        gi[unsafe_offset=idx] = (
+            g[unsafe_offset=idx].cast[DType.float32]()
+            - exp(o[unsafe_offset=idx].cast[DType.float32]()) * srow
         ).cast[dtype]()
         j += threads
 
@@ -160,9 +162,9 @@ def _log_softmax_bwd_smem_kernel[
 def _log_softmax_bwd_nosmem_kernel[
     dtype: DType
 ](
-    gi: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    g: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    o: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    gi: Pointer[Scalar[dtype], MutAnyOrigin],
+    g: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    o: Pointer[Scalar[dtype], ImmutAnyOrigin],
     rows_arg: Int64,
     cols_arg: Int64,
 ):
@@ -186,15 +188,15 @@ def _log_softmax_bwd_nosmem_kernel[
     var vsum = SIMD[DType.float32, VEC](0)
     var ssum = Float32(0)
     if tid < head:
-        ssum += g[base + tid].cast[DType.float32]()
+        ssum += g[unsafe_offset=base + tid].cast[DType.float32]()
     var v = tid
     while v < nvec:
-        var gv = g.load[width=VEC, alignment=16](base + head + v * VEC)
+        var gv = g.unsafe_load[width=VEC, alignment=16](base + head + v * VEC)
         vsum += gv.cast[DType.float32]()
         v += _NOSMEM_THREADS
     var j = tail_start + tid
     while j < cols:
-        ssum += g[base + j].cast[DType.float32]()
+        ssum += g[unsafe_offset=base + j].cast[DType.float32]()
         j += _NOSMEM_THREADS
     var srow = block.sum[block_size=_NOSMEM_THREADS, broadcast=True](
         vsum.reduce_add() + ssum
@@ -202,25 +204,29 @@ def _log_softmax_bwd_nosmem_kernel[
 
     if tid < head:
         var idx = base + tid
-        gi[idx] = (
-            g[idx].cast[DType.float32]()
-            - exp(o[idx].cast[DType.float32]()) * srow
+        gi[unsafe_offset=idx] = (
+            g[unsafe_offset=idx].cast[DType.float32]()
+            - exp(o[unsafe_offset=idx].cast[DType.float32]()) * srow
         ).cast[dtype]()
     v = tid
     while v < nvec:
         var idx = base + head + v * VEC
-        var gv = g.load[width=VEC, alignment=16](idx).cast[DType.float32]()
-        var ov = o.load[width=VEC, alignment=16](idx).cast[DType.float32]()
-        gi.store[width=VEC, alignment=16](
+        var gv = g.unsafe_load[width=VEC, alignment=16](idx).cast[
+            DType.float32
+        ]()
+        var ov = o.unsafe_load[width=VEC, alignment=16](idx).cast[
+            DType.float32
+        ]()
+        gi.unsafe_store[width=VEC, alignment=16](
             idx, (gv - exp(ov) * srow).cast[dtype]()
         )
         v += _NOSMEM_THREADS
     j = tail_start + tid
     while j < cols:
         var idx = base + j
-        gi[idx] = (
-            g[idx].cast[DType.float32]()
-            - exp(o[idx].cast[DType.float32]()) * srow
+        gi[unsafe_offset=idx] = (
+            g[unsafe_offset=idx].cast[DType.float32]()
+            - exp(o[unsafe_offset=idx].cast[DType.float32]()) * srow
         ).cast[dtype]()
         j += _NOSMEM_THREADS
 
@@ -232,9 +238,9 @@ def _log_softmax_bwd_nosmem_kernel[
 def _log_softmax_bwd_reg_kernel[
     dtype: DType, threads: Int, slots: Int
 ](
-    gi: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    g: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    o: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    gi: Pointer[Scalar[dtype], MutAnyOrigin],
+    g: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    o: Pointer[Scalar[dtype], ImmutAnyOrigin],
     rows_arg: Int64,
     cols_arg: Int64,
 ):
@@ -264,16 +270,18 @@ def _log_softmax_bwd_reg_kernel[
         var vsum = SIMD[DType.float32, VEC](0)
         var ssum = Float32(0)
         if tid < head:
-            ssum += g[base + tid].cast[DType.float32]()
+            ssum += g[unsafe_offset=base + tid].cast[DType.float32]()
         comptime for u in range(slots):
             var v = tid + u * threads
             if v < nvec:
-                var gv = g.load[width=VEC, alignment=16](base + head + v * VEC)
+                var gv = g.unsafe_load[width=VEC, alignment=16](
+                    base + head + v * VEC
+                )
                 cache[u] = gv
                 vsum += gv.cast[DType.float32]()
         var j = tail_start + tid
         while j < cols:
-            ssum += g[base + j].cast[DType.float32]()
+            ssum += g[unsafe_offset=base + j].cast[DType.float32]()
             j += threads
         var srow = block.sum[block_size=threads, broadcast=True](
             vsum.reduce_add() + ssum
@@ -281,27 +289,27 @@ def _log_softmax_bwd_reg_kernel[
 
         if tid < head:
             var idx = base + tid
-            gi[idx] = (
-                g[idx].cast[DType.float32]()
-                - exp(o[idx].cast[DType.float32]()) * srow
+            gi[unsafe_offset=idx] = (
+                g[unsafe_offset=idx].cast[DType.float32]()
+                - exp(o[unsafe_offset=idx].cast[DType.float32]()) * srow
             ).cast[dtype]()
         comptime for u in range(slots):
             var v = tid + u * threads
             if v < nvec:
                 var idx = base + head + v * VEC
                 var gv = cache[u].cast[DType.float32]()
-                var ov = o.load[width=VEC, alignment=16](idx).cast[
+                var ov = o.unsafe_load[width=VEC, alignment=16](idx).cast[
                     DType.float32
                 ]()
-                gi.store[width=VEC, alignment=16](
+                gi.unsafe_store[width=VEC, alignment=16](
                     idx, (gv - exp(ov) * srow).cast[dtype]()
                 )
         j = tail_start + tid
         while j < cols:
             var idx = base + j
-            gi[idx] = (
-                g[idx].cast[DType.float32]()
-                - exp(o[idx].cast[DType.float32]()) * srow
+            gi[unsafe_offset=idx] = (
+                g[unsafe_offset=idx].cast[DType.float32]()
+                - exp(o[unsafe_offset=idx].cast[DType.float32]()) * srow
             ).cast[dtype]()
             j += threads
 
@@ -312,9 +320,9 @@ def _log_softmax_bwd_reg_kernel[
 def _enqueue_bwd_reg[
     dtype: DType, slots: Int
 ](
-    gi: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    g: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    o: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    gi: Pointer[Scalar[dtype], MutAnyOrigin],
+    g: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    o: Pointer[Scalar[dtype], ImmutAnyOrigin],
     rows: Int,
     cols: Int,
     blocks: Int,
@@ -361,8 +369,10 @@ def _enqueue_cached_smem[
     var name = String(t"TMB_KERNEL_{key}_{ctx.id()}")
     comptime FuncT = type_of(ctx.compile_function[func]())
 
-    if global_ptr := _get_global_or_null(name):
-        var fptr = global_ptr.value().bitcast[FuncT]()
+    var global_ptr = _get_global_or_null(name)
+
+    if global_ptr:
+        var fptr = global_ptr.value().unsafe_bitcast[FuncT]()
         ctx.enqueue_function(
             fptr[],
             *args,
@@ -381,11 +391,11 @@ def _enqueue_cached_smem[
         )
     else:
         compiled = ctx.compile_function[func]()
-    var fptr = alloc[FuncT](1)
-    fptr.init_pointee_move(compiled^)
+    var fptr = unsafe_alloc[FuncT](1)
+    fptr.unsafe_write(compiled^)
     external_call["KGEN_CompilerRT_InsertGlobal", NoneType](
         StringSlice(name),
-        fptr.bitcast[NoneType](),
+        fptr.unsafe_bitcast[NoneType](),
     )
     ctx.enqueue_function(
         fptr[],
@@ -422,9 +432,9 @@ def _dyn_smem_capacity(ctx: DeviceContext) -> Int:
 def enqueue_log_softmax_backward[
     dtype: DType
 ](
-    gi: UnsafePointer[Scalar[dtype], MutAnyOrigin],
-    g: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
-    o: UnsafePointer[Scalar[dtype], ImmutAnyOrigin],
+    gi: Pointer[Scalar[dtype], MutAnyOrigin],
+    g: Pointer[Scalar[dtype], ImmutAnyOrigin],
+    o: Pointer[Scalar[dtype], ImmutAnyOrigin],
     rows: Int,
     cols: Int,
     ctx: DeviceContext,

--- a/torch_mojo_backend/eager_kernels/softmax_backward_ops/softmax_backward_ops.mojo
+++ b/torch_mojo_backend/eager_kernels/softmax_backward_ops/softmax_backward_ops.mojo
@@ -52,10 +52,8 @@ def _log_softmax_backward_go(
                     _make_ptr[dt](grad_input_addr).as_unsafe_any_origin(),
                     _make_ptr[dt](grad_output_addr)
                     .as_unsafe_any_origin()
-                    .as_immutable(),
-                    _make_ptr[dt](output_addr)
-                    .as_unsafe_any_origin()
-                    .as_immutable(),
+                    .as_imm(),
+                    _make_ptr[dt](output_addr).as_unsafe_any_origin().as_imm(),
                     rows,
                     cols,
                     ctx,

--- a/torch_mojo_backend/eager_kernels/tensor_holder.mojo
+++ b/torch_mojo_backend/eager_kernels/tensor_holder.mojo
@@ -23,7 +23,7 @@
 from std.os import abort
 from std.gpu import block_dim, block_idx, grid_dim, thread_idx
 from max.gpu.host import DeviceContext, DeviceBuffer, DeviceEvent, HostBuffer
-from std.memory import memcpy
+from std.memory import unsafe_memcpy
 from std.python import Python, PythonObject
 from std.python._cpython import PyObjectPtr, Py_ssize_t
 from std.python.bindings import PythonModuleBuilder
@@ -99,7 +99,7 @@ def _stage_pageable_h2d(
 ) raises -> PythonObject:
     """Copy pageable CPU bytes to pinned memory, then enqueue pinned H2D."""
     var staging = ctx.enqueue_create_host_buffer[DType.uint8](nbytes)
-    memcpy(
+    unsafe_memcpy(
         dest=staging.unsafe_ptr(),
         src=_u8_ptr(host_ptr),
         count=nbytes,
@@ -123,7 +123,7 @@ def _stage_pageable_h2d(
 @always_inline
 def _u8_ptr(
     addr: Int,
-) -> UnsafePointer[Scalar[DType.uint8], MutUntrackedOrigin]:
+) -> Pointer[Scalar[DType.uint8], MutUntrackedOrigin]:
     return _make_ptr[DType.uint8](addr)
 
 
@@ -263,8 +263,8 @@ def copy_to_pinned_host(
 
 
 def _d2d_copy_vec4_kernel(
-    dst_ptr: UnsafePointer[Scalar[DType.uint32], MutAnyOrigin],
-    src_ptr: UnsafePointer[Scalar[DType.uint32], ImmutAnyOrigin],
+    dst_ptr: Pointer[Scalar[DType.uint32], MutAnyOrigin],
+    src_ptr: Pointer[Scalar[DType.uint32], ImmutAnyOrigin],
     vec_count_arg: Int64,
     tail_words_arg: Int64,
 ):
@@ -283,7 +283,9 @@ def _d2d_copy_vec4_kernel(
     var gid = Int(block_idx.x) * Int(block_dim.x) + Int(thread_idx.x)
     var gstride = Int(grid_dim.x) * Int(block_dim.x)
     if gid < tail_words:
-        dst_ptr[vec_count * 4 + gid] = src_ptr[vec_count * 4 + gid]
+        dst_ptr[unsafe_offset=vec_count * 4 + gid] = src_ptr[
+            unsafe_offset=vec_count * 4 + gid
+        ]
     # Each thread owns a group of 16 consecutive 16-byte chunks — one
     # sequential 256-byte stream per thread, the length the strided-permute
     # rowloop kernel measured streaming at ~2x the one-chunk-per-thread
@@ -293,14 +295,15 @@ def _d2d_copy_vec4_kernel(
     while g < groups:
         var b = g * 16
         for j in range(16):
-            dst_ptr.store[width=4, alignment=16](
-                (b + j) * 4, src_ptr.load[width=4, alignment=16]((b + j) * 4)
+            dst_ptr.unsafe_store[width=4, alignment=16](
+                (b + j) * 4,
+                src_ptr.unsafe_load[width=4, alignment=16]((b + j) * 4),
             )
         g += gstride
     var c = groups * 16 + gid
     if c < vec_count:
-        dst_ptr.store[width=4, alignment=16](
-            c * 4, src_ptr.load[width=4, alignment=16](c * 4)
+        dst_ptr.unsafe_store[width=4, alignment=16](
+            c * 4, src_ptr.unsafe_load[width=4, alignment=16](c * 4)
         )
 
 
@@ -346,7 +349,7 @@ def _copy_d2d_raw(
                 _make_ptr[DType.uint32](dst_addr).as_unsafe_any_origin(),
                 _make_ptr[DType.uint32](src_addr)
                 .as_unsafe_any_origin()
-                .as_immutable(),
+                .as_imm(),
                 Int64(vec_count),
                 Int64(words - vec_count * 4),
             )
@@ -363,13 +366,13 @@ def _copy_d2d_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         _copy_d2d_raw(
-            _raw_ctx(args[0]),
-            _raw_int(args[1]),
-            _raw_int(args[2]),
-            _raw_int(args[3]),
+            _raw_ctx(args[unsafe_offset=0]),
+            _raw_int(args[unsafe_offset=1]),
+            _raw_int(args[unsafe_offset=2]),
+            _raw_int(args[unsafe_offset=3]),
         )
         return _raw_ret_none()
     except e:
@@ -393,7 +396,9 @@ def read_scalar(
             var src = _wrap_raw(ctx, Int(py=dev_ptr), size_of[dt]())
             src.enqueue_copy_to(staging.unsafe_ptr())
             ctx.synchronize()
-            var val = staging.unsafe_ptr().bitcast[Scalar[dt]]()[0]
+            var val = staging.unsafe_ptr().unsafe_bitcast[Scalar[dt]]()[
+                unsafe_offset=0
+            ]
             comptime if dt == DType.bool:
                 return PythonObject(Bool(val))
             elif dt.is_floating_point():
@@ -511,10 +516,16 @@ def _copy_strided_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         _copy_strided_go(
-            args[0], args[1], args[2], args[3], args[4], args[5], args[6]
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+            args[unsafe_offset=6],
         )
     except e:
         return _spec_unsupported(e)
@@ -587,9 +598,16 @@ def _strided_fill_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
-        _strided_fill_go(args[0], args[1], args[2], args[3], args[4], args[5])
+        _strided_fill_go(
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+        )
     except e:
         return _spec_unsupported(e)
     return _raw_ret_none()
@@ -642,19 +660,19 @@ def _make_spec_dispatcher(
     args_safe: Pointer[PyObjectPtr, MutUntrackedOrigin],
     nargs: Py_ssize_t,
 ) abi("C") -> PyObjectPtr:
-    var args = UnsafePointer(args_safe)
+    var args = Pointer(args_safe)
     try:
         return _make_spec_go(
-            args[0],
-            args[1],
-            args[2],
-            args[3],
-            args[4],
-            args[5],
-            args[6],
-            args[7],
-            args[8],
-            args[9],
+            args[unsafe_offset=0],
+            args[unsafe_offset=1],
+            args[unsafe_offset=2],
+            args[unsafe_offset=3],
+            args[unsafe_offset=4],
+            args[unsafe_offset=5],
+            args[unsafe_offset=6],
+            args[unsafe_offset=7],
+            args[unsafe_offset=8],
+            args[unsafe_offset=9],
         )
     except e:
         return _spec_unsupported(e)

--- a/torch_mojo_backend/eager_kernels/tf32_matmul_ops/tf32_gemm_kernels.mojo
+++ b/torch_mojo_backend/eager_kernels/tf32_matmul_ops/tf32_gemm_kernels.mojo
@@ -99,10 +99,10 @@ def _tile_body[
     THREADS: Int,
     STAGES: Int,
 ](
-    c: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    a: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    b: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    bias: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    c: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    a: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    b: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    bias: Pointer[Scalar[DType.float32], MutAnyOrigin],
     m: Int,
     n: Int,
     k: Int,
@@ -165,16 +165,18 @@ def _tile_body[
 
         var bz = Int(block_idx.z)
         while bz < batch_count:
-            var a_base = a + bz * a_bs
-            var b_base = b + bz * b_bs
-            var c_base = c + bz * c_bs
+            var a_base = a.unsafe_offset(bz * a_bs)
+            var b_base = b.unsafe_offset(bz * b_bs)
+            var c_base = c.unsafe_offset(bz * c_bs)
 
             @parameter
             @always_inline
             def copy_a(ktile: Int, stage: Int):
-                var sa_ptr = smem + stage * STAGE_WORDS
+                var sa_ptr = smem.unsafe_offset(stage * STAGE_WORDS)
                 var k0 = ktile * _BK
-                var tile = a_base + (k0 * lda + m0 if TA else m0 * lda + k0)
+                var tile = a_base.unsafe_offset(
+                    k0 * lda + m0 if TA else m0 * lda + k0
+                )
                 var rows_avail = (k - k0) if TA else (m - m0)
                 var cols_avail = (m - m0) if TA else (k - k0)
                 if a_vec != 0:
@@ -184,10 +186,14 @@ def _tile_body[
                         if idx < AR * AV:
                             var r = idx // AV
                             var col = (idx - r * AV) * 4
-                            var dst = sa_ptr + r * (AC + APAD) + col
+                            var dst = sa_ptr.unsafe_offset(
+                                r * (AC + APAD) + col
+                            )
                             if r < rows_avail and col + 3 < cols_avail:
                                 async_copy[16](
-                                    (tile + r * lda + col).address_space_cast[
+                                    (
+                                        tile.unsafe_offset(r * lda + col)
+                                    ).unsafe_address_space_cast[
                                         AddressSpace.GLOBAL
                                     ](),
                                     dst,
@@ -199,37 +205,45 @@ def _tile_body[
                                     if r < rows_avail and col + j < cols_avail:
                                         async_copy[4](
                                             (
-                                                tile + r * lda + col + j
-                                            ).address_space_cast[
+                                                tile.unsafe_offset(
+                                                    r * lda + col + j
+                                                )
+                                            ).unsafe_address_space_cast[
                                                 AddressSpace.GLOBAL
                                             ](),
-                                            dst + j,
+                                            dst.unsafe_offset(j),
                                         )
                                     else:
-                                        dst[j] = 0.0
+                                        dst[unsafe_offset=j] = 0.0
                 else:
                     comptime for i in range(ceildiv(AR * AC, THREADS)):
                         var idx = tid + i * THREADS
                         if idx < AR * AC:
                             var r = idx // AC
                             var col = idx - r * AC
-                            var dst = sa_ptr + r * (AC + APAD) + col
+                            var dst = sa_ptr.unsafe_offset(
+                                r * (AC + APAD) + col
+                            )
                             if r < rows_avail and col < cols_avail:
                                 async_copy[4](
-                                    (tile + r * lda + col).address_space_cast[
+                                    (
+                                        tile.unsafe_offset(r * lda + col)
+                                    ).unsafe_address_space_cast[
                                         AddressSpace.GLOBAL
                                     ](),
                                     dst,
                                 )
                             else:
-                                dst[0] = 0.0
+                                dst[unsafe_offset=0] = 0.0
 
             @parameter
             @always_inline
             def copy_b(ktile: Int, stage: Int):
-                var sb_ptr = smem + stage * STAGE_WORDS + SA
+                var sb_ptr = smem.unsafe_offset(stage * STAGE_WORDS + SA)
                 var k0 = ktile * _BK
-                var tile = b_base + (n0 * ldb + k0 if TB else k0 * ldb + n0)
+                var tile = b_base.unsafe_offset(
+                    n0 * ldb + k0 if TB else k0 * ldb + n0
+                )
                 var rows_avail = (n - n0) if TB else (k - k0)
                 var cols_avail = (k - k0) if TB else (n - n0)
                 if b_vec != 0:
@@ -239,10 +253,14 @@ def _tile_body[
                         if idx < BR * BV:
                             var r = idx // BV
                             var col = (idx - r * BV) * 4
-                            var dst = sb_ptr + r * (BC + BPAD) + col
+                            var dst = sb_ptr.unsafe_offset(
+                                r * (BC + BPAD) + col
+                            )
                             if r < rows_avail and col + 3 < cols_avail:
                                 async_copy[16](
-                                    (tile + r * ldb + col).address_space_cast[
+                                    (
+                                        tile.unsafe_offset(r * ldb + col)
+                                    ).unsafe_address_space_cast[
                                         AddressSpace.GLOBAL
                                     ](),
                                     dst,
@@ -252,30 +270,36 @@ def _tile_body[
                                     if r < rows_avail and col + j < cols_avail:
                                         async_copy[4](
                                             (
-                                                tile + r * ldb + col + j
-                                            ).address_space_cast[
+                                                tile.unsafe_offset(
+                                                    r * ldb + col + j
+                                                )
+                                            ).unsafe_address_space_cast[
                                                 AddressSpace.GLOBAL
                                             ](),
-                                            dst + j,
+                                            dst.unsafe_offset(j),
                                         )
                                     else:
-                                        dst[j] = 0.0
+                                        dst[unsafe_offset=j] = 0.0
                 else:
                     comptime for i in range(ceildiv(BR * BC, THREADS)):
                         var idx = tid + i * THREADS
                         if idx < BR * BC:
                             var r = idx // BC
                             var col = idx - r * BC
-                            var dst = sb_ptr + r * (BC + BPAD) + col
+                            var dst = sb_ptr.unsafe_offset(
+                                r * (BC + BPAD) + col
+                            )
                             if r < rows_avail and col < cols_avail:
                                 async_copy[4](
-                                    (tile + r * ldb + col).address_space_cast[
+                                    (
+                                        tile.unsafe_offset(r * ldb + col)
+                                    ).unsafe_address_space_cast[
                                         AddressSpace.GLOBAL
                                     ](),
                                     dst,
                                 )
                             else:
-                                dst[0] = 0.0
+                                dst[unsafe_offset=0] = 0.0
 
             # The batch loop reuses all stages; the previous iteration's
             # consumers must drain before new copies land in stage 0.
@@ -302,8 +326,8 @@ def _tile_body[
                     copy_b(prefetch, prefetch % STAGES)
                 async_copy_commit_group()
 
-                var sa_ptr = smem + (kt % STAGES) * STAGE_WORDS
-                var sb_ptr = sa_ptr + SA
+                var sa_ptr = smem.unsafe_offset((kt % STAGES) * STAGE_WORDS)
+                var sb_ptr = sa_ptr.unsafe_offset(SA)
                 comptime for ks in range(_BK // 8):
                     var a_frag = InlineArray[SIMD[DType.float32, 4], MT](
                         uninitialized=True
@@ -314,20 +338,32 @@ def _tile_body[
                                 wm0 + mt * 16 + g
                             )
                             a_frag[mt] = SIMD[DType.float32, 4](
-                                _tf32(sa_ptr[base]),
-                                _tf32(sa_ptr[base + 8]),
-                                _tf32(sa_ptr[base + 4 * (AC + APAD)]),
-                                _tf32(sa_ptr[base + 4 * (AC + APAD) + 8]),
+                                _tf32(sa_ptr[unsafe_offset=base]),
+                                _tf32(sa_ptr[unsafe_offset=base + 8]),
+                                _tf32(
+                                    sa_ptr[unsafe_offset=base + 4 * (AC + APAD)]
+                                ),
+                                _tf32(
+                                    sa_ptr[
+                                        unsafe_offset=base + 4 * (AC + APAD) + 8
+                                    ]
+                                ),
                             )
                         else:
                             var base = (wm0 + mt * 16 + g) * (AC + APAD) + (
                                 ks * 8 + t
                             )
                             a_frag[mt] = SIMD[DType.float32, 4](
-                                _tf32(sa_ptr[base]),
-                                _tf32(sa_ptr[base + 8 * (AC + APAD)]),
-                                _tf32(sa_ptr[base + 4]),
-                                _tf32(sa_ptr[base + 8 * (AC + APAD) + 4]),
+                                _tf32(sa_ptr[unsafe_offset=base]),
+                                _tf32(
+                                    sa_ptr[unsafe_offset=base + 8 * (AC + APAD)]
+                                ),
+                                _tf32(sa_ptr[unsafe_offset=base + 4]),
+                                _tf32(
+                                    sa_ptr[
+                                        unsafe_offset=base + 8 * (AC + APAD) + 4
+                                    ]
+                                ),
                             )
                     var b_frag = InlineArray[SIMD[DType.float32, 2], NT](
                         uninitialized=True
@@ -338,16 +374,18 @@ def _tile_body[
                                 ks * 8 + t
                             )
                             b_frag[nt] = SIMD[DType.float32, 2](
-                                _tf32(sb_ptr[base]),
-                                _tf32(sb_ptr[base + 4]),
+                                _tf32(sb_ptr[unsafe_offset=base]),
+                                _tf32(sb_ptr[unsafe_offset=base + 4]),
                             )
                         else:
                             var base = (ks * 8 + t) * (BC + BPAD) + (
                                 wn0 + nt * 8 + g
                             )
                             b_frag[nt] = SIMD[DType.float32, 2](
-                                _tf32(sb_ptr[base]),
-                                _tf32(sb_ptr[base + 4 * (BC + BPAD)]),
+                                _tf32(sb_ptr[unsafe_offset=base]),
+                                _tf32(
+                                    sb_ptr[unsafe_offset=base + 4 * (BC + BPAD)]
+                                ),
                             )
                     comptime for mt in range(MT):
                         comptime for nt in range(NT):
@@ -363,23 +401,23 @@ def _tile_body[
                 var bias0 = Float32(0.0)
                 var bias1 = Float32(0.0)
                 if has_bias != 0 and col < n:
-                    bias0 = bias[col]
+                    bias0 = bias[unsafe_offset=col]
                     if col + 1 < n:
-                        bias1 = bias[col + 1]
+                        bias1 = bias[unsafe_offset=col + 1]
                 comptime for mt in range(MT):
                     var v = acc[mt * NT + nt]
                     var row = m0 + wm0 + mt * 16 + g
                     if c_vec != 0:
                         if col < n:
                             if row < m:
-                                c_base.store[width=2, alignment=8](
+                                c_base.unsafe_store[width=2, alignment=8](
                                     row * n + col,
                                     SIMD[DType.float32, 2](
                                         v[0] + bias0, v[1] + bias1
                                     ),
                                 )
                             if row + 8 < m:
-                                c_base.store[width=2, alignment=8](
+                                c_base.unsafe_store[width=2, alignment=8](
                                     (row + 8) * n + col,
                                     SIMD[DType.float32, 2](
                                         v[2] + bias0, v[3] + bias1
@@ -388,14 +426,22 @@ def _tile_body[
                     else:
                         if row < m:
                             if col < n:
-                                c_base[row * n + col] = v[0] + bias0
+                                c_base[unsafe_offset=row * n + col] = (
+                                    v[0] + bias0
+                                )
                             if col + 1 < n:
-                                c_base[row * n + col + 1] = v[1] + bias1
+                                c_base[unsafe_offset=row * n + col + 1] = (
+                                    v[1] + bias1
+                                )
                         if row + 8 < m:
                             if col < n:
-                                c_base[(row + 8) * n + col] = v[2] + bias0
+                                c_base[unsafe_offset=(row + 8) * n + col] = (
+                                    v[2] + bias0
+                                )
                             if col + 1 < n:
-                                c_base[(row + 8) * n + col + 1] = v[3] + bias1
+                                c_base[
+                                    unsafe_offset=(row + 8) * n + col + 1
+                                ] = (v[3] + bias1)
             bz += Int(grid_dim.z)
     else:
         # Portable SIMT fallback so importing this module on another
@@ -403,9 +449,9 @@ def _tile_body[
         # devices on the existing strict fallback path.
         var bz = Int(block_idx.z)
         while bz < batch_count:
-            var a_base = a + bz * a_bs
-            var b_base = b + bz * b_bs
-            var c_base = c + bz * c_bs
+            var a_base = a.unsafe_offset(bz * a_bs)
+            var b_base = b.unsafe_offset(bz * b_bs)
+            var c_base = c.unsafe_offset(bz * c_bs)
             var idx = tid
             while idx < BM * BN:
                 var mm = idx // BN
@@ -415,12 +461,16 @@ def _tile_body[
                 if row < m and col < n:
                     var total = Float32(0.0)
                     for r in range(k):
-                        var av = a_base[r * lda + row if TA else row * lda + r]
-                        var bv = b_base[col * ldb + r if TB else r * ldb + col]
+                        var av = a_base[
+                            unsafe_offset=r * lda + row if TA else row * lda + r
+                        ]
+                        var bv = b_base[
+                            unsafe_offset=col * ldb + r if TB else r * ldb + col
+                        ]
                         total += _tf32(av) * _tf32(bv)
                     if has_bias != 0:
-                        total += bias[col]
-                    c_base[row * n + col] = total
+                        total += bias[unsafe_offset=col]
+                    c_base[unsafe_offset=row * n + col] = total
                 idx += THREADS
             bz += Int(grid_dim.z)
 
@@ -436,10 +486,10 @@ def _gemm_tile[
     THREADS: Int,
     STAGES: Int,
 ](
-    c: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    a: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    b: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    bias: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    c: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    a: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    b: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    bias: Pointer[Scalar[DType.float32], MutAnyOrigin],
     m_arg: Int64,
     n_arg: Int64,
     k_arg: Int64,
@@ -473,9 +523,9 @@ def _bmm_tile[
     THREADS: Int,
     STAGES: Int,
 ](
-    c: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    a: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    b: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    c: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    a: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    b: Pointer[Scalar[DType.float32], MutAnyOrigin],
     m_arg: Int64,
     n_arg: Int64,
     k_arg: Int64,
@@ -530,10 +580,10 @@ def _launch_tile[
     THREADS: Int,
     STAGES: Int,
 ](
-    c: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    a: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    b: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    bias: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    c: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    a: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    b: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    bias: Pointer[Scalar[DType.float32], MutAnyOrigin],
     m: Int,
     n: Int,
     k: Int,
@@ -611,10 +661,10 @@ def _launch_tile[
 def _dispatch[
     BATCHED: Bool, TA: Bool, TB: Bool
 ](
-    c: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    a: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    b: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    bias: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    c: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    a: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    b: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    bias: Pointer[Scalar[DType.float32], MutAnyOrigin],
     m: Int,
     n: Int,
     k: Int,
@@ -710,10 +760,10 @@ def _dispatch[
 
 
 def enqueue_tf32_gemm_f32(
-    output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    a: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    b: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    bias: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    a: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    b: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    bias: Pointer[Scalar[DType.float32], MutAnyOrigin],
     m: Int,
     n: Int,
     k: Int,
@@ -743,9 +793,9 @@ def enqueue_tf32_gemm_f32(
 
 
 def enqueue_tf32_bmm_f32(
-    output: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    a: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
-    b: UnsafePointer[Scalar[DType.float32], MutAnyOrigin],
+    output: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    a: Pointer[Scalar[DType.float32], MutAnyOrigin],
+    b: Pointer[Scalar[DType.float32], MutAnyOrigin],
     batch_count: Int,
     m: Int,
     n: Int,

--- a/torch_mojo_backend/mojo_kernels/activations.mojo
+++ b/torch_mojo_backend/mojo_kernels/activations.mojo
@@ -25,15 +25,15 @@ struct GeluBackwardNoneKernel(ElementwiseBinaryOp):
         comptime M_SQRT1_2 = 0.7071067811865476  # sqrt(1/2) = 1/sqrt(2)
         comptime PDF_CONSTANT = 0.39894228040143276  # M_2_SQRTPI * M_SQRT1_2 * 0.5
 
-        x = input
-        grad_out = grad_output
+        var x = input
+        var grad_out = grad_output
 
         # Compute CDF term: 0.5 * (1 + erf(x * M_SQRT1_2))
-        cdf = 0.5 * (1.0 + math.erf(x * M_SQRT1_2))
+        var cdf = 0.5 * (1.0 + math.erf(x * M_SQRT1_2))
 
         # Compute PDF term: PDF_CONSTANT * exp(-0.5 * x²)
-        x_squared = x * x
-        pdf = PDF_CONSTANT * math.exp(-0.5 * x_squared)
+        var x_squared = x * x
+        var pdf = PDF_CONSTANT * math.exp(-0.5 * x_squared)
 
         # Gradient: grad_out * (CDF + x * PDF)
         return grad_out * (cdf + x * pdf)
@@ -60,24 +60,24 @@ struct GeluBackwardTanhKernel(ElementwiseBinaryOp):
         comptime k_Beta = 0.7978845608028654  # sqrt(2) * sqrt(2/π) * 0.5
         comptime k_Kappa = 0.044715
 
-        x = input
-        grad_out = grad_output
+        var x = input
+        var grad_out = grad_output
 
         # Compute inner = kBeta * (x + kKappa * x³)
-        x_squared = x * x
-        x_cubed = x_squared * x
-        inner = k_Beta * (x + k_Kappa * x_cubed)
-        tanh_inner = math.tanh(inner)
+        var x_squared = x * x
+        var x_cubed = x_squared * x
+        var inner = k_Beta * (x + k_Kappa * x_cubed)
+        var tanh_inner = math.tanh(inner)
 
         # Left term derivatives
-        left = 0.5 * x
-        right = 1.0 + tanh_inner
-        left_derivative = 0.5 * right
+        var left = 0.5 * x
+        var right = 1.0 + tanh_inner
+        var left_derivative = 0.5 * right
 
         # Right term derivatives
-        tanh_derivative = 1.0 - tanh_inner * tanh_inner
-        inner_derivative = k_Beta * (1.0 + 3.0 * k_Kappa * x_squared)
-        right_derivative = left * tanh_derivative * inner_derivative
+        var tanh_derivative = 1.0 - tanh_inner * tanh_inner
+        var inner_derivative = k_Beta * (1.0 + 3.0 * k_Kappa * x_squared)
+        var right_derivative = left * tanh_derivative * inner_derivative
 
         # Total gradient
         return grad_out * (left_derivative + right_derivative)

--- a/torch_mojo_backend/mojo_kernels/attention.mojo
+++ b/torch_mojo_backend/mojo_kernels/attention.mojo
@@ -68,7 +68,9 @@ def _gpt2_decode_attention_kernel[
     ]()
 
     for d in range(tid, head_dim, THREADS):
-        q_smem[d] = query.ptr[q_base + d].cast[DType.float32]()
+        q_smem[unsafe_offset=d] = query.ptr[unsafe_offset=q_base + d].cast[
+            DType.float32
+        ]()
     barrier()
 
     var row_max = Float32.MIN
@@ -76,45 +78,53 @@ def _gpt2_decode_attention_kernel[
         var krow = kv_base + j * head_dim
         var dot = Float32(0)
         for d in range(0, head_dim, 4):
-            var k4 = key.ptr.load[width=4, alignment=vec_align](krow + d).cast[
-                DType.float32
-            ]()
-            var q4 = q_smem.load[width=4, alignment=16](d)
+            var k4 = key.ptr.unsafe_load[width=4, alignment=vec_align](
+                krow + d
+            ).cast[DType.float32]()
+            var q4 = q_smem.unsafe_load[width=4, alignment=16](d)
             dot += (q4 * k4).reduce_add()
-        var score = dot * scale + mask.ptr[mask_base + j].cast[DType.float32]()
-        scores[j] = score
+        var score = (
+            dot * scale
+            + mask.ptr[unsafe_offset=mask_base + j].cast[DType.float32]()
+        )
+        scores[unsafe_offset=j] = score
         row_max = max(row_max, score)
 
-    reduction[tid] = row_max
+    reduction[unsafe_offset=tid] = row_max
     barrier()
     var stride = THREADS // 2
     comptime for _ in range(8):
         if tid < stride:
-            reduction[tid] = max(reduction[tid], reduction[tid + stride])
+            reduction[unsafe_offset=tid] = max(
+                reduction[unsafe_offset=tid],
+                reduction[unsafe_offset=tid + stride],
+            )
         barrier()
         stride //= 2
     if tid == 0:
-        broadcast[0] = reduction[0]
+        broadcast[unsafe_offset=0] = reduction[unsafe_offset=0]
     barrier()
-    row_max = broadcast[0]
+    row_max = broadcast[unsafe_offset=0]
 
     var row_sum = Float32(0)
     for j in range(tid, kv_len, THREADS):
-        var probability = exp(scores[j] - row_max)
-        scores[j] = probability
+        var probability = exp(scores[unsafe_offset=j] - row_max)
+        scores[unsafe_offset=j] = probability
         row_sum += probability
-    reduction[tid] = row_sum
+    reduction[unsafe_offset=tid] = row_sum
     barrier()
     stride = THREADS // 2
     comptime for _ in range(8):
         if tid < stride:
-            reduction[tid] += reduction[tid + stride]
+            reduction[unsafe_offset=tid] += reduction[
+                unsafe_offset=tid + stride
+            ]
         barrier()
         stride //= 2
     if tid == 0:
-        broadcast[1] = reduction[0]
+        broadcast[unsafe_offset=1] = reduction[unsafe_offset=0]
     barrier()
-    var inv_sum = 1.0 / broadcast[1]
+    var inv_sum = 1.0 / broadcast[unsafe_offset=1]
 
     # GPT-2 has D=64 on AMD wave64. Split the KV reduction across all four
     # wavefronts instead of leaving three quarters of the block idle during
@@ -125,19 +135,23 @@ def _gpt2_decode_attention_kernel[
     if lane < head_dim:
         for j in range(wave, kv_len, 4):
             acc += (
-                scores[j]
-                * value.ptr[kv_base + j * head_dim + lane].cast[DType.float32]()
+                scores[unsafe_offset=j]
+                * value.ptr[unsafe_offset=kv_base + j * head_dim + lane].cast[
+                    DType.float32
+                ]()
             )
-    reduction[tid] = acc
+    reduction[unsafe_offset=tid] = acc
     barrier()
     if wave == 0 and lane < head_dim:
         acc = (
-            reduction[lane]
-            + reduction[64 + lane]
-            + reduction[128 + lane]
-            + reduction[192 + lane]
+            reduction[unsafe_offset=lane]
+            + reduction[unsafe_offset=64 + lane]
+            + reduction[unsafe_offset=128 + lane]
+            + reduction[unsafe_offset=192 + lane]
         )
-        output.ptr[out_base + lane] = (acc * inv_sum).cast[dtype]()
+        output.ptr[unsafe_offset=out_base + lane] = (acc * inv_sum).cast[
+            dtype
+        ]()
 
 
 @compiler.register("gpt2_decode_attention")


### PR DESCRIPTION
## Summary

Building every `-D` specialization of every Mojo entry module (about 280 builds per target) reported roughly 4,400 warning sites across 61 files, nearly all Mojo 1.0 deprecations. This PR clears all of them; the tree now builds with zero warnings for `sm_90a`, `gfx942` and `apple-m4`.

What changed, by warning kind:

- **Pointer API renames**: `UnsafePointer` → `Pointer`; `load`/`store` → `unsafe_load`/`unsafe_store`; `p[i]` → `p[unsafe_offset=i]`; `p + i` → `p.unsafe_offset(i)`; `bitcast`, `address_space_cast`, `init_pointee_move`, `free`, `memcpy`, `as_immutable`, `alloc` to their renamed or `unsafe_`-prefixed spellings; `SIMDSize` → `SIMDLength`. Chained pointer arithmetic is collapsed into a single `unsafe_offset(a + b)` call, and `(p.unsafe_offset(i))[unsafe_offset=0]` into `p[unsafe_offset=i]`.
- **Syntax**: `@parameter if` / `@parameter for` → `comptime if` / `comptime for`; implicit variable declarations get `var`; the eleven `if global_ptr := _get_global_or_null(...)` cache lookups become `var global_ptr = ...` / `if global_ptr:`.
- **Real code smells the compiler flagged**: four unreachable `return`s after `comptime assert False` are removed; six `var x = <default>` initializers that every branch overwrote are declared as `var x: T`.
- **Vendored FA4 sources** (`eager_flash_attention/`) are edited in place but not reformatted, matching the pre-commit exclusion; over-long lines introduced by the renames were wrapped by hand.
- `current_bench/bench_mfma_direct.mojo` imported `DeviceContext` from `std.gpu.host`, which no longer exists; it now imports from `max.gpu.host`. It still fails to compile for an unrelated pre-existing reason (it passes `Int` kernel arguments).

No Python changed except a one-word doc snippet in `docs/strided_owning_tensors_design.md`.

## How it was done

The compiler's `--experimental-export-fixit` covers the plain renames; positional `__getitem__`, `__add__`/`__sub__`/`__iadd__`, `@parameter`, implicit-`var` and `alloc` carry no fix-it and were rewritten from the diagnostic `line:col` and caret span, iterating build/apply until no warnings remained. About 25 multi-line pointer expressions were edited by hand.

## Verification

| Check | Result |
|---|---|
| Warnings, `sm_90a` (`--emit llvm` and `--emit shared-lib`) | 0 |
| Warnings, `gfx942` and `apple-m4` cross-compile | 0 |
| `uvx pre-commit run --all-files` | all hooks pass, no edits |
| `tests/test_fa4_host_wiring.py` + `tests/test_sdpa_host_wiring.py` (H100) | 24 passed |
| `tests/test_aten_functions.py` (H100, serial) | 607 passed, 1 failed |
| Focused rerun of every test that failed in any long run, this branch vs. pristine `main` | 87 passed on both |

The Hopper-only kernels (gemm16, FA4) refuse to cross-compile for AMD/Apple targets and `matmul_ops` bf16 aborts the compiler for `gfx942`; pristine `main` behaves identically, so that is pre-existing.

Long serial runs of `tests/test_eager_kernels.py` on the cluster are flaky on both trees: this branch and a pristine-`main` worktree both aborted inside autograd backward in the same region of the file, and `main`'s aten run died silently mid-way while this branch's completed. Every individual failure passes when rerun in isolation on both trees, so I attribute them to sticky GPU state in long runs on those nodes rather than to this change. I could not get a fully green end-to-end `test_eager_kernels.py` run on either tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yfCEsnquoGy4FQqZSWeNu

