### PR TITLE
Mojo collectives behind NCCL's C ABI (single node, experimental)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,9 @@ Always use uv to run commands to ensure the correct environment is activated. Ne
     every specialization compiles inline at its first call and is cached in
     `__mojocache__`; build timings print by default
     (`TORCH_MOJO_BACKEND_TRACE=0` silences them).
+  - `TORCH_MOJO_BACKEND_CCL=mojo` swaps NCCL/RCCL for the in-repo Mojo
+    collectives (`docs/distributed.md`, "Mojo collectives"); default is
+    the vendor library.
 - **Model Examples**: `demo_scripts/` contains examples showing real-world usage:
   - GPT-2, Gemma3 (LLM models)
   - VGG, DenseNet (vision models)

--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -265,3 +265,45 @@ srun --ntasks-per-node=1 --gpus-per-task=4 --cpus-per-task=96 -- \
     --rdzv-backend=c10d --rdzv-endpoint="$MASTER_ADDR:29500" \
     --rdzv-id="$SLURM_JOB_ID" demo_scripts/nanogpt_ddp.py ...
 ```
+
+## Mojo collectives (experimental): `TORCH_MOJO_BACKEND_CCL=mojo`
+
+An in-repo replacement for NCCL/RCCL's intra-node collectives, written in Mojo
+and exposed through **NCCL's own C ABI**: `torch_mojo_backend/distributed/mojoccl/`
+builds `libmojoccl.so` on first use (into the eager kernels' `__mojocache__`,
+same lock/atomic-rename machinery) and `nccl.py` dlopens it instead of
+`libnccl.so.2` when `TORCH_MOJO_BACKEND_CCL=mojo`. `process_group.py` is
+unchanged; NCCL/RCCL stays the default. Design and measurements:
+`docs/mojo_collectives_feasibility.md` (study) and
+`docs/mojo_collectives_kernel_results.md` (kernels).
+
+Scope, deliberately narrow — it is an experiment showing Mojo can write
+NCCL-class collectives, not a general library:
+
+- one node, 2–8 ranks, one process per GPU under torchrun (`MAX_WORLD = 8`);
+  multi-node is not implemented (the study's plan keeps NCCL/RCCL for the
+  inter-node shard allreduce, hierarchically);
+- `ncclAllReduce` (float32/float16/bfloat16/int32/int64, SUM and AVG),
+  `ncclBroadcast` and `ncclAllGather` (every dtype, byte-granular);
+  `ncclReduce`, `ncclReduceScatter`, `ncclSend`, `ncclRecv` return
+  `ncclInvalidUsage`, so DDP works and anything needing them does not;
+- the rendezvous is a directory under `/dev/shm` encoded in the 128-byte
+  `ncclUniqueId` (rank 0 removes it once every rank has opened its peers);
+- every rank owns one IPC-shared staging region (`MOJOCCL_REGION_MB`, default
+  256 MiB, multiple of 4 KiB; larger requests are chunked). MAX's own
+  allocations cannot be shared across processes (§5.6 of the study), which
+  is why the kernels stage through this region; the push / local-reduce /
+  pull design makes the staging free;
+- a rank that stops responding makes its peers time out after 60 s inside the
+  kernel and `ncclCommGetAsyncError` reports it; there is no abort path.
+
+Measured on 8×H100 SXM through the process group (wall over 20 launches,
+median of 5, interleaved legs; NCCL 2.31.2 NVLS for comparison): 1 MiB 29 vs
+31 µs, 9 MiB 70 vs 92, 27 MiB (the DDP bucket) 164 vs 181, 168 MiB 975 vs
+755, 512 MiB 2.95 vs 2.15 ms. The large sizes are the unicast ceiling
+(~310 GB/s per direction over NVSwitch); matching NCCL there needs NVLS
+multicast (`cuMulticastCreate`), not implemented. nanoGPT-124M DDP on 8 ranks
+runs at the same throughput and the same losses within the training step's
+own run-to-run noise. AMD: the same source cross-compiles for gfx942 (the
+one vendor gate is a release fence on AMD's `s_barrier`), but it has not run
+on an MI300A yet.

--- a/docs/mojo_collectives_feasibility.md
+++ b/docs/mojo_collectives_feasibility.md
@@ -1,0 +1,439 @@
+# Replacing NCCL/RCCL with Mojo collectives for GPT-2 DDP — feasibility study
+
+Date 2026-09-08. Author: Fable 5.1 agent. Scope as briefed: nanoGPT-124M DDP on
+(a) Kyutai 8×H100 SXM nodes (NVSwitch, IB 400 Gb/s, driver 570 / CUDA 12.8) and
+(b) CINES Adastra 4×MI300A nodes (ROCm 6.4.3, RCCL 2.22.3, Slingshot/cxi), one
+process per GPU under torchrun. Bar: NCCL/RCCL-class time on exactly this
+traffic. Everything under `/home/gabriel/ddp_work/mojo_collectives/` (`proto/`
+sources and binaries, `logs/` raw job output). Repo checkout untouched.
+
+Software read: NCCL master 2.31.2 (`/home/gabriel/projects/nccl`, cited as
+`nccl:path:line`), RCCL **2.30.7** develop (`/home/gabriel/projects/rocm-system/projects/rccl`,
+cited `rccl:path:line`; the monorepo has no 2.22.3 tag — deltas to Adastra's
+2.22.3 taken from `rccl:CHANGELOG.md`), modular checkout f807c5a (Jul 2026,
+`modular:path:line`), installed MAX 26.5.0 / Mojo 1.0.0 (`.venv`, precompiled
+`comm.mojoc` etc.). Stock reference torch 2.11.0+cu128 with NCCL 2.28.9
+(`~/ddp_work/torch_cu128`); the repo's own PG uses nvidia-nccl-cu12 2.31.2.
+
+## 1. Verdict (engineering estimate)
+
+Feasible, and the intra-node half is already demonstrated: a 120-line
+reduce-scatter + all-gather kernel written from scratch in Mojo, run as **8
+separate processes** with buffers exchanged through `cuIpcGetMemHandle` /
+`cuIpcOpenMemHandle` called from Mojo, allreduces the 27 MiB GPT-2 gradient
+bucket in **163–165 µs (300–304 GB/s busbw)** against **175 µs (283 GB/s)** for
+NCCL 2.28.9's NVLS/SIMPLE path on the same node class — i.e. at the size that
+matters it is 6% faster than NCCL, and it reaches 75% of NCCL-NVLS (92% of
+NCCL-ring) at 512 MiB, where NCCL's SHARP multicast wins. The same source
+cross-compiles unchanged for gfx942 except a comptime gate around the NVLS
+(multimem) variant, and the AMDGCN it emits (`sc0 sc1` system-scope loads/stores,
+`buffer_wbl2 sc0 sc1` / `buffer_inv sc0 sc1`) is exactly what RCCL relies on.
+Cost: **M1 intra-node NVIDIA in the ProcessGroup ≈ 3–4 weeks; M2 MI300A
+validation ≈ 2–3 weeks (needs Adastra time; kernel untested there); M3
+multi-node ≈ 2 weeks if the inter-node hop stays on NCCL/RCCL (hierarchical
+RS → inter-node allreduce of the 1/8 shard → AG), or 8–16 weeks for a pure-Mojo
+IB-verbs + libfabric/cxi transport, which is a host-proxy/RDMA project, not a
+kernel one.** Two decisions move the estimate: (1) how user tensors reach peer
+processes — MAX's allocator memory is **not** exportable with legacy IPC
+(measured: `cuIpcGetMemHandle` → `CUDA_ERROR_INVALID_VALUE`), so either the
+library owns `cuMemAlloc`/`hipMalloc`-ed staging buffers and copies in/out
+(measured +27% at 27 MiB, +27% at 168 MiB, all hidden except the tail bucket) or
+MAX's VMM arena becomes exportable with `cuMemExportToShareableHandle` — today
+it is not (measured: the 256 MiB `cuMemCreate` chunks carry
+`requestedHandleTypes = 0`, §5.6), so this needs a one-line change in MAX; (2) whether multi-node is in scope for the experiment at all.
+GPT-2 DDP is not communication-bound on either topology (~2.8 ms of NVLink time
+per ~45 ms step, 12 of 13 buckets overlapped), so any of the measured variants
+keeps end-to-end throughput within ~1% of NCCL; the bar is met intra-node.
+
+## 2. GPT-2 traffic profile (derived from source)
+
+Model/config: `demo_scripts/nanogpt_ddp.py` — GPT-2 124M, `vocab 50304`,
+`bias=False`, fp32 parameters, bf16 autocast, batch 12×1024 per rank, fused
+AdamW, `DDP(model, broadcast_buffers=False)`, defaults otherwise
+(`bucket_cap_mb=25`, `gradient_as_bucket_view=False`, no `find_unused_parameters`,
+no `static_graph`). 75 parameter tensors (wte/lm_head tied), 124,373,760 elements
+= **497,495,040 B (474.45 MiB) fp32 gradients per step**.
+
+Reducer bucketing (torch `reducer.cpp:2289-2412`: push first, close when
+`size >= limit`, limits `{1 MiB, 25 MiB}`, order = gradient-ready order, rebuilt
+once at step 2): **13 allreduces per step**
+
+| bucket | contents | bytes | MiB |
+|---|---|---|---|
+| 0 | ln_f, h.11.mlp.c_proj | 9,440,256 | 9.0 |
+| 1–11 | 6 tensors each | 28,317,696 | 27.0 each |
+| 12 | h.0.mlp.c_fc … wpe, **wte** (tied embedding, last to be ready) | 176,560,128 | **168.4, tail-exposed** |
+
+Op: `ncclSum` on values pre-divided by world size on the host
+(`reducer.cpp:384-392` `mul_out(bucket_view, grad, 1/div_factor)`; the default
+hook has no division, `default_comm_hooks.cpp:44-58`). One contiguous fp32
+tensor per bucket, in place. Step 1 is one 474 MiB allreduce (initial bucketing
+uses `sys.maxsize`). Per run: 1 allgather (8 B), broadcasts of 2,000 B,
+270,950,400 B, 226,544,640 B (parameters, `broadcast_bucket_size=250 MiB`),
+304 B, 52 B (bucket indices); an `AVG` allreduce of 4 B every 10 steps;
+`barrier()` once (routed to gloo/CPU). DDP itself only needs
+`allreduce`, `broadcast`, `allgather` (+`barrier`) from the PG
+(`torch_mojo_backend/distributed/process_group.py:393,456,522,937`).
+
+Execution today: each bucket goes to `ncclAllReduce` on a per-device side
+stream that first waits on the default stream (`process_group.py:303-335`,
+`device_streams.py:87-91`); buckets serialize on that stream and overlap
+backward; completion is the lazy fence in `mojo_device/comm_fence.py` (no
+watcher thread). Budget: 8×H100 DDP step ≈ 45 ms at B=12 (memory notes); the 12
+overlappable buckets need ≥ 17 GB/s busbw to hide — NVLink gives 300+.
+
+## 3. What NCCL / RCCL do for this traffic
+
+### 3.1 NCCL on 8×H100 NVSwitch (measured + source)
+
+Measured choices (`NCCL_DEBUG_SUBSYS=TUNING`, stock 2.28.9, `logs/proto_233567.out`):
+1 MiB → `RING/LL` 24 channels; 9–512 MiB → **`NVLS/SIMPLE`, 16 channels
+(`NVLS_NCHANNELS_SM90`, `nccl:src/transport/nvls.cc:155`), 640 threads,
+CGA cluster 4**. With `NCCL_NVLS_ENABLE=0`: 9–27 MiB → `RING/LL128` 24 ch,
+≥128 MiB → `RING/SIMPLE` 24 ch. Cost model: `nccl:src/tuning/tuning_general.cc:64`
+(`lat*latCount + nBytes/(1000*bw)`), tables `nccl:src/tuning/cost_model.cc:141-220`
+(Hopper `llMaxBw` 141 GB/s single node, LL128 36.7 GB/s/channel, NVLS
+efficiency 0.85 `nccl:src/tuning/nvls.cc:15`).
+
+What NVLS needs: `cuMulticastCreate/AddDevice/BindMem`
+(`nccl:src/transport/nvls.cc:60,344,372`), the shareable handle broadcast over the
+bootstrap socket and **the POSIX fd passed with `SCM_RIGHTS` over an AF_UNIX
+socket** (`nccl:src/proxy.cc:1583`, `nccl:src/os/linux_ipcsocket.cc:212`), device
+`multimem.ld_reduce.relaxed.sys.global.add[.v4]` / `multimem.st.global`
+(`nccl:src/device/reduce_kernel.h:1131-1198`, `nccl:src/device/op128.h:429-437`),
+fp32 sum supported (`nccl:src/include/device.h:608-623`). Multi-node NVLS
+proper is off (needs `collnetEnable`, `nccl:src/tuning/nvls.cc:38-41`); 2 nodes
+pick `NVLS_TREE/SIMPLE` (measured, §5.5).
+
+Intra-node P2P transport (what a ring/RS-AG port has to match): with driver ≥
+12000 NCCL uses the **cuMem VMM path, not `cudaIpcGetMemHandle`**
+(`nccl:src/misc/cudawrap.cc:16-51`; alloc `nccl:src/include/alloc.h:312-346`
+`cuMemCreate(POSIX_FD)`; import `nccl:src/transport/p2p.cc:267-327` via
+`cuMemImportFromShareableHandle` after the fd round-trip). H100 pairs run in
+WRITE mode (READ only for compcap 80, `nccl:src/graph/paths.cc:441-445`);
+per (peer, channel) 2 MiB send + 10 MiB recv FIFO (`nccl:src/transport/p2p.cc:410-413,489-494`),
+8 steps of 512 KiB (`NCCL_STEPS`, `nccl:src/include/device.h:26`); head/tail
+counters in **device** memory written remotely over NVLink
+(`nccl:src/transport/p2p.cc:570-605`). Plain eager `ncclAllReduce` on
+unregistered buffers never takes the direct (FIFO-bypass) path
+(`nccl:src/register/coll_reg.cc:212-214,339-343`) — NCCL copies every byte
+through its own buffers, so "staging" (option b below) is NCCL's own default
+design, not a handicap.
+
+Protocol primitives (minimum for SIMPLE + LL, `nccl:src/device/op128.h`):
+`ld.volatile.global` (:342-345), `st.relaxed.sys.global.u64` (:380),
+`fence.acq_rel.sys` (:395), 16 B `ld/st.global.v2.b64`, named
+`barrier.sync`, `__syncwarp`; LL relies on 8-byte store atomicity of the fabric
+(`nccl:src/include/device.h:75-88`), LL128 on 128-byte NVLink store atomicity
+plus warp lockstep (`nccl:src/device/prims_ll128.h:194-207`). No `__nanosleep`,
+no TMA/cluster sync in the general kernels; dynamic shmem ≈ 80 KiB
+(`nccl:src/include/device.h:573-591`).
+
+### 3.2 RCCL on 4×MI300A (source; not measurable from here)
+
+- APU detection = `hipDeviceAttributeDirectManagedMemAccessFromHost` on device 0
+  (`rccl:src/init.cc:1905-1920`); single node 4 ranks → channel multiplier
+  `nc=4` (MI300X branch), multi-node APU → `nc=6`. Tuning model 5 for gfx942
+  (`rccl:src/graph/tuning.cc:1637-1647`). Tree+Simple is removed on single-node
+  gfx942 (`rccl:src/graph/tuning.cc:1232-1236`), so intra-node AllReduce is
+  Ring/{LL,LL128,Simple}; LL128 is **off by default** on a generic 4-GPU node
+  (`ll128Enabled` only via Rome-model options or `RCCL_LL128_FORCE_ENABLE=1`,
+  `rccl:src/init.cc:1661,1946-1947`, gate `rccl:src/graph/tuning.cc:1469-1485`).
+  Multi-node AllReduce protocol override: LL ≤ 512 KiB, else SIMPLE at 25 MiB
+  (`rccl:src/rccl_wrap.cc:148-178`, ranges `rccl:src/graph/tuning.cc:556-573`).
+- Memory: every cross-agent buffer is **uncached** `hipExtMallocWithFlags(hipDeviceMallocUncached)`
+  (`rccl:src/transport/p2p.cc:282-287`), exported with legacy
+  `hipIpcGetMemHandle` / `hipIpcOpenMemHandle(LazyEnablePeerAccess)`
+  (`rccl:src/transport/p2p.cc:281-295,382-384`); fine-grain support is a hard
+  P2P precondition (`rccl:src/transport/p2p.cc:138-146`). The cuMem/VMM path is
+  auto-enabled only on gfx1250 and needs kernel ≥ 6.8 / HIP ≥ 7.2
+  (`rccl:src/misc/rocmwrap.cc:121-150`) → **on Adastra RCCL itself uses
+  hipMalloc-class staging buffers + legacy IPC**.
+- Device ordering on gfx942: 16-byte `global_load/store_dwordx4` with system
+  syncscope (`sc0 sc1`) (`rccl:src/device/op128.h:366-388`), `__hip_atomic_*`
+  RELAXED/RELEASE at `__HIP_MEMORY_SCOPE_SYSTEM` for flags
+  (`rccl:src/device/op128.h:428-468`), `fence_acq_rel_sys()` is a **no-op**
+  (`rccl:src/device/op128.h:470-475`), producer ordering =
+  `s_waitcnt lgkmcnt(0) vmcnt(0)` in the block barrier then a system-scope
+  relaxed tail store (`rccl:src/device/prims_simple.h:193-210`, "cheap fence"
+  on gfx942 `rccl:src/include/rccl_common.h:251-273`); no HDP flush on
+  gfx90a/942/950 (`rccl:src/transport/p2p.cc:468-482`); wave 64, 256 threads
+  max, 4 barrier groups (`rccl:src/include/device.h:146-157`); spin loops use
+  `s_sleep(1)`/`s_wakeup` (`rccl:src/device/prims_simple.h:127-140`). LL line
+  = two `u64` non-temporal loads / two plain `u64` stores
+  (`rccl:src/device/prims_ll.h:170-190,276-296`); LL128 line is 64 B and its
+  correctness is pinned on a single 128-bit vector store
+  (`rccl:src/device/prims_ll128.h:44-60`).
+- Slingshot: no libfabric/cxi code in RCCL; the cxi provider is an out-of-tree
+  `ncclNet_v8+` plugin (`librccl-net.so`, `rccl:src/plugin/net.cc:259,102-187`;
+  vtable `rccl:src/include/plugin/net/net_v8.h:27-80`), GPU registration via
+  `hsa_amd_portable_export_dmabuf` + `regMrDmaBuf` (`rccl:src/include/rocmwrap.h:178-197`,
+  gate `rccl:src/misc/rocmwrap.cc:292-334`), host proxy thread as in NCCL.
+
+## 4. What Mojo/MAX provides and what is missing
+
+| need | status (installed MAX 26.5 / Mojo 1.0) | evidence |
+|---|---|---|
+| kernel on GPU A reads/writes GPU B memory (same process) | yes; `enable_all_peer_access` (`modular:mojo/stdlib/std/gpu/host/device_context.mojo:7660`), raw peer pointers as kernel args | `comm/allreduce.mojo` does it; measured §5.2 |
+| cross-process buffer sharing | **absent** from MAX (`cuMemImportFromShareableHandle`, `cuIpc*`, `hipIpc*` not in `libAsyncRTMojoBindings.so`); done here via `OwnedDLHandle("libcuda.so.1")` → `cuIpcGetMemHandle/cuIpcOpenMemHandle` (64-byte struct by value passed with a 4-dummy-register stack shim; `std.ffi` has no C-struct ABI yet, MOCO-3692) | `proto/ipc_probe.mojo`, `proto/ipc_allreduce.mojo`; §5.4 |
+| exporting MAX-allocated buffers | **legacy IPC refused** (`cuIpcGetMemHandle` rc=1 on `enqueue_create_buffer` memory); VMM export: §5.6 | `logs/ipc_ar_233615.out`, `logs/vmm_233620.out` |
+| system-scope release/acquire, volatile loads, fences | yes: `Atomic[..].store[ordering=RELEASE]` / `load[ACQUIRE]` with default (system) syncscope, `UnsafePointer.store[volatile=True]`, `std.atomic.fence`; lowers to `st.release.sys.global` / `ld.acquire.sys.global` / `st|ld.volatile.global` on sm_90a and `global_store/load … sc0 sc1`, `buffer_wbl2 sc0 sc1`, `buffer_inv sc0 sc1`, `flat_* sc0 sc1` on gfx942 | `proto/asm/rsag_sm_90a.asm`, `proto/asm/rsag_gfx942.asm` (dumped with `max.gpu.host.compile._compile_code`) |
+| working in-kernel cross-GPU barrier | yes, `comm.sync._multi_gpu_barrier` + `Signal` (vLLM-style, portable NVIDIA/AMD) | `modular:max/kernels/src/comm/sync.mojo:330-479` |
+| tuned intra-node allreduce | yes, `comm.allreduce` 1-stage/2-stage/Lamport/multimem, arch table sm_90a/sm_100a/CDNA3/CDNA4 (`modular:max/kernels/src/comm/allreduce.mojo:257-469`); single-process, rank = `ctx.id()`; no MI300A entry (falls to CDNA3: 32 blocks, 1-stage) | measured §5.2 |
+| NVLS / multicast | `DeviceMulticastBuffer(List[DeviceContext])` + `multimem_ld_reduce/st` — **single process only**, no handle export | `device_context.mojo:7896`, `memory.mojo:3118` |
+| side stream + priority, events, cross-device stream wait | Mojo `create_stream(priority=)`, `DeviceStream.enqueue_function(DeviceFunction)`; Python `DeviceStream` (no priority), `DeviceEvent.is_ready()`; closure-capturing kernels cannot be launched on a `DeviceStream` from a shared-lib build (m0 issue modular-1) — the prototype kernel is capture-free | repo `mojo_device/device_streams.py` |
+| host-mapped flags / host callbacks (proxy designs) | `CompletionFlag`, `DeviceStream.wait_for_host_value`, `enqueue_host_func` (CUDA only), pinned `enqueue_create_host_buffer` | `device_context.mojo:2356,2389,2529,4300` |
+| calling libcuda/libamdhip64 | `OwnedDLHandle` + `get_function[Ret](name)`; MAX already dlopened them | `modular:mojo/stdlib/std/ffi/__init__.mojo:316,380` |
+| passing a `DeviceContext` into an extension | `_ctx_ptr` → `DeviceContext(OpaquePointer(unsafe_from_address=…))` | `eager_kernels/__init__.py:904-909`, `op_utils/__init__.mojo:865-869` |
+| rendezvous | none in Mojo; the PG already has the c10d store (`process_group.py:352-365`) | file exchange stands in for it in the probes |
+| pinned SM clock via SLURM comment | did not take (SM 1980 MHz under load in every job) | `logs/proto_233567.out` |
+
+Inline `Signal` cost: `size_of[Signal]()` ≈ 24.75 MiB per rank (24 MiB Lamport
+region unused by RS/AG); a slim counter-only struct would be 768 KiB.
+
+## 5. Measurements
+
+All on kyutai_debug 8×H100 80GB HBM3 nodes, SM clock 1980 MHz (unpinned), 5 reps
+× 20 back-to-back calls per size, median; device time = CUDA events (stock
+torch) / wall over 20 launches with host enqueue ≤ 16 µs per launch (Mojo;
+`RESULT_DEV`/`kernel span` = in-kernel `globaltimer` per-rank span, within 3% of
+wall everywhere). busbw = algbw × 2(N−1)/N. Raw logs in `logs/`.
+
+### 5.1 NCCL reference, 8 ranks, 1 node
+
+Job 233527 node `cl02s04dgx10`, job 233567 node `cl02s01dgx27`:
+`torchrun --standalone --nproc-per-node=8 nccl_ref_stock.py|nccl_ref_stock2.py`
+(cu128 venv, `NCCL_DEBUG=INFO NCCL_DEBUG_SUBSYS=TUNING`). fp32 (bf16 within 2%):
+
+| MiB | NCCL default (NVLS on) | algo | NCCL `NCCL_NVLS_ENABLE=0` | algo |
+|---|---|---|---|---|
+| 1 | 0.026 ms · 71 GB/s | RING LL 24ch | 0.033 · 56 | RING LL |
+| 9 | 0.087 · 190 | NVLS SIMPLE 16ch | 0.077 · 214 | RING LL128 24ch |
+| 16 | 0.121 · 244 | NVLS | 0.116 · 253 | RING LL128 |
+| 25 | 0.169 · 272 | NVLS | 0.174 · 263 | RING LL128 |
+| 27 | **0.175 · 283** | NVLS | 0.182 (bf16; fp32 median 0.242 noisy, min 0.182) · 272 | RING LL128 |
+| 128 | 0.585 · 401 | NVLS | 0.698 · 337 | RING SIMPLE |
+| 168 | **0.751 · 410** | NVLS | 0.896 · 344 | RING SIMPLE |
+| 512 | 2.146 · 438 | NVLS | 2.643 · 356 | RING SIMPLE |
+
+Repo PG (`nccl_ref_mojo.py`, mojo backend over nvidia-nccl-cu12 2.31.2, same
+algo choices): 25 MiB 0.177 ms, 512 MiB 2.156 ms; 1 MiB 0.107 ms wall — the
+Python PG is host-bound below ~9 MiB (NCCL device time 0.026 ms).
+
+### 5.2 Mojo intra-node prototypes, 1 process, 8 `DeviceContext`s (job 233567, node `cl02s01dgx27`)
+
+`proto/ar_proto.mojo` (`ar_proto_<dt> <bytes> 20 5 <variant> [blocks]`, built
+`uv run --no-sync mojo build --target-accelerator sm_90a -D dtype=… -D multimem=1`).
+`own` = RS+AG written here (216×256 threads, 16 B vector peer loads, MAX's
+`Signal`/`_multi_gpu_barrier` reused, output buffers double as the AG source,
+no temp payload); `max` = `comm.allreduce` (2-stage on sm_90a for these sizes,
+216 blocks, 8×msg payload); `maxmm` = `comm.allreduce[use_multimem=True]`
+via `DeviceMulticastBuffer`. fp32 µs per allreduce (bf16 within 1%):
+
+| MiB | own | MAX 2-stage | MAX multimem | NCCL NVLS | NCCL ring | own/NCCL-NVLS |
+|---|---|---|---|---|---|---|
+| 1 | 19.6 (94 GB/s) | 20.3 | 20.3 | 26 | 33 | 0.75 |
+| 9 | 66 (249) | 74 | 72 | 87 | 77 | 0.76 |
+| 16 | 107 (275) | 115 | 107 | 121 | 116 | 0.88 |
+| 25 | 153 (299) | 172 | 166 | 169 | 174 | 0.91 |
+| **27** | **164 (302)** | 174 (285) | 170 (291) | **175 (283)** | 182 | **0.94** |
+| 128 | 723 (325) | 751 | 769 | 585 | 698 | 1.24 |
+| **168** | **940 (328)** | 979 (315) | 1002 | **751 (410)** | 896 | **1.25** |
+| 512 | 2857 (329) | 2971 (316) | 3018 | 2146 (438) | 2643 | 1.33 |
+
+Grid sweep, own fp32 (µs): 27 MiB 64→187, 128→166, 216→164, 432→168, 864→180;
+512 MiB 64→3356, 128→2926, 216→2857, 432→2845, 864→2848. The own kernel
+saturates at ~330 GB/s busbw = 190 GB/s of NVLink reads per GPU; NCCL ring
+reaches 356, NVLS 438. MAX's multimem path is not faster than its 2-stage path
+here (unicast-bound copy phases).
+
+### 5.3 Correctness/ABI probe, 2 processes, `cuIpc*` from Mojo (job 233615, node `cl02s01dgx15`; earlier 233572)
+
+`proto/ipc_probe.mojo export 0 …` / `import 1 …`, 128 MiB uint32:
+`cuIpcGetMemHandle` on MAX `enqueue_create_buffer` memory → **rc 1
+(CUDA_ERROR_INVALID_VALUE)**; on `cuMemAlloc_v2` memory → rc 0;
+`cuIpcOpenMemHandle` (struct-by-value via stack shim) → ok; importer read
+pattern (0 wrong of 33,554,432), **peer read 369 GB/s**, wrote pattern+1, released
+a flag with `Atomic.store[RELEASE]` (system scope); exporter observed the flag
+and verified all 33,554,432 elements: **PASS** (also GPU 3→6). Lesson recorded
+in the source: one legacy handle per allocation; opening the same allocation
+twice in a process fails with CUDA_ERROR_ALREADY_MAPPED (208).
+
+### 5.4 Mojo allreduce, 8 processes over IPC (job 233615, node `cl02s01dgx15`)
+
+`proto/ipc_allreduce.mojo`: each rank `cuMemAlloc`s one region
+[Signal | input | output], exports one handle to a file (stand-in for the
+c10d store), imports the 7 peers' regions, runs the §5.2 `own` kernel. `direct`
+= the collective operates on those library-owned buffers; `staging` = the user
+tensor lives in a MAX buffer and every call copies it in and the result back
+(option b), copies included in the time. µs per allreduce, max over ranks:
+
+| MiB | direct fp32 | direct bf16 | staging fp32 | staging bf16 | NCCL NVLS |
+|---|---|---|---|---|---|
+| 9 | 66 (250 GB/s) | 68 | 82 | 85 | 87 |
+| **27** | **165 (300)** | 163 | **210 (236)** | 210 | **175** |
+| 168 | 946 (326) | 947 | 1200 | 1198 | 751 |
+| 512 | 2861 (328) | 2858 | 3624 | 3622 | 2146 |
+
+Cross-process costs nothing versus single-process (§5.2). `cuIpcOpenMemHandle`
+took 10–17 ms per peer (70–118 ms per rank for 7 peers, one-off). Staging adds
+one D2D round trip per direction (≈2.5 TB/s HBM): +45 µs at 27 MiB. Writing the
+AG result straight into the user output and staging only the input would halve
+that (not measured).
+
+### 5.5 NCCL reference, 16 ranks, 2 nodes (job 233608, nodes `cl02s01dgx15`+`cl02s03dgx28`)
+
+Stock cu128, IB with GPUDirect RDMA (12 HCAs seen, 10×400 Gb/s IB + 2×100 Gb/s
+RoCE unmerged), algo `NVLS_TREE/SIMPLE` 16 ch for ≥9 MiB, `TREE/LL128` at 1 MiB:
+fp32 1 MiB 0.082 ms (24 GB/s), 9 MiB 0.221 (80; min 0.165), 16 MiB 0.200 (158),
+**27 MiB 0.259 (205)**, 128 MiB 0.764 (329), **168 MiB 0.946 (349)**,
+512 MiB 2.397 (420). Reference busbw at large sizes agrees with the earlier
+~392 GB/s measurement.
+
+### 5.6 VMM export of MAX-owned memory (job 233620, `proto/vmm_probe.mojo`)
+
+`cuPointerGetAttribute` dump (MEMPOOL_HANDLE, RANGE/MAPPING size,
+ALLOWED_HANDLE_TYPES, IS_LEGACY_CUDA_IPC_CAPABLE) + `cuMemRetainAllocationHandle`
+→ `cuMemGetAllocationPropertiesFromHandle` → `cuMemExportToShareableHandle`
+(POSIX fd) → fd passed with `pidfd_getfd` → `cuMemImportFromShareableHandle`
++ `cuMemAddressReserve/Map/SetAccess` in the importer, with and without
+`MODULAR_DEVICE_CONTEXT_MEMORY_MANAGER_VMM=1`.
+
+Result (node `cl02s02dgx26`, kernel 5.15.0-1108, driver 570.211.01, identical
+with and without the knob): MAX's `enqueue_create_buffer` memory is **VMM**, not
+a mempool — `MEMPOOL_HANDLE = 0`, `IS_LEGACY_CUDA_IPC_CAPABLE = 0`,
+`RANGE_START 0x420000000`, `RANGE_SIZE 307,090,161,664 B (286 GiB)` VA arena,
+`MAPPING_SIZE 268,435,456 B` (256 MiB physical chunks), `ALLOWED_HANDLE_TYPES = 0`.
+`cuMemRetainAllocationHandle` → rc 0 (a real `cuMemCreate` handle), but its
+`CUmemAllocationProp.requestedHandleTypes = 0`, so
+**`cuMemExportToShareableHandle` → rc 1 (CUDA_ERROR_INVALID_VALUE)**. Option (a)
+is therefore not available on MAX 26.5 as shipped: the chunks were created
+without `CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR`. It is a one-line change on
+Modular's side (`requestedHandleTypes` at `cuMemCreate`; NCCL sets it,
+`nccl:src/include/alloc.h:312-346`) — the natural upstream ask — after which the
+importer half of this probe (fd via `pidfd_getfd`/`SCM_RIGHTS`, import, map one
+256 MiB chunk per peer, offset arithmetic) applies unchanged, and the mapping
+granularity (256 MiB chunks, handle cached per chunk) makes the per-tensor
+exchange cheap. Until then the library must own the buffers (option b, §5.4);
+option (c) does not exist (no IPC/export symbol in MAX's Mojo or Python API,
+§4). AMD side from source: RCCL on ROCm 6.4.3 uses legacy
+`hipIpcGetMemHandle` on `hipExtMallocWithFlags(hipDeviceMallocUncached)` buffers
+(§3.2) — i.e. also library-owned staging; `hipMemExportToShareableHandle` exists
+but RCCL only enables the VMM path on gfx1250 with HIP ≥ 7.2
+(`rccl:src/misc/rocmwrap.cc:121-150`), so option (b) is the expected path there
+too, and whether MAX's HIP allocator memory accepts `hipIpcGetMemHandle` is
+untested (it is `hipMalloc`-class by default per `docs/distributed.md`, VMM with
+`MODULAR_DEVICE_CONTEXT_MEMORY_MANAGER_VMM=1`).
+
+## 6. One codebase for NVIDIA and AMD
+
+Demonstrated by cross-compilation (`--target-accelerator gfx942`, no device):
+`ar_proto.mojo` and `ipc_allreduce.mojo` build for gfx942 with **one** gate —
+`comptime MM = get_defined_bool["multimem"]() and has_nvidia_gpu_accelerator()`
+around the `DeviceMulticastBuffer`/`use_multimem` path (multimem is sm_90+ only,
+`modular:mojo/stdlib/std/gpu/memory/memory.mojo:3085`); `ipc_probe.mojo` builds
+with a comptime name switch (`hipIpcGetMemHandle`/`hipIpcOpenMemHandle`/`hipMalloc`/
+`hipSetDevice` vs `cuIpc*`/`cuMemAlloc_v2`/`cuDevicePrimaryCtxRetain+cuCtxSetCurrent`;
+identical signatures, same 64-byte handle struct). The kernel body is vendor-free:
+`global_perf_counter_ns` → `s_memrealtime`, `Atomic` → `sc0 sc1` + `buffer_wbl2`/
+`buffer_inv` (matches RCCL's `__hip_atomic_* SYSTEM` + `dwordx4 sc0 sc1`, §3.2),
+16 B vectors → `global_load/store_dwordx4`, BLOCK=256 ≤ RCCL's gfx942 max.
+
+Unavoidable per-vendor shims (all host-side, ~100 lines total): driver library
+and function names; making the device current; **staging allocation flags** —
+on MI300 the FIFO/flag buffers must be `hipExtMallocWithFlags(hipDeviceMallocUncached)`
+(RCCL's precondition, §3.2), `hipMalloc` is not enough for polled flags; on
+NVIDIA plain `cuMemAlloc`. Tuning: block count (216 on H100; MAX uses 32–64 on
+CDNA; RCCL `nc=4` channels for 4 ranks), spin-loop `s_sleep`, 4 APUs on xGMI
+(48 GB/s per link, 2 links per pair per `rome_model_80`, `rccl:src/graph/rome_models.cc:2214-2287`)
+vs 8 on NVSwitch — expect ~100–150 GB/s busbw, measured only on Adastra.
+Not verified anywhere here: MI300A runtime behaviour of the barrier, hipIpc of
+MAX-allocated memory on ROCm (default MAX allocator differs from CUDA's; the
+`…MEMORY_MANAGER_VMM=1` knob the repo documents for Adastra changes it again).
+
+## 7. Multi-node
+
+What the inter-node hop takes, from source: NCCL `net_ib` is ~13.5k lines that
+are **not** a plugin (compiled into libnccl, `nccl:src/transport/CMakeLists.txt:15`);
+a minimal re-implementation needs the verbs set (`ibv_open_device/alloc_pd/
+create_cq/create_qp`, three `ibv_modify_qp` state masks `nccl:src/transport/net_ib/connect.cc:370-502`,
+`ibv_reg_mr`/`ibv_reg_dmabuf_mr` with fd from `cuMemGetHandleForAddressRange`
+`nccl:src/transport/net.cc:1014-1016`, `ibv_post_send` WRITE/WRITE_WITH_IMM,
+`ibv_poll_cq`), a TCP/store exchange of QPN/LID/GID + CTS fifo address/rkeys,
+the 8-slot credit ring with host-pinned GPU-mapped head/tail
+(`nccl:src/transport/net.cc:958-976`), the CTS record protocol verbatim
+(`nccl:src/transport/net_ib/common.h:268,540-546`; `p2p.cc:275-411`), a
+non-blocking progress thread owning all verbs calls, and an MR cache
+(`nccl:src/transport/net_ib/reg.cc:10-64`). Estimate 2–3k lines Mojo + a
+host thread; 6–10 weeks to NCCL-class bandwidth on this fabric. Slingshot:
+another libfabric/cxi backend (RCCL's is an external plugin with no in-tree
+code; `fi_*` calls + `hsa_amd_portable_export_dmabuf`), 4–8 weeks, only testable
+on Adastra. No GPU-side new features are needed for either (host proxy +
+volatile flags), so this is not a language question; it is a transport port.
+
+Honest first scope: **Mojo intra-node, NCCL/RCCL inter-node**. Hierarchical
+allreduce per bucket: Mojo RS (my 1/8 shard reduced within the node) → one
+`ncclAllReduce` per local rank over a communicator of size nNodes (3.4 MiB at
+27 MiB; the PG already knows `ncclCommInitRank` with a store key) → Mojo AG.
+Expected ≈ 165 µs + IB allreduce of 3.4 MiB (~60–90 µs at 400 Gb/s per HCA) ≈
+230–260 µs vs NCCL's 259 µs NVLS_TREE at 2 nodes (§5.5) — parity within the
+noise, and the dependency on NCCL drops to `ncclAllReduce` on a small
+communicator. Alternative for a fully vendor-free run: stage the shard through
+host memory and gloo (already instantiated in the PG) — ~3.4 MiB × 2 over PCIe
++ TCP, ~1–3 ms per bucket, hidden behind backward for buckets 0–11 but a
+~5–10 ms exposed tail; acceptable for a demo, not for the bar.
+
+## 8. Minimal plan
+
+M1 — intra-node NVIDIA in the PG (3–4 weeks). Extension `eager_kernels/collectives_ops/`
+(receives `_ctx_ptr` + raw pointers like every eager kernel); per-rank
+library-owned region [Signal | in-stage | out-stage] sized to the largest
+bucket (grow-on-demand needs an all-rank sync, m0 issue modular-4);
+`cuIpcGetMemHandle` → 64 bytes through the c10d store key `mojo-ipc-<rank>-<gen>`
+→ `cuIpcOpenMemHandle` at first collective; RS+AG kernel launched capture-free
+on the existing comm `DeviceStream`; `allreduce` (+`broadcast`, `allgather` via
+the same peer-load kernel) for same-node tensors, NCCL untouched for the rest;
+completion via the existing `comm_fence`. Acceptance: 13-bucket step parity
+with NCCL losses, 27 MiB ≤ 210 µs staged / ≤ 175 µs if §5.6 allows direct
+export. Decision gate: ask Modular for `CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR` on
+the arena chunks (§5.6) — direct export removes the staging copies and the
+size cap; the importer code is already written in `proto/vmm_probe.mojo`.
+
+M2 — MI300A (2–3 weeks incl. cluster access). Swap names, uncached staging
+allocation, `hipSetDevice`; tune blocks (32/64/128) and add `s_sleep` backoff;
+validate barrier + IPC on 4 APUs; measure vs RCCL (`NCCL_DEBUG=INFO` for its
+protocol) at 27/168 MiB.
+
+M3 — multi-node (2 weeks): hierarchical RS → NCCL/RCCL shard allreduce → AG,
+on both clusters; keep `TORCH_MOJO_BACKEND_COMM_STREAM`-style kill switch to
+fall back to plain NCCL.
+
+Optional M4 — NVLS in Mojo (2–3 weeks, NVIDIA only): `cuMulticastCreate`
++ `cuMemExportToShareableHandle` fd passing (needs an AF_UNIX `SCM_RIGHTS`
+helper, ~100 lines) + MAX's existing `multimem_ld_reduce` kernel path; only
+worth it for the 168 MiB tail bucket (+0.2 ms/step today).
+
+## 9. Open risks
+
+- Legacy IPC does not accept MAX's allocations (measured); the VMM export path
+  depends on how MAX created its arena (§5.6). If neither works, staging is
+  permanent: +45 µs per 27 MiB bucket, hidden, and the region size caps the
+  largest single collective (step-1's 474 MiB allreduce → chunk it).
+- Cross-process spin barriers have no abort: a dead rank hangs peers in-kernel
+  (NCCL has abort flags, `nccl:src/device/primitives.h:154-164`). Needs a
+  host watchdog + a poisoned generation counter.
+- `Signal` lifetime contract: peers read my region after my kernel retires
+  (m0 issue modular-4); the next start barrier orders reuse, so buffers must
+  never be freed/resized without an all-rank host sync.
+- MAX frees are stream-ordered on the owning stream only (memory note): every
+  user tensor a side-stream collective touches must stay `record_use`-fenced,
+  as the PG does today.
+- `globaltimer`/`s_memrealtime` are per-GPU; never subtract stamps across GPUs.
+- RCCL/MI300A numbers are extrapolated from source (2.30.7 read, 2.22.3 deployed);
+  fine-grained/uncached memory semantics for polled flags on the APU are the
+  first thing to test there.
+- Mojo `std.ffi` has no C struct-by-value ABI; the 64-byte handle shim is
+  x86-64 SysV specific (fine for both clusters, not portable to aarch64 hosts).
+- ptxas 12.8 / driver 570 gate as for every kernel here; SLURM clock pin via
+  `--comment` did not apply — all numbers at boost clock, NVLink-bound so low
+  sensitivity.

--- a/docs/mojo_collectives_kernel_results.md
+++ b/docs/mojo_collectives_kernel_results.md
@@ -1,0 +1,370 @@
+# Mojo intra-node collectives — measured results
+
+Deliverable: `collectives_kernels.mojo` (this directory). Harness: `harness.mojo`
++ `validate.sbatch` (correctness + the tables below, NCCL legs interleaved),
+`ab.sbatch` (the NCCL A/B alone), `sweep.sbatch` / `tune.sbatch` /
+`diag.sbatch` (the tuning sweeps), `bench.sbatch`, `smoke.sbatch`.
+`./build.sh` builds the per-dtype harnesses and the assembly dumps;
+`./build.sh sweeps` also builds the `-D`-tuned variants the sweep scripts
+expect. Raw logs: `/home/gabriel/ddp_work/logs/ccl_*.log`.
+
+All numbers: 8xH100 SXM (NVSwitch), one process per GPU, regions exchanged with
+`cuIpcGetMemHandle`/`cuIpcOpenMemHandle`, **staged** (user tensors in
+MAX-allocated memory; every copy the design needs is inside the measurement),
+20 back-to-back launches x 5 reps, median, max over ranks. Device time = wall
+over the 20 launches / 20, cross-checked against an in-kernel `globaltimer`
+span recorded by stamp kernels on the same stream (they agree to <0.5%
+everywhere; the CSV prints both). SM clock 1980 MHz (boost, unpinned — the
+SLURM `--comment=gpu_clock` pin does not take on this cluster; checked per job).
+
+Nodes: `cl02s01dgx18`, `cl02s01dgx04`, `cl02s01dgx16`, `cl02s04dgx01`. Node to
+node spread on the same code is ~2%, so cross-job comparisons below are only
+made within a job.
+
+## 1. Headline: same-node A/B against NCCL (job 233776, shipped constants)
+
+Legs interleaved within each round (NCCL NVLS, mojo fp32, mojo bf16, NCCL ring),
+3 rounds, same node, same job. NCCL = stock torch 2.11.0+cu128 / NCCL 2.28.9,
+device time from CUDA events, max over ranks — the same statistic the Mojo
+harness prints.
+
+fp32, world 8 (us):
+
+| bytes | **mojo** | NCCL default (NVLS) | NCCL ring (`NCCL_NVLS_ENABLE=0`) | mojo / NVLS | target |
+|---|---|---|---|---|---|
+| 4 B | **9.4** | 18.4 | 17.5 | 0.51x | <= 25 ✔ |
+| 256 KiB | **15.3** | 19.9 | 19.5 | 0.77x | — |
+| 512 KiB | **21.4** | 19.6 | 19.6 | 1.09x | — |
+| 1 MiB | **23.6** | 24.7 | 25.0 | 0.96x | — |
+| 9 MiB | **64.6** | 85.8 | 76.4 | 0.75x | <= 91 ✔ |
+| **27 MiB** (DDP bucket) | **163.8** | 174.9 | 181.8 | **0.94x** | <= 184 ✔ |
+| 168 MiB (tail bucket) | **958** | 750 | 899 | 1.28x | "as close as unicast gets" |
+| 512 MiB | **2860** | 2146 | 2636 | 1.33x | — |
+
+bf16, world 8: 9.4 / 15.4 / 21.4 / 23.6 / 64.8 / **163.1** / 959 / 2856 us —
+within 0.5% of fp32 at every size (target: 2%).
+
+world 4 (fp32): 8.4 / 10.9 / 14.0 / 18.3 / 56.5 / 135.7 / 814 / 2437 us.
+world 2 (fp32): 8.0 / 8.9 / 10.3 / 15.4 / 40.9 / 101.0 / 623 / 1856 us.
+
+**The three stated targets are met with the staging included**, and the two
+sizes that matter for GPT-2 DDP (9 and 27 MiB) beat NCCL's best algorithm on
+the same node by 25% and 6%. The feasibility study's *direct* kernel (operating
+on library-owned buffers, no user tensors involved) was 66 / 165 us at 9 /
+27 MiB: **the staging now costs nothing measurable**, against +25% (82 /
+210 us) for the naive copy-in/copy-out staging the study measured. The one
+size where NCCL wins below 1 MiB is 512 KiB (21.4 vs 19.6), at the top of the
+one-shot regime.
+
+## 2. Why the staging became free
+
+The user's tensors are MAX-allocated and cannot be exported by IPC, so peers can
+only read the library's region. Instead of copying the input in and the result
+out, the kernel makes the *transfers themselves* do the staging:
+
+* **push** — each rank reads its own input straight from user memory and writes
+  shard *s* into peer *s*'s slot. That write is the copy-in and it is the NVLink
+  transfer the reduce-scatter needed anyway.
+* **reduce** — each rank sums the `world` contributions to its own shard (its own
+  from user memory, the peers' from its region) and writes the result both to
+  its region and to its slice of the user output.
+* **pull** — each rank reads the peers' reduced shards straight into the user
+  output.
+
+NVLink traffic per GPU is `2*(world-1)/world*bytes` — the unicast minimum, the
+same as a direct reduce-scatter + all-gather — and no local byte is copied that
+the direct kernel would not also copy. Three cross-GPU syncs: a start barrier
+(the arena-reuse invariant, see §6) plus one per data dependency.
+
+Messages at or below 512 KiB take a **one-shot** path instead — every rank
+pushes its whole input to every peer and reduces locally, `(world-1)x` the
+NVLink bytes but one data sync instead of two. Measured crossover (one-shot vs
+two-shot, us): 128 KiB 9.3/19.0, 256 KiB 12.3/19.3, 512 KiB 18.1/19.8, 1 MiB
+30.0/20.5 (job 233731, before the start barrier added ~2.5 us to both).
+
+## 3. What tops out where: the unicast ceiling at 168 MiB
+
+At 168 MiB the kernel is 1.07x NCCL ring and 1.28x NCCL NVLS. The decomposition
+below says why, and it is measured, not modelled.
+
+`allgather` with 21 MiB per rank (= 168 MiB output) moves exactly the same
+154 MB of NVLink reads per GPU as the allreduce's pull phase, and nothing else
+except a local 22 MB stage copy: **502-508 us**, i.e. **~305 GB/s per GPU per
+direction**. The allreduce at 168 MiB is 958-990 us for a push (154 MB out)
+plus a pull (154 MB in), i.e. **~315 GB/s per direction** — the same rate. So:
+
+* both NVLink phases already run at the rate a pure peer-copy kernel achieves;
+* the local reduce costs **~30 us of the ~980** (980 - 2x~480), not the ~110 us
+  a naive HBM model predicts — the memory system absorbs it;
+* therefore **pipelining the reduce behind the transfers can win at most ~3%**,
+  and was not implemented (see §6, negative results).
+
+The ceiling for this design is the fabric rate under all-to-all traffic:
+**~310 GB/s per direction per GPU, 69% of NVLink4's 450 GB/s**. NCCL ring gets
+343 GB/s (899 us) with neighbour-only traffic — ~10% better fabric efficiency
+that a direct (all-to-all) reduce-scatter/all-gather does not reach by tuning
+(every knob was swept, §5); closing it needs a different schedule, an
+N-1-step ring, which is a different kernel and would give up the latency win
+at 9-27 MiB that matters more for this workload.
+
+**NCCL NVLS's 750 us is out of reach for any unicast kernel**, and not by a
+small margin of tuning: `multimem.ld_reduce` has the NVSwitch do the reduction,
+so each GPU moves `2*bytes/world` across the fabric instead of
+`2*bytes*(world-1)/world` — 7x fewer bytes at world 8. To match it we would need
+`cuMulticastCreate` + `cuMemExportToShareableHandle` + fd passing over an
+AF_UNIX socket (`SCM_RIGHTS`), and — the part that reaches outside this file —
+the region would have to be allocated with `cuMemCreate`/`cuMemMap` instead of
+`cuMemAlloc` so it can be bound to the multicast object. MAX's
+`DeviceMulticastBuffer` is single-process and cannot be reused across processes.
+That is the exact gap; it was not attempted here because the region allocator
+belongs to the plumbing layer.
+
+Consequences for GPT-2 DDP: buckets 0-11 (9 and 27 MiB) are faster than NCCL and
+overlapped with backward anyway; the exposed 168 MiB tail bucket costs
++0.21 ms/step versus NCCL NVLS, on a ~45 ms step.
+
+## 4. Broadcast and allgather
+
+| collective | size | first design (us) | **shipped design (us)** |
+|---|---|---|---|
+| broadcast | 27 MiB | 552 (root stages, all read) | **154-157** |
+| broadcast | 168 MiB | 3374 | **927-1035** |
+| broadcast | 256 MiB | — | **1436** |
+| allgather | 3.4 MiB/rank (27 MiB out) | — | **96-98** |
+| allgather | 21 MiB/rank (168 MiB out) | — | **502-508** |
+| allgather | 32 MiB/rank (256 MiB out) | — | **778** |
+
+(ranges are across nodes, jobs 233776/233789/233794; world 3 also measured:
+broadcast 27 MiB 118 us, allgather 9 MiB/rank 77 us.)
+
+The first broadcast put `(world−1)·nbytes` on the root's single outbound link
+(552 us at 27 MiB where the fabric can do ~150). The shipped one is **scatter +
+all-gather**: the root scatters shard *p* into rank *p*'s stage (nbytes out of
+the root, spread over the peers), then every non-root rank gathers the `world`
+shards. 3.6× faster, and both phases are permutations, so no link carries more
+than `nbytes`. It is out-of-place capable (ncclBroadcast semantics): only the
+root reads `send_ptr`, everyone writes `recv_ptr`, and when the two differ on
+the root it copies locally instead of gathering its own message back over
+NVLink. Allgather is a local stage + a peer gather — already the unicast
+minimum — and honours a `stride_bytes` that differs from `nbytes_per_rank` so
+the ABI layer can chunk one rank's contribution across calls. DDP's two
+~250 MiB parameter broadcasts cost ~1.4 ms each instead of ~5 ms.
+
+## 5. Tuning sweeps
+
+Grid (blocks of 256 threads), fp32 world 8, µs:
+
+| blocks | 4 B | 1 MiB | 9 MiB | 27 MiB | 168 MiB | 512 MiB |
+|---|---|---|---|---|---|---|
+| 64 | — | — | — | — | 1000 | 2955 |
+| 96 | 6.8 | 20.6 | 63.2 | 177.2 | 991 | 2982 |
+| 128 | 6.7 | 20.6 | 65.7 | 166.9 | **977** | **2826** |
+| 132 | 6.9 | 20.7 | 67.4 | 167.5 | 993 | 2934 |
+| 160 | — | — | — | — | 1104 | 3458 |
+| **216** | 6.8 | 20.5 | **61.1** | 167.4 | 1002 | 3030 |
+| 264 | 6.8 | 20.6 | 66.6 | **164.7** | 951 | 3051 |
+| 432 | 6.9 | 20.7 | 64.0 | 169.8 | 1075 | 3331 |
+| 864 | 6.7 | 20.5 | 63.5 | 175.0 | 1000 | 3168 |
+
+Two regimes, hence the two constants in the file (`_AR_MAX_BLOCKS` = 216 below
+64 MiB, `_AR_BIG_BLOCKS` = 128 at and above it; both fitted on H100 and marked
+as such):
+
+* **small/medium**: more threads win because the transfer is latency-bound —
+  216 blocks is the flat optimum at 9 MiB (61.1 vs 65.7 at 128).
+* **large**: a grid that fits in **one wave** of the 132 SMs wins, because the
+  barrier is per block index: with more blocks than SMs the second wave runs the
+  *whole* collective after the first, on fewer SMs. 128 blocks is 7% faster than
+  216 at 512 MiB (2826 vs 3030). 160 blocks (1.2 waves, a long tail wave) is the
+  worst point measured — 3458 µs, 22% worse than 128.
+
+Unroll (16-byte vectors in flight per thread in the copy loops), fp32 world 8:
+
+| unroll | 9 MiB | 27 MiB | 168 MiB | 512 MiB |
+|---|---|---|---|---|
+| 1 | 62.2 | 168.1 | 1083 | 3222 |
+| 2 | 61.3 | 163.9 | 1025 | 3162 |
+| **4** | 61.5 | 167.1 | **994** | **3078** |
+| 8 | 61.6 | 164.5 | 1026 | 3369 |
+
+Memory-level parallelism matters only in the bandwidth-bound regime (+9% from
+U=1 to U=4 at 168 MiB) and is flat below 27 MiB. U=8 regresses (register
+pressure). `_UNROLL = 4`.
+
+One-shot/two-shot threshold (job 233731, three interleaved rounds, measured
+before the start barrier added ~2.5 us to every leg). Each column is the same
+size run by two builds differing only in `-D ccl_oneshot_max`, so the pair
+isolates the path, not the size:
+
+| bytes | 64 KiB | 128 KiB | 256 KiB | 512 KiB | 1 MiB | 2 MiB | 4 MiB |
+|---|---|---|---|---|---|---|---|
+| one-shot | 7.5 | **9.3** | **12.2** | **18.1** | 30.0 | 51.9 | 97.0 |
+| two-shot | 7.5 | 19.0 | 19.3 | 19.9 | **20.5** | **24.2** | **34.5** |
+
+The crossover sits just above 512 KiB, so `_ONESHOT_MAX_BYTES = 512 KiB`. Below
+256 KiB the one-shot path is 2x faster; above 1 MiB it degrades as
+`(world-1)x` the bytes should.
+
+## 6. Negative results (do not re-explore)
+
+* **Pipelining the local reduce behind the transfers** (chunk the shard, give
+  each chunk its own pair of flags, and run `reduce(c+1)` concurrently with
+  `pull(c)` — half the block's warps on each): designed, costed, **not
+  implemented**, because the measurement in §3 bounds the win. The reduce is
+  worth ~30 µs of the 988 at 168 MiB, and K chunks recover at most
+  `(K−1)/K · 30 µs` while adding `2K` syncs at ~2–3 µs each: K=4 nets ≈ +7 µs,
+  i.e. nothing. The design is sound and written down here so nobody re-derives
+  it: the matching invariant is per *block*, not per thread (block *b* must
+  produce exactly the indices block *b* of its peers consumes, and with a
+  grid-stride loop that set is fixed by the loop shape), so threads inside a
+  block may be split by role as long as every phase keeps the same
+  block→index mapping. Worth revisiting only if the reduce ever gets more
+  expensive (a wider dtype conversion, a fused op).
+* **A stack array of peer pointers in the reduce loop** (`InlineArray[Pointer,
+  MAX_WORLD]`, the natural way to write it, and what MAX's `_multi_gpu_barrier`
+  warns about as MOCO-1431): the array is demoted to **local memory**, so the
+  PTX shows `ld.local.b64` per pointer per iteration and every payload load
+  becomes a generic-address `ld.v4.b32` instead of `ld.global.v4.b32`. Forming
+  the address arithmetically inside the unrolled loop fixes it: 18
+  `ld.global.v4.b32`, zero local traffic.
+* **More blocks**: 432 and 864 are worse everywhere (see the table); the
+  intuition "more blocks fill NVLink better" is wrong once the grid exceeds one
+  or two waves, because the per-block barrier serialises waves.
+* **Broadcast by staging the whole message on the root**: 3.6× slower than
+  scatter + all-gather (552 vs 154 us at 27 MiB). Do not "simplify" it back.
+* **A byte copier that falls back to single bytes when a pointer is
+  misaligned**: `_copy_bytes` chooses 16-byte vectors or a fallback per call,
+  and for a byte collective the writer and the reader are different ranks
+  looking at different pointer pairs (the root's `send` vs a peer's `recv`), so
+  they can disagree. A byte-wise fallback would then give writer and reader
+  different index -> block mappings, and the barrier is per block index: block 3
+  would read a chunk block 0 wrote, with nothing ordering them. Both paths now
+  walk the same 16-byte chunks in the same grid-stride order; only the
+  instructions inside a chunk differ. Found by inspection, not by a failing
+  test — it needs `send` and `recv` to have different 16-byte alignment.
+* **Dropping the start barrier** (two syncs per allreduce instead of three,
+  ordering the arena reuse out of the phase structure alone): measured 2.5–3 µs
+  cheaper at every size, and **wrong**. That argument only holds for a run of
+  identically shaped collectives. DDP interleaves a 4-byte one-shot allreduce
+  and byte collectives with 27 MiB two-shot allreduces, whose staging layouts
+  overlap; with only the data syncs, rank R's push for generation g+1 is
+  concurrent with a slower rank's reads for generation g whenever the two
+  generations lay the arena out differently. The start barrier reduces the
+  whole question to one invariant (§ "Buffer-reuse invariant" in the source),
+  and `harness.mojo mix` — 800 interleaved generations of exactly that pattern,
+  both allreduces in place so a single corrupted generation survives to the end
+  — is the regression test.
+
+## 7. Correctness
+
+`harness.mojo verify` (job 233776, 94 passing cases) checks every result against
+a host reference recomputed from the same deterministic splitmix64 fill (no
+RNG):
+
+* dtypes float32, bfloat16, float16, int32, int64 — world 8; plus float32 world
+  4, 2 and **1**, int64 world 3, bfloat16 world 5, int32 world 7 (odd worlds
+  take the runtime-`world` kernel instantiation; world 1 degenerates to
+  `out = scale * in` and is exercised, not special-cased away).
+* sizes 1, 2, 3, 1003, one page, 65537 and `(cap−1)/element_size` elements — i.e.
+  ragged, non-multiples of the 16-byte vector width, and the 4-byte case.
+* every size run twice: out-of-place and **in-place** (`in_ptr == out_ptr`).
+* float32 is checked **exactly** (the fill is k/128 with |k| ≤ 128, so the sum of
+  8 is exact in fp32 and the ×1/8 scale is a power of two); bf16/fp16 to half a
+  bf16 ulp; **int64 against an Int64 reference with samples of magnitude 2⁵⁶**,
+  which no fp64 reference could verify.
+* the region's error word is read back after every case (it stays 0).
+
+`harness.mojo mix` is the interleaving regression test: 200 rounds x (4-byte
+one-shot allreduce, 27 MiB two-shot allreduce, 2000-byte broadcast, 8-byte
+allgather) = **800 generations** whose staging layouts overlap, both allreduces
+in place with `scale = 1/world` so the value is idempotent once every rank holds
+the mean and a single corrupted generation anywhere in the run is still visible
+in the final buffer. Passes for float32 and bfloat16 at world 8, float32 at world 4 and bfloat16 at
+world 5 (jobs 233776, 233789, 233794). This is the test that the start barrier
+exists for.
+
+Broadcast and allgather results are checked byte-for-byte against the same hash
+(sampled every 997 bytes) in the `ops` suite.
+
+## 8. Build
+
+Both targets build from the one file, no vendor `#ifdef` in the device code:
+
+```
+uv run --no-sync mojo build harness.mojo -I . --target-accelerator sm_90a  -D dtype=float32 -o harness_float32
+uv run --no-sync mojo build harness.mojo -I . --target-accelerator gfx942  -D dtype=float32 -o harness_f32_gfx942
+```
+
+`collectives_kernels.mojo` compiles warning-free on both. The emitted device
+code is what NCCL/RCCL rely on (`asm/` holds the dumps, produced by
+`dump_asm.mojo` with no GPU present):
+
+| | sm_90a | gfx942 |
+|---|---|---|
+| flag publish | `st.release.sys.global.b64` | `global_store … sc0 sc1` + `buffer_wbl2 sc0 sc1` |
+| flag wait | `ld.acquire.sys.global.b64` | `global_load … sc0 sc1` + `buffer_inv sc0 sc1` |
+| payload | `ld/st.global.v4.b32` (18/12 in the allreduce) | `global_load/store_dwordx4` (18/12) |
+| block barrier | `bar.sync` | `s_barrier` |
+| deadline | `%globaltimer` | `s_memrealtime` |
+
+Blocks are 256 threads (RCCL's gfx942 maximum) and every layout is wave-64
+safe. The file has exactly **one** comptime vendor gate, in `_sync`: gfx942
+emits its workgroup barrier as `s_waitcnt lgkmcnt(0); s_barrier`, which does
+*not* wait on vector memory, so another wave's payload stores can still be in
+flight when one thread publishes the flag. RCCL solves this by putting
+`vmcnt(0)` inside its block barrier; the portable spelling is a release fence
+in every thread, which lowers to `s_waitcnt vmcnt(0)` + `buffer_wbl2 sc0 sc1`.
+NVIDIA needs nothing there (`bar.sync` is a CTA-scope fence and the release
+store is cumulative over it — what NCCL's `postPeer` relies on), and the gate
+is comptime, so the sm_90a instruction mix is byte-identical with and without
+it (checked by diffing the dumps).
+
+AMD numbers are unmeasured (no MI300A here). Two things the AMD host side will
+need, from RCCL's source: the region must be allocated **uncached**
+(`hipExtMallocWithFlags(hipDeviceMallocUncached)`) — RCCL's precondition for
+polled flags on MI300 — and the tuning constants above are H100 fits and are
+marked as such in the source.
+
+## 9. What the ABI layer needs to know
+
+Six exported names, matching the contract exactly: `signal_bytes`,
+`error_offset`, `region_init(ctx, region)` (no stream — it blocks),
+`allreduce[dtype](ctx, stream, ...)`, `broadcast(...)`,
+`allgather(..., stride_bytes=-1)`. `MAX_WORLD = 8`. Everything is enqueued on
+the stream passed in and returns right after the enqueue; `ctx` is only the
+compile/cache handle (`DeviceFunction`s are cached process-globally per
+`ctx.id()`, so the per-call cost is the enqueue, not a ~180 us
+`compile_function`).
+
+Preconditions the file enforces by raising, all of them cheap host-side checks:
+
+* `numel * size_of[dtype]() <= cap_bytes`, `nbytes <= cap_bytes`,
+  `nbytes_per_rank <= cap_bytes` — the caller chunks anything larger (it does).
+* **`in_ptr` and `out_ptr` of `allreduce` must be 16-byte aligned.** The payload
+  loops use 16-byte vectors, which fault on a misaligned address. Every
+  allocator-returned pointer satisfies this and so does every chunk offset the
+  ABI layer forms (they are multiples of `cap_bytes`); a mid-tensor *view* may
+  not, and such a tensor must be staged into an aligned buffer by the caller
+  rather than have the kernel guess. `broadcast`/`allgather` need no such rule —
+  the byte copier checks alignment at run time and falls back to a scalar loop.
+* `world` in `1..8` (world 1 works and degenerates to `out = scale * in`),
+  `rank < world`, `generation >= 1`, `cap_bytes` a positive multiple of 4096.
+* `scale` is applied on the final write for floating-point dtypes and ignored
+  for integers (the caller passes 1.0 there, which is what NCCL's `ncclAvg`
+  does anyway).
+
+Two notes on the surrounding layer:
+
+* **The error word is device memory.** `error_offset()` is a byte offset into
+  the region, which is `cuMemAlloc`/`hipMalloc` memory: it cannot be read by
+  dereferencing a host pointer (that faults or reads garbage). Copy it back with
+  `cuMemcpyDtoH` / a one-thread kernel, as `harness.mojo`'s `check_error` does.
+  A nonzero value is `code * 1_000_000 + phase` and means some block gave up
+  waiting for a peer (60 s deadline, measured with the GPU's own timer, never
+  compared across GPUs); the collective's result is undefined from that
+  generation on.
+* `generation` must be strictly increasing per communicator **across all
+  collective kinds** — the flag values are `generation * 8 + phase` and the
+  start barrier's whole job is to order one generation's writes after the
+  previous generation's reads. A repeated or decreasing generation silently
+  passes barriers it should not.

--- a/tests/ddp_worker.py
+++ b/tests/ddp_worker.py
@@ -21,6 +21,14 @@ import torch.distributed as dist
 from torch.nn.parallel import DistributedDataParallel as DDP
 
 from torch_mojo_backend import register_mojo_devices
+from torch_mojo_backend.distributed import nccl
+from torch_mojo_backend.distributed.process_group import (
+    MojoProcessGroup,
+    _nccl_dtype,
+    _nccl_red_op,
+    _ptr_of,
+)
+from torch_mojo_backend.mojo_device import torch_mojo_device_module
 
 # mojoccl (torch_mojo_backend/distributed/mojoccl) implements AllReduce/
 # Broadcast/AllGather only -- Reduce/ReduceScatter/Send/Recv return
@@ -236,6 +244,225 @@ def run_lazy_fence(failures: list[str]):
     dist.barrier()
 
 
+# ---------------------------------------------------------------------------
+# stress: mojoccl-only regression coverage ported from the kernel harness
+# (/home/gabriel/ddp_work/mojo_collectives/kernel/harness.mojo `mix` and
+# `verify`) into the real torchrun/c10d path -- vendor NCCL/RCCL never see
+# this mode (nothing here would fail against them; it exists to catch
+# mojoccl-specific ABI bugs like the interleaving bug RESULTS.md §6 found).
+# ---------------------------------------------------------------------------
+
+_VERIFY_DTYPES: list[torch.dtype] = [
+    torch.float32,
+    torch.float16,
+    torch.bfloat16,
+    torch.int32,
+    torch.int64,
+]
+_INT_DTYPES = (torch.int32, torch.int64)
+
+
+def _fill(dtype: torch.dtype, rank: int, n: int) -> torch.Tensor:
+    """Deterministic per-(rank, index) values, no RNG, on the CPU.
+
+    Integers land in [-128, 127]: exact CPU references, no overflow summing
+    up to 8 ranks. Floats are k/128 with |k| <= 128: exactly representable
+    in fp16/bf16/fp32 (<= 8 significant bits), so only the cross-rank SUM can
+    round, never the fill itself -- the same trick harness.mojo's _val_f64
+    uses and for the same reason.
+    """
+    idx = torch.arange(n, dtype=torch.int64)
+    h = (rank * 1000003 + idx * 2654435761) & 0xFF
+    if dtype in _INT_DTYPES:
+        return (h - 128).to(dtype)
+    return ((h.to(torch.float64) - 128.0) / 128.0).to(dtype)
+
+
+def _reference(dtype: torch.dtype, world: int, n: int, avg: bool) -> torch.Tensor:
+    """The CPU sum (or, for floats, AVG) of `_fill(dtype, r, n)` over every
+    rank r, accumulated wide (int64 / float64) then rounded once to `dtype`
+    -- mojoccl ignores `scale` for integer dtypes (collectives_kernels.mojo's
+    allreduce docstring: "ignored for integer dtypes"), so AVG on int32/int64
+    is SUM, matching what the library actually computes, not what real NCCL's
+    ncclAvg would do.
+    """
+    acc_dtype = torch.int64 if dtype in _INT_DTYPES else torch.float64
+    acc = torch.zeros(n, dtype=acc_dtype)
+    for r in range(world):
+        acc += _fill(dtype, r, n).to(acc_dtype)
+    if avg and dtype not in _INT_DTYPES:
+        acc = acc / world
+    return acc.to(dtype)
+
+
+def _matches(dtype: torch.dtype, got: torch.Tensor, want: torch.Tensor) -> bool:
+    """Exact for float32/int32/int64; half a bf16 ulp for fp16/bf16 -- the
+    same tolerance harness.mojo's verify_ar uses, validated there against
+    this exact kernel (RESULTS.md §7)."""
+    if dtype in (torch.float16, torch.bfloat16):
+        got64 = got.to(torch.float64)
+        want64 = want.to(torch.float64)
+        tol = 0.004 * torch.clamp(want64.abs(), min=1.0)
+        return bool((got64 - want64).abs().le(tol).all())
+    return torch.equal(got, want)
+
+
+def _pg_comm(tensor: torch.Tensor) -> tuple[nccl.NcclComm, int]:
+    """(NcclComm, default-stream handle) for `tensor`'s device, bypassing
+    dist.all_reduce's always-in-place call shape (process_group.py always
+    passes the same pointer as sendbuff and recvbuff) so the verify matrix
+    below can also exercise a genuine sendbuff != recvbuff ncclAllReduce.
+    `dist.group.WORLD` is this backend's own `MojoProcessGroup` instance
+    directly -- no C++ PG wraps it (see MojoProcessGroup.__init__).
+
+    Callers MUST synchronize the device before enqueuing on the returned
+    stream if a prior collective on this comm went through dist.all_reduce:
+    that path can run on a side comm-stream (TORCH_MOJO_BACKEND_COMM_STREAM,
+    the default), and NCCL/RCCL-style comms require every op on a
+    communicator to execute in issue order across ranks
+    (process_group.py's `_fence_default` exists for exactly this) -- this
+    raw call bypasses that fencing, so the caller re-establishes the
+    ordering with a full sync instead.
+    """
+    pg = dist.group.WORLD
+    assert isinstance(pg, MojoProcessGroup)
+    comm, stream, _ = pg._device_state(tensor)
+    return comm, stream
+
+
+def _stress_mix(failures: list[str], rank: int, world: int):
+    """Port of `harness.mojo mix`: several hundred generations interleaving a
+    4-byte one-shot allreduce, a 27 MiB two-shot allreduce, a broadcast and
+    an allgather, all sharing mojoccl's staging arena with different
+    layouts -- the pattern that found the interleaving bug (RESULTS.md §6).
+    The two allreduces run in place with AVG, which is idempotent once every
+    rank holds the mean, so a single corrupted generation anywhere in the
+    200 rounds (800 generations) still shows up in the final check. The
+    broadcast/allgather payloads are cheap (2 KiB, 8 B/rank) and change every
+    round, so they are verified every round instead.
+    """
+    rounds = 200
+    big_n = (27 * 1024 * 1024) // 4  # 27 MiB of float32
+
+    a_small = torch.full((1,), float(rank + 1), device="mojo")
+    a_big = torch.full((big_n,), float(rank + 1), device="mojo")
+    bcast_n = 500  # 2000 bytes of float32
+    bcast_buf = torch.zeros(bcast_n, device="mojo")
+    ag_per_rank = 2
+    ag_in = torch.zeros(ag_per_rank, device="mojo")
+    ag_out = torch.zeros(world * ag_per_rank, device="mojo")
+
+    bcast_ok = True
+    gather_ok = True
+    for r in range(rounds):
+        dist.all_reduce(a_small, op=dist.ReduceOp.AVG)
+        dist.all_reduce(a_big, op=dist.ReduceOp.AVG)
+
+        bval = float((r % 97) + 1) * 0.25
+        if rank == 0:
+            bcast_buf.fill_(bval)
+        dist.broadcast(bcast_buf, src=0)
+        if not bool((bcast_buf.cpu() == bval).all()):
+            bcast_ok = False
+
+        ag_in.fill_(float(r * 1000 + rank))
+        dist.all_gather_into_tensor(ag_out, ag_in)
+        want = torch.cat(
+            [torch.full((ag_per_rank,), float(r * 1000 + p)) for p in range(world)]
+        )
+        if not torch.equal(ag_out.cpu(), want):
+            gather_ok = False
+
+    _check(failures, "stress.mix.broadcast", bcast_ok)
+    _check(failures, "stress.mix.allgather", gather_ok)
+
+    expected_mean = float(world + 1) / 2.0
+    small_ok = bool(torch.allclose(a_small.cpu(), torch.full((1,), expected_mean)))
+    big_ok = bool(torch.allclose(a_big.cpu(), torch.full((big_n,), expected_mean)))
+    _check(failures, "stress.mix.allreduce_4B", small_ok)
+    _check(failures, "stress.mix.allreduce_27MiB", big_ok)
+    dist.barrier()
+
+
+def _stress_verify_matrix(failures: list[str], rank: int, world: int):
+    """dtypes x ragged sizes x {SUM, AVG} x {in place, out of place}.
+
+    Sizes: 1, 1003 (not a multiple of the 16-byte vector width), a size one
+    element short of the region cap, and one element past it (forces the ABI
+    layer's chunking loop). MOJOCCL_REGION_MB is set small for this mode (see
+    test_distributed.py) specifically so "past the cap" stays a small tensor.
+    """
+    cap_bytes = int(os.environ.get("MOJOCCL_REGION_MB", "256")) * 1024 * 1024
+
+    for dtype in _VERIFY_DTYPES:
+        item_bytes = torch.zeros((), dtype=dtype).element_size()
+        max_elems = cap_bytes // item_bytes
+        sizes = [1, 1003, max(1, (cap_bytes - 1) // item_bytes), max_elems + 1]
+        for n in sizes:
+            for op, avg in ((dist.ReduceOp.SUM, False), (dist.ReduceOp.AVG, True)):
+                want = _reference(dtype, world, n, avg)
+                tag = f"stress.verify.{dtype}.n{n}.{op.name}"
+
+                x = _fill(dtype, rank, n).to("mojo")
+                dist.all_reduce(x, op=op)
+                _check(failures, f"{tag}.inplace", _matches(dtype, x.cpu(), want))
+
+                # Full sync: the in-place step above may have run on the
+                # comm side-stream: see _pg_comm's docstring.
+                torch_mojo_device_module.synchronize()
+                src = _fill(dtype, rank, n).to("mojo")
+                dst = torch.zeros(n, dtype=dtype, device="mojo")
+                comm, stream = _pg_comm(src)
+                comm.all_reduce(
+                    _ptr_of(src),
+                    _ptr_of(dst),
+                    n,
+                    _nccl_dtype(dtype),
+                    _nccl_red_op(op),
+                    stream,
+                )
+                _check(failures, f"{tag}.outofplace", _matches(dtype, dst.cpu(), want))
+    dist.barrier()
+
+
+def _stress_broadcast_allgather_edges(failures: list[str], rank: int, world: int):
+    """Broadcast from a non-zero root; allgather with a per-rank size that is
+    not a multiple of 16 bytes (12 bytes of float32)."""
+    root = world - 1
+    n = 777
+    buf = torch.zeros(n, device="mojo")
+    if rank == root:
+        buf.copy_(_fill(torch.float32, root, n).to("mojo"))
+    dist.broadcast(buf, src=root)
+    want_bcast = _fill(torch.float32, root, n)
+    _check(
+        failures, "stress.broadcast_nonzero_root", torch.equal(buf.cpu(), want_bcast)
+    )
+
+    per_rank = 3  # 12 bytes -- not a multiple of 16
+    mine = _fill(torch.float32, rank, per_rank).to("mojo")
+    out = torch.zeros(world * per_rank, device="mojo")
+    dist.all_gather_into_tensor(out, mine)
+    want_gather = torch.cat([_fill(torch.float32, r, per_rank) for r in range(world)])
+    _check(
+        failures, "stress.allgather_non16_per_rank", torch.equal(out.cpu(), want_gather)
+    )
+    dist.barrier()
+
+
+def run_stress(failures: list[str]):
+    rank = dist.get_rank()
+    world = dist.get_world_size()
+    if not _MOJO_CCL:
+        print(
+            f"[rank {rank}] SKIP stress (mojoccl-only regression coverage)", flush=True
+        )
+        return
+    _stress_mix(failures, rank, world)
+    _stress_verify_matrix(failures, rank, world)
+    _stress_broadcast_allgather_edges(failures, rank, world)
+
+
 def main():
     mode = sys.argv[1]
 
@@ -248,6 +475,8 @@ def main():
         run_ddp_parity(failures)
     elif mode == "lazy_fence":
         run_lazy_fence(failures)
+    elif mode == "stress":
+        run_stress(failures)
     else:
         raise ValueError(f"unknown mode {mode}")
     dist.destroy_process_group()

--- a/tests/ddp_worker.py
+++ b/tests/ddp_worker.py
@@ -22,6 +22,12 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 
 from torch_mojo_backend import register_mojo_devices
 
+# mojoccl (torch_mojo_backend/distributed/mojoccl) implements AllReduce/
+# Broadcast/AllGather only -- Reduce/ReduceScatter/Send/Recv return
+# ncclInvalidUsage (DDP on GPT-2 needs only the first three). Skip the
+# checks that need the unimplemented ops rather than fail on them.
+_MOJO_CCL = os.environ.get("TORCH_MOJO_BACKEND_CCL") == "mojo"
+
 
 class ElemwiseNet(torch.nn.Module):
     """Matmul-free so it runs even where GEMM routes are unavailable."""
@@ -78,13 +84,21 @@ def run_collectives(failures: list[str]):
     )
     _check(failures, "all_gather_into_tensor", ok)
 
-    src = torch.arange(world * 3, dtype=torch.float32, device="mojo")
-    out = torch.zeros(3, device="mojo")
-    dist.reduce_scatter_tensor(out, src)
-    exp = (
-        torch.arange(world * 3, dtype=torch.float32)[rank * 3 : (rank + 1) * 3] * world
-    )
-    _check(failures, "reduce_scatter_tensor", bool((out.cpu() == exp).all()))
+    if _MOJO_CCL:
+        print(
+            f"[rank {rank}] SKIP reduce_scatter_tensor "
+            "(mojoccl does not implement ncclReduceScatter)",
+            flush=True,
+        )
+    else:
+        src = torch.arange(world * 3, dtype=torch.float32, device="mojo")
+        out = torch.zeros(3, device="mojo")
+        dist.reduce_scatter_tensor(out, src)
+        exp = (
+            torch.arange(world * 3, dtype=torch.float32)[rank * 3 : (rank + 1) * 3]
+            * world
+        )
+        _check(failures, "reduce_scatter_tensor", bool((out.cpu() == exp).all()))
 
     objs: list[dict[str, int] | None] = [None] * world
     dist.all_gather_object(objs, {"rank": rank})
@@ -99,19 +113,26 @@ def run_collectives(failures: list[str]):
     )
 
     if world > 1:
-        s = torch.full((7,), float(rank), device="mojo")
-        r = torch.zeros(7, device="mojo")
-        if rank % 2 == 0:
-            dist.send(s, (rank + 1) % world)
-            dist.recv(r, (rank - 1) % world)
+        if _MOJO_CCL:
+            print(
+                f"[rank {rank}] SKIP send_recv_ring "
+                "(mojoccl does not implement ncclSend/ncclRecv)",
+                flush=True,
+            )
         else:
-            dist.recv(r, (rank - 1) % world)
-            dist.send(s, (rank + 1) % world)
-        _check(
-            failures,
-            "send_recv_ring",
-            bool((r.cpu() == float((rank - 1) % world)).all()),
-        )
+            s = torch.full((7,), float(rank), device="mojo")
+            r = torch.zeros(7, device="mojo")
+            if rank % 2 == 0:
+                dist.send(s, (rank + 1) % world)
+                dist.recv(r, (rank - 1) % world)
+            else:
+                dist.recv(r, (rank - 1) % world)
+                dist.send(s, (rank + 1) % world)
+            _check(
+                failures,
+                "send_recv_ring",
+                bool((r.cpu() == float((rank - 1) % world)).all()),
+            )
 
     dist.barrier()
 

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -340,12 +340,23 @@ def _run_torchrun(nproc: int, mode: str, extra_env: dict[str, str] | None = None
         )
 
 
+@pytest.mark.parametrize("ccl", ["vendor", "mojo"])
 @pytest.mark.parametrize("comm_stream", ["1", "0"], ids=["side-stream", "same-stream"])
 @pytest.mark.parametrize("mode", ["collectives", "ddp_parity", "lazy_fence"])
-def test_two_rank_nccl(mode: str, comm_stream: str):
+def test_two_rank_nccl(mode: str, comm_stream: str, ccl: str):
+    """`ccl="mojo"` runs the same workers against mojoccl
+    (torch_mojo_backend/distributed/mojoccl), the in-repo NCCL-API library,
+    instead of vendor NCCL/RCCL -- same process_group.py, same ddp_worker.py,
+    only the loaded .so differs (nccl.py's `load()`). ddp_worker.py itself
+    skips the two collectives mojoccl does not implement yet
+    (ReduceScatter, Send/Recv) when this is set.
+    """
     if _gpu_count() < 2:
         pytest.skip("needs at least 2 GPUs")
-    _run_torchrun(2, mode, {"TORCH_MOJO_BACKEND_COMM_STREAM": comm_stream})
+    extra_env = {"TORCH_MOJO_BACKEND_COMM_STREAM": comm_stream}
+    if ccl == "mojo":
+        extra_env["TORCH_MOJO_BACKEND_CCL"] = "mojo"
+    _run_torchrun(2, mode, extra_env)
 
 
 def _measure_overhead_microseconds(no_hook: bool) -> dict[str, float]:

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -342,7 +342,7 @@ def _run_torchrun(nproc: int, mode: str, extra_env: dict[str, str] | None = None
 
 @pytest.mark.parametrize("ccl", ["vendor", "mojo"])
 @pytest.mark.parametrize("comm_stream", ["1", "0"], ids=["side-stream", "same-stream"])
-@pytest.mark.parametrize("mode", ["collectives", "ddp_parity", "lazy_fence"])
+@pytest.mark.parametrize("mode", ["collectives", "ddp_parity", "lazy_fence", "stress"])
 def test_two_rank_nccl(mode: str, comm_stream: str, ccl: str):
     """`ccl="mojo"` runs the same workers against mojoccl
     (torch_mojo_backend/distributed/mojoccl), the in-repo NCCL-API library,
@@ -350,12 +350,24 @@ def test_two_rank_nccl(mode: str, comm_stream: str, ccl: str):
     only the loaded .so differs (nccl.py's `load()`). ddp_worker.py itself
     skips the two collectives mojoccl does not implement yet
     (ReduceScatter, Send/Recv) when this is set.
+
+    `mode="stress"` is mojoccl-specific regression coverage ported from the
+    kernel harness (docs/mojo_collectives_kernel_results.md §6-7): the
+    interleaving pattern that found a silent-corruption bug, plus a
+    dtype/size/op/placement verify matrix. It exercises nothing vendor
+    NCCL/RCCL doesn't already cover elsewhere, so it only runs for
+    `ccl="mojo"`. MOJOCCL_REGION_MB is pinned small so its "past the region
+    cap" cases stay cheap tensors instead of needing a real 256 MiB region.
     """
     if _gpu_count() < 2:
         pytest.skip("needs at least 2 GPUs")
+    if mode == "stress" and ccl != "mojo":
+        pytest.skip("stress is mojoccl-only regression coverage")
     extra_env = {"TORCH_MOJO_BACKEND_COMM_STREAM": comm_stream}
     if ccl == "mojo":
         extra_env["TORCH_MOJO_BACKEND_CCL"] = "mojo"
+    if mode == "stress":
+        extra_env["MOJOCCL_REGION_MB"] = "4"
     _run_torchrun(2, mode, extra_env)
 
 

--- a/torch_mojo_backend/distributed/mojoccl/bootstrap.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/bootstrap.mojo
@@ -1,0 +1,149 @@
+# /dev/shm rendezvous bootstrap for mojoccl's ncclCommInitRank.
+#
+# Real NCCL exchanges per-rank IPC handles over its own bootstrap socket,
+# whose address is encoded in the 128-byte ncclUniqueId. This library has no
+# socket bootstrap yet, so it stands in with a directory: the rank that calls
+# ncclGetUniqueId creates a fresh dir under /dev/shm and encodes its path in
+# the id (that id then travels through the caller's OWN rendezvous -- for
+# this repo, the c10d store in distributed/process_group.py, unchanged).
+# Every rank's ncclCommInitRank decodes the path back out, atomically writes
+# its own `rank<r>.handle` file there, and polls for the rest.
+#
+# This is intra-node only. The design leaves room for a multi-node TCP
+# bootstrap later (encode "host:port" instead of a path, listen instead of
+# mkdir) without changing ncclCommInitRank's call shape.
+
+from std.ffi import OwnedDLHandle, CStringSlice
+from std.memory.alloc import unsafe_alloc
+from std.pathlib import Path
+from std.tempfile import mkdtemp
+from std.time import sleep, perf_counter_ns
+from std.collections.string import chr
+
+comptime UID_BYTES = 128
+comptime HANDLE_BYTES = 64
+
+
+def create_rendezvous_dir() raises -> String:
+    """Called once, by the rank that generates the unique id."""
+    return mkdtemp(prefix="mojoccl-", dir="/dev/shm")
+
+
+def encode_dir(dir: String, out_bytes: Pointer[UInt8, MutAnyOrigin]) raises:
+    """Writes `dir`'s UTF-8 bytes, NUL-padded, into the 128-byte unique id."""
+    for i in range(UID_BYTES):
+        out_bytes[unsafe_offset=i] = 0
+    var db = dir.as_bytes()
+    if len(db) > UID_BYTES - 2:
+        raise Error(
+            "mojoccl: rendezvous directory path too long for the 128-byte"
+            " unique id"
+        )
+    for i in range(len(db)):
+        out_bytes[unsafe_offset=i] = db[i]
+
+
+def decode_dir(in_bytes: Pointer[UInt8, MutAnyOrigin]) raises -> String:
+    """The inverse of `encode_dir`, reading up to the first NUL byte."""
+    var n = 0
+    while n < UID_BYTES and Int(in_bytes[unsafe_offset=n]) != 0:
+        n += 1
+    if n == 0:
+        raise Error("mojoccl: empty rendezvous directory in the unique id")
+    var s = String(capacity=n)
+    for i in range(n):
+        s += chr(Int(in_bytes[unsafe_offset=i]))
+    return s^
+
+
+def _to_cstr(s: String) -> Pointer[Int8, ImmutAnyOrigin]:
+    """A heap copy of `s`'s bytes plus a trailing NUL.
+
+    `CStringSlice`'s constructors only VALIDATE an existing terminator
+    (`std.ffi.cstring._validate_bytes`); neither copies. A plain `String`'s
+    backing storage carries no such terminator (measured: both the
+    `StringSlice` and `Span[Byte]` constructors raise "CStringSlice is not
+    nul-terminated" on one), so this builds the terminated buffer by hand.
+    """
+    var src = s.as_bytes()
+    var n = len(src)
+    var buf = unsafe_alloc[UInt8](n + 1)
+    for i in range(n):
+        buf[unsafe_offset=i] = src[i]
+    buf[unsafe_offset=n] = 0
+    return Pointer[Int8, ImmutAnyOrigin](unsafe_from_address=Int(buf))
+
+
+def _rename(old: String, new: String) raises:
+    """POSIX rename(2) via libc -- the atomic-publish half of the handle
+    write. Not in std.os yet, so called directly (the same OwnedDLHandle +
+    get_function shape as every other FFI call in this library)."""
+    var libc = OwnedDLHandle("libc.so.6")
+    var old_c = CStringSlice(unsafe_from_ptr=_to_cstr(old))
+    var new_c = CStringSlice(unsafe_from_ptr=_to_cstr(new))
+    var rc = libc.get_function[Int32]("rename")(
+        old_c.unsafe_ptr(), new_c.unsafe_ptr()
+    )
+    if rc != 0:
+        raise Error("mojoccl: rename to " + new + " failed, rc=" + String(rc))
+
+
+def write_rank_handle(
+    dir: String, rank: Int, ordinal: Int, handle: Pointer[UInt8, MutAnyOrigin]
+) raises:
+    """Atomically publishes this rank's (device ordinal, IPC handle) pair.
+
+    Written as space-separated decimal integers (matches
+    proto/ipc_probe.mojo's handle-file convention) so there is no binary
+    layout to keep in sync between writer and reader.
+    """
+    var final_path = dir + "/rank" + String(rank) + ".handle"
+    var tmp_path = dir + "/.rank" + String(rank) + ".handle.tmp"
+    var s = String(ordinal)
+    for i in range(HANDLE_BYTES):
+        s += " " + String(Int(handle[unsafe_offset=i]))
+    with open(tmp_path, "w") as f:
+        f.write(s)
+    _rename(tmp_path, final_path)
+
+
+def read_rank_handle(
+    dir: String, rank: Int, out_handle: Pointer[UInt8, MutAnyOrigin]
+) raises -> Int:
+    """Reads a published handle file; returns the peer's device ordinal and
+    fills `out_handle[0:64]`."""
+    var path = dir + "/rank" + String(rank) + ".handle"
+    var s: String
+    with open(path, "r") as f:
+        s = f.read()
+    var k = 0
+    var ordinal = -1
+    for part in s.split(" "):
+        if part.byte_length() == 0:
+            continue
+        if ordinal == -1:
+            ordinal = Int(part)
+        else:
+            out_handle[unsafe_offset=k] = UInt8(Int(part))
+            k += 1
+    if k != HANDLE_BYTES or ordinal == -1:
+        raise Error("mojoccl: malformed handle file " + path)
+    return ordinal
+
+
+def wait_for_rank(dir: String, rank: Int, timeout_s: Float64) raises:
+    """Blocks until `rank`'s handle file exists, or raises past the timeout."""
+    var path = dir + "/rank" + String(rank) + ".handle"
+    var t0 = perf_counter_ns()
+    var deadline_ns = Int(timeout_s * 1.0e9)
+    while not Path(path).exists():
+        if perf_counter_ns() - t0 > deadline_ns:
+            raise Error(
+                "mojoccl: timeout after "
+                + String(timeout_s)
+                + "s waiting for rank "
+                + String(rank)
+                + " at "
+                + dir
+            )
+        sleep(0.02)

--- a/torch_mojo_backend/distributed/mojoccl/bootstrap.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/bootstrap.mojo
@@ -15,6 +15,7 @@
 
 from std.ffi import OwnedDLHandle, CStringSlice
 from std.memory.alloc import unsafe_alloc
+from std.os import remove, rmdir
 from std.pathlib import Path
 from std.tempfile import mkdtemp
 from std.time import sleep, perf_counter_ns
@@ -88,6 +89,13 @@ def _rename(old: String, new: String) raises:
         raise Error("mojoccl: rename to " + new + " failed, rc=" + String(rc))
 
 
+def _atomic_write(final_path: String, tmp_path: String, content: String) raises:
+    """write+rename: readers never observe a partially written file."""
+    with open(tmp_path, "w") as f:
+        f.write(content)
+    _rename(tmp_path, final_path)
+
+
 def write_rank_handle(
     dir: String, rank: Int, ordinal: Int, handle: Pointer[UInt8, MutAnyOrigin]
 ) raises:
@@ -97,14 +105,25 @@ def write_rank_handle(
     proto/ipc_probe.mojo's handle-file convention) so there is no binary
     layout to keep in sync between writer and reader.
     """
-    var final_path = dir + "/rank" + String(rank) + ".handle"
-    var tmp_path = dir + "/.rank" + String(rank) + ".handle.tmp"
     var s = String(ordinal)
     for i in range(HANDLE_BYTES):
         s += " " + String(Int(handle[unsafe_offset=i]))
-    with open(tmp_path, "w") as f:
-        f.write(s)
-    _rename(tmp_path, final_path)
+    _atomic_write(
+        dir + "/rank" + String(rank) + ".handle",
+        dir + "/.rank" + String(rank) + ".handle.tmp",
+        s,
+    )
+
+
+def write_rank_done(dir: String, rank: Int) raises:
+    """Atomically publishes that this rank has opened every peer's IPC
+    handle. Rank 0 waits for every rank's marker (`wait_for_done`) before
+    removing `dir` (`remove_rendezvous_dir`) -- see ncclCommInitRank."""
+    _atomic_write(
+        dir + "/rank" + String(rank) + ".done",
+        dir + "/.rank" + String(rank) + ".done.tmp",
+        "1",
+    )
 
 
 def read_rank_handle(
@@ -131,9 +150,7 @@ def read_rank_handle(
     return ordinal
 
 
-def wait_for_rank(dir: String, rank: Int, timeout_s: Float64) raises:
-    """Blocks until `rank`'s handle file exists, or raises past the timeout."""
-    var path = dir + "/rank" + String(rank) + ".handle"
+def _wait_for_file(path: String, rank: Int, timeout_s: Float64, dir: String) raises:
     var t0 = perf_counter_ns()
     var deadline_ns = Int(timeout_s * 1.0e9)
     while not Path(path).exists():
@@ -147,3 +164,36 @@ def wait_for_rank(dir: String, rank: Int, timeout_s: Float64) raises:
                 + dir
             )
         sleep(0.02)
+
+
+def wait_for_rank(dir: String, rank: Int, timeout_s: Float64) raises:
+    """Blocks until `rank`'s handle file exists, or raises past the timeout."""
+    _wait_for_file(dir + "/rank" + String(rank) + ".handle", rank, timeout_s, dir)
+
+
+def wait_for_done(dir: String, rank: Int, timeout_s: Float64) raises:
+    """Blocks until `rank`'s done marker (`write_rank_done`) exists, or
+    raises past the timeout."""
+    _wait_for_file(dir + "/rank" + String(rank) + ".done", rank, timeout_s, dir)
+
+
+def remove_rendezvous_dir(dir: String, nranks: Int) raises:
+    """Removes every rank's handle/done file, then the directory itself.
+
+    Called once, by rank 0, once every rank's done marker has landed
+    (normal completion) or on an init failure rank 0 hit after creating
+    `dir` (`ncclGetUniqueId`). Per-file removal is best-effort -- a file a
+    peer never got around to writing is not an error here -- but the final
+    `rmdir` is not: a non-empty directory after every known file was
+    cleared means something unexpected is in there, worth surfacing.
+    """
+    for r in range(nranks):
+        try:
+            remove(dir + "/rank" + String(r) + ".handle")
+        except:
+            pass
+        try:
+            remove(dir + "/rank" + String(r) + ".done")
+        except:
+            pass
+    rmdir(dir)

--- a/torch_mojo_backend/distributed/mojoccl/bootstrap.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/bootstrap.mojo
@@ -150,7 +150,9 @@ def read_rank_handle(
     return ordinal
 
 
-def _wait_for_file(path: String, rank: Int, timeout_s: Float64, dir: String) raises:
+def _wait_for_file(
+    path: String, rank: Int, timeout_s: Float64, dir: String
+) raises:
     var t0 = perf_counter_ns()
     var deadline_ns = Int(timeout_s * 1.0e9)
     while not Path(path).exists():
@@ -168,7 +170,9 @@ def _wait_for_file(path: String, rank: Int, timeout_s: Float64, dir: String) rai
 
 def wait_for_rank(dir: String, rank: Int, timeout_s: Float64) raises:
     """Blocks until `rank`'s handle file exists, or raises past the timeout."""
-    _wait_for_file(dir + "/rank" + String(rank) + ".handle", rank, timeout_s, dir)
+    _wait_for_file(
+        dir + "/rank" + String(rank) + ".handle", rank, timeout_s, dir
+    )
 
 
 def wait_for_done(dir: String, rank: Int, timeout_s: Float64) raises:
@@ -182,18 +186,16 @@ def remove_rendezvous_dir(dir: String, nranks: Int) raises:
 
     Called once, by rank 0, once every rank's done marker has landed
     (normal completion) or on an init failure rank 0 hit after creating
-    `dir` (`ncclGetUniqueId`). Per-file removal is best-effort -- a file a
-    peer never got around to writing is not an error here -- but the final
-    `rmdir` is not: a non-empty directory after every known file was
-    cleared means something unexpected is in there, worth surfacing.
+    `dir` (`ncclGetUniqueId`). A file a peer never got around to writing is
+    not an error here and is skipped; any other failure propagates, and so
+    does the final `rmdir`: a non-empty directory after every known file
+    was cleared means something unexpected is in there, worth surfacing.
     """
     for r in range(nranks):
-        try:
-            remove(dir + "/rank" + String(r) + ".handle")
-        except:
-            pass
-        try:
-            remove(dir + "/rank" + String(r) + ".done")
-        except:
-            pass
+        var handle = dir + "/rank" + String(r) + ".handle"
+        if Path(handle).exists():
+            remove(handle)
+        var done = dir + "/rank" + String(r) + ".done"
+        if Path(done).exists():
+            remove(done)
     rmdir(dir)

--- a/torch_mojo_backend/distributed/mojoccl/collectives_kernels.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/collectives_kernels.mojo
@@ -1,0 +1,423 @@
+# STAND-IN collectives kernel for mojoccl.
+#
+# Correctness over speed, as directed: single-thread-block copy/reduce
+# kernels plus a page-sized signal area and a generation-based barrier built
+# on plain system-scope Atomic release/acquire (the flag pattern
+# proto/ipc_probe.mojo measured working, PASS at §5.3 of
+# docs/mojo_collectives_feasibility.md in the main worktree) -- not MAX's
+# comm.Signal, whose embedded Lamport region alone is ~24.75 MiB/rank, far
+# more than this needs. This file is expected to be replaced wholesale by
+# the production kernel (kernel/collectives_kernels.mojo, written in
+# parallel against this same function-signature contract); nothing outside
+# this file should need to change on that swap.
+#
+# Region layout per rank (see mojoccl.mojo): [0, signal_bytes()) signal area,
+# then stage_in of cap_bytes, then stage_out of cap_bytes. `regions[r]` is
+# rank r's region base as mapped in THIS process (own allocation for
+# r == rank, an opened IPC mapping otherwise).
+
+from std.atomic import Atomic, Ordering
+from std.builtin.device_passable import DevicePassable
+from std.ffi import _get_global_or_null, external_call
+from max.gpu.sync import barrier
+from std.gpu import thread_idx, MAX_THREADS_PER_BLOCK_METADATA
+from std.memory.alloc import unsafe_alloc
+from std.sys import get_accum_type
+from std.time import global_perf_counter_ns
+from std.utils import StaticTuple
+from max.gpu.host import DeviceContext, DeviceStream, DeviceBuffer
+
+from driver import zero_bytes
+
+comptime MAX_WORLD = 8
+comptime BLOCK = 256
+# One page: [0] error word (UInt64), [8] barrier counter (UInt64), padding.
+comptime SIG_BYTES = 4096
+comptime ERR_OFF = 0
+comptime BAR_OFF = 8
+comptime BARRIER_TIMEOUT_NS: UInt64 = 30_000_000_000
+
+
+def signal_bytes() -> Int:
+    return SIG_BYTES
+
+
+def error_offset() -> Int:
+    return ERR_OFF
+
+
+def region_init(ctx: DeviceContext, region: Int) raises:
+    """Zeros the signal area of a freshly allocated region.
+
+    No `stream` parameter (unlike the collectives below): this runs once per
+    rank at communicator creation, on `ctx`'s own queue, before any user
+    stream touches the region -- zero_bytes blocks, so every later
+    collective (issued on the caller's external stream) is guaranteed to see
+    the zeroed area.
+    """
+    zero_bytes(ctx, region, SIG_BYTES)
+
+
+@always_inline
+def _err_ptr(region: Int64) -> Pointer[UInt64, MutAnyOrigin]:
+    return Pointer[UInt64, MutAnyOrigin](
+        unsafe_from_address=Int(region) + ERR_OFF
+    )
+
+
+@always_inline
+def _bar_ptr(region: Int64) -> Pointer[UInt64, MutAnyOrigin]:
+    return Pointer[UInt64, MutAnyOrigin](
+        unsafe_from_address=Int(region) + BAR_OFF
+    )
+
+
+@always_inline
+def _gen_barrier(
+    regions: StaticTuple[Int64, MAX_WORLD],
+    rank: Int32,
+    world: Int32,
+    target: UInt64,
+):
+    """A full, symmetric cross-rank barrier: every participant publishes
+    `target` into its own region and waits for every OTHER participant to
+    reach at least `target` too, before any of them may proceed.
+
+    Symmetric on purpose (publish AND wait, both phases of every call): a
+    one-way "publish and move on" would let a fast rank start overwriting
+    its stage buffers for the NEXT generation while a slow peer is still
+    reading THIS generation's data out of them. `target` is derived from the
+    caller-supplied generation counter, strictly increasing per
+    communicator, so no double-buffering of the counter itself is needed --
+    every call in the process's lifetime gets a fresh target.
+    """
+    if thread_idx.x == 0:
+        Atomic[DType.uint64].store[ordering=Ordering.RELEASE](
+            _bar_ptr(regions[Int(rank)]), target
+        )
+    if Int(thread_idx.x) < Int(world):
+        var peer_ptr = _bar_ptr(regions[Int(thread_idx.x)])
+        var t0 = global_perf_counter_ns()
+        while (
+            Atomic[DType.uint64].load[ordering=Ordering.ACQUIRE](peer_ptr)
+            < target
+        ):
+            if global_perf_counter_ns() - t0 > BARRIER_TIMEOUT_NS:
+                Atomic[DType.uint64].store[ordering=Ordering.RELEASE](
+                    _err_ptr(regions[Int(rank)]), UInt64(1)
+                )
+                break
+    barrier()
+
+
+@always_inline
+def _enqueue_cached_stream[
+    declared_arg_types: TypeList[Trait=AnyType, ...],
+    //,
+    func: def(* args: * declared_arg_types) thin -> None,
+    *Ts: DevicePassable,
+](
+    ctx: DeviceContext,
+    stream: DeviceStream,
+    key: String,
+    threads: Int,
+    *args: *Ts,
+) raises:
+    """Enqueue `func` (grid of 1 block) on the caller's `stream`, compiling
+    it at most once per process and context.
+
+    Self-contained copy of eager_kernels/op_utils's `_enqueue_cached`
+    pattern (this library builds and loads standalone, outside that
+    package): compile once via `ctx`, cache the `DeviceFunction` in the
+    process-global registry, enqueue onto `stream` on every call after.
+    """
+    var name = String(t"MOJOCCL_KERNEL_{key}_{ctx.id()}")
+    comptime FuncT = type_of(ctx.compile_function[func]())
+    var global_ptr = _get_global_or_null(name)
+    if global_ptr:
+        var fptr = global_ptr.value().unsafe_bitcast[FuncT]()
+        stream.enqueue_function(
+            fptr[], *args, grid_dim=(1, 1, 1), block_dim=(threads,)
+        )
+        return
+    var compiled = ctx.compile_function[func]()
+    var fptr = unsafe_alloc[FuncT](1)
+    fptr.unsafe_write(compiled^)
+    external_call["KGEN_CompilerRT_InsertGlobal", NoneType](
+        StringSlice(name), fptr.unsafe_bitcast[NoneType]()
+    )
+    stream.enqueue_function(
+        fptr[], *args, grid_dim=(1, 1, 1), block_dim=(threads,)
+    )
+
+
+# ---------------------------------------------------------------------------
+# allreduce: copy-in, barrier, every rank independently sums every peer's
+# stage_in (no reduce-scatter partitioning -- simplest correct thing, per
+# "plain copy-in / RS+AG / copy-out is fine"), barrier, copy-out. Generic
+# Float64 accumulation covers all five dtypes with one code path; SUM is
+# exact for the small integer values these tests use, AVG divides via
+# `scale`.
+# ---------------------------------------------------------------------------
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(BLOCK))
+)
+def _allreduce_kernel[
+    dtype: DType
+](
+    regions: StaticTuple[Int64, MAX_WORLD],
+    rank: Int32,
+    world: Int32,
+    in_ptr: Int64,
+    out_ptr: Int64,
+    numel: Int32,
+    cap_bytes: Int32,
+    scale: Float32,
+    generation: UInt64,
+):
+    var my_region = Int(regions[Int(rank)])
+    var stage_in = Pointer[Scalar[dtype], MutAnyOrigin](
+        unsafe_from_address=my_region + SIG_BYTES
+    )
+    var src = Pointer[Scalar[dtype], MutAnyOrigin](
+        unsafe_from_address=Int(in_ptr)
+    )
+    var n = Int(numel)
+    var tid = Int(thread_idx.x)
+    for i in range(tid, n, BLOCK):
+        stage_in[unsafe_offset=i] = src[unsafe_offset=i]
+
+    _gen_barrier(regions, rank, world, 2 * generation)
+
+    var stage_out = Pointer[Scalar[dtype], MutAnyOrigin](
+        unsafe_from_address=my_region + SIG_BYTES + Int(cap_bytes)
+    )
+    var w = Int(world)
+    var fscale = Float64(scale)
+    for i in range(tid, n, BLOCK):
+        var acc: Float64 = 0
+        for p in range(w):
+            var peer_in = Pointer[Scalar[dtype], MutAnyOrigin](
+                unsafe_from_address=Int(regions[p]) + SIG_BYTES
+            )
+            acc += Float64(peer_in[unsafe_offset=i])
+        stage_out[unsafe_offset=i] = Scalar[dtype](acc * fscale)
+
+    _gen_barrier(regions, rank, world, 2 * generation + 1)
+
+    var dst = Pointer[Scalar[dtype], MutAnyOrigin](
+        unsafe_from_address=Int(out_ptr)
+    )
+    for i in range(tid, n, BLOCK):
+        dst[unsafe_offset=i] = stage_out[unsafe_offset=i]
+
+
+def allreduce[
+    dtype: DType
+](
+    ctx: DeviceContext,
+    stream: DeviceStream,
+    rank: Int,
+    world: Int,
+    regions: StaticTuple[Int, MAX_WORLD],
+    in_ptr: Int,
+    out_ptr: Int,
+    numel: Int,
+    cap_bytes: Int,
+    scale: Float32,
+    generation: Int,
+) raises:
+    var regions64 = StaticTuple[Int64, MAX_WORLD](fill=0)
+    for i in range(MAX_WORLD):
+        regions64[i] = Int64(regions[i])
+    comptime kern = _allreduce_kernel[dtype]
+    _enqueue_cached_stream[kern](
+        ctx,
+        stream,
+        String("allreduce_") + String(dtype),
+        BLOCK,
+        regions64,
+        Int32(rank),
+        Int32(world),
+        Int64(in_ptr),
+        Int64(out_ptr),
+        Int32(numel),
+        Int32(cap_bytes),
+        scale,
+        UInt64(generation),
+    )
+
+
+# ---------------------------------------------------------------------------
+# broadcast: root copies its send buffer into its own stage_in, barrier,
+# every rank (root included) copies root's stage_in into its own recv
+# buffer, barrier. Byte-granular: NCCL's broadcast moves opaque bytes, no
+# reduction, so there is no dtype to specialize on.
+# ---------------------------------------------------------------------------
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(BLOCK))
+)
+def _broadcast_kernel(
+    regions: StaticTuple[Int64, MAX_WORLD],
+    rank: Int32,
+    root: Int32,
+    world: Int32,
+    send_ptr: Int64,
+    recv_ptr: Int64,
+    nbytes: Int32,
+    generation: UInt64,
+):
+    var my_region = Int(regions[Int(rank)])
+    var stage = Pointer[UInt8, MutAnyOrigin](
+        unsafe_from_address=my_region + SIG_BYTES
+    )
+    var n = Int(nbytes)
+    var tid = Int(thread_idx.x)
+    if rank == root:
+        var src = Pointer[UInt8, MutAnyOrigin](
+            unsafe_from_address=Int(send_ptr)
+        )
+        for i in range(tid, n, BLOCK):
+            stage[unsafe_offset=i] = src[unsafe_offset=i]
+
+    _gen_barrier(regions, rank, world, 2 * generation)
+
+    var root_stage = Pointer[UInt8, MutAnyOrigin](
+        unsafe_from_address=Int(regions[Int(root)]) + SIG_BYTES
+    )
+    var dst = Pointer[UInt8, MutAnyOrigin](unsafe_from_address=Int(recv_ptr))
+    for i in range(tid, n, BLOCK):
+        dst[unsafe_offset=i] = root_stage[unsafe_offset=i]
+
+    _gen_barrier(regions, rank, world, 2 * generation + 1)
+
+
+def broadcast(
+    ctx: DeviceContext,
+    stream: DeviceStream,
+    rank: Int,
+    root: Int,
+    world: Int,
+    regions: StaticTuple[Int, MAX_WORLD],
+    send_ptr: Int,
+    recv_ptr: Int,
+    nbytes: Int,
+    cap_bytes: Int,
+    generation: Int,
+) raises:
+    if nbytes > cap_bytes:
+        raise Error("mojoccl: broadcast nbytes exceeds the region capacity")
+    var regions64 = StaticTuple[Int64, MAX_WORLD](fill=0)
+    for i in range(MAX_WORLD):
+        regions64[i] = Int64(regions[i])
+    comptime kern = _broadcast_kernel
+    _enqueue_cached_stream[kern](
+        ctx,
+        stream,
+        String("broadcast"),
+        BLOCK,
+        regions64,
+        Int32(rank),
+        Int32(root),
+        Int32(world),
+        Int64(send_ptr),
+        Int64(recv_ptr),
+        Int32(nbytes),
+        UInt64(generation),
+    )
+
+
+# ---------------------------------------------------------------------------
+# allgather: every rank copies its chunk into its own stage_in, barrier,
+# every rank copies every peer's stage_in into the right slice of its own
+# output, barrier.
+# ---------------------------------------------------------------------------
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(BLOCK))
+)
+def _allgather_kernel(
+    regions: StaticTuple[Int64, MAX_WORLD],
+    rank: Int32,
+    world: Int32,
+    in_ptr: Int64,
+    out_ptr: Int64,
+    nbytes: Int32,
+    stride_bytes: Int32,
+    generation: UInt64,
+):
+    var my_region = Int(regions[Int(rank)])
+    var stage = Pointer[UInt8, MutAnyOrigin](
+        unsafe_from_address=my_region + SIG_BYTES
+    )
+    var src = Pointer[UInt8, MutAnyOrigin](unsafe_from_address=Int(in_ptr))
+    var n = Int(nbytes)
+    var tid = Int(thread_idx.x)
+    for i in range(tid, n, BLOCK):
+        stage[unsafe_offset=i] = src[unsafe_offset=i]
+
+    _gen_barrier(regions, rank, world, 2 * generation)
+
+    var dst = Pointer[UInt8, MutAnyOrigin](unsafe_from_address=Int(out_ptr))
+    var w = Int(world)
+    var stride = Int(stride_bytes)
+    for p in range(w):
+        var peer_stage = Pointer[UInt8, MutAnyOrigin](
+            unsafe_from_address=Int(regions[p]) + SIG_BYTES
+        )
+        var base = p * stride
+        for i in range(tid, n, BLOCK):
+            dst[unsafe_offset=base + i] = peer_stage[unsafe_offset=i]
+
+    _gen_barrier(regions, rank, world, 2 * generation + 1)
+
+
+def allgather(
+    ctx: DeviceContext,
+    stream: DeviceStream,
+    rank: Int,
+    world: Int,
+    regions: StaticTuple[Int, MAX_WORLD],
+    in_ptr: Int,
+    out_ptr: Int,
+    nbytes_per_rank: Int,
+    cap_bytes: Int,
+    generation: Int,
+    stride_bytes: Int = -1,
+) raises:
+    """`stride_bytes` (default `nbytes_per_rank`) is the OUTPUT layout's true
+    per-rank size, in bytes, separate from `nbytes_per_rank` (how much THIS
+    call moves). They differ only when the caller chunks one rank's
+    contribution across several calls: each chunk still lands at
+    `peer * stride_bytes + chunk_offset` in the flat `[rank0 | rank1 | ...]`
+    output, never at `peer * nbytes_per_rank`. A one-call (unchunked)
+    allgather needs no stride argument at all.
+    """
+    if nbytes_per_rank > cap_bytes:
+        raise Error(
+            "mojoccl: allgather nbytes_per_rank exceeds the region capacity"
+        )
+    var stride = nbytes_per_rank if stride_bytes < 0 else stride_bytes
+    var regions64 = StaticTuple[Int64, MAX_WORLD](fill=0)
+    for i in range(MAX_WORLD):
+        regions64[i] = Int64(regions[i])
+    comptime kern = _allgather_kernel
+    _enqueue_cached_stream[kern](
+        ctx,
+        stream,
+        String("allgather"),
+        BLOCK,
+        regions64,
+        Int32(rank),
+        Int32(world),
+        Int64(in_ptr),
+        Int64(out_ptr),
+        Int32(nbytes_per_rank),
+        Int32(stride),
+        UInt64(generation),
+    )

--- a/torch_mojo_backend/distributed/mojoccl/collectives_kernels.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/collectives_kernels.mojo
@@ -246,7 +246,7 @@ def _record_error(
 ):
     """Publish a failure in my own region's error word (host-readable)."""
     if thread_idx.x == 0:
-        Atomic[DType.uint64].store[ordering = Ordering.RELEASE](
+        Atomic[DType.uint64].store[ordering=Ordering.RELEASE](
             regions[rank].unsafe_bitcast[UInt64](),
             UInt64(code) * 1_000_000 + UInt64(phase),
         )
@@ -276,7 +276,7 @@ def _sync(
     learns that through shared memory so no thread is left inside a `barrier()`.
     """
     var failed = stack_allocation[
-        1, DType.uint32, address_space = AddressSpace.SHARED
+        1, DType.uint32, address_space=AddressSpace.SHARED
     ]()
     if thread_idx.x == 0:
         failed[unsafe_offset=0] = 0
@@ -289,21 +289,20 @@ def _sync(
         # `s_waitcnt vmcnt(0)` + `buffer_wbl2 sc0 sc1`). NVIDIA needs nothing:
         # `bar.sync` is a CTA-scope fence and the release store below is
         # cumulative over it, which is what NCCL's postPeer relies on.
-        fence[ordering = Ordering.RELEASE]()
+        fence[ordering=Ordering.RELEASE]()
     barrier()
 
     if Int(thread_idx.x) < world:
         var peer = Int(thread_idx.x)
         var bid = Int(block_idx.x)
-        Atomic[DType.uint64].store[ordering = Ordering.RELEASE](
+        Atomic[DType.uint64].store[ordering=Ordering.RELEASE](
             _flags(regions[peer]).unsafe_offset(bid * MAX_WORLD + rank),
             target,
         )
         var mine = _flags(regions[rank]).unsafe_offset(bid * MAX_WORLD + peer)
         var spins = 0
         while (
-            Atomic[DType.uint64].load[ordering = Ordering.ACQUIRE](mine)
-            < target
+            Atomic[DType.uint64].load[ordering=Ordering.ACQUIRE](mine) < target
         ):
             spins += 1
             if spins >= _SPIN_CHECK:
@@ -365,7 +364,7 @@ def _copy_scalar_tail[
 ):
     """The `numel % W` elements a 16-byte vector loop cannot cover."""
     for i in range(tid, count, stride):
-        dst[unsafe_offset = base + i] = src[unsafe_offset = base + i]
+        dst[unsafe_offset=base + i] = src[unsafe_offset=base + i]
 
 
 @always_inline
@@ -394,7 +393,7 @@ def _copy_bytes[
     else:
         for v in range(tid, nvec, stride):
             comptime for j in range(16):
-                dst[unsafe_offset = v * 16 + j] = src[unsafe_offset = v * 16 + j]
+                dst[unsafe_offset=v * 16 + j] = src[unsafe_offset=v * 16 + j]
     _copy_scalar_tail(dst, src, nvec * 16, nbytes - nvec * 16, tid, stride)
 
 
@@ -492,9 +491,11 @@ def _ar_twoshot_kernel[
             s -= world
         var src = in_ptr.unsafe_offset(_vstart(s, q, rem) * W)
         var vc = _vcount(s, q, rem)
-        var dst = regions[s].unsafe_offset(
-            push_off + slot_stride * rank
-        ).unsafe_bitcast[Scalar[dtype]]()
+        var dst = (
+            regions[s]
+            .unsafe_offset(push_off + slot_stride * rank)
+            .unsafe_bitcast[Scalar[dtype]]()
+        )
         _copy_vec[dtype, W, U](dst, src, vc, tid, stride)
         if tail > 0 and s == world - 1:
             _copy_scalar_tail(dst, src, vc * W, tail, tid, stride)
@@ -509,9 +510,9 @@ def _ar_twoshot_kernel[
     var my_tail = tail if rank == world - 1 else 0
     var uin = in_ptr.unsafe_offset(my_vs * W)
     var uout = out_ptr.unsafe_offset(my_vs * W)
-    var shard = regions[rank].unsafe_offset(shard_off).unsafe_bitcast[
-        Scalar[dtype]
-    ]()
+    var shard = (
+        regions[rank].unsafe_offset(shard_off).unsafe_bitcast[Scalar[dtype]]()
+    )
 
     # Slot pointers are formed by arithmetic inside the unrolled loop, never
     # held in an array: a stack array of `world` pointers is demoted to local
@@ -577,9 +578,9 @@ def _ar_twoshot_kernel[
             p -= world
         var vs = _vstart(p, q, rem)
         var vc = _vcount(p, q, rem)
-        var src = regions[p].unsafe_offset(shard_off).unsafe_bitcast[
-            Scalar[dtype]
-        ]()
+        var src = (
+            regions[p].unsafe_offset(shard_off).unsafe_bitcast[Scalar[dtype]]()
+        )
         var dst = out_ptr.unsafe_offset(vs * W)
         _copy_vec[dtype, W, U](dst, src, vc, tid, stride)
         if tail > 0 and p == world - 1:
@@ -636,9 +637,11 @@ def _ar_oneshot_kernel[
         var s = rank + i
         if s >= world:
             s -= world
-        var dst = regions[s].unsafe_offset(
-            push_off + slot_stride * rank
-        ).unsafe_bitcast[Scalar[dtype]]()
+        var dst = (
+            regions[s]
+            .unsafe_offset(push_off + slot_stride * rank)
+            .unsafe_bitcast[Scalar[dtype]]()
+        )
         _copy_vec[dtype, W, U](dst, in_ptr, nvec, tid, stride)
         if tail > 0:
             _copy_scalar_tail(dst, in_ptr, nvec * W, tail, tid, stride)
@@ -872,8 +875,9 @@ def _zero_kernel(ptr: Pointer[UInt32, MutAnyOrigin], nwords: Int32):
 
 @always_inline
 def _enqueue_cached[
-    declared_arg_types: TypeList[Trait=AnyType, ...], //,
-    func: def (*args: *declared_arg_types) thin -> None,
+    declared_arg_types: TypeList[Trait=AnyType, ...],
+    //,
+    func: def(* args: * declared_arg_types) thin -> None,
     *Ts: DevicePassable,
 ](
     ctx: DeviceContext,
@@ -984,12 +988,8 @@ def _launch_allreduce[
     var esize = size_of[dtype]()
     var nvec = numel // W
     var tail = numel - nvec * W
-    var ip = Pointer[Scalar[dtype], MutAnyOrigin](
-        unsafe_from_address=in_ptr
-    )
-    var op = Pointer[Scalar[dtype], MutAnyOrigin](
-        unsafe_from_address=out_ptr
-    )
+    var ip = Pointer[Scalar[dtype], MutAnyOrigin](unsafe_from_address=in_ptr)
+    var op = Pointer[Scalar[dtype], MutAnyOrigin](unsafe_from_address=out_ptr)
 
     if one_shot:
         # `world` slots, each a whole message, at the base of the arena. They
@@ -1000,9 +1000,7 @@ def _launch_allreduce[
         if world * slot > 2 * cap_bytes:
             raise Error("collectives: one-shot slots exceed the region")
         var push_off = arena
-        var blocks = min(
-            _AR_MAX_BLOCKS, max(1, (nvec + BLOCK - 1) // BLOCK)
-        )
+        var blocks = min(_AR_MAX_BLOCKS, max(1, (nvec + BLOCK - 1) // BLOCK))
         _enqueue_cached[_ar_oneshot_kernel[dtype, W, _UNROLL, NW]](
             ctx,
             stream,
@@ -1024,9 +1022,7 @@ def _launch_allreduce[
 
     var q = nvec // world
     var rem = nvec % world
-    var max_shard_elems = max(
-        (q + (1 if rem > 0 else 0)) * W, q * W + tail
-    )
+    var max_shard_elems = max((q + (1 if rem > 0 else 0)) * W, q * W + tail)
     var slot = _align_up(max_shard_elems * esize, 16)
     var push_off = arena
     var shard_off = arena + world * slot
@@ -1105,23 +1101,63 @@ def allreduce[
 
     if world == 8:
         _launch_allreduce[dtype, W, 8](
-            ctx, stream, rp, in_ptr, out_ptr, numel, world, rank, cap_bytes, scale,
-            generation, one_shot,
+            ctx,
+            stream,
+            rp,
+            in_ptr,
+            out_ptr,
+            numel,
+            world,
+            rank,
+            cap_bytes,
+            scale,
+            generation,
+            one_shot,
         )
     elif world == 4:
         _launch_allreduce[dtype, W, 4](
-            ctx, stream, rp, in_ptr, out_ptr, numel, world, rank, cap_bytes, scale,
-            generation, one_shot,
+            ctx,
+            stream,
+            rp,
+            in_ptr,
+            out_ptr,
+            numel,
+            world,
+            rank,
+            cap_bytes,
+            scale,
+            generation,
+            one_shot,
         )
     elif world == 2:
         _launch_allreduce[dtype, W, 2](
-            ctx, stream, rp, in_ptr, out_ptr, numel, world, rank, cap_bytes, scale,
-            generation, one_shot,
+            ctx,
+            stream,
+            rp,
+            in_ptr,
+            out_ptr,
+            numel,
+            world,
+            rank,
+            cap_bytes,
+            scale,
+            generation,
+            one_shot,
         )
     else:
         _launch_allreduce[dtype, W, 0](
-            ctx, stream, rp, in_ptr, out_ptr, numel, world, rank, cap_bytes, scale,
-            generation, one_shot,
+            ctx,
+            stream,
+            rp,
+            in_ptr,
+            out_ptr,
+            numel,
+            world,
+            rank,
+            cap_bytes,
+            scale,
+            generation,
+            one_shot,
         )
 
 

--- a/torch_mojo_backend/distributed/mojoccl/collectives_kernels.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/collectives_kernels.mojo
@@ -1,145 +1,903 @@
-# STAND-IN collectives kernel for mojoccl.
+# Intra-node collectives (allreduce / broadcast / allgather) over IPC-mapped
+# peer regions -- a Mojo replacement for the NCCL/RCCL calls a DDP
+# ProcessGroup makes inside one node.
 #
-# Correctness over speed, as directed: single-thread-block copy/reduce
-# kernels plus a page-sized signal area and a generation-based barrier built
-# on plain system-scope Atomic release/acquire (the flag pattern
-# proto/ipc_probe.mojo measured working, PASS at §5.3 of
-# docs/mojo_collectives_feasibility.md in the main worktree) -- not MAX's
-# comm.Signal, whose embedded Lamport region alone is ~24.75 MiB/rank, far
-# more than this needs. This file is expected to be replaced wholesale by
-# the production kernel (kernel/collectives_kernels.mojo, written in
-# parallel against this same function-signature contract); nothing outside
-# this file should need to change on that swap.
+# One library-owned device allocation per rank ("the region"), shared to the
+# peers by cuIpc/hipIpc (the plumbing layer owns that half), laid out as
 #
-# Region layout per rank (see mojoccl.mojo): [0, signal_bytes()) signal area,
-# then stage_in of cap_bytes, then stage_out of cap_bytes. `regions[r]` is
-# rank r's region base as mapped in THIS process (own allocation for
-# r == rank, an opened IPC mapping otherwise).
+#   [0, SIGNAL_BYTES)                            signal area, zero at creation
+#   [SIGNAL_BYTES, SIGNAL_BYTES + cap)           "stage_in"
+#   [SIGNAL_BYTES + cap, SIGNAL_BYTES + 2*cap)   "stage_out"
+#
+# The two cap-sized halves are library scratch; this file uses them as one
+# 2*cap byte staging arena and places its own sub-areas inside it, always
+# within those bounds:
+#   allreduce two-shot: `world` push slots of max-shard size, then the reduced
+#                       shard (`_launch_allreduce`, which raises if that ever
+#                       fails to fit -- it cannot, since world*shard ~ numel
+#                       <= cap and the arena is 2*cap);
+#   allreduce one-shot: two generation-parity halves of `world` whole-message
+#                       slots (used only when they fit);
+#   broadcast/allgather: the base of the arena, one message-sized stage per
+#                        rank (the caller chunks anything larger than cap).
+#
+# Why the data path looks like it does
+# ------------------------------------
+# The user's tensors live in MAX-allocated memory, which cannot be exported
+# with legacy IPC (measured: `cuIpcGetMemHandle` -> CUDA_ERROR_INVALID_VALUE),
+# so peers can only ever read the region.  The naive way to bridge that -- copy
+# the input into stage_in, run a direct reduce-scatter + all-gather over the
+# regions, copy the result back out -- costs two extra full HBM round trips
+# (+45 us on the 27 MiB GPT-2 bucket, measured in the feasibility study, 210 us
+# vs 165 us direct).  Both copies are avoidable:
+#
+#   phase 1  PUSH   every rank reads its own input straight out of user memory
+#                   and writes shard s into peer s's slot `rank` of the arena.
+#                   That write IS the copy-in, and it travels over NVLink.
+#   phase 2  REDUCE each rank sums the `world` contributions to its own shard
+#                   (its own straight from user memory, the peers' from the
+#                   arena), scales, and writes the result to the arena and to
+#                   its slice of the user output.
+#   phase 3  PULL   each rank reads the other ranks' reduced shards out of
+#                   their arenas directly into its user output.
+#
+# NVLink traffic is 2*(world-1)/world * bytes per GPU -- the unicast minimum,
+# the same as a direct reduce-scatter + all-gather -- and no byte is copied
+# locally that the direct kernel would not also copy.  The staging is free.
+#
+# Synchronisation
+# ---------------
+# The signal area holds one UInt64 flag per (block, writer rank).  Rank r's
+# block b publishes `generation * PHASES_PER_GEN + phase` into every peer's
+# flags[b][r] with a system-scope release store and then waits for its own
+# flags[b][p] to reach that value for every peer p.  Flag values are derived
+# from `generation`, never reset, and compared with `>=`, so a peer that is a
+# whole call ahead can never deadlock a peer that is behind and nothing has to
+# be cleared between calls.  Every collective opens with a start barrier, so
+# one rule covers the whole arena: no generation writes it until every rank has
+# finished reading the previous generation.  That is what lets collectives of
+# different kinds and sizes share the staging area -- see the invariant above
+# `_ar_twoshot_kernel`.
+#
+# Broadcast is scatter + all-gather, not "root stages, everyone reads": the
+# latter puts (world-1) x nbytes on the root's one outbound link and measured
+# 3.6x slower.  Allgather is a local stage + a peer gather, which is already
+# the unicast minimum.
+#
+# Every spin is bounded (default 60 s, measured with the GPU's own timer --
+# never compared across GPUs).  On timeout the kernel stores a nonzero code
+# into its own region's error word (byte `error_offset()`) and returns instead
+# of hanging the node.
+#
+# Portability: NVIDIA and AMD share every line of the device code.  Ordering is
+# `Atomic[...].store[RELEASE]` / `load[ACQUIRE]` at default (system) scope,
+# which lowers to `st.release.sys.global` / `ld.acquire.sys.global` on sm_90a
+# and to `global_store/load ... sc0 sc1` + `buffer_wbl2 sc0 sc1` / `buffer_inv
+# sc0 sc1` on gfx942 -- exactly the instructions RCCL relies on.  Blocks are
+# 256 threads (RCCL's gfx942 maximum) and every layout is wave-64 safe.
+#
+# Every host function takes the DeviceStream to enqueue on (production wraps
+# the caller's foreign cudaStream_t with `DeviceContext.create_external_stream`);
+# `ctx` is only the handle used to compile and cache the DeviceFunction.
+#
+# Builds for both targets:
+#   uv run --no-sync mojo build collectives_kernels.mojo --target-accelerator sm_90a
+#   uv run --no-sync mojo build collectives_kernels.mojo --target-accelerator gfx942
 
-from std.atomic import Atomic, Ordering
+from std.atomic import Atomic, Ordering, fence
 from std.builtin.device_passable import DevicePassable
+from std.collections import InlineArray
 from std.ffi import _get_global_or_null, external_call
+from std.gpu import (
+    MAX_THREADS_PER_BLOCK_METADATA,
+    block_idx,
+    global_idx,
+    grid_dim,
+    thread_idx,
+)
+from max.gpu.host import DeviceContext, DeviceStream
 from max.gpu.sync import barrier
-from std.gpu import thread_idx, MAX_THREADS_PER_BLOCK_METADATA
+from std.memory import AddressSpace, stack_allocation
 from std.memory.alloc import unsafe_alloc
-from std.sys import get_accum_type
+from std.sys import (
+    get_defined_int,
+    has_amd_gpu_accelerator,
+    size_of,
+)
 from std.time import global_perf_counter_ns
 from std.utils import StaticTuple
-from max.gpu.host import DeviceContext, DeviceStream, DeviceBuffer
 
-from driver import zero_bytes
+# ===-------------------------------------------------------------------=== #
+# Compile-time configuration
+# ===-------------------------------------------------------------------=== #
 
 comptime MAX_WORLD = 8
+"""Largest world size a single region can address (one flag column per rank)."""
+
 comptime BLOCK = 256
-# One page: [0] error word (UInt64), [8] barrier counter (UInt64), padding.
-comptime SIG_BYTES = 4096
-comptime ERR_OFF = 0
-comptime BAR_OFF = 8
-comptime BARRIER_TIMEOUT_NS: UInt64 = 30_000_000_000
+"""Threads per block. 256 is RCCL's gfx942 maximum and is wave-64 safe."""
+
+comptime MAX_BLOCKS = 1024
+"""Flag rows in the signal area; every grid this file launches is <= this."""
+
+comptime _FLAG_BYTE_OFFSET = 4096
+"""Start of the flag matrix inside the signal area (the first page holds the
+error word and stays free for future host-visible state)."""
+
+comptime _SIGNAL_BYTES = 128 * 1024
+"""Signal-area size: 4 KiB header + MAX_BLOCKS*MAX_WORLD*8 B of flags = 68 KiB,
+rounded to 128 KiB. Two orders of magnitude below MAX's 24.75 MiB `Signal`."""
+
+comptime PHASES_PER_GEN = 8
+"""Flag values are `generation * PHASES_PER_GEN + phase`; this bounds the
+number of syncs one collective call may perform (three, for the two-shot
+allreduce). Small on purpose: the flag is a UInt64 and the generation counter
+never resets, so headroom costs nothing, but a tight bound documents the
+contract."""
+
+comptime DEFAULT_TIMEOUT_NS = 60_000_000_000
+"""Spin-loop deadline (60 s), measured with this GPU's own timer."""
+
+comptime _SPIN_CHECK = 4096
+"""Spins between two reads of the (not free) global timer."""
+
+# The tuning constants below carry a `-D` override so the benchmark harness
+# can sweep them without editing this file; the defaults are what a plain
+# build (and therefore production) uses.
+
+comptime _UNROLL = get_defined_int["ccl_unroll", 4]()
+"""16-byte vectors in flight per thread in the NVLink copy loops."""
+
+comptime _ONESHOT_MAX_BYTES = get_defined_int["ccl_oneshot_max", 512 * 1024]()
+"""At or below this an allreduce uses the one-shot path: (world-1)x the NVLink
+bytes but one sync instead of two, which wins while the transfer is
+latency-bound. Measured crossover on 8xH100/NVSwitch (us, one-shot vs
+two-shot): 128 KiB 9.3/19.0, 256 KiB 12.3/19.3, 512 KiB 18.1/19.8,
+1 MiB 30.0/20.5 -- so the crossover sits just above 512 KiB. The path is taken
+only if 2*world message-sized slots also fit the region."""
+
+comptime _AR_MAX_BLOCKS = get_defined_int["ccl_ar_blocks", 216]()
+"""Grid cap for allreduce, fitted on H100 (132 SMs) / NVSwitch; see the block
+sweep in RESULTS.md. Not portable: re-fit it on another card."""
+
+comptime _AR_BIG_BYTES = get_defined_int["ccl_ar_big_bytes", 64 * 1024 * 1024]()
+"""Above this message size the allreduce grid drops to `_AR_BIG_BLOCKS`."""
+
+comptime _AR_BIG_BLOCKS = get_defined_int["ccl_ar_big_blocks", 128]()
+"""Grid cap for large allreduces. A grid that fits in one wave of an H100's
+132 SMs measured 8% faster at 512 MiB than 216 blocks (2825 vs 3065 us) and
+the same at 168 MiB, because the barrier is per block index: with more blocks
+than SMs the second wave runs the whole collective after the first, on fewer
+SMs. Fitted on H100 (132 SMs); re-fit on another card."""
+
+comptime _COPY_MAX_BLOCKS = get_defined_int["ccl_copy_blocks", 432]()
+"""Grid cap for the pure-copy collectives (broadcast / allgather)."""
+
+# Error codes written to the region's error word (`error_offset()`).
+comptime ERR_ALLREDUCE_SYNC = 1
+comptime ERR_BROADCAST_SYNC = 2
+comptime ERR_ALLGATHER_SYNC = 3
+
+
+# ===-------------------------------------------------------------------=== #
+# Region geometry (host + device agree; every rank computes the same numbers)
+# ===-------------------------------------------------------------------=== #
 
 
 def signal_bytes() -> Int:
-    return SIG_BYTES
+    """Bytes of signal/flag area at the base of every rank's region."""
+    comptime assert (
+        _AR_MAX_BLOCKS <= MAX_BLOCKS
+        and _AR_BIG_BLOCKS <= MAX_BLOCKS
+        and _COPY_MAX_BLOCKS <= MAX_BLOCKS
+    ), "grid caps must fit the flag matrix"
+    comptime assert BLOCK >= MAX_WORLD, "the sync needs one thread per peer"
+    comptime assert (
+        _FLAG_BYTE_OFFSET + MAX_BLOCKS * MAX_WORLD * 8 <= _SIGNAL_BYTES
+    ), "the flag matrix must fit the signal area"
+    return _SIGNAL_BYTES
 
 
 def error_offset() -> Int:
-    return ERR_OFF
+    """Byte offset, inside the signal area, of the UInt64 error word.
 
-
-def region_init(ctx: DeviceContext, region: Int) raises:
-    """Zeros the signal area of a freshly allocated region.
-
-    No `stream` parameter (unlike the collectives below): this runs once per
-    rank at communicator creation, on `ctx`'s own queue, before any user
-    stream touches the region -- zero_bytes blocks, so every later
-    collective (issued on the caller's external stream) is guaranteed to see
-    the zeroed area.
+    Zero means "no error". A nonzero value is `code * 1_000_000 + phase`, with
+    `code` one of the `ERR_*` constants above; it means some block gave up
+    waiting for a peer and the collective's result is undefined from that
+    generation on.
     """
-    zero_bytes(ctx, region, SIG_BYTES)
+    return 0
 
 
 @always_inline
-def _err_ptr(region: Int64) -> Pointer[UInt64, MutAnyOrigin]:
-    return Pointer[UInt64, MutAnyOrigin](
-        unsafe_from_address=Int(region) + ERR_OFF
-    )
+def _align_up(x: Int, a: Int) -> Int:
+    return (x + a - 1) // a * a
 
 
 @always_inline
-def _bar_ptr(region: Int64) -> Pointer[UInt64, MutAnyOrigin]:
-    return Pointer[UInt64, MutAnyOrigin](
-        unsafe_from_address=Int(region) + BAR_OFF
-    )
+def _flag_target(generation: Int, phase: Int) -> UInt64:
+    """The flag value that marks `phase` of `generation`.
+
+    Strictly increasing in (generation, phase), never reset, so waiters compare
+    with `>=` and a peer running ahead is harmless.
+    """
+    return UInt64(generation) * UInt64(PHASES_PER_GEN) + UInt64(phase)
+
+
+# ===-------------------------------------------------------------------=== #
+# Device-side primitives
+# ===-------------------------------------------------------------------=== #
 
 
 @always_inline
-def _gen_barrier(
-    regions: StaticTuple[Int64, MAX_WORLD],
-    rank: Int32,
-    world: Int32,
-    target: UInt64,
+def _flags(
+    region: Pointer[UInt8, MutAnyOrigin],
+) -> Pointer[UInt64, MutAnyOrigin]:
+    """flags[block][writer_rank], row-major, MAX_WORLD columns."""
+    return region.unsafe_offset(_FLAG_BYTE_OFFSET).unsafe_bitcast[UInt64]()
+
+
+@always_inline
+def _record_error(
+    regions: InlineArray[Pointer[UInt8, MutAnyOrigin], MAX_WORLD],
+    rank: Int,
+    code: Int,
+    phase: Int,
 ):
-    """A full, symmetric cross-rank barrier: every participant publishes
-    `target` into its own region and waits for every OTHER participant to
-    reach at least `target` too, before any of them may proceed.
-
-    Symmetric on purpose (publish AND wait, both phases of every call): a
-    one-way "publish and move on" would let a fast rank start overwriting
-    its stage buffers for the NEXT generation while a slow peer is still
-    reading THIS generation's data out of them. `target` is derived from the
-    caller-supplied generation counter, strictly increasing per
-    communicator, so no double-buffering of the counter itself is needed --
-    every call in the process's lifetime gets a fresh target.
-    """
+    """Publish a failure in my own region's error word (host-readable)."""
     if thread_idx.x == 0:
-        Atomic[DType.uint64].store[ordering=Ordering.RELEASE](
-            _bar_ptr(regions[Int(rank)]), target
+        Atomic[DType.uint64].store[ordering = Ordering.RELEASE](
+            regions[rank].unsafe_bitcast[UInt64](),
+            UInt64(code) * 1_000_000 + UInt64(phase),
         )
-    if Int(thread_idx.x) < Int(world):
-        var peer_ptr = _bar_ptr(regions[Int(thread_idx.x)])
-        var t0 = global_perf_counter_ns()
-        while (
-            Atomic[DType.uint64].load[ordering=Ordering.ACQUIRE](peer_ptr)
-            < target
-        ):
-            if global_perf_counter_ns() - t0 > BARRIER_TIMEOUT_NS:
-                Atomic[DType.uint64].store[ordering=Ordering.RELEASE](
-                    _err_ptr(regions[Int(rank)]), UInt64(1)
-                )
-                break
+
+
+@always_inline
+def _sync(
+    regions: InlineArray[Pointer[UInt8, MutAnyOrigin], MAX_WORLD],
+    world: Int,
+    rank: Int,
+    target: UInt64,
+    t0: UInt64,
+    timeout_ns: UInt64,
+) -> Bool:
+    """Block-scoped barrier across the same block index on every rank.
+
+    Thread `p` (p < world) publishes `target` into peer p's flags[bid][rank]
+    with a release store -- which orders every payload write this block made
+    into peer memory before the flag becomes visible -- then waits for peer p's
+    flag in my own region to reach `target`.
+
+    Blocks are matched by index: every collective in this file gives block b of
+    every rank exactly the same grid-stride slice of the index space, so block b
+    only ever consumes bytes block b of a peer produced.
+
+    Returns False if any participating thread hit the deadline; the whole block
+    learns that through shared memory so no thread is left inside a `barrier()`.
+    """
+    var failed = stack_allocation[
+        1, DType.uint32, address_space = AddressSpace.SHARED
+    ]()
+    if thread_idx.x == 0:
+        failed[unsafe_offset=0] = 0
+    comptime if has_amd_gpu_accelerator():
+        # gfx942's `s_barrier` is emitted with `s_waitcnt lgkmcnt(0)` only, so
+        # another wave's payload stores can still be in flight when one thread
+        # publishes the flag; RCCL puts `vmcnt(0)` inside its block barrier for
+        # exactly this reason (rccl:src/device/prims_simple.h:193-210), and a
+        # release fence in every thread is the portable spelling (it lowers to
+        # `s_waitcnt vmcnt(0)` + `buffer_wbl2 sc0 sc1`). NVIDIA needs nothing:
+        # `bar.sync` is a CTA-scope fence and the release store below is
+        # cumulative over it, which is what NCCL's postPeer relies on.
+        fence[ordering = Ordering.RELEASE]()
     barrier()
 
+    if Int(thread_idx.x) < world:
+        var peer = Int(thread_idx.x)
+        var bid = Int(block_idx.x)
+        Atomic[DType.uint64].store[ordering = Ordering.RELEASE](
+            _flags(regions[peer]).unsafe_offset(bid * MAX_WORLD + rank),
+            target,
+        )
+        var mine = _flags(regions[rank]).unsafe_offset(bid * MAX_WORLD + peer)
+        var spins = 0
+        while (
+            Atomic[DType.uint64].load[ordering = Ordering.ACQUIRE](mine)
+            < target
+        ):
+            spins += 1
+            if spins >= _SPIN_CHECK:
+                spins = 0
+                # Same-GPU timer difference only; never compared across GPUs.
+                if global_perf_counter_ns() - t0 > timeout_ns:
+                    failed[unsafe_offset=0] = 1
+                    break
+    barrier()
+    return failed[unsafe_offset=0] == 0
+
 
 @always_inline
-def _enqueue_cached_stream[
-    declared_arg_types: TypeList[Trait=AnyType, ...],
-    //,
-    func: def(* args: * declared_arg_types) thin -> None,
+def _copy_vec[
+    dtype: DType, W: Int, U: Int
+](
+    dst: Pointer[Scalar[dtype], MutAnyOrigin],
+    src: Pointer[Scalar[dtype], MutAnyOrigin],
+    nvec: Int,
+    tid: Int,
+    stride: Int,
+):
+    """Grid-stride copy of `nvec` 16-byte vectors, `U` of them in flight.
+
+    Both pointers must be 16-byte aligned, which every address this file forms
+    is (region sub-areas are multiples of 16 B from a page-aligned base; user
+    pointers come from MAX's allocator; shard starts are multiples of W).
+    """
+    var v = tid
+    var lim = nvec - (U - 1) * stride
+    while v < lim:
+        var tmp = InlineArray[SIMD[dtype, W], U](uninitialized=True)
+        comptime for u in range(U):
+            tmp[u] = src.unsafe_load[width=W, alignment=16](
+                (v + u * stride) * W
+            )
+        comptime for u in range(U):
+            dst.unsafe_store[width=W, alignment=16](
+                (v + u * stride) * W, tmp[u]
+            )
+        v += U * stride
+    while v < nvec:
+        dst.unsafe_store[width=W, alignment=16](
+            v * W, src.unsafe_load[width=W, alignment=16](v * W)
+        )
+        v += stride
+
+
+@always_inline
+def _copy_scalar_tail[
+    dtype: DType
+](
+    dst: Pointer[Scalar[dtype], MutAnyOrigin],
+    src: Pointer[Scalar[dtype], MutAnyOrigin],
+    base: Int,
+    count: Int,
+    tid: Int,
+    stride: Int,
+):
+    """The `numel % W` elements a 16-byte vector loop cannot cover."""
+    for i in range(tid, count, stride):
+        dst[unsafe_offset = base + i] = src[unsafe_offset = base + i]
+
+
+@always_inline
+def _copy_bytes[
+    U: Int
+](
+    dst: Pointer[UInt8, MutAnyOrigin],
+    src: Pointer[UInt8, MutAnyOrigin],
+    nbytes: Int,
+    tid: Int,
+    stride: Int,
+):
+    """dtype-agnostic byte copy: 16-byte vectors when both sides allow it.
+
+    Both paths walk the *same* 16-byte chunks in the same grid-stride order, so
+    the chunk -> block mapping does not depend on which path a given call takes.
+    That matters: for a byte collective the writer and the reader are different
+    ranks looking at different pointer pairs (the root's `send` and a peer's
+    `recv`), so they can disagree about alignment, and the per-block barrier
+    only orders block b against block b. A fallback that walked single bytes
+    would let block 3 read a chunk block 0 wrote.
+    """
+    var nvec = nbytes // 16
+    if (Int(dst) | Int(src)) % 16 == 0:
+        _copy_vec[DType.uint8, 16, U](dst, src, nvec, tid, stride)
+    else:
+        for v in range(tid, nvec, stride):
+            comptime for j in range(16):
+                dst[unsafe_offset = v * 16 + j] = src[unsafe_offset = v * 16 + j]
+    _copy_scalar_tail(dst, src, nvec * 16, nbytes - nvec * 16, tid, stride)
+
+
+# ===-------------------------------------------------------------------=== #
+# Shard partition. Every rank derives the same table from (numel, world).
+# ===-------------------------------------------------------------------=== #
+
+
+@always_inline
+def _vstart(s: Int, q: Int, rem: Int) -> Int:
+    """First 16-byte vector of rank `s`'s shard."""
+    return s * q + min(s, rem)
+
+
+@always_inline
+def _vcount(s: Int, q: Int, rem: Int) -> Int:
+    """16-byte vectors in rank `s`'s shard (the `numel % W` scalar tail, if
+    any, belongs to the last rank and is counted separately)."""
+    return q + (1 if s < rem else 0)
+
+
+# ===-------------------------------------------------------------------=== #
+# Allreduce -- two-shot (push / reduce / pull)
+# ===-------------------------------------------------------------------=== #
+#
+# Buffer-reuse invariant. Every collective in this file opens with a start
+# barrier, so the whole arena obeys one rule:
+#
+#     no rank writes an arena byte for generation g until every rank has
+#     finished reading arena bytes for generation g-1
+#
+# (a rank reaches generation g's start barrier only after its own generation
+# g-1 work has retired, and nobody passes that barrier until all have arrived).
+# That is what lets collectives of different kinds and sizes share the arena
+# and interleave freely -- which they do: DDP issues a 4-byte one-shot
+# allreduce and an 8-byte allgather in between 27 MiB two-shot allreduces, and
+# their staging layouts overlap. Dropping the start barrier saves ~2.5 us and
+# is only sound for a run of identically shaped collectives; it was measured
+# (166.4 us vs 169 us at 27 MiB) and rejected as a correctness trap.
+#
+# Within a call the two data syncs order the three phases:
+#     start(g) < push(g) < A(g) < reduce(g) < B(g) < pull(g) < start(g+1)
+# and a sync is a full N-way rendezvous of matching block indices. In-place
+# (in_ptr == out_ptr) is safe because the phases are block-matched: block b
+# writes exactly the elements block b read.
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(BLOCK))
+)
+@__name(t"ccl_allreduce_push_reduce_pull_{dtype}_w{NW}")
+def _ar_twoshot_kernel[
+    dtype: DType, W: Int, U: Int, NW: Int
+](
+    regions: InlineArray[Pointer[UInt8, MutAnyOrigin], MAX_WORLD],
+    in_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    numel: Int64,
+    slot_stride_b: Int64,
+    push_off_b: Int64,
+    shard_off_b: Int64,
+    world_i: Int32,
+    rank_i: Int32,
+    flag_base: UInt64,
+    scale: Float32,
+    timeout_ns: UInt64,
+):
+    comptime accum = DType.float32 if (
+        dtype == DType.bfloat16 or dtype == DType.float16
+    ) else dtype
+    var t0 = global_perf_counter_ns()
+    var world = NW if NW > 0 else Int(world_i)
+    var rank = Int(rank_i)
+    var tid = Int(global_idx.x)
+    var stride = Int(grid_dim.x) * BLOCK
+    var n = Int(numel)
+    var nvec = n // W
+    var q = nvec // world
+    var rem = nvec % world
+    var tail = n - nvec * W
+    var slot_stride = Int(slot_stride_b)
+    var push_off = Int(push_off_b)
+    var shard_off = Int(shard_off_b)
+
+    # --- phase 0: start barrier -- nobody writes the arena for generation g
+    # until every rank has finished reading it for generation g-1 ------------
+    if not _sync(regions, world, rank, flag_base, t0, timeout_ns):
+        _record_error(regions, rank, ERR_ALLREDUCE_SYNC, 0)
+        return
+
+    # --- phase 1: push shard s of my input into peer s's slot `rank` --------
+    for i in range(1, world):
+        var s = rank + i
+        if s >= world:
+            s -= world
+        var src = in_ptr.unsafe_offset(_vstart(s, q, rem) * W)
+        var vc = _vcount(s, q, rem)
+        var dst = regions[s].unsafe_offset(
+            push_off + slot_stride * rank
+        ).unsafe_bitcast[Scalar[dtype]]()
+        _copy_vec[dtype, W, U](dst, src, vc, tid, stride)
+        if tail > 0 and s == world - 1:
+            _copy_scalar_tail(dst, src, vc * W, tail, tid, stride)
+
+    if not _sync(regions, world, rank, flag_base + 1, t0, timeout_ns):
+        _record_error(regions, rank, ERR_ALLREDUCE_SYNC, 1)
+        return
+
+    # --- phase 2: reduce my shard, to the arena and to the user output ------
+    var my_vs = _vstart(rank, q, rem)
+    var my_vc = _vcount(rank, q, rem)
+    var my_tail = tail if rank == world - 1 else 0
+    var uin = in_ptr.unsafe_offset(my_vs * W)
+    var uout = out_ptr.unsafe_offset(my_vs * W)
+    var shard = regions[rank].unsafe_offset(shard_off).unsafe_bitcast[
+        Scalar[dtype]
+    ]()
+
+    # Slot pointers are formed by arithmetic inside the unrolled loop, never
+    # held in an array: a stack array of `world` pointers is demoted to local
+    # memory (MOCO-1431) and turns every payload load into a generic-address
+    # `ld.v4.b32` plus an `ld.local.b64` of the pointer itself.
+    var slots = regions[rank].unsafe_offset(push_off)
+
+    for v in range(tid, my_vc, stride):
+        var acc = uin.unsafe_load[width=W, alignment=16](v * W).cast[accum]()
+        comptime if NW > 0:
+            comptime for j in range(1, NW):
+                var p = rank + j
+                if p >= NW:
+                    p -= NW
+                acc += (
+                    slots.unsafe_offset(slot_stride * p)
+                    .unsafe_bitcast[Scalar[dtype]]()
+                    .unsafe_load[width=W, alignment=16](v * W)
+                    .cast[accum]()
+                )
+        else:
+            for j in range(1, world):
+                var p = rank + j
+                if p >= world:
+                    p -= world
+                acc += (
+                    slots.unsafe_offset(slot_stride * p)
+                    .unsafe_bitcast[Scalar[dtype]]()
+                    .unsafe_load[width=W, alignment=16](v * W)
+                    .cast[accum]()
+                )
+        comptime if accum.is_floating_point():
+            acc *= SIMD[accum, W](scale.cast[accum]())
+        var res = acc.cast[dtype]()
+        shard.unsafe_store[width=W, alignment=16](v * W, res)
+        uout.unsafe_store[width=W, alignment=16](v * W, res)
+
+    for i in range(tid, my_tail, stride):
+        var k = my_vc * W + i
+        var a = uin[unsafe_offset=k].cast[accum]()
+        for j in range(1, world):
+            var p = rank + j
+            if p >= world:
+                p -= world
+            a += (
+                slots.unsafe_offset(slot_stride * p)
+                .unsafe_bitcast[Scalar[dtype]]()[unsafe_offset=k]
+                .cast[accum]()
+            )
+        comptime if accum.is_floating_point():
+            a *= scale.cast[accum]()
+        shard[unsafe_offset=k] = a.cast[dtype]()
+        uout[unsafe_offset=k] = a.cast[dtype]()
+
+    if not _sync(regions, world, rank, flag_base + 2, t0, timeout_ns):
+        _record_error(regions, rank, ERR_ALLREDUCE_SYNC, 2)
+        return
+
+    # --- phase 3: pull the peers' reduced shards into the user output -------
+    for i in range(1, world):
+        var p = rank + i
+        if p >= world:
+            p -= world
+        var vs = _vstart(p, q, rem)
+        var vc = _vcount(p, q, rem)
+        var src = regions[p].unsafe_offset(shard_off).unsafe_bitcast[
+            Scalar[dtype]
+        ]()
+        var dst = out_ptr.unsafe_offset(vs * W)
+        _copy_vec[dtype, W, U](dst, src, vc, tid, stride)
+        if tail > 0 and p == world - 1:
+            _copy_scalar_tail(dst, src, vc * W, tail, tid, stride)
+
+
+# ===-------------------------------------------------------------------=== #
+# Allreduce -- one-shot (push whole input / reduce), for small messages
+# ===-------------------------------------------------------------------=== #
+#
+# (world-1)x the NVLink bytes of the two-shot path but one data sync instead of
+# two, which wins while latency dominates: measured 9.3 us against 19.0 us at
+# 128 KiB, with the crossover just above 512 KiB.
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(BLOCK))
+)
+@__name(t"ccl_allreduce_oneshot_{dtype}_w{NW}")
+def _ar_oneshot_kernel[
+    dtype: DType, W: Int, U: Int, NW: Int
+](
+    regions: InlineArray[Pointer[UInt8, MutAnyOrigin], MAX_WORLD],
+    in_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    numel: Int64,
+    slot_stride_b: Int64,
+    push_off_b: Int64,
+    world_i: Int32,
+    rank_i: Int32,
+    flag_base: UInt64,
+    scale: Float32,
+    timeout_ns: UInt64,
+):
+    comptime accum = DType.float32 if (
+        dtype == DType.bfloat16 or dtype == DType.float16
+    ) else dtype
+    var t0 = global_perf_counter_ns()
+    var world = NW if NW > 0 else Int(world_i)
+    var rank = Int(rank_i)
+    var tid = Int(global_idx.x)
+    var stride = Int(grid_dim.x) * BLOCK
+    var n = Int(numel)
+    var nvec = n // W
+    var tail = n - nvec * W
+    var slot_stride = Int(slot_stride_b)
+    var push_off = Int(push_off_b)
+
+    if not _sync(regions, world, rank, flag_base, t0, timeout_ns):
+        _record_error(regions, rank, ERR_ALLREDUCE_SYNC, 0)
+        return
+
+    for i in range(1, world):
+        var s = rank + i
+        if s >= world:
+            s -= world
+        var dst = regions[s].unsafe_offset(
+            push_off + slot_stride * rank
+        ).unsafe_bitcast[Scalar[dtype]]()
+        _copy_vec[dtype, W, U](dst, in_ptr, nvec, tid, stride)
+        if tail > 0:
+            _copy_scalar_tail(dst, in_ptr, nvec * W, tail, tid, stride)
+
+    if not _sync(regions, world, rank, flag_base + 1, t0, timeout_ns):
+        _record_error(regions, rank, ERR_ALLREDUCE_SYNC, 1)
+        return
+
+    var slots = regions[rank].unsafe_offset(push_off)
+
+    for v in range(tid, nvec, stride):
+        var acc = in_ptr.unsafe_load[width=W, alignment=16](v * W).cast[accum]()
+        comptime if NW > 0:
+            comptime for j in range(1, NW):
+                var p = rank + j
+                if p >= NW:
+                    p -= NW
+                acc += (
+                    slots.unsafe_offset(slot_stride * p)
+                    .unsafe_bitcast[Scalar[dtype]]()
+                    .unsafe_load[width=W, alignment=16](v * W)
+                    .cast[accum]()
+                )
+        else:
+            for j in range(1, world):
+                var p = rank + j
+                if p >= world:
+                    p -= world
+                acc += (
+                    slots.unsafe_offset(slot_stride * p)
+                    .unsafe_bitcast[Scalar[dtype]]()
+                    .unsafe_load[width=W, alignment=16](v * W)
+                    .cast[accum]()
+                )
+        comptime if accum.is_floating_point():
+            acc *= SIMD[accum, W](scale.cast[accum]())
+        out_ptr.unsafe_store[width=W, alignment=16](v * W, acc.cast[dtype]())
+
+    for i in range(tid, tail, stride):
+        var k = nvec * W + i
+        var a = in_ptr[unsafe_offset=k].cast[accum]()
+        for j in range(1, world):
+            var p = rank + j
+            if p >= world:
+                p -= world
+            a += (
+                slots.unsafe_offset(slot_stride * p)
+                .unsafe_bitcast[Scalar[dtype]]()[unsafe_offset=k]
+                .cast[accum]()
+            )
+        comptime if accum.is_floating_point():
+            a *= scale.cast[accum]()
+        out_ptr[unsafe_offset=k] = a.cast[dtype]()
+
+
+# ===-------------------------------------------------------------------=== #
+# Broadcast and allgather -- one peer-copy kernel each, chunked to `cap`
+# ===-------------------------------------------------------------------=== #
+#
+# Both walk the buffer in chunks of `cap` bytes and alternate between the two
+# cap-sized halves of the arena, so the write of chunk c races only against
+# reads of chunk c-1 (the other half); reads of chunk c-2 are ordered before
+# it by the sync of chunk c-1. A leading sync separates the first two chunks
+# from the previous call's reads.
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(BLOCK))
+)
+@__name("ccl_broadcast_scatter_gather_bytes")
+def _bcast_kernel[
+    U: Int
+](
+    regions: InlineArray[Pointer[UInt8, MutAnyOrigin], MAX_WORLD],
+    send: Pointer[UInt8, MutAnyOrigin],
+    recv: Pointer[UInt8, MutAnyOrigin],
+    nbytes: Int64,
+    stage_off_b: Int64,
+    world_i: Int32,
+    rank_i: Int32,
+    root_i: Int32,
+    flag_base: UInt64,
+    timeout_ns: UInt64,
+):
+    """Broadcast as scatter + all-gather.
+
+    The obvious design -- root stages the whole message, everybody reads it --
+    puts `(world-1) * nbytes` on the root's single outbound link and measured
+    552 us on 27 MiB where the fabric could do 150. Instead the root scatters
+    shard p into rank p's stage (nbytes out of the root, spread over the peers)
+    and every other rank gathers the `world` shards, so the read side is a
+    permutation too and no link carries more than nbytes.
+
+    Out-of-place capable (ncclBroadcast): the root reads `send`, everyone
+    writes `recv`, and the root copies `send` to `recv` locally when they
+    differ (cheaper than gathering its own message back over NVLink).
+    """
+    var t0 = global_perf_counter_ns()
+    var world = Int(world_i)
+    var rank = Int(rank_i)
+    var root = Int(root_i)
+    var tid = Int(global_idx.x)
+    var stride = Int(grid_dim.x) * BLOCK
+    var n = Int(nbytes)
+    var stage_off = Int(stage_off_b)
+    var nv = n // 16
+    var q = nv // world
+    var rem = nv % world
+    var mtail = n - nv * 16
+
+    if not _sync(regions, world, rank, flag_base, t0, timeout_ns):
+        _record_error(regions, rank, ERR_BROADCAST_SYNC, 0)
+        return
+
+    if rank == root:
+        for i in range(world):
+            var p = root + i
+            if p >= world:
+                p -= world
+            var vc = _vcount(p, q, rem)
+            _copy_bytes[U](
+                regions[p].unsafe_offset(stage_off),
+                send.unsafe_offset(_vstart(p, q, rem) * 16),
+                vc * 16 + (mtail if p == world - 1 else 0),
+                tid,
+                stride,
+            )
+        if Int(send) != Int(recv):
+            _copy_bytes[U](recv, send, n, tid, stride)
+
+    if not _sync(regions, world, rank, flag_base + 1, t0, timeout_ns):
+        _record_error(regions, rank, ERR_BROADCAST_SYNC, 1)
+        return
+
+    if rank != root:
+        for i in range(world):
+            var p = rank + i
+            if p >= world:
+                p -= world
+            var vc = _vcount(p, q, rem)
+            _copy_bytes[U](
+                recv.unsafe_offset(_vstart(p, q, rem) * 16),
+                regions[p].unsafe_offset(stage_off),
+                vc * 16 + (mtail if p == world - 1 else 0),
+                tid,
+                stride,
+            )
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(BLOCK))
+)
+@__name("ccl_allgather_bytes")
+def _allgather_kernel[
+    U: Int
+](
+    regions: InlineArray[Pointer[UInt8, MutAnyOrigin], MAX_WORLD],
+    in_ptr: Pointer[UInt8, MutAnyOrigin],
+    out_ptr: Pointer[UInt8, MutAnyOrigin],
+    nbytes: Int64,
+    stride_b: Int64,
+    stage_off_b: Int64,
+    world_i: Int32,
+    rank_i: Int32,
+    flag_base: UInt64,
+    timeout_ns: UInt64,
+):
+    """Local stage + peer gather -- already the unicast minimum: `nbytes` of
+    local copy and `(world-1)*nbytes` of peer reads per GPU.
+
+    Rank r's contribution lands at `out_ptr + r*stride_b`; `stride_b` is the
+    output layout's true per-rank size, which differs from `nbytes` when the
+    caller splits one rank's contribution across several calls.
+    """
+    var t0 = global_perf_counter_ns()
+    var world = Int(world_i)
+    var rank = Int(rank_i)
+    var tid = Int(global_idx.x)
+    var stride = Int(grid_dim.x) * BLOCK
+    var n = Int(nbytes)
+    var out_stride = Int(stride_b)
+    var stage_off = Int(stage_off_b)
+
+    if not _sync(regions, world, rank, flag_base, t0, timeout_ns):
+        _record_error(regions, rank, ERR_ALLGATHER_SYNC, 0)
+        return
+
+    _copy_bytes[U](
+        regions[rank].unsafe_offset(stage_off), in_ptr, n, tid, stride
+    )
+    _copy_bytes[U](
+        out_ptr.unsafe_offset(rank * out_stride), in_ptr, n, tid, stride
+    )
+
+    if not _sync(regions, world, rank, flag_base + 1, t0, timeout_ns):
+        _record_error(regions, rank, ERR_ALLGATHER_SYNC, 1)
+        return
+
+    for i in range(1, world):
+        var p = rank + i
+        if p >= world:
+            p -= world
+        _copy_bytes[U](
+            out_ptr.unsafe_offset(p * out_stride),
+            regions[p].unsafe_offset(stage_off),
+            n,
+            tid,
+            stride,
+        )
+
+
+# ===-------------------------------------------------------------------=== #
+# region_init
+# ===-------------------------------------------------------------------=== #
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(BLOCK))
+)
+@__name("ccl_zero_signal_area")
+def _zero_kernel(ptr: Pointer[UInt32, MutAnyOrigin], nwords: Int32):
+    var i = Int(global_idx.x)
+    if i < Int(nwords):
+        ptr[unsafe_offset=i] = 0
+
+
+# ===-------------------------------------------------------------------=== #
+# Cached launch (compile_function costs ~180 us per call; do it once)
+# ===-------------------------------------------------------------------=== #
+
+
+@always_inline
+def _enqueue_cached[
+    declared_arg_types: TypeList[Trait=AnyType, ...], //,
+    func: def (*args: *declared_arg_types) thin -> None,
     *Ts: DevicePassable,
 ](
     ctx: DeviceContext,
     stream: DeviceStream,
     key: String,
-    threads: Int,
+    blocks: Int,
     *args: *Ts,
 ) raises:
