### PR TITLE
FA4 loader: tolerate filesystems that refuse flock (ENOLCK on NFS)

### DIFF
--- a/torch_mojo_backend/eager_flash_attention/__init__.py
+++ b/torch_mojo_backend/eager_flash_attention/__init__.py
@@ -4,13 +4,14 @@ The large vendored kernels deliberately live outside ``eager_kernels`` so a
 FlashAttention change does not invalidate every ordinary eager extension.
 """
 
-import fcntl
 import hashlib
 import importlib
 from pathlib import Path
 from types import ModuleType
 
 import mojo.importer  # noqa: F401 - installs the .mojo import hook
+
+from torch_mojo_backend import eager_kernels
 
 _PACKAGE_DIR = Path(__file__).parent
 _CACHE_DIR = _PACKAGE_DIR / "__mojocache__"
@@ -40,7 +41,9 @@ def load_fa4_ops() -> ModuleType:
 
     _CACHE_DIR.mkdir(exist_ok=True)
     with open(_CACHE_DIR / ".compile.lock", "w") as lock_file:
-        fcntl.flock(lock_file, fcntl.LOCK_EX)
+        # Dedupes concurrent builds only; NFS homes without a lock manager
+        # raise ENOLCK, and building redundantly is the right fallback there.
+        eager_kernels._flock_or_none(lock_file)
         _MODULE = importlib.import_module(
             "torch_mojo_backend.eager_flash_attention.fa4_ops"
         )


### PR DESCRIPTION
## Summary

`eager_flash_attention.load_fa4_ops` guarded its first-use build with a bare `fcntl.flock`. On an NFS home without a lock manager that raises `OSError: [Errno 37] No locks available`, and every torchrun rank of a nanoGPT DDP run died with it the first time the FA4 bridge had to be built on a node (seen today on the Kyutai cluster; the second run on the same node passed because the `.so` then existed).

The eager-kernel loader already treats this lock as a dedupe of concurrent identical builds rather than something correctness depends on (`eager_kernels._flock_or_none`: ENOLCK/ENOSYS/EOPNOTSUPP → build without dedupe, with a trace line). Reuse it here.

## Testing

- `ruff`, `ty` clean; the module imports (no cycle: `eager_kernels` does not import the FA layer).
- Behaviour on a locking filesystem is unchanged (`_flock_or_none` takes the lock as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167VthrN76wtxabswrkrnJB