-    """Enqueue `func` (grid of 1 block) on the caller's `stream`, compiling
-    it at most once per process and context.
-
-    Self-contained copy of eager_kernels/op_utils's `_enqueue_cached`
-    pattern (this library builds and loads standalone, outside that
-    package): compile once via `ctx`, cache the `DeviceFunction` in the
-    process-global registry, enqueue onto `stream` on every call after.
-    """
-    var name = String(t"MOJOCCL_KERNEL_{key}_{ctx.id()}")
+    """Enqueue `func` on `stream`, compiling it at most once per process and
+    context. `ctx` is only the compilation/caching handle -- the launch always
+    goes to the stream the caller handed us, which in production is a foreign
+    `cudaStream_t` wrapped by `DeviceContext.create_external_stream`. Same
+    caching pattern as the repo's eager kernels."""
+    var name = String(t"CCL_KERNEL_{key}_{ctx.id()}")
     comptime FuncT = type_of(ctx.compile_function[func]())
+
     var global_ptr = _get_global_or_null(name)
     if global_ptr:
         var fptr = global_ptr.value().unsafe_bitcast[FuncT]()
         stream.enqueue_function(
-            fptr[], *args, grid_dim=(1, 1, 1), block_dim=(threads,)
+            fptr[], *args, grid_dim=(blocks,), block_dim=(BLOCK,)
         )
         return
+
     var compiled = ctx.compile_function[func]()
     var fptr = unsafe_alloc[FuncT](1)
     fptr.unsafe_write(compiled^)
@@ -147,71 +905,155 @@ def _enqueue_cached_stream[
         StringSlice(name), fptr.unsafe_bitcast[NoneType]()
     )
     stream.enqueue_function(
-        fptr[], *args, grid_dim=(1, 1, 1), block_dim=(threads,)
+        fptr[], *args, grid_dim=(blocks,), block_dim=(BLOCK,)
     )
 
 
-# ---------------------------------------------------------------------------
-# allreduce: copy-in, barrier, every rank independently sums every peer's
-# stage_in (no reduce-scatter partitioning -- simplest correct thing, per
-# "plain copy-in / RS+AG / copy-out is fine"), barrier, copy-out. Generic
-# Float64 accumulation covers all five dtypes with one code path; SUM is
-# exact for the small integer values these tests use, AVG divides via
-# `scale`.
-# ---------------------------------------------------------------------------
+@always_inline
+def _region_ptrs(
+    regions: StaticTuple[Int, MAX_WORLD], rank: Int, world: Int
+) -> InlineArray[Pointer[UInt8, MutAnyOrigin], MAX_WORLD]:
+    """Peer region bases as mapped in this process. Unused slots are filled
+    with my own region so no kernel can ever hold a null pointer."""
+    var out = InlineArray[Pointer[UInt8, MutAnyOrigin], MAX_WORLD](
+        uninitialized=True
+    )
+    for r in range(MAX_WORLD):
+        var addr = regions[r] if r < world else regions[rank]
+        out[r] = Pointer[UInt8, MutAnyOrigin](unsafe_from_address=addr)
+    return out^
 
 
-@__llvm_metadata(
-    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(BLOCK))
-)
-def _allreduce_kernel[
-    dtype: DType
+def _check_common(
+    rank: Int, world: Int, cap_bytes: Int, generation: Int
+) raises:
+    if world < 1 or world > MAX_WORLD:
+        raise Error("collectives: world must be in 1.." + String(MAX_WORLD))
+    if rank < 0 or rank >= world:
+        raise Error("collectives: rank out of range")
+    if generation < 1:
+        raise Error("collectives: generation must start at 1")
+    if cap_bytes <= 0 or cap_bytes % 4096 != 0:
+        raise Error("collectives: cap_bytes must be a positive 4 KiB multiple")
+
+
+# ===-------------------------------------------------------------------=== #
+# Public API
+# ===-------------------------------------------------------------------=== #
+
+
+def region_init(ctx: DeviceContext, region: Int) raises:
+    """Zero the signal area of this rank's region and block until it is done.
+
+    Called once per rank at communicator creation, on `ctx`'s own queue -- no
+    `stream` parameter, unlike the collectives: this must be complete before
+    any peer writes a flag into the area, and the caller only has to make the
+    ranks meet (its own rendezvous) after calling it.
+    """
+    var words = _SIGNAL_BYTES // 4
+    _enqueue_cached[_zero_kernel](
+        ctx,
+        ctx.stream(),
+        "zero",
+        (words + BLOCK - 1) // BLOCK,
+        Pointer[UInt32, MutAnyOrigin](unsafe_from_address=region),
+        Int32(words),
+    )
+    ctx.synchronize()
+
+
+@always_inline
+def _launch_allreduce[
+    dtype: DType, W: Int, NW: Int
 ](
-    regions: StaticTuple[Int64, MAX_WORLD],
-    rank: Int32,
-    world: Int32,
-    in_ptr: Int64,
-    out_ptr: Int64,
-    numel: Int32,
-    cap_bytes: Int32,
+    ctx: DeviceContext,
+    stream: DeviceStream,
+    regions: InlineArray[Pointer[UInt8, MutAnyOrigin], MAX_WORLD],
+    in_ptr: Int,
+    out_ptr: Int,
+    numel: Int,
+    world: Int,
+    rank: Int,
+    cap_bytes: Int,
     scale: Float32,
-    generation: UInt64,
-):
-    var my_region = Int(regions[Int(rank)])
-    var stage_in = Pointer[Scalar[dtype], MutAnyOrigin](
-        unsafe_from_address=my_region + SIG_BYTES
+    generation: Int,
+    one_shot: Bool,
+) raises:
+    var arena = _SIGNAL_BYTES
+    var arena_end = _SIGNAL_BYTES + 2 * cap_bytes
+    var esize = size_of[dtype]()
+    var nvec = numel // W
+    var tail = numel - nvec * W
+    var ip = Pointer[Scalar[dtype], MutAnyOrigin](
+        unsafe_from_address=in_ptr
     )
-    var src = Pointer[Scalar[dtype], MutAnyOrigin](
-        unsafe_from_address=Int(in_ptr)
+    var op = Pointer[Scalar[dtype], MutAnyOrigin](
+        unsafe_from_address=out_ptr
     )
-    var n = Int(numel)
-    var tid = Int(thread_idx.x)
-    for i in range(tid, n, BLOCK):
-        stage_in[unsafe_offset=i] = src[unsafe_offset=i]
 
-    _gen_barrier(regions, rank, world, 2 * generation)
+    if one_shot:
+        # `world` slots, each a whole message, at the base of the arena. They
+        # overlap the two-shot staging on purpose: the start barrier orders
+        # every generation's writes after the previous generation's reads, so
+        # collectives of different shapes and sizes may interleave freely.
+        var slot = _align_up(numel * esize, 16)
+        if world * slot > 2 * cap_bytes:
+            raise Error("collectives: one-shot slots exceed the region")
+        var push_off = arena
+        var blocks = min(
+            _AR_MAX_BLOCKS, max(1, (nvec + BLOCK - 1) // BLOCK)
+        )
+        _enqueue_cached[_ar_oneshot_kernel[dtype, W, _UNROLL, NW]](
+            ctx,
+            stream,
+            String(t"ar1_{dtype}_{NW}"),
+            blocks,
+            regions,
+            ip,
+            op,
+            Int64(numel),
+            Int64(slot),
+            Int64(push_off),
+            Int32(world),
+            Int32(rank),
+            _flag_target(generation, 0),
+            scale,
+            UInt64(DEFAULT_TIMEOUT_NS),
+        )
+        return
 
-    var stage_out = Pointer[Scalar[dtype], MutAnyOrigin](
-        unsafe_from_address=my_region + SIG_BYTES + Int(cap_bytes)
+    var q = nvec // world
+    var rem = nvec % world
+    var max_shard_elems = max(
+        (q + (1 if rem > 0 else 0)) * W, q * W + tail
     )
-    var w = Int(world)
-    var fscale = Float64(scale)
-    for i in range(tid, n, BLOCK):
-        var acc: Float64 = 0
-        for p in range(w):
-            var peer_in = Pointer[Scalar[dtype], MutAnyOrigin](
-                unsafe_from_address=Int(regions[p]) + SIG_BYTES
-            )
-            acc += Float64(peer_in[unsafe_offset=i])
-        stage_out[unsafe_offset=i] = Scalar[dtype](acc * fscale)
-
-    _gen_barrier(regions, rank, world, 2 * generation + 1)
-
-    var dst = Pointer[Scalar[dtype], MutAnyOrigin](
-        unsafe_from_address=Int(out_ptr)
+    var slot = _align_up(max_shard_elems * esize, 16)
+    var push_off = arena
+    var shard_off = arena + world * slot
+    if shard_off + slot > arena_end:
+        raise Error("collectives: allreduce staging exceeds the region")
+    var cap_blocks = (
+        _AR_BIG_BLOCKS if numel * esize >= _AR_BIG_BYTES else _AR_MAX_BLOCKS
     )
-    for i in range(tid, n, BLOCK):
-        dst[unsafe_offset=i] = stage_out[unsafe_offset=i]
+    var blocks = min(cap_blocks, max(1, (q + 1 + BLOCK - 1) // BLOCK))
+    _enqueue_cached[_ar_twoshot_kernel[dtype, W, _UNROLL, NW]](
+        ctx,
+        stream,
+        String(t"ar2_{dtype}_{NW}"),
+        blocks,
+        regions,
+        ip,
+        op,
+        Int64(numel),
+        Int64(slot),
+        Int64(push_off),
+        Int64(shard_off),
+        Int32(world),
+        Int32(rank),
+        _flag_target(generation, 0),
+        scale,
+        UInt64(DEFAULT_TIMEOUT_NS),
+    )
 
 
 def allreduce[
@@ -229,71 +1071,58 @@ def allreduce[
     scale: Float32,
     generation: Int,
 ) raises:
-    var regions64 = StaticTuple[Int64, MAX_WORLD](fill=0)
-    for i in range(MAX_WORLD):
-        regions64[i] = Int64(regions[i])
-    comptime kern = _allreduce_kernel[dtype]
-    _enqueue_cached_stream[kern](
-        ctx,
-        stream,
-        String("allreduce_") + String(dtype),
-        BLOCK,
-        regions64,
-        Int32(rank),
-        Int32(world),
-        Int64(in_ptr),
-        Int64(out_ptr),
-        Int32(numel),
-        Int32(cap_bytes),
-        scale,
-        UInt64(generation),
-    )
+    """out[i] = scale * sum over ranks of in_r[i], enqueued on `stream`.
 
-
-# ---------------------------------------------------------------------------
-# broadcast: root copies its send buffer into its own stage_in, barrier,
-# every rank (root included) copies root's stage_in into its own recv
-# buffer, barrier. Byte-granular: NCCL's broadcast moves opaque bytes, no
-# reduction, so there is no dtype to specialize on.
-# ---------------------------------------------------------------------------
-
-
-@__llvm_metadata(
-    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(BLOCK))
-)
-def _broadcast_kernel(
-    regions: StaticTuple[Int64, MAX_WORLD],
-    rank: Int32,
-    root: Int32,
-    world: Int32,
-    send_ptr: Int64,
-    recv_ptr: Int64,
-    nbytes: Int32,
-    generation: UInt64,
-):
-    var my_region = Int(regions[Int(rank)])
-    var stage = Pointer[UInt8, MutAnyOrigin](
-        unsafe_from_address=my_region + SIG_BYTES
-    )
-    var n = Int(nbytes)
-    var tid = Int(thread_idx.x)
-    if rank == root:
-        var src = Pointer[UInt8, MutAnyOrigin](
-            unsafe_from_address=Int(send_ptr)
+    `in_ptr` may equal `out_ptr`. `numel * size_of[dtype]()` must be <=
+    `cap_bytes`. `scale` is applied on the final write and ignored for integer
+    dtypes (the caller passes 1.0 there).
+    """
+    _check_common(rank, world, cap_bytes, generation)
+    if numel == 0:
+        return
+    if numel < 0:
+        raise Error("collectives: numel must be >= 0")
+    comptime W = 16 // size_of[dtype]()
+    if numel * size_of[dtype]() > cap_bytes:
+        raise Error("collectives: allreduce message exceeds cap_bytes")
+    if (in_ptr | out_ptr) % 16 != 0:
+        # The payload loops use 16-byte vector loads/stores, which fault (or
+        # silently misbehave) on a misaligned address. Every allocator-returned
+        # pointer satisfies this; a mid-tensor view may not, and the caller
+        # must stage such a tensor into an aligned buffer rather than have this
+        # kernel guess. Byte collectives have a scalar fallback and need no
+        # such rule.
+        raise Error(
+            "collectives: allreduce needs 16-byte aligned in_ptr and out_ptr"
         )
-        for i in range(tid, n, BLOCK):
-            stage[unsafe_offset=i] = src[unsafe_offset=i]
-
-    _gen_barrier(regions, rank, world, 2 * generation)
-
-    var root_stage = Pointer[UInt8, MutAnyOrigin](
-        unsafe_from_address=Int(regions[Int(root)]) + SIG_BYTES
+    var rp = _region_ptrs(regions, rank, world)
+    # world == 1 needs no special case: the push and pull loops are empty, the
+    # sync is a self-rendezvous, and the reduce degenerates to out = scale*in.
+    var bytes = numel * size_of[dtype]()
+    var one_shot = bytes <= _ONESHOT_MAX_BYTES and (
+        world * _align_up(bytes, 16) <= 2 * cap_bytes
     )
-    var dst = Pointer[UInt8, MutAnyOrigin](unsafe_from_address=Int(recv_ptr))
-    for i in range(tid, n, BLOCK):
-        dst[unsafe_offset=i] = root_stage[unsafe_offset=i]
 
-    _gen_barrier(regions, rank, world, 2 * generation + 1)
+    if world == 8:
+        _launch_allreduce[dtype, W, 8](
+            ctx, stream, rp, in_ptr, out_ptr, numel, world, rank, cap_bytes, scale,
+            generation, one_shot,
+        )
+    elif world == 4:
+        _launch_allreduce[dtype, W, 4](
+            ctx, stream, rp, in_ptr, out_ptr, numel, world, rank, cap_bytes, scale,
+            generation, one_shot,
+        )
+    elif world == 2:
+        _launch_allreduce[dtype, W, 2](
+            ctx, stream, rp, in_ptr, out_ptr, numel, world, rank, cap_bytes, scale,
+            generation, one_shot,
+        )
+    else:
+        _launch_allreduce[dtype, W, 0](
+            ctx, stream, rp, in_ptr, out_ptr, numel, world, rank, cap_bytes, scale,
+            generation, one_shot,
+        )
 
 
 def broadcast(
@@ -309,72 +1138,42 @@ def broadcast(
     cap_bytes: Int,
     generation: Int,
 ) raises:
+    """recv on every rank <- send on `root`, dtype-agnostic, on `stream`.
+
+    Out-of-place capable: `send_ptr` and `recv_ptr` may differ (only the root
+    reads `send_ptr`). `nbytes` must be <= `cap_bytes`; the caller chunks
+    anything larger.
+    """
+    _check_common(rank, world, cap_bytes, generation)
+    if root < 0 or root >= world:
+        raise Error("collectives: root out of range")
+    if nbytes == 0:
+        return
+    if nbytes < 0:
+        raise Error("collectives: nbytes must be >= 0")
     if nbytes > cap_bytes:
-        raise Error("mojoccl: broadcast nbytes exceeds the region capacity")
-    var regions64 = StaticTuple[Int64, MAX_WORLD](fill=0)
-    for i in range(MAX_WORLD):
-        regions64[i] = Int64(regions[i])
-    comptime kern = _broadcast_kernel
-    _enqueue_cached_stream[kern](
+        raise Error("collectives: broadcast message exceeds cap_bytes")
+    var rp = _region_ptrs(regions, rank, world)
+    var blocks = min(
+        _COPY_MAX_BLOCKS,
+        max(1, (nbytes // 16 // world + BLOCK - 1) // BLOCK),
+    )
+    _enqueue_cached[_bcast_kernel[_UNROLL]](
         ctx,
         stream,
-        String("broadcast"),
-        BLOCK,
-        regions64,
+        "bcast",
+        blocks,
+        rp,
+        Pointer[UInt8, MutAnyOrigin](unsafe_from_address=send_ptr),
+        Pointer[UInt8, MutAnyOrigin](unsafe_from_address=recv_ptr),
+        Int64(nbytes),
+        Int64(_SIGNAL_BYTES),
+        Int32(world),
         Int32(rank),
         Int32(root),
-        Int32(world),
-        Int64(send_ptr),
-        Int64(recv_ptr),
-        Int32(nbytes),
-        UInt64(generation),
+        _flag_target(generation, 0),
+        UInt64(DEFAULT_TIMEOUT_NS),
     )
-
-
-# ---------------------------------------------------------------------------
-# allgather: every rank copies its chunk into its own stage_in, barrier,
-# every rank copies every peer's stage_in into the right slice of its own
-# output, barrier.
-# ---------------------------------------------------------------------------
-
-
-@__llvm_metadata(
-    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(BLOCK))
-)
-def _allgather_kernel(
-    regions: StaticTuple[Int64, MAX_WORLD],
-    rank: Int32,
-    world: Int32,
-    in_ptr: Int64,
-    out_ptr: Int64,
-    nbytes: Int32,
-    stride_bytes: Int32,
-    generation: UInt64,
-):
-    var my_region = Int(regions[Int(rank)])
-    var stage = Pointer[UInt8, MutAnyOrigin](
-        unsafe_from_address=my_region + SIG_BYTES
-    )
-    var src = Pointer[UInt8, MutAnyOrigin](unsafe_from_address=Int(in_ptr))
-    var n = Int(nbytes)
-    var tid = Int(thread_idx.x)
-    for i in range(tid, n, BLOCK):
-        stage[unsafe_offset=i] = src[unsafe_offset=i]
-
-    _gen_barrier(regions, rank, world, 2 * generation)
-
-    var dst = Pointer[UInt8, MutAnyOrigin](unsafe_from_address=Int(out_ptr))
-    var w = Int(world)
-    var stride = Int(stride_bytes)
-    for p in range(w):
-        var peer_stage = Pointer[UInt8, MutAnyOrigin](
-            unsafe_from_address=Int(regions[p]) + SIG_BYTES
-        )
-        var base = p * stride
-        for i in range(tid, n, BLOCK):
-            dst[unsafe_offset=base + i] = peer_stage[unsafe_offset=i]
-
-    _gen_barrier(regions, rank, world, 2 * generation + 1)
 
 
 def allgather(
@@ -390,34 +1189,41 @@ def allgather(
     generation: Int,
     stride_bytes: Int = -1,
 ) raises:
-    """`stride_bytes` (default `nbytes_per_rank`) is the OUTPUT layout's true
-    per-rank size, in bytes, separate from `nbytes_per_rank` (how much THIS
-    call moves). They differ only when the caller chunks one rank's
-    contribution across several calls: each chunk still lands at
-    `peer * stride_bytes + chunk_offset` in the flat `[rank0 | rank1 | ...]`
-    output, never at `peer * nbytes_per_rank`. A one-call (unchunked)
-    allgather needs no stride argument at all.
+    """out[r*stride_bytes ...] <- rank r's `nbytes_per_rank` input, on `stream`.
+
+    `stride_bytes` defaults to `nbytes_per_rank` and is the output layout's
+    true per-rank size, which differs when the caller splits one rank's
+    contribution across several calls. `nbytes_per_rank` must be <=
+    `cap_bytes`.
     """
+    _check_common(rank, world, cap_bytes, generation)
+    if nbytes_per_rank == 0:
+        return
+    if nbytes_per_rank < 0:
+        raise Error("collectives: nbytes_per_rank must be >= 0")
     if nbytes_per_rank > cap_bytes:
-        raise Error(
-            "mojoccl: allgather nbytes_per_rank exceeds the region capacity"
-        )
-    var stride = nbytes_per_rank if stride_bytes < 0 else stride_bytes
-    var regions64 = StaticTuple[Int64, MAX_WORLD](fill=0)
-    for i in range(MAX_WORLD):
-        regions64[i] = Int64(regions[i])
-    comptime kern = _allgather_kernel
-    _enqueue_cached_stream[kern](
+        raise Error("collectives: allgather message exceeds cap_bytes")
+    var stride = stride_bytes if stride_bytes >= 0 else nbytes_per_rank
+    if stride < nbytes_per_rank:
+        raise Error("collectives: stride_bytes < nbytes_per_rank")
+    var rp = _region_ptrs(regions, rank, world)
+    var blocks = min(
+        _COPY_MAX_BLOCKS,
+        max(1, (nbytes_per_rank // 16 + BLOCK - 1) // BLOCK),
+    )
+    _enqueue_cached[_allgather_kernel[_UNROLL]](
         ctx,
         stream,
-        String("allgather"),
-        BLOCK,
-        regions64,
-        Int32(rank),
+        "allgather",
+        blocks,
+        rp,
+        Pointer[UInt8, MutAnyOrigin](unsafe_from_address=in_ptr),
+        Pointer[UInt8, MutAnyOrigin](unsafe_from_address=out_ptr),
+        Int64(nbytes_per_rank),
+        Int64(stride),
+        Int64(_SIGNAL_BYTES),
         Int32(world),
-        Int64(in_ptr),
-        Int64(out_ptr),
-        Int32(nbytes_per_rank),
-        Int32(stride),
-        UInt64(generation),
+        Int32(rank),
+        _flag_target(generation, 0),
+        UInt64(DEFAULT_TIMEOUT_NS),
     )

--- a/torch_mojo_backend/distributed/mojoccl/driver.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/driver.mojo
@@ -1,0 +1,150 @@
+# Vendor CUDA/HIP driver shims for mojoccl.
+#
+# MAX's own allocator memory cannot be exported with legacy IPC (measured:
+# cuIpcGetMemHandle rc=1 on enqueue_create_buffer memory -- see
+# docs/mojo_collectives_feasibility.md in the main worktree, section 5.6), so
+# this library owns raw driver allocations (cuMemAlloc_v2 / hipExtMallocWith-
+# Flags) for its communication regions and shares them with legacy IPC
+# (cuIpc*/hipIpc*). Mirrors proto/ipc_probe.mojo's driver-call shape, called
+# through the library MAX already dlopened -- no C shim, no NCCL/RCCL.
+
+from std.ffi import OwnedDLHandle
+from max.gpu.host import DeviceContext, DeviceBuffer
+from std.sys import has_amd_gpu_accelerator
+
+comptime AMD = has_amd_gpu_accelerator()
+comptime DRIVER_LIB = "libamdhip64.so" if AMD else "libcuda.so.1"
+comptime FN_ALLOC = "hipExtMallocWithFlags" if AMD else "cuMemAlloc_v2"
+comptime FN_GET_HANDLE = "hipIpcGetMemHandle" if AMD else "cuIpcGetMemHandle"
+comptime FN_OPEN_HANDLE = "hipIpcOpenMemHandle" if AMD else "cuIpcOpenMemHandle"
+comptime FN_CLOSE_HANDLE = "hipIpcCloseMemHandle" if AMD else "cuIpcCloseMemHandle"
+comptime FN_FREE = "hipFree" if AMD else "cuMemFree_v2"
+comptime FN_GET_DEVICE = "hipGetDevice" if AMD else "cuCtxGetDevice"
+# CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS == hipIpcMemLazyEnablePeerAccess == 1
+comptime IPC_LAZY_PEER: UInt32 = 1
+# hipDeviceMallocUncached: cross-agent flag buffers must be uncached on AMD
+# (RCCL's own precondition for polled P2P flags); NVIDIA needs no such flag.
+comptime HIP_DEVICE_MALLOC_UNCACHED: UInt32 = 0x2
+
+comptime HANDLE_BYTES = 64
+
+
+def open_driver() raises -> OwnedDLHandle:
+    return OwnedDLHandle(DRIVER_LIB)
+
+
+def _check(rc: Int32, what: String) raises:
+    if rc != 0:
+        raise Error(what + " failed, rc=" + String(rc))
+
+
+def current_device_ordinal(lib: OwnedDLHandle) raises -> Int:
+    """The GPU this thread already has current.
+
+    NCCL's binding contract is "the device current on the calling thread"
+    (cudaSetDevice / hipSetDevice); nccl.py's set_current_device runs this
+    before ncclCommInitRank, matching real NCCL/RCCL -- so this queries
+    rather than sets, unlike proto/ipc_probe.mojo's standalone `make_current`.
+    """
+    var dev: Int32 = 0
+    _check(
+        lib.get_function[Int32](FN_GET_DEVICE)(Pointer(to=dev)), FN_GET_DEVICE
+    )
+    return Int(dev)
+
+
+def alloc_region(lib: OwnedDLHandle, nbytes: Int) raises -> Int:
+    """cuMemAlloc_v2 / hipExtMallocWithFlags(hipDeviceMallocUncached, size).
+
+    Returns the base device address. Not zeroed -- the caller zeros the
+    signal-area prefix via `zero_bytes` (region_init).
+    """
+    var base: Int = 0
+    comptime if AMD:
+        _check(
+            lib.get_function[Int32](FN_ALLOC)(
+                Pointer(to=base), nbytes, HIP_DEVICE_MALLOC_UNCACHED
+            ),
+            FN_ALLOC,
+        )
+    else:
+        _check(
+            lib.get_function[Int32](FN_ALLOC)(Pointer(to=base), nbytes),
+            FN_ALLOC,
+        )
+    return base
+
+
+def free_region(lib: OwnedDLHandle, addr: Int) raises:
+    _check(lib.get_function[Int32](FN_FREE)(addr), FN_FREE)
+
+
+def get_handle(
+    lib: OwnedDLHandle, addr: Int, out_bytes: Pointer[UInt8, MutAnyOrigin]
+) raises:
+    """cuIpcGetMemHandle / hipIpcGetMemHandle: fills `out_bytes[0:64]`."""
+    _check(
+        lib.get_function[Int32](FN_GET_HANDLE)(out_bytes, addr), FN_GET_HANDLE
+    )
+
+
+def open_handle(
+    lib: OwnedDLHandle, handle: Pointer[UInt8, MutAnyOrigin]
+) raises -> Int:
+    """cuIpcOpenMemHandle / hipIpcOpenMemHandle(..., LazyEnablePeerAccess).
+
+    `CUipcMemHandle`/`hipIpcMemHandle_t` is a 64-byte struct passed BY VALUE
+    (SysV MEMORY class: no integer register, pushed on the stack as 8 qwords)
+    after the two real leading args (pdptr -> rdi, flags -> esi) -- the exact
+    shim proto/ipc_probe.mojo uses and measured working (§5.3): four dummy
+    Int64 args exhaust rdx/rcx/r8/r9, then the 8 handle qwords land on the
+    stack where a real C caller would place them. `std.ffi` has no C-struct
+    ABI yet (MOCO-3692/3709).
+    """
+    var opn = lib.get_function[Int32](FN_OPEN_HANDLE)
+    var h64 = handle.unsafe_bitcast[UInt64]()
+    var ptr: Int = 0
+    _check(
+        opn(
+            Pointer(to=ptr),
+            IPC_LAZY_PEER,
+            Int64(0),
+            Int64(0),
+            Int64(0),
+            Int64(0),
+            h64[unsafe_offset=0],
+            h64[unsafe_offset=1],
+            h64[unsafe_offset=2],
+            h64[unsafe_offset=3],
+            h64[unsafe_offset=4],
+            h64[unsafe_offset=5],
+            h64[unsafe_offset=6],
+            h64[unsafe_offset=7],
+        ),
+        FN_OPEN_HANDLE,
+    )
+    return ptr
+
+
+def close_handle(lib: OwnedDLHandle, addr: Int) raises:
+    _check(lib.get_function[Int32](FN_CLOSE_HANDLE)(addr), FN_CLOSE_HANDLE)
+
+
+def zero_bytes(ctx: DeviceContext, addr: Int, nbytes: Int) raises:
+    """Zero-fill `nbytes` at a raw device address, blocking.
+
+    Blocking (unlike every per-collective op here) is fine: this runs once
+    per rank, at communicator creation, on `ctx`'s own queue -- while later
+    collectives run on the caller-supplied external stream, so without a
+    synchronize here the first collective could race this region_init.
+    """
+    var buf = DeviceBuffer[DType.uint8](
+        ctx,
+        Pointer[Scalar[DType.uint8], MutUntrackedOrigin](
+            unsafe_from_address=addr
+        ),
+        nbytes,
+        owning=False,
+    )
+    ctx.enqueue_memset(buf, 0)
+    ctx.synchronize()

--- a/torch_mojo_backend/distributed/mojoccl/driver.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/driver.mojo
@@ -10,7 +10,7 @@
 
 from std.ffi import OwnedDLHandle
 from max.gpu.host import DeviceContext, DeviceBuffer
-from std.sys import has_amd_gpu_accelerator
+from std.sys import has_amd_gpu_accelerator, stderr
 
 comptime AMD = has_amd_gpu_accelerator()
 comptime DRIVER_LIB = "libamdhip64.so" if AMD else "libcuda.so.1"
@@ -148,3 +148,13 @@ def zero_bytes(ctx: DeviceContext, addr: Int, nbytes: Int) raises:
     )
     ctx.enqueue_memset(buf, 0)
     ctx.synchronize()
+
+
+def warn_teardown(what: String, e: Error):
+    """Best-effort cleanup that failed: say so on stderr rather than hide it.
+    The error that started the teardown is the one propagating; this one only
+    needs to be visible."""
+    print(
+        "mojoccl: " + what + " failed during teardown: " + String(e),
+        file=stderr,
+    )

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -384,9 +384,25 @@ def ncclCommInitRank(
         for r in range(Int(nranks)):
             if r == Int(rank):
                 continue
-            wait_for_rank(dir, r, timeout_s)
-            _ = read_rank_handle(dir, r, _any(peer_handle))
-            regions[r] = open_handle(lib, _any(peer_handle))
+            try:
+                wait_for_rank(dir, r, timeout_s)
+                _ = read_rank_handle(dir, r, _any(peer_handle))
+                regions[r] = open_handle(lib, _any(peer_handle))
+            except:
+                # A peer past this one never got opened: close whatever
+                # peers < r WERE opened and free our own region before
+                # propagating, so a failed init leaks no IPC mappings.
+                for r2 in range(Int(nranks)):
+                    if r2 != Int(rank) and regions[r2] != 0:
+                        try:
+                            close_handle(lib, regions[r2])
+                        except:
+                            pass
+                try:
+                    free_region(lib, base)
+                except:
+                    pass
+                raise
 
         var state = CommState(
             rank=Int(rank),
@@ -402,7 +418,7 @@ def ncclCommInitRank(
         handle_ptr.unsafe_write(state^)
         comm_out[] = Int64(Int(handle_ptr))
         return NCCL_SUCCESS
-    except e:
+    except:
         return NCCL_INTERNAL_ERROR
 
 

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -43,7 +43,10 @@ from bootstrap import (
     decode_dir,
     encode_dir,
     read_rank_handle,
+    remove_rendezvous_dir,
+    wait_for_done,
     wait_for_rank,
+    write_rank_done,
     write_rank_handle,
 )
 from collectives_kernels import (
@@ -355,69 +358,105 @@ def ncclCommInitRank(
         idbuf64[unsafe_offset=15] = id15
         var dir = decode_dir(_any(idbuf))
 
-        var lib = open_driver()
-        var ordinal = current_device_ordinal(lib)
-        var ctx = DeviceContext(device_id=ordinal)
+        # Everything below either succeeds together or is unwound together:
+        # a failure past this point (region alloc, handle exchange, the
+        # peer-open loop, the done-marker wait) is caught here so rank 0 can
+        # remove the rendezvous directory it created in ncclGetUniqueId --
+        # otherwise it and every rank's handle/done file leak in /dev/shm
+        # forever, since no other rank will ever revisit this path.
+        try:
+            var lib = open_driver()
+            var ordinal = current_device_ordinal(lib)
+            var ctx = DeviceContext(device_id=ordinal)
 
-        var cap_bytes = _region_cap_bytes()
-        # A positive multiple of 4096 (the production kernel's own
-        # precondition, RESULTS.md §9) is what keeps every per-chunk offset
-        # `ncclAllReduce` forms (multiples of cap_bytes, one full chunk at a
-        # time) 16-byte aligned for every supported dtype -- 4096 divides
-        # evenly by 2, 4 and 8. A misconfigured MOJOCCL_REGION_MB (e.g. 0)
-        # would otherwise degrade chunk offsets to non-16-byte-aligned
-        # single-element steps.
-        if cap_bytes <= 0 or cap_bytes % 4096 != 0:
-            return NCCL_INVALID_ARGUMENT
-        var region_bytes = signal_bytes() + 2 * cap_bytes
-        var base = alloc_region(lib, region_bytes)
-        region_init(ctx, base)
+            var cap_bytes = _region_cap_bytes()
+            # A positive multiple of 4096 (the production kernel's own
+            # precondition, RESULTS.md §9) is what keeps every per-chunk
+            # offset `ncclAllReduce` forms (multiples of cap_bytes, one full
+            # chunk at a time) 16-byte aligned for every supported dtype --
+            # 4096 divides evenly by 2, 4 and 8. A misconfigured
+            # MOJOCCL_REGION_MB (e.g. 0) would otherwise degrade chunk
+            # offsets to non-16-byte-aligned single-element steps.
+            if cap_bytes <= 0 or cap_bytes % 4096 != 0:
+                if Int(rank) == 0:
+                    try:
+                        remove_rendezvous_dir(dir, Int(nranks))
+                    except:
+                        pass
+                return NCCL_INVALID_ARGUMENT
+            var region_bytes = signal_bytes() + 2 * cap_bytes
+            var base = alloc_region(lib, region_bytes)
+            region_init(ctx, base)
 
-        var my_handle = unsafe_alloc[UInt8](HANDLE_BYTES)
-        get_handle(lib, base, _any(my_handle))
-        write_rank_handle(dir, Int(rank), ordinal, _any(my_handle))
+            var my_handle = unsafe_alloc[UInt8](HANDLE_BYTES)
+            get_handle(lib, base, _any(my_handle))
+            write_rank_handle(dir, Int(rank), ordinal, _any(my_handle))
 
-        var timeout_s = _bootstrap_timeout_s()
-        var regions = StaticTuple[Int, MAX_WORLD](fill=0)
-        regions[Int(rank)] = base
-        var peer_handle = unsafe_alloc[UInt8](HANDLE_BYTES)
-        for r in range(Int(nranks)):
-            if r == Int(rank):
-                continue
-            try:
-                wait_for_rank(dir, r, timeout_s)
-                _ = read_rank_handle(dir, r, _any(peer_handle))
-                regions[r] = open_handle(lib, _any(peer_handle))
-            except:
-                # A peer past this one never got opened: close whatever
-                # peers < r WERE opened and free our own region before
-                # propagating, so a failed init leaks no IPC mappings.
-                for r2 in range(Int(nranks)):
-                    if r2 != Int(rank) and regions[r2] != 0:
-                        try:
-                            close_handle(lib, regions[r2])
-                        except:
-                            pass
+            var timeout_s = _bootstrap_timeout_s()
+            var regions = StaticTuple[Int, MAX_WORLD](fill=0)
+            regions[Int(rank)] = base
+            var peer_handle = unsafe_alloc[UInt8](HANDLE_BYTES)
+            for r in range(Int(nranks)):
+                if r == Int(rank):
+                    continue
                 try:
-                    free_region(lib, base)
+                    wait_for_rank(dir, r, timeout_s)
+                    _ = read_rank_handle(dir, r, _any(peer_handle))
+                    regions[r] = open_handle(lib, _any(peer_handle))
+                except:
+                    # A peer past this one never got opened: close whatever
+                    # peers < r WERE opened and free our own region before
+                    # propagating, so a failed init leaks no IPC mappings.
+                    for r2 in range(Int(nranks)):
+                        if r2 != Int(rank) and regions[r2] != 0:
+                            try:
+                                close_handle(lib, regions[r2])
+                            except:
+                                pass
+                    try:
+                        free_region(lib, base)
+                    except:
+                        pass
+                    raise
+
+            # Done protocol: every rank marks itself done once it has opened
+            # every peer's handle; rank 0 (and only rank 0) waits for all
+            # `nranks` markers and then removes `dir` -- otherwise
+            # /dev/shm/mojoccl-* directories and their per-rank handle files
+            # accumulate forever on a shared node (mkdtemp never cleans up
+            # after itself). Other ranks return as soon as their own marker
+            # is written; they do not wait for the directory to disappear.
+            write_rank_done(dir, Int(rank))
+            if Int(rank) == 0:
+                for r in range(Int(nranks)):
+                    if r != 0:
+                        wait_for_done(dir, r, timeout_s)
+                try:
+                    remove_rendezvous_dir(dir, Int(nranks))
+                except:
+                    pass  # a leftover /dev/shm dir is a nuisance, not a correctness bug
+
+            var state = CommState(
+                rank=Int(rank),
+                world=Int(nranks),
+                ordinal=ordinal,
+                ctx=ctx,
+                driver=lib^,
+                cap_bytes=cap_bytes,
+                regions=regions,
+                owned_base=base,
+            )
+            var handle_ptr = unsafe_alloc[CommState](1)
+            handle_ptr.unsafe_write(state^)
+            comm_out[] = Int64(Int(handle_ptr))
+            return NCCL_SUCCESS
+        except:
+            if Int(rank) == 0:
+                try:
+                    remove_rendezvous_dir(dir, Int(nranks))
                 except:
                     pass
-                raise
-
-        var state = CommState(
-            rank=Int(rank),
-            world=Int(nranks),
-            ordinal=ordinal,
-            ctx=ctx,
-            driver=lib^,
-            cap_bytes=cap_bytes,
-            regions=regions,
-            owned_base=base,
-        )
-        var handle_ptr = unsafe_alloc[CommState](1)
-        handle_ptr.unsafe_write(state^)
-        comm_out[] = Int64(Int(handle_ptr))
-        return NCCL_SUCCESS
+            raise
     except:
         return NCCL_INTERNAL_ERROR
 

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -183,8 +183,11 @@ def _wrap_stream(ctx: DeviceContext, handle: Int64) raises -> DeviceStream:
 
 @export
 def ncclGetVersion(version: Pointer[Int32, MutAnyOrigin]) abi("C") -> Int32:
-    # 2.31.2-shaped: matches the pinned header this ABI was written against.
-    version[] = 22031
+    # 2.31.2, encoded per nccl.h.in's NCCL_VERSION macro: X*10000+Y*100+Z for
+    # Y>8 (true from 2.9 on) -- 2*10000 + 31*100 + 2 = 23102, matching the
+    # pinned header this ABI was written against. (A prior value here, 22031,
+    # did not decode to 2.31.2 under that formula.)
+    version[] = 23102
     return NCCL_SUCCESS
 
 

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -69,11 +69,18 @@ comptime NCCL_INVALID_USAGE: Int32 = 5
 comptime NCCL_REMOTE_ERROR: Int32 = 6
 comptime NCCL_IN_PROGRESS: Int32 = 7
 
-# ncclDataType_t (nccl.h.in:466-479) -- values this library implements.
+# ncclDataType_t (nccl.h.in:466-479). AllReduce runs a real kernel and only
+# instantiates the five below; Broadcast/AllGather move raw bytes (item size
+# x count -> nbytes) and accept every type in the enum.
+comptime NCCL_INT8: Int32 = 0
+comptime NCCL_UINT8: Int32 = 1
 comptime NCCL_INT32: Int32 = 2
+comptime NCCL_UINT32: Int32 = 3
 comptime NCCL_INT64: Int32 = 4
+comptime NCCL_UINT64: Int32 = 5
 comptime NCCL_FLOAT16: Int32 = 6
 comptime NCCL_FLOAT32: Int32 = 7
+comptime NCCL_FLOAT64: Int32 = 8
 comptime NCCL_BFLOAT16: Int32 = 9
 
 # ncclRedOp_t (nccl.h.in:448-463) -- values this library implements.
@@ -103,9 +110,33 @@ def _bootstrap_timeout_s() -> Float64:
 
 
 def _dtype_item_bytes(nccl_dtype: Int32) -> Int:
+    """Item size for the five dtypes AllReduce's kernel is instantiated for."""
     if nccl_dtype == NCCL_INT32 or nccl_dtype == NCCL_FLOAT32:
         return 4
     elif nccl_dtype == NCCL_INT64:
+        return 8
+    elif nccl_dtype == NCCL_FLOAT16 or nccl_dtype == NCCL_BFLOAT16:
+        return 2
+    else:
+        return 0
+
+
+def _any_dtype_item_bytes(nccl_dtype: Int32) -> Int:
+    """Item size for every ncclDataType_t -- Broadcast/AllGather move raw
+    bytes and never look at the dtype beyond this."""
+    if nccl_dtype == NCCL_INT8 or nccl_dtype == NCCL_UINT8:
+        return 1
+    elif (
+        nccl_dtype == NCCL_INT32
+        or nccl_dtype == NCCL_UINT32
+        or nccl_dtype == NCCL_FLOAT32
+    ):
+        return 4
+    elif (
+        nccl_dtype == NCCL_INT64
+        or nccl_dtype == NCCL_UINT64
+        or nccl_dtype == NCCL_FLOAT64
+    ):
         return 8
     elif nccl_dtype == NCCL_FLOAT16 or nccl_dtype == NCCL_BFLOAT16:
         return 2
@@ -687,7 +718,7 @@ def ncclBroadcast(
     stream: Int64,
 ) abi("C") -> Int32:
     try:
-        var item = _dtype_item_bytes(datatype)
+        var item = _any_dtype_item_bytes(datatype)
         if item == 0:
             return NCCL_INVALID_ARGUMENT
         var ptr = _comm_ptr(comm)
@@ -733,7 +764,7 @@ def ncclAllGather(
     stream: Int64,
 ) abi("C") -> Int32:
     try:
-        var item = _dtype_item_bytes(datatype)
+        var item = _any_dtype_item_bytes(datatype)
         if item == 0:
             return NCCL_INVALID_ARGUMENT
         var ptr = _comm_ptr(comm)

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -20,6 +20,7 @@
 # (collectives_kernels.mojo), swapped out wholesale once the production
 # kernel lands.
 
+from std.collections import Dict
 from std.ffi import OwnedDLHandle
 from std.gpu import global_idx
 from std.memory.alloc import unsafe_alloc
@@ -166,6 +167,7 @@ struct CommState(Movable):
     var generation: Int
     var last_stream: Int64
     var aborted: Bool
+    var stream_cache: Dict[Int64, DeviceStream]
 
     def __init__(
         out self,
@@ -189,6 +191,7 @@ struct CommState(Movable):
         self.generation = 0
         self.last_stream = 0
         self.aborted = False
+        self.stream_cache = Dict[Int64, DeviceStream]()
 
 
 @always_inline
@@ -204,11 +207,23 @@ def _any(p: Pointer[UInt8, MutUntrackedOrigin]) -> Pointer[UInt8, MutAnyOrigin]:
     return Pointer[UInt8, MutAnyOrigin](unsafe_from_address=Int(p))
 
 
-@always_inline
-def _wrap_stream(ctx: DeviceContext, handle: Int64) raises -> DeviceStream:
-    return ctx.create_external_stream(
-        OpaquePointer[MutAnyOrigin](unsafe_from_address=Int(handle))
-    )
+def _ensure_stream_cached(mut state: CommState, handle: Int64) raises:
+    """`create_external_stream` wraps a raw `cudaStream_t`/`hipStream_t` in a
+    `DeviceStream`; every collective call was re-wrapping the SAME handle
+    (torch hands this library one stable stream per torch.Stream for the
+    whole communicator's life -- it is not reused across streams), so cache
+    the wrapper in `state.stream_cache` keyed by the raw handle instead of
+    re-wrapping on every call. A handle not seen before is wrapped and
+    inserted; callers then read `state.stream_cache[handle]` directly (a
+    `ref`, no copy). If a handle were ever reused for a different stream this
+    would keep returning the stale wrapper -- not something a torch process
+    does, but worth knowing if that assumption ever breaks.
+    """
+    if handle not in state.stream_cache:
+        var wrapped = state.ctx.create_external_stream(
+            OpaquePointer[MutAnyOrigin](unsafe_from_address=Int(handle))
+        )
+        _ = state.stream_cache.insert(handle, wrapped^)
 
 
 def _copy_error_word(
@@ -537,8 +552,15 @@ def ncclCommGetAsyncError(
         # can give is "everything enqueued so far landed", same as before --
         # only the read itself changes, from a host dereference of device
         # memory (wrong) to a real D2H copy (_read_error_word).
+        # Not cached: an error poll, not a collective -- rare enough that the
+        # wrap cost this library's cache exists to avoid does not matter here,
+        # and this is the one call site that needs a *fresh* wrap or the
+        # comm's own default stream depending on whether a collective has
+        # run yet, which does not fit the single-handle cache lookup below.
         var s = (
-            _wrap_stream(state.ctx, state.last_stream)
+            state.ctx.create_external_stream(
+                OpaquePointer[MutAnyOrigin](unsafe_from_address=Int(state.last_stream))
+            )
             if state.last_stream != 0
             else DeviceStream(state.ctx)
         )
@@ -620,7 +642,8 @@ def ncclAllReduce(
         if state.aborted:
             return NCCL_INVALID_USAGE
         state.last_stream = stream
-        var s = _wrap_stream(state.ctx, stream)
+        _ensure_stream_cached(state, stream)
+        ref s = state.stream_cache[stream]
         var scale = Float32(1.0)
         if op == NCCL_AVG:
             scale = Float32(1.0) / Float32(state.world)
@@ -703,7 +726,7 @@ def ncclAllReduce(
                 )
             done += chunk
         return NCCL_SUCCESS
-    except e:
+    except:
         return NCCL_INTERNAL_ERROR
 
 
@@ -728,7 +751,8 @@ def ncclBroadcast(
         if Int(root) < 0 or Int(root) >= state.world:
             return NCCL_INVALID_ARGUMENT
         state.last_stream = stream
-        var s = _wrap_stream(state.ctx, stream)
+        _ensure_stream_cached(state, stream)
+        ref s = state.stream_cache[stream]
         var total_bytes = Int(count) * item
         var max_bytes = max(item, state.cap_bytes)
         var done = 0
@@ -750,7 +774,7 @@ def ncclBroadcast(
             )
             done += chunk
         return NCCL_SUCCESS
-    except e:
+    except:
         return NCCL_INTERNAL_ERROR
 
 
@@ -772,7 +796,8 @@ def ncclAllGather(
         if state.aborted:
             return NCCL_INVALID_USAGE
         state.last_stream = stream
-        var s = _wrap_stream(state.ctx, stream)
+        _ensure_stream_cached(state, stream)
+        ref s = state.stream_cache[stream]
         var per_rank_bytes = Int(sendcount) * item
         var max_bytes = max(item, state.cap_bytes)
         var done = 0
@@ -794,7 +819,7 @@ def ncclAllGather(
             )
             done += chunk
         return NCCL_SUCCESS
-    except e:
+    except:
         return NCCL_INTERNAL_ERROR
 
 

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -21,10 +21,11 @@
 # kernel lands.
 
 from std.ffi import OwnedDLHandle
+from std.gpu import global_idx
 from std.memory.alloc import unsafe_alloc
 from std.os import getenv
 from std.utils import StaticTuple
-from max.gpu.host import DeviceContext, DeviceStream
+from max.gpu.host import DeviceContext, DeviceBuffer, DeviceStream
 
 from driver import (
     HANDLE_BYTES,
@@ -174,6 +175,51 @@ def _wrap_stream(ctx: DeviceContext, handle: Int64) raises -> DeviceStream:
     return ctx.create_external_stream(
         OpaquePointer[MutAnyOrigin](unsafe_from_address=Int(handle))
     )
+
+
+def _copy_error_word(
+    dst: Pointer[UInt64, MutAnyOrigin], src: Pointer[UInt64, MutAnyOrigin]
+):
+    """One-thread device kernel: copies the error word out of a region's
+    signal area -- raw driver memory (`cuMemAlloc`/`hipExtMallocWithFlags`),
+    not host-accessible -- into a proper `DeviceBuffer` `enqueue_copy` can
+    D2H-copy from. Mirrors the production kernel harness's `_copy_u64`
+    (kernel/harness.mojo, `check_error`): the error word cannot be read by
+    dereferencing a host pointer at the region address, that faults or reads
+    garbage.
+    """
+    if global_idx.x == 0:
+        dst[unsafe_offset=0] = src[unsafe_offset=0]
+
+
+def _read_error_word(
+    ctx: DeviceContext, stream: DeviceStream, region: Int
+) raises -> UInt64:
+    """The UInt64 error word at `region + error_offset()`, fetched to the
+    host via a real device-to-host copy (see `_copy_error_word`).
+
+    Enqueues the copy kernel on `stream` -- ordered after whatever
+    collective on it last wrote the word -- then a D2H `enqueue_copy`, then
+    blocks for both. Callers that need the fully up-to-date word (a peer's
+    in-flight barrier timeout, not just what already landed) must
+    synchronize `stream` themselves first, as `ncclCommGetAsyncError` does.
+    """
+    var src = Pointer[UInt64, MutAnyOrigin](
+        unsafe_from_address=region + error_offset()
+    )
+    var dev_word = ctx.enqueue_create_buffer[DType.uint64](1)
+    var compiled = ctx.compile_function[_copy_error_word]()
+    stream.enqueue_function(
+        compiled,
+        dev_word.unsafe_ptr(),
+        src,
+        grid_dim=(1, 1, 1),
+        block_dim=(32, 1, 1),
+    )
+    var host_word = unsafe_alloc[UInt64](1)
+    ctx.enqueue_copy(host_word, dev_word)
+    ctx.synchronize()
+    return host_word[unsafe_offset=0]
 
 
 # ---------------------------------------------------------------------------
@@ -392,13 +438,18 @@ def ncclCommGetAsyncError(
         if state.aborted:
             err_out[] = NCCL_SYSTEM_ERROR
             return NCCL_SUCCESS
-        if state.last_stream != 0:
-            var s = _wrap_stream(state.ctx, state.last_stream)
-            s.synchronize()
-        var err_word = Pointer[UInt64, MutAnyOrigin](
-            unsafe_from_address=state.regions[state.rank] + error_offset()
+        # Synchronize first: the freshest read this cheaply-checkable word
+        # can give is "everything enqueued so far landed", same as before --
+        # only the read itself changes, from a host dereference of device
+        # memory (wrong) to a real D2H copy (_read_error_word).
+        var s = (
+            _wrap_stream(state.ctx, state.last_stream)
+            if state.last_stream != 0
+            else DeviceStream(state.ctx)
         )
-        err_out[] = NCCL_REMOTE_ERROR if Int(err_word[]) != 0 else NCCL_SUCCESS
+        s.synchronize()
+        var word = _read_error_word(state.ctx, s, state.regions[state.rank])
+        err_out[] = NCCL_REMOTE_ERROR if Int(word) != 0 else NCCL_SUCCESS
         return NCCL_SUCCESS
     except e:
         return NCCL_INTERNAL_ERROR

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -37,6 +37,7 @@ from driver import (
     get_handle,
     open_driver,
     open_handle,
+    warn_teardown,
 )
 from bootstrap import (
     UID_BYTES,
@@ -427,8 +428,8 @@ def ncclCommInitRank(
                 if Int(rank) == 0:
                     try:
                         remove_rendezvous_dir(dir, Int(nranks))
-                    except:
-                        pass
+                    except e:
+                        warn_teardown("removing the rendezvous dir", e)
                 return NCCL_INVALID_ARGUMENT
             var region_bytes = signal_bytes() + 2 * cap_bytes
             var base = alloc_region(lib, region_bytes)
@@ -457,12 +458,12 @@ def ncclCommInitRank(
                         if r2 != Int(rank) and regions[r2] != 0:
                             try:
                                 close_handle(lib, regions[r2])
-                            except:
-                                pass
+                            except e:
+                                warn_teardown("closing a peer's IPC handle", e)
                     try:
                         free_region(lib, base)
-                    except:
-                        pass
+                    except e:
+                        warn_teardown("freeing the region", e)
                     raise
 
             # Done protocol: every rank marks itself done once it has opened
@@ -479,8 +480,8 @@ def ncclCommInitRank(
                         wait_for_done(dir, r, timeout_s)
                 try:
                     remove_rendezvous_dir(dir, Int(nranks))
-                except:
-                    pass  # a leftover /dev/shm dir is a nuisance, not a correctness bug
+                except e:
+                    warn_teardown("removing the rendezvous dir", e)
 
             var state = CommState(
                 rank=Int(rank),
@@ -500,8 +501,8 @@ def ncclCommInitRank(
             if Int(rank) == 0:
                 try:
                     remove_rendezvous_dir(dir, Int(nranks))
-                except:
-                    pass
+                except e:
+                    warn_teardown("removing the rendezvous dir", e)
             raise
     except:
         return NCCL_INTERNAL_ERROR
@@ -557,13 +558,11 @@ def ncclCommGetAsyncError(
         # and this is the one call site that needs a *fresh* wrap or the
         # comm's own default stream depending on whether a collective has
         # run yet, which does not fit the single-handle cache lookup below.
-        var s = (
-            state.ctx.create_external_stream(
-                OpaquePointer[MutAnyOrigin](unsafe_from_address=Int(state.last_stream))
+        var s = state.ctx.create_external_stream(
+            OpaquePointer[MutAnyOrigin](
+                unsafe_from_address=Int(state.last_stream)
             )
-            if state.last_stream != 0
-            else DeviceStream(state.ctx)
-        )
+        ) if state.last_stream != 0 else DeviceStream(state.ctx)
         s.synchronize()
         var word = _read_error_word(state.ctx, s, state.regions[state.rank])
         err_out[] = NCCL_REMOTE_ERROR if Int(word) != 0 else NCCL_SUCCESS

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -279,6 +279,15 @@ def ncclCommInitRank(
     id14: UInt64,
     id15: UInt64,
 ) abi("C") -> Int32:
+    # `regions` (CommState and every collective kernel's argument list) is a
+    # fixed StaticTuple[.., MAX_WORLD]: a larger world would index past its
+    # end. Guard explicitly rather than rely on StaticTuple's own bounds
+    # check, whose behavior under a release (non-debug) build is not this
+    # library's contract to depend on.
+    if Int(nranks) > MAX_WORLD or Int(nranks) < 1:
+        return NCCL_INVALID_ARGUMENT
+    if Int(rank) < 0 or Int(rank) >= Int(nranks):
+        return NCCL_INVALID_ARGUMENT
     try:
         var idbuf = unsafe_alloc[UInt8](UID_BYTES)
         var idbuf64 = idbuf.unsafe_bitcast[UInt64]()

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -1,0 +1,689 @@
+# mojoccl: a Mojo shared library exporting NCCL's C ABI (nccl.h), so
+# torch_mojo_backend/distributed/nccl.py can dlopen it exactly like
+# libnccl.so.2/librccl.so.1 (TORCH_MOJO_BACKEND_CCL=mojo), and so external
+# tools (nccl-tests) can link it as a libnccl.so drop-in.
+#
+# Signatures, enum values and ncclResult_t codes are pinned to
+# /home/gabriel/projects/nccl/src/nccl.h.in (2.31.2) -- the source of truth
+# is nccl.py's `_declare()`, which this library's exports were written
+# against. AllReduce/Broadcast/AllGather are real; Reduce/ReduceScatter/
+# Send/Recv return ncclInvalidUsage (GPT-2 DDP needs only the first three;
+# tests/ddp_worker.py skips the checks that need them when
+# TORCH_MOJO_BACKEND_CCL=mojo is set).
+#
+# One process per GPU, one region per rank, raw driver-owned memory shared
+# with legacy IPC (driver.mojo) -- MAX's own allocator memory cannot be
+# exported that way (see docs/mojo_collectives_feasibility.md in the main
+# worktree, §5.6). Bootstrap (the handle exchange ncclCommInitRank itself
+# must do) rides a /dev/shm directory encoded in the 128-byte unique id
+# (bootstrap.mojo); the collectives are the STAND-IN kernel
+# (collectives_kernels.mojo), swapped out wholesale once the production
+# kernel lands.
+
+from std.ffi import OwnedDLHandle
+from std.memory.alloc import unsafe_alloc
+from std.os import getenv
+from std.utils import StaticTuple
+from max.gpu.host import DeviceContext, DeviceStream
+
+from driver import (
+    HANDLE_BYTES,
+    alloc_region,
+    close_handle,
+    current_device_ordinal,
+    free_region,
+    get_handle,
+    open_driver,
+    open_handle,
+)
+from bootstrap import (
+    UID_BYTES,
+    create_rendezvous_dir,
+    decode_dir,
+    encode_dir,
+    read_rank_handle,
+    wait_for_rank,
+    write_rank_handle,
+)
+from collectives_kernels import (
+    MAX_WORLD,
+    allgather,
+    allreduce,
+    broadcast,
+    error_offset,
+    region_init,
+    signal_bytes,
+)
+
+# ncclResult_t (nccl.h.in:44-53)
+comptime NCCL_SUCCESS: Int32 = 0
+comptime NCCL_UNHANDLED_CUDA_ERROR: Int32 = 1
+comptime NCCL_SYSTEM_ERROR: Int32 = 2
+comptime NCCL_INTERNAL_ERROR: Int32 = 3
+comptime NCCL_INVALID_ARGUMENT: Int32 = 4
+comptime NCCL_INVALID_USAGE: Int32 = 5
+comptime NCCL_REMOTE_ERROR: Int32 = 6
+comptime NCCL_IN_PROGRESS: Int32 = 7
+
+# ncclDataType_t (nccl.h.in:466-479) -- values this library implements.
+comptime NCCL_INT32: Int32 = 2
+comptime NCCL_INT64: Int32 = 4
+comptime NCCL_FLOAT16: Int32 = 6
+comptime NCCL_FLOAT32: Int32 = 7
+comptime NCCL_BFLOAT16: Int32 = 9
+
+# ncclRedOp_t (nccl.h.in:448-463) -- values this library implements.
+comptime NCCL_SUM: Int32 = 0
+comptime NCCL_AVG: Int32 = 4
+
+comptime DEFAULT_REGION_MB = 256
+comptime DEFAULT_BOOTSTRAP_TIMEOUT_S: Float64 = 120.0
+
+
+def _region_cap_bytes() -> Int:
+    var s = getenv("MOJOCCL_REGION_MB", String(DEFAULT_REGION_MB))
+    try:
+        return Int(s) * 1024 * 1024
+    except:
+        return DEFAULT_REGION_MB * 1024 * 1024
+
+
+def _bootstrap_timeout_s() -> Float64:
+    var s = getenv(
+        "MOJOCCL_BOOTSTRAP_TIMEOUT_S", String(DEFAULT_BOOTSTRAP_TIMEOUT_S)
+    )
+    try:
+        return Float64(s)
+    except:
+        return DEFAULT_BOOTSTRAP_TIMEOUT_S
+
+
+def _dtype_item_bytes(nccl_dtype: Int32) -> Int:
+    if nccl_dtype == NCCL_INT32 or nccl_dtype == NCCL_FLOAT32:
+        return 4
+    elif nccl_dtype == NCCL_INT64:
+        return 8
+    elif nccl_dtype == NCCL_FLOAT16 or nccl_dtype == NCCL_BFLOAT16:
+        return 2
+    else:
+        return 0
+
+
+# ---------------------------------------------------------------------------
+# Communicator state, behind the opaque `ncclComm_t` (void*) every exported
+# function after ncclCommInitRank receives. Heap-allocated once per
+# communicator and never freed on destroy (the struct itself is a few
+# hundred bytes; only the GPU region and peer IPC mappings -- the resources
+# that matter -- are released there). `regions` is padded to MAX_WORLD with
+# zeros; only indices < world are ever read.
+# ---------------------------------------------------------------------------
+
+
+struct CommState(Movable):
+    var rank: Int
+    var world: Int
+    var ordinal: Int
+    var ctx: DeviceContext
+    var driver: OwnedDLHandle
+    var cap_bytes: Int
+    var regions: StaticTuple[Int, MAX_WORLD]
+    var owned_base: Int
+    var generation: Int
+    var last_stream: Int64
+    var aborted: Bool
+
+    def __init__(
+        out self,
+        rank: Int,
+        world: Int,
+        ordinal: Int,
+        ctx: DeviceContext,
+        var driver: OwnedDLHandle,
+        cap_bytes: Int,
+        regions: StaticTuple[Int, MAX_WORLD],
+        owned_base: Int,
+    ):
+        self.rank = rank
+        self.world = world
+        self.ordinal = ordinal
+        self.ctx = ctx
+        self.driver = driver^
+        self.cap_bytes = cap_bytes
+        self.regions = regions
+        self.owned_base = owned_base
+        self.generation = 0
+        self.last_stream = 0
+        self.aborted = False
+
+
+@always_inline
+def _comm_ptr(comm: Int64) -> Pointer[CommState, MutAnyOrigin]:
+    return Pointer[CommState, MutAnyOrigin](unsafe_from_address=Int(comm))
+
+
+@always_inline
+def _any(p: Pointer[UInt8, MutUntrackedOrigin]) -> Pointer[UInt8, MutAnyOrigin]:
+    """Rebinds an `unsafe_alloc`-returned pointer's origin to `MutAnyOrigin`,
+    matching what driver.mojo/bootstrap.mojo (and the exported ABI functions
+    they share signatures with) declare."""
+    return Pointer[UInt8, MutAnyOrigin](unsafe_from_address=Int(p))
+
+
+@always_inline
+def _wrap_stream(ctx: DeviceContext, handle: Int64) raises -> DeviceStream:
+    return ctx.create_external_stream(
+        OpaquePointer[MutAnyOrigin](unsafe_from_address=Int(handle))
+    )
+
+
+# ---------------------------------------------------------------------------
+# Version / error string / unique id
+# ---------------------------------------------------------------------------
+
+
+@export
+def ncclGetVersion(version: Pointer[Int32, MutAnyOrigin]) abi("C") -> Int32:
+    # 2.31.2-shaped: matches the pinned header this ABI was written against.
+    version[] = 22031
+    return NCCL_SUCCESS
+
+
+comptime _ERR_SUCCESS: StaticString = "no error"
+comptime _ERR_UNHANDLED_CUDA: StaticString = "unhandled cuda/hip error"
+comptime _ERR_SYSTEM: StaticString = "system error"
+comptime _ERR_INTERNAL: StaticString = "internal error"
+comptime _ERR_INVALID_ARGUMENT: StaticString = "invalid argument"
+comptime _ERR_INVALID_USAGE: StaticString = (
+    "invalid usage (not implemented by mojoccl)"
+)
+comptime _ERR_REMOTE: StaticString = "remote error (a peer's barrier timed out)"
+comptime _ERR_IN_PROGRESS: StaticString = "operation in progress"
+comptime _ERR_UNKNOWN: StaticString = "unknown result code"
+
+
+@export
+def ncclGetErrorString(
+    result: Int32,
+) abi("C") -> Pointer[UInt8, ImmStaticOrigin]:
+    if result == NCCL_SUCCESS:
+        return _ERR_SUCCESS.unsafe_ptr()
+    elif result == NCCL_UNHANDLED_CUDA_ERROR:
+        return _ERR_UNHANDLED_CUDA.unsafe_ptr()
+    elif result == NCCL_SYSTEM_ERROR:
+        return _ERR_SYSTEM.unsafe_ptr()
+    elif result == NCCL_INTERNAL_ERROR:
+        return _ERR_INTERNAL.unsafe_ptr()
+    elif result == NCCL_INVALID_ARGUMENT:
+        return _ERR_INVALID_ARGUMENT.unsafe_ptr()
+    elif result == NCCL_INVALID_USAGE:
+        return _ERR_INVALID_USAGE.unsafe_ptr()
+    elif result == NCCL_REMOTE_ERROR:
+        return _ERR_REMOTE.unsafe_ptr()
+    elif result == NCCL_IN_PROGRESS:
+        return _ERR_IN_PROGRESS.unsafe_ptr()
+    else:
+        return _ERR_UNKNOWN.unsafe_ptr()
+
+
+@export
+def ncclGetUniqueId(uid_out: Pointer[UInt8, MutAnyOrigin]) abi("C") -> Int32:
+    try:
+        var dir = create_rendezvous_dir()
+        encode_dir(dir, uid_out)
+        return NCCL_SUCCESS
+    except e:
+        return NCCL_SYSTEM_ERROR
+
+
+# ---------------------------------------------------------------------------
+# ncclCommInitRank -- the one struct-by-value export. `ncclUniqueId commId`
+# is 128 bytes, SysV MEMORY class: it consumes no integer register and is
+# pushed on the stack by a real C caller, so `rank` (declared after it) gets
+# the next FREE register (rdx), not the one following `nranks` textually.
+# Mirrored here by 3 real leading params (comm/nranks/rank -> rdi/esi/edx),
+# 3 Int64 dummies exhausting rcx/r8/r9, then 16 UInt64 stack params that ARE
+# the struct -- the callee-side twin of the caller-side shim
+# proto/ipc_probe.mojo uses for cuIpcOpenMemHandle. Verified host-only with
+# ctypes against this exact parameter shape (register/stack layout, no GPU
+# needed): a probe function of this shape decoded nranks, rank and a
+# checksum of the 16 id words correctly when called exactly as
+# ncclCommInitRank(comm, nranks, ncclUniqueId, rank) would be.
+# ---------------------------------------------------------------------------
+
+
+@export
+def ncclCommInitRank(
+    comm_out: Pointer[Int64, MutAnyOrigin],
+    nranks: Int32,
+    rank: Int32,
+    _r1: Int64,
+    _r2: Int64,
+    _r3: Int64,
+    id0: UInt64,
+    id1: UInt64,
+    id2: UInt64,
+    id3: UInt64,
+    id4: UInt64,
+    id5: UInt64,
+    id6: UInt64,
+    id7: UInt64,
+    id8: UInt64,
+    id9: UInt64,
+    id10: UInt64,
+    id11: UInt64,
+    id12: UInt64,
+    id13: UInt64,
+    id14: UInt64,
+    id15: UInt64,
+) abi("C") -> Int32:
+    try:
+        var idbuf = unsafe_alloc[UInt8](UID_BYTES)
+        var idbuf64 = idbuf.unsafe_bitcast[UInt64]()
+        idbuf64[unsafe_offset=0] = id0
+        idbuf64[unsafe_offset=1] = id1
+        idbuf64[unsafe_offset=2] = id2
+        idbuf64[unsafe_offset=3] = id3
+        idbuf64[unsafe_offset=4] = id4
+        idbuf64[unsafe_offset=5] = id5
+        idbuf64[unsafe_offset=6] = id6
+        idbuf64[unsafe_offset=7] = id7
+        idbuf64[unsafe_offset=8] = id8
+        idbuf64[unsafe_offset=9] = id9
+        idbuf64[unsafe_offset=10] = id10
+        idbuf64[unsafe_offset=11] = id11
+        idbuf64[unsafe_offset=12] = id12
+        idbuf64[unsafe_offset=13] = id13
+        idbuf64[unsafe_offset=14] = id14
+        idbuf64[unsafe_offset=15] = id15
+        var dir = decode_dir(_any(idbuf))
+
+        var lib = open_driver()
+        var ordinal = current_device_ordinal(lib)
+        var ctx = DeviceContext(device_id=ordinal)
+
+        var cap_bytes = _region_cap_bytes()
+        var region_bytes = signal_bytes() + 2 * cap_bytes
+        var base = alloc_region(lib, region_bytes)
+        region_init(ctx, base)
+
+        var my_handle = unsafe_alloc[UInt8](HANDLE_BYTES)
+        get_handle(lib, base, _any(my_handle))
+        write_rank_handle(dir, Int(rank), ordinal, _any(my_handle))
+
+        var timeout_s = _bootstrap_timeout_s()
+        var regions = StaticTuple[Int, MAX_WORLD](fill=0)
+        regions[Int(rank)] = base
+        var peer_handle = unsafe_alloc[UInt8](HANDLE_BYTES)
+        for r in range(Int(nranks)):
+            if r == Int(rank):
+                continue
+            wait_for_rank(dir, r, timeout_s)
+            _ = read_rank_handle(dir, r, _any(peer_handle))
+            regions[r] = open_handle(lib, _any(peer_handle))
+
+        var state = CommState(
+            rank=Int(rank),
+            world=Int(nranks),
+            ordinal=ordinal,
+            ctx=ctx,
+            driver=lib^,
+            cap_bytes=cap_bytes,
+            regions=regions,
+            owned_base=base,
+        )
+        var handle_ptr = unsafe_alloc[CommState](1)
+        handle_ptr.unsafe_write(state^)
+        comm_out[] = Int64(Int(handle_ptr))
+        return NCCL_SUCCESS
+    except e:
+        return NCCL_INTERNAL_ERROR
+
+
+# ---------------------------------------------------------------------------
+# Communicator lifecycle
+# ---------------------------------------------------------------------------
+
+
+@export
+def ncclCommDestroy(comm: Int64) abi("C") -> Int32:
+    try:
+        var ptr = _comm_ptr(comm)
+        ref state = ptr[]
+        if not state.aborted:
+            state.ctx.synchronize()
+            for r in range(state.world):
+                if r != state.rank:
+                    close_handle(state.driver, state.regions[r])
+            free_region(state.driver, state.owned_base)
+        return NCCL_SUCCESS
+    except e:
+        return NCCL_INTERNAL_ERROR
+
+
+@export
+def ncclCommAbort(comm: Int64) abi("C") -> Int32:
+    ref state = _comm_ptr(comm)[]
+    # No wait, no cleanup of GPU resources here (a dead peer may hang
+    # forever inside its own barrier spin) -- matches ncclCommAbort's
+    # documented "don't wait" contract. ncclCommDestroy is never called
+    # after abort() by nccl.py's NcclComm.
+    state.aborted = True
+    return NCCL_SUCCESS
+
+
+@export
+def ncclCommGetAsyncError(
+    comm: Int64, err_out: Pointer[Int32, MutAnyOrigin]
+) abi("C") -> Int32:
+    try:
+        ref state = _comm_ptr(comm)[]
+        if state.aborted:
+            err_out[] = NCCL_SYSTEM_ERROR
+            return NCCL_SUCCESS
+        if state.last_stream != 0:
+            var s = _wrap_stream(state.ctx, state.last_stream)
+            s.synchronize()
+        var err_word = Pointer[UInt64, MutAnyOrigin](
+            unsafe_from_address=state.regions[state.rank] + error_offset()
+        )
+        err_out[] = NCCL_REMOTE_ERROR if Int(err_word[]) != 0 else NCCL_SUCCESS
+        return NCCL_SUCCESS
+    except e:
+        return NCCL_INTERNAL_ERROR
+
+
+@export
+def ncclCommCount(
+    comm: Int64, count_out: Pointer[Int32, MutAnyOrigin]
+) abi("C") -> Int32:
+    ref state = _comm_ptr(comm)[]
+    count_out[] = Int32(state.world)
+    return NCCL_SUCCESS
+
+
+@export
+def ncclCommUserRank(
+    comm: Int64, rank_out: Pointer[Int32, MutAnyOrigin]
+) abi("C") -> Int32:
+    ref state = _comm_ptr(comm)[]
+    rank_out[] = Int32(state.rank)
+    return NCCL_SUCCESS
+
+
+# ---------------------------------------------------------------------------
+# Group semantics: every op here already executes on the same stream, in
+# issue order, so aggregating a group buys nothing -- immediate execution is
+# correct, per the design brief.
+# ---------------------------------------------------------------------------
+
+
+@export
+def ncclGroupStart() abi("C") -> Int32:
+    return NCCL_SUCCESS
+
+
+@export
+def ncclGroupEnd() abi("C") -> Int32:
+    return NCCL_SUCCESS
+
+
+# ---------------------------------------------------------------------------
+# Collectives
+# ---------------------------------------------------------------------------
+
+
+@export
+def ncclAllReduce(
+    sendbuff: Int64,
+    recvbuff: Int64,
+    count: Int64,
+    datatype: Int32,
+    op: Int32,
+    comm: Int64,
+    stream: Int64,
+) abi("C") -> Int32:
+    try:
+        var item = _dtype_item_bytes(datatype)
+        if item == 0:
+            return NCCL_INVALID_ARGUMENT
+        if op != NCCL_SUM and op != NCCL_AVG:
+            return NCCL_INVALID_USAGE
+        var ptr = _comm_ptr(comm)
+        ref state = ptr[]
+        if state.aborted:
+            return NCCL_INVALID_USAGE
+        state.last_stream = stream
+        var s = _wrap_stream(state.ctx, stream)
+        var scale = Float32(1.0)
+        if op == NCCL_AVG:
+            scale = Float32(1.0) / Float32(state.world)
+        var max_elems = max(1, state.cap_bytes // item)
+        var total = Int(count)
+        var done = 0
+        while done < total:
+            var chunk = min(max_elems, total - done)
+            state.generation += 1
+            var off = done * item
+            if datatype == NCCL_INT32:
+                allreduce[DType.int32](
+                    state.ctx,
+                    s,
+                    state.rank,
+                    state.world,
+                    state.regions,
+                    Int(sendbuff) + off,
+                    Int(recvbuff) + off,
+                    chunk,
+                    state.cap_bytes,
+                    scale,
+                    state.generation,
+                )
+            elif datatype == NCCL_INT64:
+                allreduce[DType.int64](
+                    state.ctx,
+                    s,
+                    state.rank,
+                    state.world,
+                    state.regions,
+                    Int(sendbuff) + off,
+                    Int(recvbuff) + off,
+                    chunk,
+                    state.cap_bytes,
+                    scale,
+                    state.generation,
+                )
+            elif datatype == NCCL_FLOAT16:
+                allreduce[DType.float16](
+                    state.ctx,
+                    s,
+                    state.rank,
+                    state.world,
+                    state.regions,
+                    Int(sendbuff) + off,
+                    Int(recvbuff) + off,
+                    chunk,
+                    state.cap_bytes,
+                    scale,
+                    state.generation,
+                )
+            elif datatype == NCCL_FLOAT32:
+                allreduce[DType.float32](
+                    state.ctx,
+                    s,
+                    state.rank,
+                    state.world,
+                    state.regions,
+                    Int(sendbuff) + off,
+                    Int(recvbuff) + off,
+                    chunk,
+                    state.cap_bytes,
+                    scale,
+                    state.generation,
+                )
+            else:  # NCCL_BFLOAT16, ruled in by _dtype_item_bytes above
+                allreduce[DType.bfloat16](
+                    state.ctx,
+                    s,
+                    state.rank,
+                    state.world,
+                    state.regions,
+                    Int(sendbuff) + off,
+                    Int(recvbuff) + off,
+                    chunk,
+                    state.cap_bytes,
+                    scale,
+                    state.generation,
+                )
+            done += chunk
+        return NCCL_SUCCESS
+    except e:
+        return NCCL_INTERNAL_ERROR
+
+
+@export
+def ncclBroadcast(
+    sendbuff: Int64,
+    recvbuff: Int64,
+    count: Int64,
+    datatype: Int32,
+    root: Int32,
+    comm: Int64,
+    stream: Int64,
+) abi("C") -> Int32:
+    try:
+        var item = _dtype_item_bytes(datatype)
+        if item == 0:
+            return NCCL_INVALID_ARGUMENT
+        var ptr = _comm_ptr(comm)
+        ref state = ptr[]
+        if state.aborted:
+            return NCCL_INVALID_USAGE
+        if Int(root) < 0 or Int(root) >= state.world:
+            return NCCL_INVALID_ARGUMENT
+        state.last_stream = stream
+        var s = _wrap_stream(state.ctx, stream)
+        var total_bytes = Int(count) * item
+        var max_bytes = max(item, state.cap_bytes)
+        var done = 0
+        while done < total_bytes:
+            var chunk = min(max_bytes, total_bytes - done)
+            state.generation += 1
+            broadcast(
+                state.ctx,
+                s,
+                state.rank,
+                Int(root),
+                state.world,
+                state.regions,
+                Int(sendbuff) + done,
+                Int(recvbuff) + done,
+                chunk,
+                state.cap_bytes,
+                state.generation,
+            )
+            done += chunk
+        return NCCL_SUCCESS
+    except e:
+        return NCCL_INTERNAL_ERROR
+
+
+@export
+def ncclAllGather(
+    sendbuff: Int64,
+    recvbuff: Int64,
+    sendcount: Int64,
+    datatype: Int32,
+    comm: Int64,
+    stream: Int64,
+) abi("C") -> Int32:
+    try:
+        var item = _dtype_item_bytes(datatype)
+        if item == 0:
+            return NCCL_INVALID_ARGUMENT
+        var ptr = _comm_ptr(comm)
+        ref state = ptr[]
+        if state.aborted:
+            return NCCL_INVALID_USAGE
+        state.last_stream = stream
+        var s = _wrap_stream(state.ctx, stream)
+        var per_rank_bytes = Int(sendcount) * item
+        var max_bytes = max(item, state.cap_bytes)
+        var done = 0
+        while done < per_rank_bytes:
+            var chunk = min(max_bytes, per_rank_bytes - done)
+            state.generation += 1
+            allgather(
+                state.ctx,
+                s,
+                state.rank,
+                state.world,
+                state.regions,
+                Int(sendbuff) + done,
+                Int(recvbuff) + done,
+                chunk,
+                state.cap_bytes,
+                state.generation,
+                stride_bytes=per_rank_bytes,
+            )
+            done += chunk
+        return NCCL_SUCCESS
+    except e:
+        return NCCL_INTERNAL_ERROR
+
+
+# ---------------------------------------------------------------------------
+# Not implemented: DDP on GPT-2 needs only AllReduce/Broadcast/AllGather (+
+# barrier, which routes to gloo -- see process_group.py). Returning
+# ncclInvalidUsage rather than silently mis-computing is the point.
+# ---------------------------------------------------------------------------
+
+
+@export
+def ncclReduce(
+    sendbuff: Int64,
+    recvbuff: Int64,
+    count: Int64,
+    datatype: Int32,
+    op: Int32,
+    root: Int32,
+    comm: Int64,
+    stream: Int64,
+) abi("C") -> Int32:
+    return NCCL_INVALID_USAGE
+
+
+@export
+def ncclReduceScatter(
+    sendbuff: Int64,
+    recvbuff: Int64,
+    count: Int64,
+    datatype: Int32,
+    op: Int32,
+    comm: Int64,
+    stream: Int64,
+) abi("C") -> Int32:
+    return NCCL_INVALID_USAGE
+
+
+@export
+def ncclSend(
+    sendbuff: Int64,
+    count: Int64,
+    datatype: Int32,
+    peer: Int32,
+    comm: Int64,
+    stream: Int64,
+) abi("C") -> Int32:
+    return NCCL_INVALID_USAGE
+
+
+@export
+def ncclRecv(
+    recvbuff: Int64,
+    count: Int64,
+    datatype: Int32,
+    peer: Int32,
+    comm: Int64,
+    stream: Int64,
+) abi("C") -> Int32:
+    return NCCL_INVALID_USAGE

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -360,6 +360,15 @@ def ncclCommInitRank(
         var ctx = DeviceContext(device_id=ordinal)
 
         var cap_bytes = _region_cap_bytes()
+        # A positive multiple of 4096 (the production kernel's own
+        # precondition, RESULTS.md §9) is what keeps every per-chunk offset
+        # `ncclAllReduce` forms (multiples of cap_bytes, one full chunk at a
+        # time) 16-byte aligned for every supported dtype -- 4096 divides
+        # evenly by 2, 4 and 8. A misconfigured MOJOCCL_REGION_MB (e.g. 0)
+        # would otherwise degrade chunk offsets to non-16-byte-aligned
+        # single-element steps.
+        if cap_bytes <= 0 or cap_bytes % 4096 != 0:
+            return NCCL_INVALID_ARGUMENT
         var region_bytes = signal_bytes() + 2 * cap_bytes
         var base = alloc_region(lib, region_bytes)
         region_init(ctx, base)
@@ -511,6 +520,15 @@ def ncclAllReduce(
             return NCCL_INVALID_ARGUMENT
         if op != NCCL_SUM and op != NCCL_AVG:
             return NCCL_INVALID_USAGE
+        # The production kernel's payload loops use 16-byte vector
+        # loads/stores on in_ptr/out_ptr and fault on a misaligned address
+        # (RESULTS.md §9). Every allocator-returned pointer and every chunk
+        # offset this function forms satisfy that (cap_bytes is validated a
+        # multiple of 4096 at init) -- only a mid-tensor view the caller
+        # passes directly can violate it, so reject that case here with a
+        # clear error instead of letting the kernel raise.
+        if Int(sendbuff) % 16 != 0 or Int(recvbuff) % 16 != 0:
+            return NCCL_INVALID_ARGUMENT
         var ptr = _comm_ptr(comm)
         ref state = ptr[]
         if state.aborted:

--- a/torch_mojo_backend/distributed/mojoccl_build.py
+++ b/torch_mojo_backend/distributed/mojoccl_build.py
@@ -1,0 +1,31 @@
+"""Builds libmojoccl.so on first use and returns its cached path.
+
+Reuses the eager-kernel loader's ungated-build machinery (`_build_extension`
+in `torch_mojo_backend/eager_kernels/__init__.py`): the same file-lock,
+atomic-rename and `__mojocache__` cache tensor_holder.mojo builds through,
+just pointed at `mojoccl.mojo` instead. That path builds a Python CPython
+extension normally, but `_build_extension` itself only runs `mojo build
+--emit shared-lib` and returns the output path -- nothing about it assumes a
+`PyInit_*` symbol, so it works unchanged for a plain C-ABI shared library
+loaded with ctypes rather than importlib.
+"""
+
+import threading
+from pathlib import Path
+
+from torch_mojo_backend.eager_kernels import _build_extension
+
+_ENTRY = Path(__file__).parent / "mojoccl" / "mojoccl.mojo"
+
+_LOCK = threading.Lock()
+_CACHED: list[Path] = []
+
+
+def ensure_built() -> str:
+    """Build (if needed) and return the path to libmojoccl.so."""
+    with _LOCK:
+        if _CACHED:
+            return str(_CACHED[0])
+        path = _build_extension(_ENTRY, None)
+        _CACHED.append(path)
+        return str(path)

--- a/torch_mojo_backend/distributed/nccl.py
+++ b/torch_mojo_backend/distributed/nccl.py
@@ -33,6 +33,7 @@ import functools
 import os
 from pathlib import Path
 
+from torch_mojo_backend.distributed import mojoccl_build
 from torch_mojo_backend.mojo_device import cuda_peer, hip_peer
 
 # nccl.h: ncclResult_t
@@ -62,6 +63,10 @@ NCCL_UNIQUE_ID_BYTES = 128
 
 _NCCL_LIB_ENV = "TORCH_MOJO_BACKEND_NCCL_LIB"
 _RCCL_LIB_ENV = "TORCH_MOJO_BACKEND_RCCL_LIB"
+# "mojo": build (first use only, cached) and use libmojoccl.so -- the
+# in-repo NCCL-API implementation (torch_mojo_backend/distributed/mojoccl) --
+# instead of vendor NCCL/RCCL. Same C ABI, same `_declare()` argtypes below.
+_CCL_ENV = "TORCH_MOJO_BACKEND_CCL"
 
 # MAX's `Device.api` string -> the library implementing the NCCL API there.
 _LIBRARY_NAME_OF = {"cuda": "NCCL", "hip": "RCCL"}
@@ -253,6 +258,11 @@ def load(api: str) -> CclLibrary:
             f"no NCCL-API collective library for the {api!r} device api; the "
             "mojo distributed backend supports NVIDIA (NCCL) and AMD (RCCL) GPUs"
         ) from None
+    if os.environ.get(_CCL_ENV) == "mojo":
+        path = mojoccl_build.ensure_built()
+        lib = ctypes.CDLL(path, mode=ctypes.RTLD_GLOBAL)
+        _declare(lib)
+        return CclLibrary(lib, path, "mojoccl")
     paths = _candidate_librccl_paths() if api == "hip" else _candidate_libnccl_paths()
     errors = []
     for path in paths:


### PR DESCRIPTION
## Summary

An experiment: can Mojo write NCCL/RCCL-class collectives, for one narrow case (nanoGPT-124M DDP on 8×H100 and 4×MI300A nodes), from one source for both vendors? This PR is the single-node half.

`torch_mojo_backend/distributed/mojoccl/` is a Mojo shared library exporting **NCCL's own C ABI** (`ncclGetUniqueId`, `ncclCommInitRank`, `ncclAllReduce`, `ncclBroadcast`, `ncclAllGather`, group/query/error calls; 18 symbols). `nccl.py` dlopens it instead of `libnccl.so.2` when `TORCH_MOJO_BACKEND_CCL=mojo` (that switch plus a 30-line build helper are the only Python changes; `process_group.py` is untouched). NCCL/RCCL stays the default.

- **Kernels**: reduce-scatter + all-gather over IPC-mapped peer regions, in a push / local-reduce / pull form where the transfers *are* the staging, so the copy MAX's non-exportable allocations force costs nothing extra (`docs/mojo_collectives_kernel_results.md`). Same source for `sm_90a` and `gfx942` behind one comptime gate.
- **Cross-process**: each rank owns one `cuMemAlloc`/`hipExtMallocWithFlags(uncached)` region shared through legacy IPC handles; the 128-byte `ncclUniqueId` encodes a `/dev/shm` rendezvous directory (rank 0 removes it after every rank has opened its peers). The by-value `ncclUniqueId` argument is handled with a callee-side x86-64 SysV stack shim, verified from ctypes.
- **Design basis**: `docs/mojo_collectives_feasibility.md` (NCCL/RCCL behaviour for this traffic with source references, what MAX exposes, the measured prototypes, why MAX memory cannot be exported, the multi-node plan).

## Results (8×H100 SXM, through the process group, wall over 20 launches, median of 5, interleaved legs, NCCL 2.31.2 with NVLS)

| size | Mojo | NCCL | ratio |
|---|---|---|---|
| 1 MiB | 29 µs | 31 µs | 0.94 |
| 9 MiB (DDP bucket 0) | 70 µs | 92 µs | 0.76 |
| 27 MiB (buckets 1–11) | 164 µs | 181 µs | 0.91 |
| 168 MiB (tail bucket) | 975 µs | 755 µs | 1.29 |
| 512 MiB | 2.95 ms | 2.15 ms | 1.37 |

bf16 within 1% of fp32. The large sizes are the measured unicast ceiling over NVSwitch (~310 GB/s per direction); NCCL's numbers there are NVLS multicast, which would need `cuMulticastCreate` + fd passing + `cuMemCreate`-allocated regions (the study's M4, not done). nanoGPT DDP on 8 ranks: ~2.15 M tok/s vs 2.0–2.2 M tok/s under NCCL; losses identical through step 20 and then within the training step's own run-to-run noise (two NCCL runs differ from each other as much as Mojo differs from NCCL, first divergence at step 3 in the fourth decimal — a nondeterministic eager kernel, separate issue).

## Testing

- `tests/test_distributed.py::test_two_rank_nccl` is parametrized over `ccl=vendor|mojo`: collectives, DDP parity, lazy fence, plus a new `stress` mode (800 interleaved generations mixing 4 B and 27 MiB allreduces with broadcasts and allgathers, in place; the 40-case dtype × size × op × placement matrix; non-zero-root broadcast; non-16-byte allgather). 14 passed, 2 skipped (stress under vendor) on 8×H100; the 8-rank stress worker passes.
- `ruff`, `ty` clean; both targets cross-compile warning-free.

## Scope and limits

One node, 2–8 ranks, one process per GPU. `ncclReduce`/`ncclReduceScatter`/`ncclSend`/`ncclRecv` return `ncclInvalidUsage`. No abort path (peers time out after 60 s in-kernel, reported through `ncclCommGetAsyncError`). AMD: cross-compiled only, not yet run on an MI300A. Multi-node is the next milestone (Mojo intra-node, NCCL/RCCL for the inter-node shard allreduce).

Commits by the Opus/Sonnet agents carry their own `Co-Authored-By`; the work was coordinated in this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167VthrN76wtxabswrkrnJB
