### PR TITLE
Mojo collectives, multi-node: the inter-node hop in Mojo over libibverbs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ gemma-3-270m-it/
 # Agent documentation files (use AGENTS.md instead)
 skills
 __mojocache__/
+__mojocache__
 
 # Profiler artifacts: chrome traces are tens of MB, rocprofv3 writes SQLite
 # databases next to wherever it was invoked.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,9 @@ Always use uv to run commands to ensure the correct environment is activated. Ne
     every specialization compiles inline at its first call and is cached in
     `__mojocache__`; build timings print by default
     (`TORCH_MOJO_BACKEND_TRACE=0` silences them).
+  - `TORCH_MOJO_BACKEND_CCL=mojo` swaps NCCL/RCCL for the in-repo Mojo
+    collectives (`docs/distributed.md`, "Mojo collectives"); default is
+    the vendor library.
 - **Model Examples**: `demo_scripts/` contains examples showing real-world usage:
   - GPT-2, Gemma3 (LLM models)
   - VGG, DenseNet (vision models)

--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -572,7 +572,7 @@ are skipped). Addressing is LID-only, so one IB subnet.
 | `MOJOCCL_IB_TRACE` | 0 | `1`: one line per rank at destroy — HCA, port, peers, slot groups, exchanges, credit stalls, mean µs posting / in flight / flushing |
 | `MOJOCCL_REGION_MB` | 256 | staging size; single node `[signal \| stage_in cap \| stage_out cap]`, multi-node `PIPE_ARENAS` arenas of `cap/PIPE_ARENAS` halves plus a cap-sized network area. Must match on every rank — `ncclCommInitRank` checks it. On an NVLS region only the allocation is rounded up to the multicast granularity (2 MiB by default, 512 MiB under `MOJOCCL_NVLS_GRANULARITY=rec`); the halves keep the size asked for |
 | `MOJOCCL_NVLS` | 1 | `0`: no multicast region and no NVLS kernel, on every rank of the communicator (it is ANDed across ranks) |
-| `MOJOCCL_NVLS_MIN_MB` | 48 | single-node allreduces at or above this go through the switch; below it the unicast kernels keep the traffic. The default is the measured crossover |
+| `MOJOCCL_NVLS_MIN_MB` | 48 | single-node allreduces at or above this go through the switch; below it the unicast kernels keep the traffic. The default is the measured crossover. Must match on every rank — `ncclCommInitRank` checks it |
 | `MOJOCCL_NVLS_GRANULARITY` | `min` | `rec`: size the multicast object with `CU_MULTICAST_GRANULARITY_RECOMMENDED` (NCCL's choice, 512 MiB objects on H100) instead of `MINIMUM` (2 MiB) |
 | `MOJOCCL_SOCKET_DIR` | `/tmp` | where the node-local AF_UNIX sockets that carry the VMM/multicast file descriptors are bound |
 

--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -570,7 +570,7 @@ are skipped). Addressing is LID-only, so one IB subnet.
 | `MOJOCCL_IB_PROXY_CPU` | unset | pin the progress thread to this CPU |
 | `MOJOCCL_IB_RELAXED_ORDERING` | 1 | `0`: plain `ibv_reg_mr` |
 | `MOJOCCL_IB_TRACE` | 0 | `1`: one line per rank at destroy — HCA, port, peers, slot groups, exchanges, credit stalls, mean µs posting / in flight / flushing |
-| `MOJOCCL_REGION_MB` | 256 | staging size; single node `[signal \| stage_in cap \| stage_out cap]`, multi-node `PIPE_ARENAS` arenas of `cap/PIPE_ARENAS` halves plus a cap-sized network area. Must match on every rank — `ncclCommInitRank` checks it. On an NVLS region the whole thing is rounded up to the multicast granularity (512 MiB on H100) and the halves grow into the rounding |
+| `MOJOCCL_REGION_MB` | 256 | staging size; single node `[signal \| stage_in cap \| stage_out cap]`, multi-node `PIPE_ARENAS` arenas of `cap/PIPE_ARENAS` halves plus a cap-sized network area. Must match on every rank — `ncclCommInitRank` checks it. On an NVLS region only the allocation is rounded up to the multicast granularity (2 MiB by default, 512 MiB under `MOJOCCL_NVLS_GRANULARITY=rec`); the halves keep the size asked for |
 | `MOJOCCL_NVLS` | 1 | `0`: no multicast region and no NVLS kernel, on every rank of the communicator (it is ANDed across ranks) |
 | `MOJOCCL_NVLS_MIN_MB` | 48 | single-node allreduces at or above this go through the switch; below it the unicast kernels keep the traffic. The default is the measured crossover |
 | `MOJOCCL_NVLS_GRANULARITY` | `min` | `rec`: size the multicast object with `CU_MULTICAST_GRANULARITY_RECOMMENDED` (NCCL's choice, 512 MiB objects on H100) instead of `MINIMUM` (2 MiB) |

--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -291,24 +291,166 @@ NCCL-class collectives, not a general library:
   the 128-byte `ncclUniqueId` carries its address, port and a random magic
   (NCCL's shape), and `ncclCommInitRank` runs three relayed all-gathers over
   it (host identity, IPC handle plus IB connection data, barrier);
-- every rank owns one IPC-shared staging region (`MOJOCCL_REGION_MB`, default
+- every rank owns one shared staging region (`MOJOCCL_REGION_MB`, default
   256 MiB, multiple of 4 KiB; larger requests are chunked). MAX's own
   allocations cannot be shared across processes (§5.6 of the study), which
   is why the kernels stage through this region; the push / local-reduce /
-  pull design makes the staging free;
+  pull design makes the staging free. The region is either a `cuMemAlloc`
+  block shared with legacy IPC or, where NVSwitch multicast is available,
+  VMM memory bound to a multicast object — see "NVLS" below;
 - a rank that stops responding makes its peers time out after 60 s inside the
   kernel and `ncclCommGetAsyncError` reports it; there is no abort path.
 
 Measured on 8×H100 SXM through the process group (wall over 20 launches,
-median of 5, interleaved legs; NCCL 2.31.2 NVLS for comparison): 1 MiB 29 vs
-31 µs, 9 MiB 70 vs 92, 27 MiB (the DDP bucket) 164 vs 181, 168 MiB 975 vs
-755, 512 MiB 2.95 vs 2.15 ms. The large sizes are the unicast ceiling
-(~310 GB/s per direction over NVSwitch); matching NCCL there needs NVLS
-multicast (`cuMulticastCreate`), not implemented. nanoGPT-124M DDP on 8 ranks
-runs at the same throughput and the same losses within the training step's
-own run-to-run noise. AMD: the same source cross-compiles for gfx942 (the
-one vendor gate is a release fence on AMD's `s_barrier`), but it has not run
-on an MI300A yet.
+median of 5, interleaved legs; NCCL 2.31.2 NVLS for comparison), **unicast
+kernels only** — i.e. `MOJOCCL_NVLS=0`, which is what everything below the
+48 MiB crossover runs anyway: 1 MiB 29 vs 31 µs, 9 MiB 70 vs 92, 27 MiB (the
+DDP bucket) 164 vs 181, 168 MiB 988 vs 756, 512 MiB 2.99 vs 2.15 ms. The last
+two rows are where the multicast path takes over — next subsection. AMD: the
+same source cross-compiles for gfx942 (the one vendor gate is a release fence
+on AMD's `s_barrier`), but it has not run on an MI300A yet.
+
+### NVLS: the large sizes go through the switch
+
+The 168 and 512 MiB rows above are the **unicast** ceiling (~310 GB/s per
+direction over NVSwitch): a push/reduce/pull allreduce moves
+`2(world-1)/world × bytes` per GPU each way, and no schedule beats that
+while every byte travels point to point. NCCL closes it with NVSwitch
+multicast, and so does this library now.
+
+A single-node communicator whose devices all report
+`CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED` builds its region as VMM memory
+bound to a per-node multicast object, and routes allreduces of
+`MOJOCCL_NVLS_MIN_MB` (48 MiB) or more through `multimem.ld_reduce` /
+`multimem.st`: rank r pulls its 1/world slice through the switch, which sums
+the `world` contributions and returns one value, and pushes the result back
+into all `world` regions in one instruction. NVLink traffic falls to `bytes`
+per GPU each way — 1.75× less at world 8 — paid for with ~1.5× the HBM
+traffic, because the user's tensors are MAX-allocated and cannot be bound to
+a multicast object, so every byte is staged in and out. That trade is why
+the path has a size floor: 48 MiB is the measured crossover, sharp (4% the
+wrong side at 40 MiB, 4% the right side at 48) and the same for fp32 and
+bf16. int32/int64 stay unicast.
+
+**Bring-up** (`vmm.mojo`, NCCL's `src/transport/nvls.cc` sequence). The
+node's local rank 0 calls `cuMulticastCreate` and exports the object as a
+POSIX file descriptor; the fd travels to its node-mates over an AF_UNIX
+`SOCK_DGRAM` socket as an `SCM_RIGHTS` control message, which is what NCCL
+does and, unlike `pidfd_getfd`, works whatever
+`/proc/sys/kernel/yama/ptrace_scope` says. Every rank then
+`cuMulticastAddDevice`s its own device, **barrier**, `cuMemCreate`s its
+physical memory and `cuMulticastBindMem`s it at multicast offset 0 — so one
+multicast address covers the node's eight distinct allocations — and maps it
+**twice**: a multicast VA that only `multimem.*` may touch, and a plain VA
+that the unicast kernels, the staging copies and the flag spin use. Peers are
+imported with `cuMemImportFromShareableHandle` over the same sockets, because
+legacy `cuIpcOpenMemHandle` cannot open VMM memory. Then **barrier**: no rank
+issues a multimem instruction before every rank has mapped. The whole
+sequence costs 150–230 ms once per communicator, dominated by
+`cuMulticastBindMem` and the mappings.
+
+The socket name is derived from the unique id's magic and the local rank
+(`/tmp`, or `MOJOCCL_SOCKET_DIR`), so the rendezvous carries no extra round.
+`tests/multinode/selftest/fd_exchange.mojo` runs that transport over ordinary
+file descriptors with no GPU and no multicast hardware — the msghdr /
+cmsghdr / sockaddr_un structs are laid out by hand over `UInt64` words
+(`std.ffi` has no C-struct ABI) and a wrong offset does not fail loudly.
+
+**Memory.** A multicast object's size must be a multiple of what
+`cuMulticastGetGranularity` reports, and on H100 that is **512 MiB** for
+`RECOMMENDED` against **2 MiB** for `MINIMUM`. NCCL uses RECOMMENDED; this
+uses MINIMUM, so that `MOJOCCL_REGION_MB` keeps meaning what it says — at
+RECOMMENDED the default region (`128 KiB + 2 × 256 MiB`) rounds up to a 1 GiB
+allocation per rank and even a deliberately tiny test region costs 512 MiB,
+while at MINIMUM the same region is 514 MiB. `MOJOCCL_NVLS_GRANULARITY=rec`
+asks for NCCL's choice back.
+
+The NVLS kernel stages **one** buffer, not two, so it uses the whole `2 × cap`
+arena rather than a half: a 512 MiB allreduce is one launch on the default
+256 MiB region. That is safe for the same reason a broadcast may use the whole
+arena — the start barrier below.
+
+**Fallback is a decision, not a recovery.** The capability travels in the
+first bootstrap round, before anything is allocated: every rank contributes
+"my device reports multicast and `MOJOCCL_NVLS` is not 0", rank 0 additionally
+does a real `cuMulticastCreate` of a granularity-sized object and releases it
+(88 µs, and it is where a broken fabric-manager setup shows up), and every
+rank ANDs the whole column. One "no" — AMD, pre-Hopper, no NVSwitch, a rank
+with `MOJOCCL_NVLS=0` — and the whole communicator builds the `cuMemAlloc`
+region with legacy IPC exactly as before, with no half-built state to unwind.
+A failure *after* that point is reported rather than papered over, and the
+message names `MOJOCCL_NVLS=0`.
+
+**The kernel** (`nvls_kernels.mojo`) is the prototype's split-grid schedule:
+the low 25% of the blocks only drive the switch and the rest only drive HBM,
+the message is cut into `clamp(bytes/4, 21 MiB, 86 MiB)` chunks, and chunk
+c's reduction runs at the same time as chunk c+1's copy-in and chunk c-1's
+copy-out. Two things about it are worth knowing before touching it:
+
+* **The barrier is a full barrier**, not the block-index-matched one every
+  other kernel in this library uses. There, block b only ever consumes bytes
+  block b of a peer produced; here the reduce phase reads a contiguous slice
+  that *every* block of every peer helped stage. The index-matched version
+  passes every small case and fails from n = 65537 up. It is two levels: a
+  device-scope arrival counter, then one
+  `multimem.red.release.sys.global.add.u64` from the last block to arrive,
+  which posts that GPU's arrival to all eight counters in one instruction; the
+  wait is on the plain mapping, so it costs no fabric traffic.
+* **A full barrier needs the whole grid resident** or it deadlocks. The grid
+  is therefore `min(216, 2 × SM count)` blocks of 256 threads with
+  `nvvm.minctasm=2`, and 216 was fitted on H100's 132 SMs.
+* **It opens with a start barrier**, before a byte of staging is written, for
+  the same reason every other kernel in `collectives_kernels.mojo` does: the
+  arena is shared scratch, and a broadcast or an all-gather retiring just
+  before this kernel has its peers still *reading* the bytes the copy-in is
+  about to overwrite. One barrier per call, not per chunk.
+
+Everything above is behind a compile-time sm_90+ gate (`multimem` exists
+nowhere else and RCCL has no equivalent) and a runtime capability check; the
+gfx942 and sm_90a cross-compiles both stay clean.
+
+**Checking it.** `tests/ddp_worker.py stress` covers the path at 8 ranks and
+256 MiB (every dtype × ragged size × SUM/AVG × in-place/out-of-place);
+`tests/nvls_check.py` is the same shape of check at world 2 and 4, which
+`ddp_worker` never runs, over sizes that straddle both the dispatch threshold
+and the staging arena:
+
+```bash
+TORCH_MOJO_BACKEND_CCL=mojo torchrun --nproc-per-node=2 tests/nvls_check.py
+TORCH_MOJO_BACKEND_CCL=mojo torchrun --nproc-per-node=8 tests/ddp_worker.py stress
+# the numbers below: one leg per configuration, palindromic order
+TORCH_MOJO_BACKEND_CCL=mojo torchrun --nproc-per-node=8 ar_bench_gpt2.py
+MOJOCCL_NVLS=0 TORCH_MOJO_BACKEND_CCL=mojo torchrun --nproc-per-node=8 ar_bench_gpt2.py
+```
+
+**Results**, 8×H100 SXM on one node (job 234314, `cl02s01dgx05`),
+`ar_bench_gpt2.py` through the process group, medians in µs. Six legs in
+palindromic order — NCCL, unicast, NVLS, NVLS, unicast, NCCL — so a clock or
+thermal ramp cancels to first order; each column is the mean of its two legs:
+
+| dtype | MiB | unicast | **NVLS** | NCCL | NVLS/unicast | NVLS/NCCL |
+|---|---|---|---|---|---|---|
+| fp32 | 9 | 70 | 70 | 94 | 1.00 | 0.74 |
+| fp32 | 27 (DDP bucket) | 165 | 164 | 182 | **1.00** | 0.91 |
+| fp32 | 168 (tail bucket) | 988 | **799** | 756 | **0.81** | 1.06 |
+| fp32 | 512 | 2991 | **2218** | 2154 | **0.74** | 1.03 |
+| bf16 | 9 | 70 | 70 | 91 | 1.00 | 0.77 |
+| bf16 | 27 | 165 | 165 | 179 | **1.00** | 0.92 |
+| bf16 | 168 | 994 | **798** | 745 | **0.80** | 1.07 |
+| bf16 | 512 | 2988 | **2213** | 2126 | **0.74** | 1.04 |
+
+Everything at or below 27 MiB is byte-identical code and reads identical,
+which is the point of the crossover: the dispatch buys the tail bucket 19%
+and the 512 MiB bucket 26% and costs the DDP bucket nothing. Against NCCL the
+tail bucket goes from 1.31× to 1.06× and 512 MiB from 1.39× to 1.03×. 1 MiB
+is below this bench's noise floor (per-leg medians 27–59 µs on every
+configuration, NVLS or not) and is left out of the table.
+
+A seventh leg measured `MOJOCCL_NVLS_GRANULARITY=rec` — NCCL's 512 MiB
+multicast objects instead of the default 2 MiB ones — at 806/2213 fp32 and
+798/2213 bf16 for the two large sizes: **the same within noise**, and the
+2 MiB objects allocate 514 MiB per rank against 1 GiB. That granularity had
+never been measured before (the prototype only ever used RECOMMENDED).
 
 ### Multi-node
 
@@ -428,7 +570,11 @@ are skipped). Addressing is LID-only, so one IB subnet.
 | `MOJOCCL_IB_PROXY_CPU` | unset | pin the progress thread to this CPU |
 | `MOJOCCL_IB_RELAXED_ORDERING` | 1 | `0`: plain `ibv_reg_mr` |
 | `MOJOCCL_IB_TRACE` | 0 | `1`: one line per rank at destroy — HCA, port, peers, slot groups, exchanges, credit stalls, mean µs posting / in flight / flushing |
-| `MOJOCCL_REGION_MB` | 256 | staging size; single node `[signal \| stage_in cap \| stage_out cap]`, multi-node `PIPE_ARENAS` arenas of `cap/PIPE_ARENAS` halves plus a cap-sized network area. Must match on every rank — `ncclCommInitRank` checks it |
+| `MOJOCCL_REGION_MB` | 256 | staging size; single node `[signal \| stage_in cap \| stage_out cap]`, multi-node `PIPE_ARENAS` arenas of `cap/PIPE_ARENAS` halves plus a cap-sized network area. Must match on every rank — `ncclCommInitRank` checks it. On an NVLS region the whole thing is rounded up to the multicast granularity (512 MiB on H100) and the halves grow into the rounding |
+| `MOJOCCL_NVLS` | 1 | `0`: no multicast region and no NVLS kernel, on every rank of the communicator (it is ANDed across ranks) |
+| `MOJOCCL_NVLS_MIN_MB` | 48 | single-node allreduces at or above this go through the switch; below it the unicast kernels keep the traffic. The default is the measured crossover |
+| `MOJOCCL_NVLS_GRANULARITY` | `min` | `rec`: size the multicast object with `CU_MULTICAST_GRANULARITY_RECOMMENDED` (NCCL's choice, 512 MiB objects on H100) instead of `MINIMUM` (2 MiB) |
+| `MOJOCCL_SOCKET_DIR` | `/tmp` | where the node-local AF_UNIX sockets that carry the VMM/multicast file descriptors are bound |
 
 Limits and failure modes: 8 ranks per node, 16 nodes; more than one node
 with no ACTIVE InfiniBand port fails `ncclCommInitRank` with "no ACTIVE
@@ -448,11 +594,12 @@ is a 16-rank (2 nodes × 8 GPU) SLURM job: `tests/ddp_worker.py`
 allreduce device-time bench (`ar_bench_gpt2.py`) in ABBA order, and a
 40-step nanoGPT DDP run under both. `RUN_MOJO=0` keeps only the NCCL legs.
 `tests/multinode/summarize.py <job log>` turns a log into the tables below.
-`tests/multinode/selftest/` holds four GPU-free self-tests — the bootstrap,
-the RDMA transport, the pipelined transport with its credit protocol, and
-the region geometry (that last one needs no IB either). The first three run
-on a host with IB HCAs and no GPU, such as the login node, with
-`MOJOCCL_IB_PROXY=0`; they caught six bugs before any GPU time was spent.
+`tests/multinode/selftest/` holds five GPU-free self-tests — the bootstrap,
+the RDMA transport, the pipelined transport with its credit protocol, the
+region geometry, and the `SCM_RIGHTS` fd transport the NVLS bring-up uses
+(the last two need no IB either). The first three run on a host with IB HCAs
+and no GPU, such as the login node, with `MOJOCCL_IB_PROXY=0`; they caught
+six bugs before any GPU time was spent.
 
 **Results**, 16 ranks on 2×8 H100, `ar_bench_gpt2.py` through the process
 group, medians in µs. The pipeline against the commit before it, **in one
@@ -512,4 +659,42 @@ noise on these shared nodes is still as large as the gap.
 What is left at the large sizes is the intra-node half, not the network: the
 split reduce-scatter/all-gather pair is ~1004 µs at 168 MiB on one node
 against NCCL's 751 µs NVLS multicast, and the pipeline's 1192 µs is 1.19×
-that floor. Closing the rest needs `cuMulticastCreate`, not more overlap.
+that floor.
+
+**The multi-node path deliberately stays unicast**, even on a cluster where
+the single-node one takes the multicast route. Three reasons, in order of
+weight:
+
+1. *The chunking fights it.* NVLS wins only from 48 MiB up, and the pipeline
+   cuts a 168 MiB bucket into K = 5 chunks of 33.6 MiB — below the crossover.
+   Forcing chunks above it means K = 3, and by the model the chunk rule is
+   built on (total ≈ node-local + network/K, which reproduces the measured
+   1192 µs at K = 5 from a node-local 1004 µs) that trades ~125 µs of extra
+   exposed network for the ~45 µs NVLS saves node-locally: 1272 µs against
+   1192. At 8 nodes the geometry caps a chunk at 36 MiB, so the question does
+   not even arise. Only 512 MiB at 2 nodes (K = 10, chunks of 51.2 MiB, just
+   over the crossover) would gain, and only ~4%.
+2. *It would need RDMA out of VMM memory.* The inter-node write reads
+   straight out of an arena's `stage_out`, so the staging has to be inside
+   the registered MR — and `ibv_reg_mr` on a `cuMemMap`'d VA returned NULL on
+   this cluster, with no dmabuf fallback
+   (`CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED` is 0 on every device, so
+   `ibv_reg_dmabuf_mr` is unavailable). That probe deserves one more careful
+   look (it used `ibv_get_device_list()[0]` rather than the affine HCA and
+   never read `errno`) before anything leans on it.
+3. Consequently a multi-node communicator would pay 150–230 ms of multicast
+   bring-up for nothing, so it does not build a multicast region at all:
+   multi-node allocation is byte for byte what it was, which the numbers
+   confirm. Re-running this bench at 16 ranks after the NVLS work landed
+   (job 234315, `cl02s01dgx24` + `cl02s02dgx23`, the same ABBA design) reads
+   285 / 1185 / 3545 µs fp32 and 283 / 1184 / 3534 bf16 at 27 / 168 / 512 MiB
+   against the 282 / 1192 / 3541 and 274 / 1186 / 3532 recorded above — within
+   1% at every size, and `collectives`, `ddp_parity` and `stress` all pass at
+   16 ranks.
+
+The unmeasured half of point 1 is the NVLS *split* kernels themselves — a
+multicast reduce-scatter and a multicast all-gather were never written, so
+the ~45 µs above is estimated from the prototype's phase timings (copies
+275 µs and switch 707 µs at 168 MiB) and not measured. If the chunk cap ever
+rises above the crossover for the shapes that matter, this is the experiment
+to run.

--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -578,7 +578,7 @@ are skipped). Addressing is LID-only, so one IB subnet.
 | `MOJOCCL_SOCKET_IFNAME` | first UP non-loopback IPv4 interface with a default route (`bond0` here) | interface whose address rank 0 publishes in the unique id; one name, no lists |
 | `MOJOCCL_BOOTSTRAP_TIMEOUT_S` | 120 | absolute deadline for the whole rendezvous. Every socket it opens is non-blocking and every wait is a `poll(2)` computed from the deadline (`connect` included, verified with `SO_ERROR`), so no syscall can outlive it; `SO_RCVTIMEO`/`SO_SNDTIMEO` stay on as a backstop |
 | `MOJOCCL_IB_HCA` | affinity choice | exact HCA name to use instead (`mlx5_4`) |
-| `MOJOCCL_IB_TIMEOUT_S` | 60 | how long a rank waits for its peers' shards before latching an error |
+| `MOJOCCL_IB_TIMEOUT_S` | 60 | how long a rank waits for a peer that stopped answering before latching an error — **every** wait: the inter-node exchange, its wait kernel, and the intra-node and NVLS barrier spins, which read it once per process |
 | `MOJOCCL_IB_PROXY` | 1 | `0`: stream host callback instead of the progress thread |
 | `MOJOCCL_IB_PROXY_IDLE_US` | 20 | sleep quantum of the idle progress thread (it spins only during an exchange) |
 | `MOJOCCL_IB_PROXY_CPU` | unset | pin the progress thread to this CPU |
@@ -595,7 +595,8 @@ with no ACTIVE InfiniBand port fails `ncclCommInitRank` with "no ACTIVE
 InfiniBand port found" (so Slingshot on Adastra is not covered; a
 libfabric/cxi transport would be a second backend); a peer that stops
 responding is reported through `ncclCommGetAsyncError` after
-`MOJOCCL_IB_TIMEOUT_S`; a stale unique id (tag `MOJOCCL2`) is rejected with
+`MOJOCCL_IB_TIMEOUT_S` (one variable for every spin, intra-node and
+inter-node alike), or at once on `ncclCommAbort`; a stale unique id (tag `MOJOCCL2`) is rejected with
 a clear message.
 
 **Requirements.** rdma-core/libibverbs on the nodes (here MLNX OFED 24.10),

--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -605,14 +605,16 @@ between every pair of nodes, a routable interface for the TCP bootstrap.
 
 **Running the two-node job.** `tests/multinode/run_two_node_checks.sbatch`
 is a 16-rank (2 nodes × 8 GPU) SLURM job: `tests/ddp_worker.py`
-(`collectives`/`ddp_parity`/`stress`) under NCCL and under mojoccl, the
+(`collectives`/`ddp_parity`/`stress`; `abort` is single-node in
+`tests/test_distributed.py`) under NCCL and under mojoccl, the
 allreduce device-time bench (`ar_bench_gpt2.py`) in ABBA order, and a
 40-step nanoGPT DDP run under both. `RUN_MOJO=0` keeps only the NCCL legs.
 `tests/multinode/summarize.py <job log>` turns a log into the tables below.
-`tests/multinode/selftest/` holds five GPU-free self-tests — the bootstrap,
+`tests/multinode/selftest/` holds six GPU-free self-tests — the bootstrap,
 the RDMA transport, the pipelined transport with its credit protocol, the
-region geometry, and the `SCM_RIGHTS` fd transport the NVLS bring-up uses
-(the last two need no IB either). The first three run on a host with IB HCAs
+region geometry, the `SCM_RIGHTS` fd transport the NVLS bring-up uses, and
+the socket deadlines (the last three need no IB either, and the last needs
+no peers). The first three run on a host with IB HCAs
 and no GPU, such as the login node, with `MOJOCCL_IB_PROXY=0`; they caught
 six bugs before any GPU time was spent.
 

--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -576,7 +576,7 @@ are skipped). Addressing is LID-only, so one IB subnet.
 | variable | default | controls |
 |---|---|---|
 | `MOJOCCL_SOCKET_IFNAME` | first UP non-loopback IPv4 interface with a default route (`bond0` here) | interface whose address rank 0 publishes in the unique id; one name, no lists |
-| `MOJOCCL_BOOTSTRAP_TIMEOUT_S` | 120 | deadline for every bootstrap socket wait |
+| `MOJOCCL_BOOTSTRAP_TIMEOUT_S` | 120 | absolute deadline for the whole rendezvous. Every socket it opens is non-blocking and every wait is a `poll(2)` computed from the deadline (`connect` included, verified with `SO_ERROR`), so no syscall can outlive it; `SO_RCVTIMEO`/`SO_SNDTIMEO` stay on as a backstop |
 | `MOJOCCL_IB_HCA` | affinity choice | exact HCA name to use instead (`mlx5_4`) |
 | `MOJOCCL_IB_TIMEOUT_S` | 60 | how long a rank waits for its peers' shards before latching an error |
 | `MOJOCCL_IB_PROXY` | 1 | `0`: stream host callback instead of the progress thread |

--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -298,8 +298,20 @@ NCCL-class collectives, not a general library:
   pull design makes the staging free. The region is either a `cuMemAlloc`
   block shared with legacy IPC or, where NVSwitch multicast is available,
   VMM memory bound to a multicast object — see "NVLS" below;
-- a rank that stops responding makes its peers time out after 60 s inside the
-  kernel and `ncclCommGetAsyncError` reports it; there is no abort path.
+- a rank that stops responding makes its peers time out after
+  `MOJOCCL_IB_TIMEOUT_S` (60 s) inside the kernel and
+  `ncclCommGetAsyncError` reports it. `ncclCommAbort` implements nccl.h's
+  contract: it stops submissions (later collectives return
+  `ncclInvalidUsage`), raises a pinned abort word every device spin polls —
+  the intra-node barriers, the NVLS barrier and the inter-node wait kernel
+  all leave within a millisecond with their region's error word set, instead
+  of running to that deadline — stops the progress thread, and then, once
+  the local streams have gone idle (polled with `cuStreamQuery` under a 5 s
+  bound, never a wait on a peer), releases the region, the peer mappings,
+  the IB resources and the pinned memory. `ncclCommDestroy` on an aborted
+  communicator is a no-op. If the device does not go idle inside that bound
+  the memory is deliberately kept — freeing a region a kernel may still read
+  faults the process — and abort says so on stderr.
 
 Measured on 8×H100 SXM through the process group (wall over 20 launches,
 median of 5, interleaved legs; NCCL 2.31.2 NVLS for comparison), **unicast

--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -696,8 +696,13 @@ NCCL 49.7 ms vs mojoccl 51.4 ms with adjacent pairs at 1.035, 1.084 and
 0.996, inside those nodes' noise; on `--exclusive` nodes (job 234455) NCCL is
 tight at 44.6–44.9 ms and mojoccl reads 45.1, 45.7 and 50.1 ms — the
 best-decile steps are within 1.7% of NCCL, and the slow run is a mode (steps
-12–35 at a steady 51 ms, 45–46 before and after): the progress thread sharing
-a core with the rank's Python thread. Pinning it by default is the follow-up.
+12–35 at a steady 51 ms, 45–46 before and after). Pinning the progress thread
+by default (now the policy) did not remove it; binding every rank's whole
+process to a compact eighth of the task's CPUs did (job 234658, exclusive
+nodes, same six-run design, `tests/multinode/rank_bind.py` as the torchrun
+entry): NCCL 46.30 ms vs mojoccl 46.37 ms pooled medians, ratio 1.001, pairs
+0.968 / 1.005 / 1.030, and the remaining plateaus appear under both libraries
+alike. Bind ranks to CPUs when measuring; the collective library is at parity.
 
 What is left at the large sizes is the intra-node half, not the network: the
 split reduce-scatter/all-gather pair is ~1004 µs at 168 MiB on one node

--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -439,8 +439,8 @@ thermal ramp cancels to first order; each column is the mean of its two legs:
 | bf16 | 168 | 994 | **798** | 745 | **0.80** | 1.07 |
 | bf16 | 512 | 2988 | **2213** | 2126 | **0.74** | 1.04 |
 
-Everything at or below 27 MiB is byte-identical code and reads identical,
-which is the point of the crossover: the dispatch buys the tail bucket 19%
+At and below 27 MiB the two mojo columns run the same unicast kernel over the
+same layout and read the same, which is the point of the crossover: the dispatch buys the tail bucket 19%
 and the 512 MiB bucket 26% and costs the DDP bucket nothing. Against NCCL the
 tail bucket goes from 1.31× to 1.06× and 512 MiB from 1.39× to 1.03×. 1 MiB
 is below this bench's noise floor (per-leg medians 27–59 µs on every

--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -318,7 +318,10 @@ most `MOJOCCL_REGION_MB`: the intra-node reduce-scatter
 (`reduce_scatter_stage`) leaves every rank its shard of the node-reduced
 bucket in its own `stage_out`; each rank RDMA-writes that shard to the
 counterpart rank (same `local_rank`) on every other node and receives theirs
-into a third, cap-sized `network` area of its region; a small kernel sums the
+into a third, cap-sized `network` area of its region, carved once as
+`[staging cap/2 | inbox half 0 cap/4 | inbox half 1 cap/4]` so every exchange
+uses the same byte ranges (this caps one multi-node allreduce chunk at 256 MiB
+for 2 nodes and 73 MiB for 8); a small kernel sums the
 N−1 inbox shards into the shard; the intra-node all-gather
 (`allgather_finish`) then pulls the globally reduced shards into the user
 output, scaled for AVG. Broadcast and all-gather use the same RDMA path with
@@ -341,10 +344,13 @@ memory. The inbox is double-buffered by the exchange counter's parity
 carried in the immediate, which is sound only because every exchange is
 all-to-all: a rank whose shard is empty (7 of 8 ranks on DDP's 4-byte AVG
 allreduce) still posts a 16-byte credit. The GPU/network hand-off is a
-spinning progress thread per rank (one core) driven through a pinned,
-device-mapped mailbox: a one-thread kernel releases the exchange, the thread
-posts, waits for the N−1 arrivals and flushes, a second one-thread kernel
-spins until it is done. A `cuLaunchHostFunc`/`hipLaunchHostFunc` stream
+progress thread per rank driven through a pinned, device-mapped mailbox: a
+one-thread kernel releases the exchange, the thread posts, waits for the N−1
+arrivals and flushes, a second one-thread kernel spins until it is done. The
+thread spins only while an exchange is in flight; idle, it yields and then
+sleeps in `MOJOCCL_IB_PROXY_IDLE_US` steps, because a thread spinning between
+exchanges competed with the host-bound Python dispatch thread and cost ~20%
+of end-to-end training throughput at 16 ranks. A `cuLaunchHostFunc`/`hipLaunchHostFunc` stream
 callback does the same job behind `MOJOCCL_IB_PROXY=0` and costs about
 480 µs of fixed driver latency per exchange on this cluster (2.6× slower at
 the DDP bucket), which is why the thread is the default. HCA choice: the
@@ -359,6 +365,8 @@ are skipped). Addressing is LID-only, so one IB subnet.
 | `MOJOCCL_IB_HCA` | affinity choice | exact HCA name to use instead (`mlx5_4`) |
 | `MOJOCCL_IB_TIMEOUT_S` | 60 | how long a rank waits for its peers' shards before latching an error |
 | `MOJOCCL_IB_PROXY` | 1 | `0`: stream host callback instead of the progress thread |
+| `MOJOCCL_IB_PROXY_IDLE_US` | 20 | sleep quantum of the idle progress thread (it spins only during an exchange) |
+| `MOJOCCL_IB_PROXY_CPU` | unset | pin the progress thread to this CPU |
 | `MOJOCCL_IB_RELAXED_ORDERING` | 1 | `0`: plain `ibv_reg_mr` |
 | `MOJOCCL_IB_TRACE` | 0 | `1`: one line per rank at destroy — HCA, port, peers, exchanges, mean µs posting / waiting / flushing |
 | `MOJOCCL_REGION_MB` | 256 | region area size; a multi-node communicator has three areas (`signal, stage_in, stage_out, network`) |
@@ -381,23 +389,26 @@ is a 16-rank (2 nodes × 8 GPU) SLURM job: `tests/ddp_worker.py`
 allreduce device-time bench (`ar_bench_gpt2.py`) in ABBA order, and a
 40-step nanoGPT DDP run under both. `RUN_MOJO=0` keeps only the NCCL legs.
 `tests/multinode/summarize.py <job log>` turns a log into the tables below.
-`/home/gabriel/ddp_work/ib_selftest/` holds two GPU-free self-tests of the
-bootstrap and of the RDMA transport between processes (they run on the
-login node, which has IB HCAs; set `MOJOCCL_IB_PROXY=0` there).
+`tests/multinode/selftest/` holds two GPU-free self-tests of the bootstrap
+and of the RDMA transport between processes (they run on a host with IB HCAs
+and no GPU, such as the login node; set `MOJOCCL_IB_PROXY=0` there); they
+caught six bugs before any GPU time was spent.
 
-**Results**, 16 ranks on 2×8 H100 (job 234040, nodes cl02s02dgx26 +
-cl02s04dgx01), `ar_bench_gpt2.py` through the process group, ABBA legs,
-medians in µs; NCCL 2.31.2 picks `NVLS_TREE/SIMPLE` from 9 MiB up:
+**Results**, 16 ranks on 2×8 H100 (`tests/multinode/run_two_node_checks.sbatch`,
+job 234072), `ar_bench_gpt2.py` through the process group, ABBA legs within
+1% of each other, medians in µs; NCCL 2.31.2 picks `NVLS_TREE/SIMPLE` from
+9 MiB up:
 
 | MiB | mojo fp32 | NCCL fp32 | ratio | mojo bf16 | NCCL bf16 | ratio |
 |---|---|---|---|---|---|---|
-| 1 | 52–81 | 87–117 | 0.6–0.9 | 52–57 | 86 | 0.60 |
-| 9 | 119 | 174 | 0.68 | 120 | 167 | 0.72 |
-| 27 (DDP bucket) | 278 | 264 | 1.05 | 279 | 262 | 1.06 |
-| 168 (tail bucket) | 1527 | 939 | 1.63 | 1522 | 947 | 1.61 |
-| 512 | 4619 | 2366 | 1.95 | 4622 | 2385 | 1.94 |
+| 1 | 60 | 153 | 0.39 | 51 | 86 | 0.60 |
+| 9 | 119 | 174 | 0.69 | 119 | 167 | 0.72 |
+| 27 (DDP bucket) | 278 | 266 | 1.04 | 277 | 262 | 1.06 |
+| 168 (tail bucket) | 1532 | 939 | 1.63 | 1526 | 947 | 1.61 |
+| 512 | 4635 | 2363 | 1.96 | 4618 | 2380 | 1.94 |
 
-`collectives`, `ddp_parity` and `stress` pass at 16 ranks. With
+`collectives`, `ddp_parity` and `stress` pass at 16 ranks under both
+libraries, and nanoGPT-124M DDP at 16 ranks reaches the same losses. With
 `MOJOCCL_IB_TRACE=1` the RDMA itself runs at 40–45 GB/s per rank, near line
 rate for one 400 Gb/s HCA; at the bucket the mean split is 0.05 µs posting,
 ~330 µs waiting (the transfer), 2.3 µs flushing. Above 27 MiB the gap is the

--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -351,7 +351,8 @@ POSIX file descriptor; the fd travels to its node-mates over an AF_UNIX
 does and, unlike `pidfd_getfd`, works whatever
 `/proc/sys/kernel/yama/ptrace_scope` says. Every rank then
 `cuMulticastAddDevice`s its own device, **barrier**, `cuMemCreate`s its
-physical memory and `cuMulticastBindMem`s it at multicast offset 0 — so one
+physical memory (GPUDirect-RDMA-capable, so an HCA can register it) and
+`cuMulticastBindMem`s it at multicast offset 0 — so one
 multicast address covers the node's eight distinct allocations — and maps it
 **twice**: a multicast VA that only `multimem.*` may touch, and a plain VA
 that the unicast kernels, the staging copies and the flag spin use. Peers are
@@ -722,16 +723,19 @@ weight:
    1192. At 8 nodes the geometry caps a chunk at 36 MiB, so the question does
    not even arise. Only 512 MiB at 2 nodes (K = 10, chunks of 51.2 MiB, just
    over the crossover) would gain, and only ~4%.
-2. *It would need RDMA out of VMM memory.* The inter-node write reads
-   straight out of an arena's `stage_out`, so the staging has to be inside
-   the registered MR — and `ibv_reg_mr` on a `cuMemMap`'d VA returned NULL on
-   this cluster, with no dmabuf fallback
-   (`CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED` is 0 on every device, so
-   `ibv_reg_dmabuf_mr` is unavailable). That probe deserves one more careful
-   look (it used `ibv_get_device_list()[0]` rather than the affine HCA and
-   never read `errno`) before anything leans on it.
-3. Consequently a multi-node communicator would pay 150–230 ms of multicast
-   bring-up for nothing, so it does not build a multicast region at all:
+2. *It would need RDMA out of VMM memory*, which works but had to be
+   proven. The inter-node write reads straight out of an arena's
+   `stage_out`, so the staging has to be inside the registered MR.
+   `ibv_reg_mr` on a `cuMemMap`'d VA first returned NULL on this cluster; the
+   cause was the `cuMemCreate` prop, not the kind of memory: `nvidia_peermem`
+   refuses (EFAULT) a chunk created without `allocFlags.gpuDirectRDMACapable`,
+   which NCCL sets and `vmm.mojo` now sets too, after which all 12 HCAs
+   register it (`docs/mojo_collectives_nvls_results.md` §4). There is still
+   no dmabuf fallback (`CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED` is 0 on every
+   device).
+3. So, on the first reason alone, a multi-node communicator would pay
+   150–230 ms of multicast bring-up for nothing, and it does not build a
+   multicast region at all:
    multi-node allocation is byte for byte what it was, which the numbers
    confirm. Re-running this bench at 16 ranks after the NVLS work landed
    (job 234315, `cl02s01dgx24` + `cl02s02dgx23`, the same ABBA design) reads

--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -313,21 +313,57 @@ on an MI300A yet.
 ### Multi-node
 
 The inter-node hop is Mojo too: no vendor collective library anywhere.
-Each collective on a communicator spanning N nodes runs, per chunk of at
-most `MOJOCCL_REGION_MB`: the intra-node reduce-scatter
-(`reduce_scatter_stage`) leaves every rank its shard of the node-reduced
-bucket in its own `stage_out`; each rank RDMA-writes that shard to the
-counterpart rank (same `local_rank`) on every other node and receives theirs
-into a third, cap-sized `network` area of its region, carved once as
-`[staging cap/2 | inbox half 0 cap/4 | inbox half 1 cap/4]` so every exchange
-uses the same byte ranges (this caps one multi-node allreduce chunk at 256 MiB
-for 2 nodes and 73 MiB for 8); a small kernel sums the
-N−1 inbox shards into the shard; the intra-node all-gather
-(`allgather_finish`) then pulls the globally reduced shards into the user
-output, scaled for AVG. Broadcast and all-gather use the same RDMA path with
-a simpler schedule (root's node fans out to its counterparts, then
-intra-node; node blocks exchanged, then placed by global rank). Single-node
+An allreduce on a communicator spanning N nodes runs, per chunk: the
+intra-node reduce-scatter (`reduce_scatter_stage`) leaves every rank its
+shard of the node-reduced bucket in its own `stage_out`; each rank
+RDMA-writes that shard to the counterpart rank (same `local_rank`) on every
+other node and receives theirs into the `network` area of its region; a
+small kernel sums the N−1 inbox shards into the shard; the intra-node
+all-gather (`allgather_finish`) then pulls the globally reduced shards into
+the user output, scaled for AVG. Broadcast and all-gather use the same RDMA
+path with a simpler schedule (root's node fans out to its counterparts, then
+intra-node; node blocks exchanged, then placed by global rank) and stay
+unpipelined — they run at DDP init, not in the step. Single-node
 communicators keep the fused intra-node path and never touch IB.
+
+**The three phases overlap.** The bucket is cut into K chunks and issued on
+the one comm stream, with at most `PIPE_ARENAS` chunks alive:
+
+```
+RS(0) rel(0)  RS(1) rel(1)  RS(2) rel(2)  RS(3) rel(3)
+              wait(0) add(0) AG(0)  RS(4) rel(4)
+              wait(1) add(1) AG(1)  RS(5) rel(5)  …
+```
+
+so the proxy exchanges chunk k while the GPU reduce-scatters later chunks
+and all-gathers earlier ones. `K = sqrt(bytes / (local_world × 640 KB))`,
+capped at 16 by choice and raised from below by geometry when a chunk would
+not fit — the square root is of the 16 µs an extra chunk costs (two more
+launches and two more 8-way start barriers) against the 40–45 GB/s the RDMA
+runs at. It gives K = 1 up to ~10 MiB, 2 at the 27 MiB DDP bucket, 5 at
+168 MiB and 10 at 512 MiB, and keeps a chunk's shard above 1 MiB without a
+second clause.
+
+Two things make concurrent chunks safe, and neither is stream order across
+ranks. **The staging arena is replicated.** A multi-node region is
+`PIPE_ARENAS` complete arenas — each its own signal area and its own
+`[stage_in | stage_out]` of `cap/PIPE_ARENAS` — followed by one cap-sized
+network area; chunk k uses arena `k % PIPE_ARENAS`, so concurrent chunks
+cannot collide in the push slots or in the shard, and that arena's own start
+barrier is what orders chunk k+`PIPE_ARENAS` behind chunk k's pulls, the
+invariant one arena already had. `collectives_kernels.mojo` is untouched:
+the split kernels take a shifted base and a smaller cap, nothing more. The
+staging total is `2 × cap` either way, so the region is the size it always
+was. **The inbox is reused only against a credit** — see the transport
+below. `PIPE_ARENAS` (4) and the derived `INBOX_SLOTS` (5) are source
+constants in `mojoccl.mojo`, not environment variables: they are part of the
+wire layout and every rank has to agree on them.
+
+The chunk cap is now one arena, and the inbox slot group, rather than the
+whole region: 64 MiB at 2 nodes and 36 MiB at 8 with the default 256 MiB
+region, so the large sizes are chunked by geometry as well as by choice.
+`tests/multinode/selftest/geometry_test.mojo` sweeps that arithmetic over
+regions of 1 MiB–1 GiB, `local_world` 1–8 and 2–16 nodes.
 
 **Transport** (`torch_mojo_backend/distributed/mojoccl/{ibverbs,internode,
 internode_kernels,bootstrap}.mojo`): libibverbs is dlopened; setup calls are
@@ -340,17 +376,40 @@ ordering through `ibv_reg_mr_iova2`; each shard is one
 `IBV_WR_RDMA_WRITE_WITH_IMM`, empty recv work requests exist only so the
 immediate produces a completion, and a self-QP `IBV_WR_RDMA_READ` flush
 orders the payload in GPU memory behind the completion that landed in host
-memory. The inbox is double-buffered by the exchange counter's parity
-carried in the immediate, which is sound only because every exchange is
-all-to-all: a rank whose shard is empty (7 of 8 ranks on DDP's 4-byte AVG
-allreduce) still posts a 16-byte credit. The GPU/network hand-off is a
-progress thread per rank driven through a pinned, device-mapped mailbox: a
-one-thread kernel releases the exchange, the thread posts, waits for the N−1
-arrivals and flushes, a second one-thread kernel spins until it is done. The
-thread spins only while an exchange is in flight; idle, it yields and then
-sleeps in `MOJOCCL_IB_PROXY_IDLE_US` steps, because a thread spinning between
-exchanges competed with the host-bound Python dispatch thread and cost ~20%
-of end-to-end training throughput at 16 ranks. A `cuLaunchHostFunc`/`hipLaunchHostFunc` stream
+memory. Every exchange is all-to-all — a rank whose shard is empty (7 of 8
+ranks on DDP's 4-byte AVG allreduce) still posts a 16-byte placeholder — so
+that an arrival tally of N−1 is what completes one.
+
+**Flow control is explicit credits.** The second half of the network area is
+carved once into `INBOX_SLOTS` fixed groups and exchange `e` lands in
+`e % INBOX_SLOTS`; a peer may write that group again only once every
+receiver has released it, published as a cumulative "consumed through e"
+counter in a 4-byte `RDMA_WRITE_WITH_IMM` whose immediate carries a credit
+bit — NCCL's head/tail pair in miniature
+(`nccl:src/transport/net.cc`). This replaces a double-buffer-by-parity
+argument that derived reuse safety from stream order ("peer B cannot post
+e+2 before receiving my e+1 data, which I send only after my own add kernel
+for e"), which holds for exactly one exchange in flight and breaks under the
+pipelined schedule. The credit needs no kernel of its own: it rides on this
+rank's next request as `credit_upto`, the number of consumer kernels already
+enqueued ahead of that request, and when the proxy observes the request that
+kernel has run, so every kernel enqueued before it has completed.
+`INBOX_SLOTS = PIPE_ARENAS + 1` is what keeps the rank furthest behind from
+ever waiting on a credit.
+
+The GPU/network hand-off is a progress thread per rank driven through a
+pinned, device-mapped mailbox: a one-thread kernel releases the exchange
+into `MB_REQUEST`, the thread posts it, and a second one-thread kernel spins
+on `MB_DONE` until the thread has seen the N−1 arrivals and flushed. Several
+exchanges live between the two, so the thread is one non-blocking step
+function (`ib_drive`, shared with the `MOJOCCL_IB_PROXY=0` callback and the
+GPU-free self-tests) that retires exchanges in sequence order — RC ordering
+is per queue pair, so arrivals are not ordered across peers — and pipelines
+the flush read the same way. The thread spins only while something is
+outstanding; idle, it yields and then sleeps in `MOJOCCL_IB_PROXY_IDLE_US`
+steps, because a thread spinning between exchanges competed with the
+host-bound Python dispatch thread and cost ~20% of end-to-end training
+throughput at 16 ranks. A `cuLaunchHostFunc`/`hipLaunchHostFunc` stream
 callback does the same job behind `MOJOCCL_IB_PROXY=0` and costs about
 480 µs of fixed driver latency per exchange on this cluster (2.6× slower at
 the DDP bucket), which is why the thread is the default. HCA choice: the
@@ -368,8 +427,8 @@ are skipped). Addressing is LID-only, so one IB subnet.
 | `MOJOCCL_IB_PROXY_IDLE_US` | 20 | sleep quantum of the idle progress thread (it spins only during an exchange) |
 | `MOJOCCL_IB_PROXY_CPU` | unset | pin the progress thread to this CPU |
 | `MOJOCCL_IB_RELAXED_ORDERING` | 1 | `0`: plain `ibv_reg_mr` |
-| `MOJOCCL_IB_TRACE` | 0 | `1`: one line per rank at destroy — HCA, port, peers, exchanges, mean µs posting / waiting / flushing |
-| `MOJOCCL_REGION_MB` | 256 | region area size; a multi-node communicator has three areas (`signal, stage_in, stage_out, network`) |
+| `MOJOCCL_IB_TRACE` | 0 | `1`: one line per rank at destroy — HCA, port, peers, slot groups, exchanges, credit stalls, mean µs posting / in flight / flushing |
+| `MOJOCCL_REGION_MB` | 256 | staging size; single node `[signal \| stage_in cap \| stage_out cap]`, multi-node `PIPE_ARENAS` arenas of `cap/PIPE_ARENAS` halves plus a cap-sized network area. Must match on every rank — `ncclCommInitRank` checks it |
 
 Limits and failure modes: 8 ranks per node, 16 nodes; more than one node
 with no ACTIVE InfiniBand port fails `ncclCommInitRank` with "no ACTIVE
@@ -389,35 +448,68 @@ is a 16-rank (2 nodes × 8 GPU) SLURM job: `tests/ddp_worker.py`
 allreduce device-time bench (`ar_bench_gpt2.py`) in ABBA order, and a
 40-step nanoGPT DDP run under both. `RUN_MOJO=0` keeps only the NCCL legs.
 `tests/multinode/summarize.py <job log>` turns a log into the tables below.
-`tests/multinode/selftest/` holds two GPU-free self-tests of the bootstrap
-and of the RDMA transport between processes (they run on a host with IB HCAs
-and no GPU, such as the login node; set `MOJOCCL_IB_PROXY=0` there); they
-caught six bugs before any GPU time was spent.
+`tests/multinode/selftest/` holds four GPU-free self-tests — the bootstrap,
+the RDMA transport, the pipelined transport with its credit protocol, and
+the region geometry (that last one needs no IB either). The first three run
+on a host with IB HCAs and no GPU, such as the login node, with
+`MOJOCCL_IB_PROXY=0`; they caught six bugs before any GPU time was spent.
 
-**Results**, 16 ranks on 2×8 H100 (`tests/multinode/run_two_node_checks.sbatch`,
-job 234072), `ar_bench_gpt2.py` through the process group, ABBA legs within
-1% of each other, medians in µs; NCCL 2.31.2 picks `NVLS_TREE/SIMPLE` from
-9 MiB up:
+**Results**, 16 ranks on 2×8 H100, `ar_bench_gpt2.py` through the process
+group, medians in µs. The pipeline against the commit before it, **in one
+job on one node pair**, legs in ABBA order (before, after, after, before) so
+a clock or fabric drift cancels to first order (job 234237,
+`cl02s01dgx05` + `cl02s02dgx23`); K is the chunk count the rule above picks:
 
-| MiB | mojo fp32 | NCCL fp32 | ratio | mojo bf16 | NCCL bf16 | ratio |
-|---|---|---|---|---|---|---|
-| 1 | 60 | 153 | 0.39 | 51 | 86 | 0.60 |
-| 9 | 119 | 174 | 0.69 | 119 | 167 | 0.72 |
-| 27 (DDP bucket) | 278 | 266 | 1.04 | 277 | 262 | 1.06 |
-| 168 (tail bucket) | 1532 | 939 | 1.63 | 1526 | 947 | 1.61 |
-| 512 | 4635 | 2363 | 1.96 | 4618 | 2380 | 1.94 |
+| MiB | K | fp32 before | fp32 after | | bf16 before | bf16 after | |
+|---|---|---|---|---|---|---|---|
+| 1 | 1 | 107 | 107 | 1.00 | 100 | 113 | (noise, see below) |
+| 9 | 1 | 187 | 187 | 1.00 | 186 | 187 | 1.00 |
+| 27 (DDP bucket) | 2 | 342 | 282 | **0.82** | 345 | 274 | **0.80** |
+| 168 (tail bucket) | 5 | 1606 | 1192 | **0.74** | 1592 | 1186 | **0.75** |
+| 512 | 10 | 4762 | 3541 | **0.74** | 4739 | 3532 | **0.75** |
+
+1 MiB is at the noise floor of this bench (per-leg medians 90–116 µs either
+side, minima 90.3 vs 91.8 fp32 and 90.5 vs 91.4 bf16); K is 1 there and at
+9 MiB, so those two sizes run the code they always did. NCCL 2.31.2 on the
+same node pair (job 234235) reads 175 / 267 / 941 / 2359 µs fp32 and 168 /
+263 / 950 / 2392 bf16 at 9 / 27 / 168 / 512 MiB, so the pipeline takes the
+DDP bucket from 1.28× NCCL to 1.06× and the tail bucket from 1.71× to
+1.27×. `MOJOCCL_IB_TRACE=1` over the whole bench: 0.15 µs posting, 2.8 µs
+flushing, and 160–215 µs per exchange between release and retirement (which
+now includes the time later chunks spend queued behind earlier ones);
+4% of exchanges waited on a credit.
+
+**Absolute numbers here are node-pair-specific and the table above is the
+only fair comparison.** An earlier run of the same bench on a different pair
+(job 234072) read 60 / 119 / 278 / 1532 / 4635 µs for the code in the
+"before" column; two pairs measured since put that same commit at 107 / 187 /
+342 / 1606 / 4762. NCCL is nearly identical on all of them (267 ± 2 µs at
+the bucket), which is the tell: it pipelines its network hop, so its numbers
+barely move with the fabric's per-message latency, and the unpipelined
+hierarchical allreduce's numbers moved a lot. Fitting an exchange latency to
+the 9 MiB point (where K is 1, and the shard's 1.1 MiB is 28 µs of wire at
+the measured 40–45 GB/s) gives ~19 µs on the fast pair and ~87 µs on the
+others. Hiding that latency is exactly what the pipeline does, and it is why
+the gain is larger here than the exposed-transfer arithmetic alone predicts.
+
+Splitting harder does not help: at `PIPE_SPLIT_UNIT = 320_000` (K of 3 / 8 /
+14 instead of 2 / 5 / 10) the 27 MiB bucket is unchanged and 168 and 512 MiB
+regress to 1291 and 3648 µs (job 234242, same ABBA design). The extra
+exchange's latency is not fully hidden, so past the point where the network
+is covered an extra chunk only buys launches.
 
 `collectives`, `ddp_parity` and `stress` pass at 16 ranks under both
-libraries, and nanoGPT-124M DDP at 16 ranks reaches the same losses. End to
-end (six 40-step runs alternating NCCL and mojoccl on one node pair, job
-234185, median step time over steps 3–40): NCCL 49.7 ms, mojoccl 51.4 ms,
-1.036×; the three adjacent pairs read 1.035, 1.084 and 0.996, so the
-run-to-run noise on these shared nodes is as large as the gap. Of the
-~1.7 ms, ~0.6 ms is the exposed 168 MiB tail bucket (1532 vs 939 µs). With
-`MOJOCCL_IB_TRACE=1` the RDMA itself runs at 40–45 GB/s per rank, near line
-rate for one 400 Gb/s HCA; at the bucket the mean split is 0.05 µs posting,
-~330 µs waiting (the transfer), 2.3 µs flushing. Above 27 MiB the gap is the
-intra-node half (the split reduce-scatter/all-gather pair is ~1004 µs at
-168 MiB on one node against NCCL's 751 µs NVLS multicast), not the network.
-Pipelining the shard so the RDMA overlaps the reduce-scatter is the next
-lever for the large sizes.
+libraries (job 234229, `cl02s01dgx06` + `cl02s04dgx02`), including `stress`'s
+200 rounds of interleaved 4-byte / 27 MiB / broadcast / allgather
+collectives and its 256 MiB messages, which the pipeline cuts into 7 chunks.
+The `MOJOCCL_IB_PROXY=0` fallback passes `collectives` too: it cannot
+overlap (the callback blocks the stream) but the schedule and the credit
+protocol are correct on it. nanoGPT-124M DDP at 16 ranks reaches the same
+losses; end to end its median step throughput was 4173k tok/s against NCCL's
+4230k in the same job, with a second mojoccl leg at 3704k — the run-to-run
+noise on these shared nodes is still as large as the gap.
+
+What is left at the large sizes is the intra-node half, not the network: the
+split reduce-scatter/all-gather pair is ~1004 µs at 168 MiB on one node
+against NCCL's 751 µs NVLS multicast, and the pipeline's 1192 µs is 1.19×
+that floor. Closing the rest needs `cuMulticastCreate`, not more overlap.

--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -573,6 +573,27 @@ longest common `/sys/devices` prefix between the GPU's and the HCA's PCI
 paths, ties by `local_rank`; only ACTIVE InfiniBand ports (the RoCE ports
 are skipped). Addressing is LID-only, so one IB subnet.
 
+Unpinned, the OS scheduler can still park the progress thread on the same
+CPU as this rank's busy Python dispatch thread and leave it there — measured
+end to end (job 234455, 16 ranks/2×8 H100, nanoGPT DDP) as a mode in one of
+three ABBA runs: steps 4–11 at 45–46 ms (within 2% of NCCL's steady 44.6–44.9
+ms), steps 12–35 at a sustained 51 ms (~13% slower), then back to 46 ms —
+the scheduler leaving the progress thread on a shared core for a stretch of
+the run, not throughout it. `MOJOCCL_IB_PROXY_CPU` unset therefore pins by
+default:
+`sched_getaffinity` reads this process's mask, and if it holds at least
+`2 × local_world` CPUs (torchrun gives every rank of a node the same mask),
+the thread goes on that mask's CPUs taken in descending order, indexed by
+`local_rank` — the top `local_world` CPUs, distinct per rank, Python's
+threads left wherever the scheduler already put them. Within that, a
+candidate whose SMT sibling is itself another rank's pin is deprioritized in
+favor of one that isn't (`topology/thread_siblings_list`, best-effort — read
+failures just skip the check). A mask smaller than `2 × local_world` leaves
+the thread unpinned rather than fight Python for a scarce core.
+`MOJOCCL_IB_PROXY_CPU=<n>` overrides with an exact CPU;
+`MOJOCCL_IB_PROXY_CPU=none` opts out of pinning entirely.
+`MOJOCCL_IB_TRACE=1` prints the chosen CPU (or why none was chosen).
+
 | variable | default | controls |
 |---|---|---|
 | `MOJOCCL_SOCKET_IFNAME` | first UP non-loopback IPv4 interface with a default route (`bond0` here) | interface whose address rank 0 publishes in the unique id; one name, no lists |
@@ -581,7 +602,7 @@ are skipped). Addressing is LID-only, so one IB subnet.
 | `MOJOCCL_IB_TIMEOUT_S` | 60 | how long a rank waits for a peer that stopped answering before latching an error — **every** wait: the inter-node exchange, its wait kernel, and the intra-node and NVLS barrier spins, which read it once per process |
 | `MOJOCCL_IB_PROXY` | 1 | `0`: stream host callback instead of the progress thread |
 | `MOJOCCL_IB_PROXY_IDLE_US` | 20 | sleep quantum of the idle progress thread (it spins only during an exchange) |
-| `MOJOCCL_IB_PROXY_CPU` | unset | pin the progress thread to this CPU |
+| `MOJOCCL_IB_PROXY_CPU` | unset: auto-pin (mask permitting), see above | an exact CPU to pin the progress thread to; `none` disables pinning |
 | `MOJOCCL_IB_RELAXED_ORDERING` | 1 | `0`: plain `ibv_reg_mr` |
 | `MOJOCCL_IB_TRACE` | 0 | `1`: one line per rank at destroy — HCA, port, peers, slot groups, exchanges, credit stalls, mean µs posting / in flight / flushing |
 | `MOJOCCL_REGION_MB` | 256 | staging size; single node `[signal \| stage_in cap \| stage_out cap]`, multi-node `PIPE_ARENAS` arenas of `cap/PIPE_ARENAS` halves plus a cap-sized network area. Must match on every rank — `ncclCommInitRank` checks it. On an NVLS region only the allocation is rounded up to the multicast granularity (2 MiB by default, 512 MiB under `MOJOCCL_NVLS_GRANULARITY=rec`); the halves keep the size asked for |

--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -408,7 +408,12 @@ job 234072), `ar_bench_gpt2.py` through the process group, ABBA legs within
 | 512 | 4635 | 2363 | 1.96 | 4618 | 2380 | 1.94 |
 
 `collectives`, `ddp_parity` and `stress` pass at 16 ranks under both
-libraries, and nanoGPT-124M DDP at 16 ranks reaches the same losses. With
+libraries, and nanoGPT-124M DDP at 16 ranks reaches the same losses. End to
+end (six 40-step runs alternating NCCL and mojoccl on one node pair, job
+234185, median step time over steps 3–40): NCCL 49.7 ms, mojoccl 51.4 ms,
+1.036×; the three adjacent pairs read 1.035, 1.084 and 0.996, so the
+run-to-run noise on these shared nodes is as large as the gap. Of the
+~1.7 ms, ~0.6 ms is the exposed 168 MiB tail bucket (1532 vs 939 µs). With
 `MOJOCCL_IB_TRACE=1` the RDMA itself runs at 40–45 GB/s per rank, near line
 rate for one 400 Gb/s HCA; at the bucket the mean split is 0.05 µs posting,
 ~330 µs waiting (the transfer), 2.3 µs flushing. Above 27 MiB the gap is the

--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -669,9 +669,14 @@ collectives and its 256 MiB messages, which the pipeline cuts into 7 chunks.
 The `MOJOCCL_IB_PROXY=0` fallback passes `collectives` too: it cannot
 overlap (the callback blocks the stream) but the schedule and the credit
 protocol are correct on it. nanoGPT-124M DDP at 16 ranks reaches the same
-losses; end to end its median step throughput was 4173k tok/s against NCCL's
-4230k in the same job, with a second mojoccl leg at 3704k — the run-to-run
-noise on these shared nodes is still as large as the gap.
+losses. End to end, six 40-step runs alternating NCCL and mojoccl on one
+node pair (median step time over steps 3–40): on shared nodes (job 234185)
+NCCL 49.7 ms vs mojoccl 51.4 ms with adjacent pairs at 1.035, 1.084 and
+0.996, inside those nodes' noise; on `--exclusive` nodes (job 234455) NCCL is
+tight at 44.6–44.9 ms and mojoccl reads 45.1, 45.7 and 50.1 ms — the
+best-decile steps are within 1.7% of NCCL, and the slow run is a mode (steps
+12–35 at a steady 51 ms, 45–46 before and after): the progress thread sharing
+a core with the rank's Python thread. Pinning it by default is the follow-up.
 
 What is left at the large sizes is the intra-node half, not the network: the
 split reduce-scatter/all-gather pair is ~1004 µs at 168 MiB on one node

--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -280,15 +280,17 @@ unchanged; NCCL/RCCL stays the default. Design and measurements:
 Scope, deliberately narrow — it is an experiment showing Mojo can write
 NCCL-class collectives, not a general library:
 
-- one node, 2–8 ranks, one process per GPU under torchrun (`MAX_WORLD = 8`);
-  multi-node transport is in progress on this branch — see "Multi-node"
-  below;
+- 2–8 ranks per node (`MAX_WORLD = 8`), up to 16 nodes, one process per GPU
+  under torchrun; the inter-node hop is Mojo over libibverbs — see
+  "Multi-node" below;
 - `ncclAllReduce` (float32/float16/bfloat16/int32/int64, SUM and AVG),
   `ncclBroadcast` and `ncclAllGather` (every dtype, byte-granular);
   `ncclReduce`, `ncclReduceScatter`, `ncclSend`, `ncclRecv` return
   `ncclInvalidUsage`, so DDP works and anything needing them does not;
-- the rendezvous is a directory under `/dev/shm` encoded in the 128-byte
-  `ncclUniqueId` (rank 0 removes it once every rank has opened its peers);
+- the rendezvous is a TCP socket that `ncclGetUniqueId` opens on rank 0;
+  the 128-byte `ncclUniqueId` carries its address, port and a random magic
+  (NCCL's shape), and `ncclCommInitRank` runs three relayed all-gathers over
+  it (host identity, IPC handle plus IB connection data, barrier);
 - every rank owns one IPC-shared staging region (`MOJOCCL_REGION_MB`, default
   256 MiB, multiple of 4 KiB; larger requests are chunked). MAX's own
   allocations cannot be shared across processes (§5.6 of the study), which
@@ -310,107 +312,96 @@ on an MI300A yet.
 
 ### Multi-node
 
-Work in progress on this branch (`mojo-collectives-multinode`). Everything
-in this subsection describes the target design and the validation harness
-for it, not (yet) a shipped feature — check
-`torch_mojo_backend/distributed/mojoccl/` and the git log for current
-status.
+The inter-node hop is Mojo too: no vendor collective library anywhere.
+Each collective on a communicator spanning N nodes runs, per chunk of at
+most `MOJOCCL_REGION_MB`: the intra-node reduce-scatter
+(`reduce_scatter_stage`) leaves every rank its shard of the node-reduced
+bucket in its own `stage_out`; each rank RDMA-writes that shard to the
+counterpart rank (same `local_rank`) on every other node and receives theirs
+into a third, cap-sized `network` area of its region; a small kernel sums the
+N−1 inbox shards into the shard; the intra-node all-gather
+(`allgather_finish`) then pulls the globally reduced shards into the user
+output, scaled for AVG. Broadcast and all-gather use the same RDMA path with
+a simpler schedule (root's node fans out to its counterparts, then
+intra-node; node blocks exchanged, then placed by global rank). Single-node
+communicators keep the fused intra-node path and never touch IB.
+
+**Transport** (`torch_mojo_backend/distributed/mojoccl/{ibverbs,internode,
+internode_kernels,bootstrap}.mojo`): libibverbs is dlopened; setup calls are
+symbols, the data path (`ibv_post_send`/`post_recv`/`poll_cq`) is reached
+through the `ibv_context_ops` table at the header's offsets, as NCCL's
+`ibvwrap` does. One RC queue pair per remote node, attributes borrowed from
+NCCL's `net_ib/connect.cc` (cited in the source); one `ibv_reg_mr` of the
+whole region (`nvidia_peermem`; dmabuf is not implemented), with relaxed
+ordering through `ibv_reg_mr_iova2`; each shard is one
+`IBV_WR_RDMA_WRITE_WITH_IMM`, empty recv work requests exist only so the
+immediate produces a completion, and a self-QP `IBV_WR_RDMA_READ` flush
+orders the payload in GPU memory behind the completion that landed in host
+memory. The inbox is double-buffered by the exchange counter's parity
+carried in the immediate, which is sound only because every exchange is
+all-to-all: a rank whose shard is empty (7 of 8 ranks on DDP's 4-byte AVG
+allreduce) still posts a 16-byte credit. The GPU/network hand-off is a
+spinning progress thread per rank (one core) driven through a pinned,
+device-mapped mailbox: a one-thread kernel releases the exchange, the thread
+posts, waits for the N−1 arrivals and flushes, a second one-thread kernel
+spins until it is done. A `cuLaunchHostFunc`/`hipLaunchHostFunc` stream
+callback does the same job behind `MOJOCCL_IB_PROXY=0` and costs about
+480 µs of fixed driver latency per exchange on this cluster (2.6× slower at
+the DDP bucket), which is why the thread is the default. HCA choice: the
+longest common `/sys/devices` prefix between the GPU's and the HCA's PCI
+paths, ties by `local_rank`; only ACTIVE InfiniBand ports (the RoCE ports
+are skipped). Addressing is LID-only, so one IB subnet.
+
+| variable | default | controls |
+|---|---|---|
+| `MOJOCCL_SOCKET_IFNAME` | first UP non-loopback IPv4 interface with a default route (`bond0` here) | interface whose address rank 0 publishes in the unique id; one name, no lists |
+| `MOJOCCL_BOOTSTRAP_TIMEOUT_S` | 120 | deadline for every bootstrap socket wait |
+| `MOJOCCL_IB_HCA` | affinity choice | exact HCA name to use instead (`mlx5_4`) |
+| `MOJOCCL_IB_TIMEOUT_S` | 60 | how long a rank waits for its peers' shards before latching an error |
+| `MOJOCCL_IB_PROXY` | 1 | `0`: stream host callback instead of the progress thread |
+| `MOJOCCL_IB_RELAXED_ORDERING` | 1 | `0`: plain `ibv_reg_mr` |
+| `MOJOCCL_IB_TRACE` | 0 | `1`: one line per rank at destroy — HCA, port, peers, exchanges, mean µs posting / waiting / flushing |
+| `MOJOCCL_REGION_MB` | 256 | region area size; a multi-node communicator has three areas (`signal, stage_in, stage_out, network`) |
+
+Limits and failure modes: 8 ranks per node, 16 nodes; more than one node
+with no ACTIVE InfiniBand port fails `ncclCommInitRank` with "no ACTIVE
+InfiniBand port found" (so Slingshot on Adastra is not covered; a
+libfabric/cxi transport would be a second backend); a peer that stops
+responding is reported through `ncclCommGetAsyncError` after
+`MOJOCCL_IB_TIMEOUT_S`; a stale unique id (tag `MOJOCCL2`) is rejected with
+a clear message.
+
+**Requirements.** rdma-core/libibverbs on the nodes (here MLNX OFED 24.10),
+GPUDirect RDMA through `nvidia_peermem`, active InfiniBand ports reachable
+between every pair of nodes, a routable interface for the TCP bootstrap.
 
 **Running the two-node job.** `tests/multinode/run_two_node_checks.sbatch`
-is a 16-rank (2 nodes × 8 GPU) SLURM job that runs `tests/ddp_worker.py`
-(`collectives`/`ddp_parity`/`stress`), the allreduce device-time bench
-(`ar_bench_gpt2.py`), and a 40-step nanoGPT DDP run, each ABBA'd between
-real NCCL and mojoccl:
+is a 16-rank (2 nodes × 8 GPU) SLURM job: `tests/ddp_worker.py`
+(`collectives`/`ddp_parity`/`stress`) under NCCL and under mojoccl, the
+allreduce device-time bench (`ar_bench_gpt2.py`) in ABBA order, and a
+40-step nanoGPT DDP run under both. `RUN_MOJO=0` keeps only the NCCL legs.
+`tests/multinode/summarize.py <job log>` turns a log into the tables below.
+`/home/gabriel/ddp_work/ib_selftest/` holds two GPU-free self-tests of the
+bootstrap and of the RDMA transport between processes (they run on the
+login node, which has IB HCAs; set `MOJOCCL_IB_PROXY=0` there).
 
-```bash
-# Vendor-only NCCL reference (no mojoccl multi-node transport needed):
-sbatch --export=ALL,RUN_MOJO=0 tests/multinode/run_two_node_checks.sbatch
-# Full A/B once the transport below lands:
-sbatch tests/multinode/run_two_node_checks.sbatch
-# Turn a job log into one markdown report:
-uv run --no-sync python tests/multinode/summarize.py \
-    /home/gabriel/ddp_work/logs/mojoccl_2node_<jobid>.log
-```
+**Results**, 16 ranks on 2×8 H100 (job 234040, nodes cl02s02dgx26 +
+cl02s04dgx01), `ar_bench_gpt2.py` through the process group, ABBA legs,
+medians in µs; NCCL 2.31.2 picks `NVLS_TREE/SIMPLE` from 9 MiB up:
 
-See `tests/multinode/README.md` for the full leg-by-leg description, and
-`/home/gabriel/ddp_work/mojo_collectives/mn/NCCL_REFERENCE_16.md` for the
-vendor-only 16-rank NCCL reference numbers this harness already measured
-(node names, SM clock, NCCL algo/protocol choices).
-
-**Algorithm (hierarchical allreduce).** Each bucket is reduced in three
-steps: an intra-node Mojo reduce-scatter leaves every rank owning
-`1/local_world_size` of the reduced bucket (the same RS kernel the
-intra-node path already uses); each rank then exchanges its shard with its
-counterpart rank on every other node over RDMA, directly between GPUs
-using GPUDirect RDMA (`ibv_reg_dmabuf_mr` on a handle obtained from the
-device buffer, matching NCCL's own `net_ib` transport — see the
-feasibility study §7 for the verbs call sequence: queue-pair connect via
-the c10d store, `ibv_post_send` WRITE/WRITE_WITH_IMM, `ibv_poll_cq`); an
-intra-node Mojo all-gather then reassembles the fully-reduced bucket. No
-vendor collective library is on the inter-node hop — this is the
-libibverbs-based alternative in the feasibility study's §7, not the
-NCCL/RCCL-inter-node fallback its §8 minimal plan describes; the trade is
-more engineering (an RDMA transport of our own, ≈2–3k lines per the study's
-estimate) for staying inside this project's "bring the whole GPU stack
-ourselves" motto all the way to the wire.
-
-**New environment variables (TODO — to be filled in by whichever agent
-lands the transport; keep this list in sync with what it actually reads).**
-Expected, from the feasibility study's §7 verbs sketch and this project's
-existing `TORCH_MOJO_BACKEND_*`/`MOJOCCL_*` naming:
-
-- `MOJOCCL_SOCKET_IFNAME` — TODO: network interface for the store/bootstrap
-  exchange (QPN/LID/GID, rkeys), the mojoccl analog of NCCL's
-  `NCCL_SOCKET_IFNAME`.
-- `MOJOCCL_IB_HCA` — TODO: which HCA(s)/ports to use when a node has more
-  than one (this cluster's nodes report multiple IB + RoCE devices per
-  `docs/mojo_collectives_feasibility.md` §5.5 — 10×400 Gb/s IB +
-  2×100 Gb/s RoCE, unmerged); presumably an NCCL-`NCCL_IB_HCA`-style
-  include/exclude list.
-- TODO: whatever else the transport needs — a GID index override, a
-  timeout/retry knob for the RDMA connection setup, a debug-logging
-  variable analogous to `NCCL_DEBUG`, anything else that shows up in
-  `torch_mojo_backend/distributed/mojoccl/`. **The transport agent should
-  replace this TODO list with the real names and one line each on what
-  they control**, the way `docs/distributed.md` documents
-  `MOJOCCL_REGION_MB` above.
-
-**Requirements (host side).** `rdma-core`/`libibverbs` (the verbs library
-the transport dlopens, the same way `nccl.py` dlopens `libnccl.so.2` —
-no C++ build, no vendor SDK); GPUDirect RDMA support so a QP can post sends
-directly from GPU memory, either the `nvidia_peermem` kernel module (the
-classic path NCCL's `net_ib` uses, see `net_ib/connect.cc` in the
-feasibility study's citations) or a dmabuf-based path
-(`ibv_reg_dmabuf_mr` off `cuMemGetHandleForAddressRange`, the same
-mechanism the feasibility study cites for NCCL's own dmabuf registration);
-active InfiniBand (or RoCE) ports reachable between every pair of nodes.
-None of this is optional the way the intra-node kernels' IB dependency
-isn't optional either — there is no non-RDMA fallback path planned for the
-performance-bar case (a gloo/TCP-staged shard exchange is the
-"acceptable for a demo, not for the bar" alternative the feasibility study
-names in §7, and is not what this transport targets).
-
-**Not covered: Slingshot.** This RDMA/libibverbs transport is
-NVIDIA-cluster-shaped (InfiniBand/RoCE verbs). CINES Adastra's Slingshot
-fabric needs a separate libfabric/cxi transport (see the "Cluster notes
-(SLURM, Slingshot — AMD MI300A)" section above, and
-`docs/mojo_collectives_feasibility.md` §7's cxi estimate) — out of scope
-here, and multi-node mojoccl will raise or fall back to NCCL/RCCL rather
-than silently do something slow on Slingshot until that transport exists.
-
-**Results.** To be filled in from `tests/multinode/summarize.py`'s output
-once the transport lands (allreduce bench medians/ratio by dtype and size,
-`ddp_worker` pass/fail by mode, and the nanoGPT DDP step-40 loss/val-loss/
-tok-s for each leg):
-
-| dtype | size (MiB) | vendor median (µs) | mojo median (µs) | mojo/vendor |
-|---|---|---|---|---|
-| _(TODO: paste the "Allreduce bench" table from a `summarize.py` run here)_ | | | | |
-
-| ccl | mode | result |
-|---|---|---|
-| _(TODO: paste the "ddp_worker checks" table here)_ | | |
-
-| ccl | leg | step | loss | val loss | tok/s | result |
+| MiB | mojo fp32 | NCCL fp32 | ratio | mojo bf16 | NCCL bf16 | ratio |
 |---|---|---|---|---|---|---|
-| _(TODO: paste the "nanoGPT DDP training" table here)_ | | | | | | |
+| 1 | 52–81 | 87–117 | 0.6–0.9 | 52–57 | 86 | 0.60 |
+| 9 | 119 | 174 | 0.68 | 120 | 167 | 0.72 |
+| 27 (DDP bucket) | 278 | 264 | 1.05 | 279 | 262 | 1.06 |
+| 168 (tail bucket) | 1527 | 939 | 1.63 | 1522 | 947 | 1.61 |
+| 512 | 4619 | 2366 | 1.95 | 4622 | 2385 | 1.94 |
+
+`collectives`, `ddp_parity` and `stress` pass at 16 ranks. With
+`MOJOCCL_IB_TRACE=1` the RDMA itself runs at 40–45 GB/s per rank, near line
+rate for one 400 Gb/s HCA; at the bucket the mean split is 0.05 µs posting,
+~330 µs waiting (the transfer), 2.3 µs flushing. Above 27 MiB the gap is the
+intra-node half (the split reduce-scatter/all-gather pair is ~1004 µs at
+168 MiB on one node against NCCL's 751 µs NVLS multicast), not the network.
+Pipelining the shard so the RDMA overlaps the reduce-scatter is the next
+lever for the large sizes.

--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -281,8 +281,8 @@ Scope, deliberately narrow — it is an experiment showing Mojo can write
 NCCL-class collectives, not a general library:
 
 - one node, 2–8 ranks, one process per GPU under torchrun (`MAX_WORLD = 8`);
-  multi-node is not implemented (the study's plan keeps NCCL/RCCL for the
-  inter-node shard allreduce, hierarchically);
+  multi-node transport is in progress on this branch — see "Multi-node"
+  below;
 - `ncclAllReduce` (float32/float16/bfloat16/int32/int64, SUM and AVG),
   `ncclBroadcast` and `ncclAllGather` (every dtype, byte-granular);
   `ncclReduce`, `ncclReduceScatter`, `ncclSend`, `ncclRecv` return
@@ -307,3 +307,110 @@ runs at the same throughput and the same losses within the training step's
 own run-to-run noise. AMD: the same source cross-compiles for gfx942 (the
 one vendor gate is a release fence on AMD's `s_barrier`), but it has not run
 on an MI300A yet.
+
+### Multi-node
+
+Work in progress on this branch (`mojo-collectives-multinode`). Everything
+in this subsection describes the target design and the validation harness
+for it, not (yet) a shipped feature — check
+`torch_mojo_backend/distributed/mojoccl/` and the git log for current
+status.
+
+**Running the two-node job.** `tests/multinode/run_two_node_checks.sbatch`
+is a 16-rank (2 nodes × 8 GPU) SLURM job that runs `tests/ddp_worker.py`
+(`collectives`/`ddp_parity`/`stress`), the allreduce device-time bench
+(`ar_bench_gpt2.py`), and a 40-step nanoGPT DDP run, each ABBA'd between
+real NCCL and mojoccl:
+
+```bash
+# Vendor-only NCCL reference (no mojoccl multi-node transport needed):
+sbatch --export=ALL,RUN_MOJO=0 tests/multinode/run_two_node_checks.sbatch
+# Full A/B once the transport below lands:
+sbatch tests/multinode/run_two_node_checks.sbatch
+# Turn a job log into one markdown report:
+uv run --no-sync python tests/multinode/summarize.py \
+    /home/gabriel/ddp_work/logs/mojoccl_2node_<jobid>.log
+```
+
+See `tests/multinode/README.md` for the full leg-by-leg description, and
+`/home/gabriel/ddp_work/mojo_collectives/mn/NCCL_REFERENCE_16.md` for the
+vendor-only 16-rank NCCL reference numbers this harness already measured
+(node names, SM clock, NCCL algo/protocol choices).
+
+**Algorithm (hierarchical allreduce).** Each bucket is reduced in three
+steps: an intra-node Mojo reduce-scatter leaves every rank owning
+`1/local_world_size` of the reduced bucket (the same RS kernel the
+intra-node path already uses); each rank then exchanges its shard with its
+counterpart rank on every other node over RDMA, directly between GPUs
+using GPUDirect RDMA (`ibv_reg_dmabuf_mr` on a handle obtained from the
+device buffer, matching NCCL's own `net_ib` transport — see the
+feasibility study §7 for the verbs call sequence: queue-pair connect via
+the c10d store, `ibv_post_send` WRITE/WRITE_WITH_IMM, `ibv_poll_cq`); an
+intra-node Mojo all-gather then reassembles the fully-reduced bucket. No
+vendor collective library is on the inter-node hop — this is the
+libibverbs-based alternative in the feasibility study's §7, not the
+NCCL/RCCL-inter-node fallback its §8 minimal plan describes; the trade is
+more engineering (an RDMA transport of our own, ≈2–3k lines per the study's
+estimate) for staying inside this project's "bring the whole GPU stack
+ourselves" motto all the way to the wire.
+
+**New environment variables (TODO — to be filled in by whichever agent
+lands the transport; keep this list in sync with what it actually reads).**
+Expected, from the feasibility study's §7 verbs sketch and this project's
+existing `TORCH_MOJO_BACKEND_*`/`MOJOCCL_*` naming:
+
+- `MOJOCCL_SOCKET_IFNAME` — TODO: network interface for the store/bootstrap
+  exchange (QPN/LID/GID, rkeys), the mojoccl analog of NCCL's
+  `NCCL_SOCKET_IFNAME`.
+- `MOJOCCL_IB_HCA` — TODO: which HCA(s)/ports to use when a node has more
+  than one (this cluster's nodes report multiple IB + RoCE devices per
+  `docs/mojo_collectives_feasibility.md` §5.5 — 10×400 Gb/s IB +
+  2×100 Gb/s RoCE, unmerged); presumably an NCCL-`NCCL_IB_HCA`-style
+  include/exclude list.
+- TODO: whatever else the transport needs — a GID index override, a
+  timeout/retry knob for the RDMA connection setup, a debug-logging
+  variable analogous to `NCCL_DEBUG`, anything else that shows up in
+  `torch_mojo_backend/distributed/mojoccl/`. **The transport agent should
+  replace this TODO list with the real names and one line each on what
+  they control**, the way `docs/distributed.md` documents
+  `MOJOCCL_REGION_MB` above.
+
+**Requirements (host side).** `rdma-core`/`libibverbs` (the verbs library
+the transport dlopens, the same way `nccl.py` dlopens `libnccl.so.2` —
+no C++ build, no vendor SDK); GPUDirect RDMA support so a QP can post sends
+directly from GPU memory, either the `nvidia_peermem` kernel module (the
+classic path NCCL's `net_ib` uses, see `net_ib/connect.cc` in the
+feasibility study's citations) or a dmabuf-based path
+(`ibv_reg_dmabuf_mr` off `cuMemGetHandleForAddressRange`, the same
+mechanism the feasibility study cites for NCCL's own dmabuf registration);
+active InfiniBand (or RoCE) ports reachable between every pair of nodes.
+None of this is optional the way the intra-node kernels' IB dependency
+isn't optional either — there is no non-RDMA fallback path planned for the
+performance-bar case (a gloo/TCP-staged shard exchange is the
+"acceptable for a demo, not for the bar" alternative the feasibility study
+names in §7, and is not what this transport targets).
+
+**Not covered: Slingshot.** This RDMA/libibverbs transport is
+NVIDIA-cluster-shaped (InfiniBand/RoCE verbs). CINES Adastra's Slingshot
+fabric needs a separate libfabric/cxi transport (see the "Cluster notes
+(SLURM, Slingshot — AMD MI300A)" section above, and
+`docs/mojo_collectives_feasibility.md` §7's cxi estimate) — out of scope
+here, and multi-node mojoccl will raise or fall back to NCCL/RCCL rather
+than silently do something slow on Slingshot until that transport exists.
+
+**Results.** To be filled in from `tests/multinode/summarize.py`'s output
+once the transport lands (allreduce bench medians/ratio by dtype and size,
+`ddp_worker` pass/fail by mode, and the nanoGPT DDP step-40 loss/val-loss/
+tok-s for each leg):
+
+| dtype | size (MiB) | vendor median (µs) | mojo median (µs) | mojo/vendor |
+|---|---|---|---|---|
+| _(TODO: paste the "Allreduce bench" table from a `summarize.py` run here)_ | | | | |
+
+| ccl | mode | result |
+|---|---|---|
+| _(TODO: paste the "ddp_worker checks" table here)_ | | |
+
+| ccl | leg | step | loss | val loss | tok/s | result |
+|---|---|---|---|---|---|---|
+| _(TODO: paste the "nanoGPT DDP training" table here)_ | | | | | | |

--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -265,3 +265,45 @@ srun --ntasks-per-node=1 --gpus-per-task=4 --cpus-per-task=96 -- \
     --rdzv-backend=c10d --rdzv-endpoint="$MASTER_ADDR:29500" \
     --rdzv-id="$SLURM_JOB_ID" demo_scripts/nanogpt_ddp.py ...
 ```
+
+## Mojo collectives (experimental): `TORCH_MOJO_BACKEND_CCL=mojo`
+
+An in-repo replacement for NCCL/RCCL's intra-node collectives, written in Mojo
+and exposed through **NCCL's own C ABI**: `torch_mojo_backend/distributed/mojoccl/`
+builds `libmojoccl.so` on first use (into the eager kernels' `__mojocache__`,
+same lock/atomic-rename machinery) and `nccl.py` dlopens it instead of
+`libnccl.so.2` when `TORCH_MOJO_BACKEND_CCL=mojo`. `process_group.py` is
+unchanged; NCCL/RCCL stays the default. Design and measurements:
+`docs/mojo_collectives_feasibility.md` (study) and
+`docs/mojo_collectives_kernel_results.md` (kernels).
+
+Scope, deliberately narrow — it is an experiment showing Mojo can write
+NCCL-class collectives, not a general library:
+
+- one node, 2–8 ranks, one process per GPU under torchrun (`MAX_WORLD = 8`);
+  multi-node is not implemented (the study's plan keeps NCCL/RCCL for the
+  inter-node shard allreduce, hierarchically);
+- `ncclAllReduce` (float32/float16/bfloat16/int32/int64, SUM and AVG),
+  `ncclBroadcast` and `ncclAllGather` (every dtype, byte-granular);
+  `ncclReduce`, `ncclReduceScatter`, `ncclSend`, `ncclRecv` return
+  `ncclInvalidUsage`, so DDP works and anything needing them does not;
+- the rendezvous is a directory under `/dev/shm` encoded in the 128-byte
+  `ncclUniqueId` (rank 0 removes it once every rank has opened its peers);
+- every rank owns one IPC-shared staging region (`MOJOCCL_REGION_MB`, default
+  256 MiB, multiple of 4 KiB; larger requests are chunked). MAX's own
+  allocations cannot be shared across processes (§5.6 of the study), which
+  is why the kernels stage through this region; the push / local-reduce /
+  pull design makes the staging free;
+- a rank that stops responding makes its peers time out after 60 s inside the
+  kernel and `ncclCommGetAsyncError` reports it; there is no abort path.
+
+Measured on 8×H100 SXM through the process group (wall over 20 launches,
+median of 5, interleaved legs; NCCL 2.31.2 NVLS for comparison): 1 MiB 29 vs
+31 µs, 9 MiB 70 vs 92, 27 MiB (the DDP bucket) 164 vs 181, 168 MiB 975 vs
+755, 512 MiB 2.95 vs 2.15 ms. The large sizes are the unicast ceiling
+(~310 GB/s per direction over NVSwitch); matching NCCL there needs NVLS
+multicast (`cuMulticastCreate`), not implemented. nanoGPT-124M DDP on 8 ranks
+runs at the same throughput and the same losses within the training step's
+own run-to-run noise. AMD: the same source cross-compiles for gfx942 (the
+one vendor gate is a release fence on AMD's `s_barrier`), but it has not run
+on an MI300A yet.

--- a/docs/distributed.md
+++ b/docs/distributed.md
@@ -462,7 +462,9 @@ RDMA-writes that shard to the counterpart rank (same `local_rank`) on every
 other node and receives theirs into the `network` area of its region; a
 small kernel sums the N−1 inbox shards into the shard; the intra-node
 all-gather (`allgather_finish`) then pulls the globally reduced shards into
-the user output, scaled for AVG. Broadcast and all-gather use the same RDMA
+the user output. AVG's 1/world is applied by the reduce-scatter to each input
+(NCCL's PreMulSum), so no node partial or inbox sum is ever an unscaled total
+in a half dtype. Broadcast and all-gather use the same RDMA
 path with a simpler schedule (root's node fans out to its counterparts, then
 intra-node; node blocks exchanged, then placed by global rank) and stay
 unpipelined — they run at DDP init, not in the step. Single-node

--- a/docs/mojo_collectives_feasibility.md
+++ b/docs/mojo_collectives_feasibility.md
@@ -1,0 +1,439 @@
+# Replacing NCCL/RCCL with Mojo collectives for GPT-2 DDP — feasibility study
+
+Date 2026-09-08. Author: Fable 5.1 agent. Scope as briefed: nanoGPT-124M DDP on
+(a) Kyutai 8×H100 SXM nodes (NVSwitch, IB 400 Gb/s, driver 570 / CUDA 12.8) and
+(b) CINES Adastra 4×MI300A nodes (ROCm 6.4.3, RCCL 2.22.3, Slingshot/cxi), one
+process per GPU under torchrun. Bar: NCCL/RCCL-class time on exactly this
+traffic. Everything under `/home/gabriel/ddp_work/mojo_collectives/` (`proto/`
+sources and binaries, `logs/` raw job output). Repo checkout untouched.
+
+Software read: NCCL master 2.31.2 (`/home/gabriel/projects/nccl`, cited as
+`nccl:path:line`), RCCL **2.30.7** develop (`/home/gabriel/projects/rocm-system/projects/rccl`,
+cited `rccl:path:line`; the monorepo has no 2.22.3 tag — deltas to Adastra's
+2.22.3 taken from `rccl:CHANGELOG.md`), modular checkout f807c5a (Jul 2026,
+`modular:path:line`), installed MAX 26.5.0 / Mojo 1.0.0 (`.venv`, precompiled
+`comm.mojoc` etc.). Stock reference torch 2.11.0+cu128 with NCCL 2.28.9
+(`~/ddp_work/torch_cu128`); the repo's own PG uses nvidia-nccl-cu12 2.31.2.
+
+## 1. Verdict (engineering estimate)
+
+Feasible, and the intra-node half is already demonstrated: a 120-line
+reduce-scatter + all-gather kernel written from scratch in Mojo, run as **8
+separate processes** with buffers exchanged through `cuIpcGetMemHandle` /
+`cuIpcOpenMemHandle` called from Mojo, allreduces the 27 MiB GPT-2 gradient
+bucket in **163–165 µs (300–304 GB/s busbw)** against **175 µs (283 GB/s)** for
+NCCL 2.28.9's NVLS/SIMPLE path on the same node class — i.e. at the size that
+matters it is 6% faster than NCCL, and it reaches 75% of NCCL-NVLS (92% of
+NCCL-ring) at 512 MiB, where NCCL's SHARP multicast wins. The same source
+cross-compiles unchanged for gfx942 except a comptime gate around the NVLS
+(multimem) variant, and the AMDGCN it emits (`sc0 sc1` system-scope loads/stores,
+`buffer_wbl2 sc0 sc1` / `buffer_inv sc0 sc1`) is exactly what RCCL relies on.
+Cost: **M1 intra-node NVIDIA in the ProcessGroup ≈ 3–4 weeks; M2 MI300A
+validation ≈ 2–3 weeks (needs Adastra time; kernel untested there); M3
+multi-node ≈ 2 weeks if the inter-node hop stays on NCCL/RCCL (hierarchical
+RS → inter-node allreduce of the 1/8 shard → AG), or 8–16 weeks for a pure-Mojo
+IB-verbs + libfabric/cxi transport, which is a host-proxy/RDMA project, not a
+kernel one.** Two decisions move the estimate: (1) how user tensors reach peer
+processes — MAX's allocator memory is **not** exportable with legacy IPC
+(measured: `cuIpcGetMemHandle` → `CUDA_ERROR_INVALID_VALUE`), so either the
+library owns `cuMemAlloc`/`hipMalloc`-ed staging buffers and copies in/out
+(measured +27% at 27 MiB, +27% at 168 MiB, all hidden except the tail bucket) or
+MAX's VMM arena becomes exportable with `cuMemExportToShareableHandle` — today
+it is not (measured: the 256 MiB `cuMemCreate` chunks carry
+`requestedHandleTypes = 0`, §5.6), so this needs a one-line change in MAX; (2) whether multi-node is in scope for the experiment at all.
+GPT-2 DDP is not communication-bound on either topology (~2.8 ms of NVLink time
+per ~45 ms step, 12 of 13 buckets overlapped), so any of the measured variants
+keeps end-to-end throughput within ~1% of NCCL; the bar is met intra-node.
+
+## 2. GPT-2 traffic profile (derived from source)
+
+Model/config: `demo_scripts/nanogpt_ddp.py` — GPT-2 124M, `vocab 50304`,
+`bias=False`, fp32 parameters, bf16 autocast, batch 12×1024 per rank, fused
+AdamW, `DDP(model, broadcast_buffers=False)`, defaults otherwise
+(`bucket_cap_mb=25`, `gradient_as_bucket_view=False`, no `find_unused_parameters`,
+no `static_graph`). 75 parameter tensors (wte/lm_head tied), 124,373,760 elements
+= **497,495,040 B (474.45 MiB) fp32 gradients per step**.
+
+Reducer bucketing (torch `reducer.cpp:2289-2412`: push first, close when
+`size >= limit`, limits `{1 MiB, 25 MiB}`, order = gradient-ready order, rebuilt
+once at step 2): **13 allreduces per step**
+
+| bucket | contents | bytes | MiB |
+|---|---|---|---|
+| 0 | ln_f, h.11.mlp.c_proj | 9,440,256 | 9.0 |
+| 1–11 | 6 tensors each | 28,317,696 | 27.0 each |
+| 12 | h.0.mlp.c_fc … wpe, **wte** (tied embedding, last to be ready) | 176,560,128 | **168.4, tail-exposed** |
+
+Op: `ncclSum` on values pre-divided by world size on the host
+(`reducer.cpp:384-392` `mul_out(bucket_view, grad, 1/div_factor)`; the default
+hook has no division, `default_comm_hooks.cpp:44-58`). One contiguous fp32
+tensor per bucket, in place. Step 1 is one 474 MiB allreduce (initial bucketing
+uses `sys.maxsize`). Per run: 1 allgather (8 B), broadcasts of 2,000 B,
+270,950,400 B, 226,544,640 B (parameters, `broadcast_bucket_size=250 MiB`),
+304 B, 52 B (bucket indices); an `AVG` allreduce of 4 B every 10 steps;
+`barrier()` once (routed to gloo/CPU). DDP itself only needs
+`allreduce`, `broadcast`, `allgather` (+`barrier`) from the PG
+(`torch_mojo_backend/distributed/process_group.py:393,456,522,937`).
+
+Execution today: each bucket goes to `ncclAllReduce` on a per-device side
+stream that first waits on the default stream (`process_group.py:303-335`,
+`device_streams.py:87-91`); buckets serialize on that stream and overlap
+backward; completion is the lazy fence in `mojo_device/comm_fence.py` (no
+watcher thread). Budget: 8×H100 DDP step ≈ 45 ms at B=12 (memory notes); the 12
+overlappable buckets need ≥ 17 GB/s busbw to hide — NVLink gives 300+.
+
+## 3. What NCCL / RCCL do for this traffic
+
+### 3.1 NCCL on 8×H100 NVSwitch (measured + source)
+
+Measured choices (`NCCL_DEBUG_SUBSYS=TUNING`, stock 2.28.9, `logs/proto_233567.out`):
+1 MiB → `RING/LL` 24 channels; 9–512 MiB → **`NVLS/SIMPLE`, 16 channels
+(`NVLS_NCHANNELS_SM90`, `nccl:src/transport/nvls.cc:155`), 640 threads,
+CGA cluster 4**. With `NCCL_NVLS_ENABLE=0`: 9–27 MiB → `RING/LL128` 24 ch,
+≥128 MiB → `RING/SIMPLE` 24 ch. Cost model: `nccl:src/tuning/tuning_general.cc:64`
+(`lat*latCount + nBytes/(1000*bw)`), tables `nccl:src/tuning/cost_model.cc:141-220`
+(Hopper `llMaxBw` 141 GB/s single node, LL128 36.7 GB/s/channel, NVLS
+efficiency 0.85 `nccl:src/tuning/nvls.cc:15`).
+
+What NVLS needs: `cuMulticastCreate/AddDevice/BindMem`
+(`nccl:src/transport/nvls.cc:60,344,372`), the shareable handle broadcast over the
+bootstrap socket and **the POSIX fd passed with `SCM_RIGHTS` over an AF_UNIX
+socket** (`nccl:src/proxy.cc:1583`, `nccl:src/os/linux_ipcsocket.cc:212`), device
+`multimem.ld_reduce.relaxed.sys.global.add[.v4]` / `multimem.st.global`
+(`nccl:src/device/reduce_kernel.h:1131-1198`, `nccl:src/device/op128.h:429-437`),
+fp32 sum supported (`nccl:src/include/device.h:608-623`). Multi-node NVLS
+proper is off (needs `collnetEnable`, `nccl:src/tuning/nvls.cc:38-41`); 2 nodes
+pick `NVLS_TREE/SIMPLE` (measured, §5.5).
+
+Intra-node P2P transport (what a ring/RS-AG port has to match): with driver ≥
+12000 NCCL uses the **cuMem VMM path, not `cudaIpcGetMemHandle`**
+(`nccl:src/misc/cudawrap.cc:16-51`; alloc `nccl:src/include/alloc.h:312-346`
+`cuMemCreate(POSIX_FD)`; import `nccl:src/transport/p2p.cc:267-327` via
+`cuMemImportFromShareableHandle` after the fd round-trip). H100 pairs run in
+WRITE mode (READ only for compcap 80, `nccl:src/graph/paths.cc:441-445`);
+per (peer, channel) 2 MiB send + 10 MiB recv FIFO (`nccl:src/transport/p2p.cc:410-413,489-494`),
+8 steps of 512 KiB (`NCCL_STEPS`, `nccl:src/include/device.h:26`); head/tail
+counters in **device** memory written remotely over NVLink
+(`nccl:src/transport/p2p.cc:570-605`). Plain eager `ncclAllReduce` on
+unregistered buffers never takes the direct (FIFO-bypass) path
+(`nccl:src/register/coll_reg.cc:212-214,339-343`) — NCCL copies every byte
+through its own buffers, so "staging" (option b below) is NCCL's own default
+design, not a handicap.
+
+Protocol primitives (minimum for SIMPLE + LL, `nccl:src/device/op128.h`):
+`ld.volatile.global` (:342-345), `st.relaxed.sys.global.u64` (:380),
+`fence.acq_rel.sys` (:395), 16 B `ld/st.global.v2.b64`, named
+`barrier.sync`, `__syncwarp`; LL relies on 8-byte store atomicity of the fabric
+(`nccl:src/include/device.h:75-88`), LL128 on 128-byte NVLink store atomicity
+plus warp lockstep (`nccl:src/device/prims_ll128.h:194-207`). No `__nanosleep`,
+no TMA/cluster sync in the general kernels; dynamic shmem ≈ 80 KiB
+(`nccl:src/include/device.h:573-591`).
+
+### 3.2 RCCL on 4×MI300A (source; not measurable from here)
+
+- APU detection = `hipDeviceAttributeDirectManagedMemAccessFromHost` on device 0
+  (`rccl:src/init.cc:1905-1920`); single node 4 ranks → channel multiplier
+  `nc=4` (MI300X branch), multi-node APU → `nc=6`. Tuning model 5 for gfx942
+  (`rccl:src/graph/tuning.cc:1637-1647`). Tree+Simple is removed on single-node
+  gfx942 (`rccl:src/graph/tuning.cc:1232-1236`), so intra-node AllReduce is
+  Ring/{LL,LL128,Simple}; LL128 is **off by default** on a generic 4-GPU node
+  (`ll128Enabled` only via Rome-model options or `RCCL_LL128_FORCE_ENABLE=1`,
+  `rccl:src/init.cc:1661,1946-1947`, gate `rccl:src/graph/tuning.cc:1469-1485`).
+  Multi-node AllReduce protocol override: LL ≤ 512 KiB, else SIMPLE at 25 MiB
+  (`rccl:src/rccl_wrap.cc:148-178`, ranges `rccl:src/graph/tuning.cc:556-573`).
+- Memory: every cross-agent buffer is **uncached** `hipExtMallocWithFlags(hipDeviceMallocUncached)`
+  (`rccl:src/transport/p2p.cc:282-287`), exported with legacy
+  `hipIpcGetMemHandle` / `hipIpcOpenMemHandle(LazyEnablePeerAccess)`
+  (`rccl:src/transport/p2p.cc:281-295,382-384`); fine-grain support is a hard
+  P2P precondition (`rccl:src/transport/p2p.cc:138-146`). The cuMem/VMM path is
+  auto-enabled only on gfx1250 and needs kernel ≥ 6.8 / HIP ≥ 7.2
+  (`rccl:src/misc/rocmwrap.cc:121-150`) → **on Adastra RCCL itself uses
+  hipMalloc-class staging buffers + legacy IPC**.
+- Device ordering on gfx942: 16-byte `global_load/store_dwordx4` with system
+  syncscope (`sc0 sc1`) (`rccl:src/device/op128.h:366-388`), `__hip_atomic_*`
+  RELAXED/RELEASE at `__HIP_MEMORY_SCOPE_SYSTEM` for flags
+  (`rccl:src/device/op128.h:428-468`), `fence_acq_rel_sys()` is a **no-op**
+  (`rccl:src/device/op128.h:470-475`), producer ordering =
+  `s_waitcnt lgkmcnt(0) vmcnt(0)` in the block barrier then a system-scope
+  relaxed tail store (`rccl:src/device/prims_simple.h:193-210`, "cheap fence"
+  on gfx942 `rccl:src/include/rccl_common.h:251-273`); no HDP flush on
+  gfx90a/942/950 (`rccl:src/transport/p2p.cc:468-482`); wave 64, 256 threads
+  max, 4 barrier groups (`rccl:src/include/device.h:146-157`); spin loops use
+  `s_sleep(1)`/`s_wakeup` (`rccl:src/device/prims_simple.h:127-140`). LL line
+  = two `u64` non-temporal loads / two plain `u64` stores
+  (`rccl:src/device/prims_ll.h:170-190,276-296`); LL128 line is 64 B and its
+  correctness is pinned on a single 128-bit vector store
+  (`rccl:src/device/prims_ll128.h:44-60`).
+- Slingshot: no libfabric/cxi code in RCCL; the cxi provider is an out-of-tree
+  `ncclNet_v8+` plugin (`librccl-net.so`, `rccl:src/plugin/net.cc:259,102-187`;
+  vtable `rccl:src/include/plugin/net/net_v8.h:27-80`), GPU registration via
+  `hsa_amd_portable_export_dmabuf` + `regMrDmaBuf` (`rccl:src/include/rocmwrap.h:178-197`,
+  gate `rccl:src/misc/rocmwrap.cc:292-334`), host proxy thread as in NCCL.
+
+## 4. What Mojo/MAX provides and what is missing
+
+| need | status (installed MAX 26.5 / Mojo 1.0) | evidence |
+|---|---|---|
+| kernel on GPU A reads/writes GPU B memory (same process) | yes; `enable_all_peer_access` (`modular:mojo/stdlib/std/gpu/host/device_context.mojo:7660`), raw peer pointers as kernel args | `comm/allreduce.mojo` does it; measured §5.2 |
+| cross-process buffer sharing | **absent** from MAX (`cuMemImportFromShareableHandle`, `cuIpc*`, `hipIpc*` not in `libAsyncRTMojoBindings.so`); done here via `OwnedDLHandle("libcuda.so.1")` → `cuIpcGetMemHandle/cuIpcOpenMemHandle` (64-byte struct by value passed with a 4-dummy-register stack shim; `std.ffi` has no C-struct ABI yet, MOCO-3692) | `proto/ipc_probe.mojo`, `proto/ipc_allreduce.mojo`; §5.4 |
+| exporting MAX-allocated buffers | **legacy IPC refused** (`cuIpcGetMemHandle` rc=1 on `enqueue_create_buffer` memory); VMM export: §5.6 | `logs/ipc_ar_233615.out`, `logs/vmm_233620.out` |
+| system-scope release/acquire, volatile loads, fences | yes: `Atomic[..].store[ordering=RELEASE]` / `load[ACQUIRE]` with default (system) syncscope, `UnsafePointer.store[volatile=True]`, `std.atomic.fence`; lowers to `st.release.sys.global` / `ld.acquire.sys.global` / `st|ld.volatile.global` on sm_90a and `global_store/load … sc0 sc1`, `buffer_wbl2 sc0 sc1`, `buffer_inv sc0 sc1`, `flat_* sc0 sc1` on gfx942 | `proto/asm/rsag_sm_90a.asm`, `proto/asm/rsag_gfx942.asm` (dumped with `max.gpu.host.compile._compile_code`) |
+| working in-kernel cross-GPU barrier | yes, `comm.sync._multi_gpu_barrier` + `Signal` (vLLM-style, portable NVIDIA/AMD) | `modular:max/kernels/src/comm/sync.mojo:330-479` |
+| tuned intra-node allreduce | yes, `comm.allreduce` 1-stage/2-stage/Lamport/multimem, arch table sm_90a/sm_100a/CDNA3/CDNA4 (`modular:max/kernels/src/comm/allreduce.mojo:257-469`); single-process, rank = `ctx.id()`; no MI300A entry (falls to CDNA3: 32 blocks, 1-stage) | measured §5.2 |
+| NVLS / multicast | `DeviceMulticastBuffer(List[DeviceContext])` + `multimem_ld_reduce/st` — **single process only**, no handle export | `device_context.mojo:7896`, `memory.mojo:3118` |
+| side stream + priority, events, cross-device stream wait | Mojo `create_stream(priority=)`, `DeviceStream.enqueue_function(DeviceFunction)`; Python `DeviceStream` (no priority), `DeviceEvent.is_ready()`; closure-capturing kernels cannot be launched on a `DeviceStream` from a shared-lib build (m0 issue modular-1) — the prototype kernel is capture-free | repo `mojo_device/device_streams.py` |
+| host-mapped flags / host callbacks (proxy designs) | `CompletionFlag`, `DeviceStream.wait_for_host_value`, `enqueue_host_func` (CUDA only), pinned `enqueue_create_host_buffer` | `device_context.mojo:2356,2389,2529,4300` |
+| calling libcuda/libamdhip64 | `OwnedDLHandle` + `get_function[Ret](name)`; MAX already dlopened them | `modular:mojo/stdlib/std/ffi/__init__.mojo:316,380` |
+| passing a `DeviceContext` into an extension | `_ctx_ptr` → `DeviceContext(OpaquePointer(unsafe_from_address=…))` | `eager_kernels/__init__.py:904-909`, `op_utils/__init__.mojo:865-869` |
+| rendezvous | none in Mojo; the PG already has the c10d store (`process_group.py:352-365`) | file exchange stands in for it in the probes |
+| pinned SM clock via SLURM comment | did not take (SM 1980 MHz under load in every job) | `logs/proto_233567.out` |
+
+Inline `Signal` cost: `size_of[Signal]()` ≈ 24.75 MiB per rank (24 MiB Lamport
+region unused by RS/AG); a slim counter-only struct would be 768 KiB.
+
+## 5. Measurements
+
+All on kyutai_debug 8×H100 80GB HBM3 nodes, SM clock 1980 MHz (unpinned), 5 reps
+× 20 back-to-back calls per size, median; device time = CUDA events (stock
+torch) / wall over 20 launches with host enqueue ≤ 16 µs per launch (Mojo;
+`RESULT_DEV`/`kernel span` = in-kernel `globaltimer` per-rank span, within 3% of
+wall everywhere). busbw = algbw × 2(N−1)/N. Raw logs in `logs/`.
+
+### 5.1 NCCL reference, 8 ranks, 1 node
+
+Job 233527 node `cl02s04dgx10`, job 233567 node `cl02s01dgx27`:
+`torchrun --standalone --nproc-per-node=8 nccl_ref_stock.py|nccl_ref_stock2.py`
+(cu128 venv, `NCCL_DEBUG=INFO NCCL_DEBUG_SUBSYS=TUNING`). fp32 (bf16 within 2%):
+
+| MiB | NCCL default (NVLS on) | algo | NCCL `NCCL_NVLS_ENABLE=0` | algo |
+|---|---|---|---|---|
+| 1 | 0.026 ms · 71 GB/s | RING LL 24ch | 0.033 · 56 | RING LL |
+| 9 | 0.087 · 190 | NVLS SIMPLE 16ch | 0.077 · 214 | RING LL128 24ch |
+| 16 | 0.121 · 244 | NVLS | 0.116 · 253 | RING LL128 |
+| 25 | 0.169 · 272 | NVLS | 0.174 · 263 | RING LL128 |
+| 27 | **0.175 · 283** | NVLS | 0.182 (bf16; fp32 median 0.242 noisy, min 0.182) · 272 | RING LL128 |
+| 128 | 0.585 · 401 | NVLS | 0.698 · 337 | RING SIMPLE |
+| 168 | **0.751 · 410** | NVLS | 0.896 · 344 | RING SIMPLE |
+| 512 | 2.146 · 438 | NVLS | 2.643 · 356 | RING SIMPLE |
+
+Repo PG (`nccl_ref_mojo.py`, mojo backend over nvidia-nccl-cu12 2.31.2, same
+algo choices): 25 MiB 0.177 ms, 512 MiB 2.156 ms; 1 MiB 0.107 ms wall — the
+Python PG is host-bound below ~9 MiB (NCCL device time 0.026 ms).
+
+### 5.2 Mojo intra-node prototypes, 1 process, 8 `DeviceContext`s (job 233567, node `cl02s01dgx27`)
+
+`proto/ar_proto.mojo` (`ar_proto_<dt> <bytes> 20 5 <variant> [blocks]`, built
+`uv run --no-sync mojo build --target-accelerator sm_90a -D dtype=… -D multimem=1`).
+`own` = RS+AG written here (216×256 threads, 16 B vector peer loads, MAX's
+`Signal`/`_multi_gpu_barrier` reused, output buffers double as the AG source,
+no temp payload); `max` = `comm.allreduce` (2-stage on sm_90a for these sizes,
+216 blocks, 8×msg payload); `maxmm` = `comm.allreduce[use_multimem=True]`
+via `DeviceMulticastBuffer`. fp32 µs per allreduce (bf16 within 1%):
+
+| MiB | own | MAX 2-stage | MAX multimem | NCCL NVLS | NCCL ring | own/NCCL-NVLS |
+|---|---|---|---|---|---|---|
+| 1 | 19.6 (94 GB/s) | 20.3 | 20.3 | 26 | 33 | 0.75 |
+| 9 | 66 (249) | 74 | 72 | 87 | 77 | 0.76 |
+| 16 | 107 (275) | 115 | 107 | 121 | 116 | 0.88 |
+| 25 | 153 (299) | 172 | 166 | 169 | 174 | 0.91 |
+| **27** | **164 (302)** | 174 (285) | 170 (291) | **175 (283)** | 182 | **0.94** |
+| 128 | 723 (325) | 751 | 769 | 585 | 698 | 1.24 |
+| **168** | **940 (328)** | 979 (315) | 1002 | **751 (410)** | 896 | **1.25** |
+| 512 | 2857 (329) | 2971 (316) | 3018 | 2146 (438) | 2643 | 1.33 |
+
+Grid sweep, own fp32 (µs): 27 MiB 64→187, 128→166, 216→164, 432→168, 864→180;
+512 MiB 64→3356, 128→2926, 216→2857, 432→2845, 864→2848. The own kernel
+saturates at ~330 GB/s busbw = 190 GB/s of NVLink reads per GPU; NCCL ring
+reaches 356, NVLS 438. MAX's multimem path is not faster than its 2-stage path
+here (unicast-bound copy phases).
+
+### 5.3 Correctness/ABI probe, 2 processes, `cuIpc*` from Mojo (job 233615, node `cl02s01dgx15`; earlier 233572)
+
+`proto/ipc_probe.mojo export 0 …` / `import 1 …`, 128 MiB uint32:
+`cuIpcGetMemHandle` on MAX `enqueue_create_buffer` memory → **rc 1
+(CUDA_ERROR_INVALID_VALUE)**; on `cuMemAlloc_v2` memory → rc 0;
+`cuIpcOpenMemHandle` (struct-by-value via stack shim) → ok; importer read
+pattern (0 wrong of 33,554,432), **peer read 369 GB/s**, wrote pattern+1, released
+a flag with `Atomic.store[RELEASE]` (system scope); exporter observed the flag
+and verified all 33,554,432 elements: **PASS** (also GPU 3→6). Lesson recorded
+in the source: one legacy handle per allocation; opening the same allocation
+twice in a process fails with CUDA_ERROR_ALREADY_MAPPED (208).
+
+### 5.4 Mojo allreduce, 8 processes over IPC (job 233615, node `cl02s01dgx15`)
+
+`proto/ipc_allreduce.mojo`: each rank `cuMemAlloc`s one region
+[Signal | input | output], exports one handle to a file (stand-in for the
+c10d store), imports the 7 peers' regions, runs the §5.2 `own` kernel. `direct`
+= the collective operates on those library-owned buffers; `staging` = the user
+tensor lives in a MAX buffer and every call copies it in and the result back
+(option b), copies included in the time. µs per allreduce, max over ranks:
+
+| MiB | direct fp32 | direct bf16 | staging fp32 | staging bf16 | NCCL NVLS |
+|---|---|---|---|---|---|
+| 9 | 66 (250 GB/s) | 68 | 82 | 85 | 87 |
+| **27** | **165 (300)** | 163 | **210 (236)** | 210 | **175** |
+| 168 | 946 (326) | 947 | 1200 | 1198 | 751 |
+| 512 | 2861 (328) | 2858 | 3624 | 3622 | 2146 |
+
+Cross-process costs nothing versus single-process (§5.2). `cuIpcOpenMemHandle`
+took 10–17 ms per peer (70–118 ms per rank for 7 peers, one-off). Staging adds
+one D2D round trip per direction (≈2.5 TB/s HBM): +45 µs at 27 MiB. Writing the
+AG result straight into the user output and staging only the input would halve
+that (not measured).
+
+### 5.5 NCCL reference, 16 ranks, 2 nodes (job 233608, nodes `cl02s01dgx15`+`cl02s03dgx28`)
+
+Stock cu128, IB with GPUDirect RDMA (12 HCAs seen, 10×400 Gb/s IB + 2×100 Gb/s
+RoCE unmerged), algo `NVLS_TREE/SIMPLE` 16 ch for ≥9 MiB, `TREE/LL128` at 1 MiB:
+fp32 1 MiB 0.082 ms (24 GB/s), 9 MiB 0.221 (80; min 0.165), 16 MiB 0.200 (158),
+**27 MiB 0.259 (205)**, 128 MiB 0.764 (329), **168 MiB 0.946 (349)**,
+512 MiB 2.397 (420). Reference busbw at large sizes agrees with the earlier
+~392 GB/s measurement.
+
+### 5.6 VMM export of MAX-owned memory (job 233620, `proto/vmm_probe.mojo`)
+
+`cuPointerGetAttribute` dump (MEMPOOL_HANDLE, RANGE/MAPPING size,
+ALLOWED_HANDLE_TYPES, IS_LEGACY_CUDA_IPC_CAPABLE) + `cuMemRetainAllocationHandle`
+→ `cuMemGetAllocationPropertiesFromHandle` → `cuMemExportToShareableHandle`
+(POSIX fd) → fd passed with `pidfd_getfd` → `cuMemImportFromShareableHandle`
++ `cuMemAddressReserve/Map/SetAccess` in the importer, with and without
+`MODULAR_DEVICE_CONTEXT_MEMORY_MANAGER_VMM=1`.
+
+Result (node `cl02s02dgx26`, kernel 5.15.0-1108, driver 570.211.01, identical
+with and without the knob): MAX's `enqueue_create_buffer` memory is **VMM**, not
+a mempool — `MEMPOOL_HANDLE = 0`, `IS_LEGACY_CUDA_IPC_CAPABLE = 0`,
+`RANGE_START 0x420000000`, `RANGE_SIZE 307,090,161,664 B (286 GiB)` VA arena,
+`MAPPING_SIZE 268,435,456 B` (256 MiB physical chunks), `ALLOWED_HANDLE_TYPES = 0`.
+`cuMemRetainAllocationHandle` → rc 0 (a real `cuMemCreate` handle), but its
+`CUmemAllocationProp.requestedHandleTypes = 0`, so
+**`cuMemExportToShareableHandle` → rc 1 (CUDA_ERROR_INVALID_VALUE)**. Option (a)
+is therefore not available on MAX 26.5 as shipped: the chunks were created
+without `CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR`. It is a one-line change on
+Modular's side (`requestedHandleTypes` at `cuMemCreate`; NCCL sets it,
+`nccl:src/include/alloc.h:312-346`) — the natural upstream ask — after which the
+importer half of this probe (fd via `pidfd_getfd`/`SCM_RIGHTS`, import, map one
+256 MiB chunk per peer, offset arithmetic) applies unchanged, and the mapping
+granularity (256 MiB chunks, handle cached per chunk) makes the per-tensor
+exchange cheap. Until then the library must own the buffers (option b, §5.4);
+option (c) does not exist (no IPC/export symbol in MAX's Mojo or Python API,
+§4). AMD side from source: RCCL on ROCm 6.4.3 uses legacy
+`hipIpcGetMemHandle` on `hipExtMallocWithFlags(hipDeviceMallocUncached)` buffers
+(§3.2) — i.e. also library-owned staging; `hipMemExportToShareableHandle` exists
+but RCCL only enables the VMM path on gfx1250 with HIP ≥ 7.2
+(`rccl:src/misc/rocmwrap.cc:121-150`), so option (b) is the expected path there
+too, and whether MAX's HIP allocator memory accepts `hipIpcGetMemHandle` is
+untested (it is `hipMalloc`-class by default per `docs/distributed.md`, VMM with
+`MODULAR_DEVICE_CONTEXT_MEMORY_MANAGER_VMM=1`).
+
+## 6. One codebase for NVIDIA and AMD
+
+Demonstrated by cross-compilation (`--target-accelerator gfx942`, no device):
+`ar_proto.mojo` and `ipc_allreduce.mojo` build for gfx942 with **one** gate —
+`comptime MM = get_defined_bool["multimem"]() and has_nvidia_gpu_accelerator()`
+around the `DeviceMulticastBuffer`/`use_multimem` path (multimem is sm_90+ only,
+`modular:mojo/stdlib/std/gpu/memory/memory.mojo:3085`); `ipc_probe.mojo` builds
+with a comptime name switch (`hipIpcGetMemHandle`/`hipIpcOpenMemHandle`/`hipMalloc`/
+`hipSetDevice` vs `cuIpc*`/`cuMemAlloc_v2`/`cuDevicePrimaryCtxRetain+cuCtxSetCurrent`;
+identical signatures, same 64-byte handle struct). The kernel body is vendor-free:
+`global_perf_counter_ns` → `s_memrealtime`, `Atomic` → `sc0 sc1` + `buffer_wbl2`/
+`buffer_inv` (matches RCCL's `__hip_atomic_* SYSTEM` + `dwordx4 sc0 sc1`, §3.2),
+16 B vectors → `global_load/store_dwordx4`, BLOCK=256 ≤ RCCL's gfx942 max.
+
+Unavoidable per-vendor shims (all host-side, ~100 lines total): driver library
+and function names; making the device current; **staging allocation flags** —
+on MI300 the FIFO/flag buffers must be `hipExtMallocWithFlags(hipDeviceMallocUncached)`
+(RCCL's precondition, §3.2), `hipMalloc` is not enough for polled flags; on
+NVIDIA plain `cuMemAlloc`. Tuning: block count (216 on H100; MAX uses 32–64 on
+CDNA; RCCL `nc=4` channels for 4 ranks), spin-loop `s_sleep`, 4 APUs on xGMI
+(48 GB/s per link, 2 links per pair per `rome_model_80`, `rccl:src/graph/rome_models.cc:2214-2287`)
+vs 8 on NVSwitch — expect ~100–150 GB/s busbw, measured only on Adastra.
+Not verified anywhere here: MI300A runtime behaviour of the barrier, hipIpc of
+MAX-allocated memory on ROCm (default MAX allocator differs from CUDA's; the
+`…MEMORY_MANAGER_VMM=1` knob the repo documents for Adastra changes it again).
+
+## 7. Multi-node
+
+What the inter-node hop takes, from source: NCCL `net_ib` is ~13.5k lines that
+are **not** a plugin (compiled into libnccl, `nccl:src/transport/CMakeLists.txt:15`);
+a minimal re-implementation needs the verbs set (`ibv_open_device/alloc_pd/
+create_cq/create_qp`, three `ibv_modify_qp` state masks `nccl:src/transport/net_ib/connect.cc:370-502`,
+`ibv_reg_mr`/`ibv_reg_dmabuf_mr` with fd from `cuMemGetHandleForAddressRange`
+`nccl:src/transport/net.cc:1014-1016`, `ibv_post_send` WRITE/WRITE_WITH_IMM,
+`ibv_poll_cq`), a TCP/store exchange of QPN/LID/GID + CTS fifo address/rkeys,
+the 8-slot credit ring with host-pinned GPU-mapped head/tail
+(`nccl:src/transport/net.cc:958-976`), the CTS record protocol verbatim
+(`nccl:src/transport/net_ib/common.h:268,540-546`; `p2p.cc:275-411`), a
+non-blocking progress thread owning all verbs calls, and an MR cache
+(`nccl:src/transport/net_ib/reg.cc:10-64`). Estimate 2–3k lines Mojo + a
+host thread; 6–10 weeks to NCCL-class bandwidth on this fabric. Slingshot:
+another libfabric/cxi backend (RCCL's is an external plugin with no in-tree
+code; `fi_*` calls + `hsa_amd_portable_export_dmabuf`), 4–8 weeks, only testable
+on Adastra. No GPU-side new features are needed for either (host proxy +
+volatile flags), so this is not a language question; it is a transport port.
+
+Honest first scope: **Mojo intra-node, NCCL/RCCL inter-node**. Hierarchical
+allreduce per bucket: Mojo RS (my 1/8 shard reduced within the node) → one
+`ncclAllReduce` per local rank over a communicator of size nNodes (3.4 MiB at
+27 MiB; the PG already knows `ncclCommInitRank` with a store key) → Mojo AG.
+Expected ≈ 165 µs + IB allreduce of 3.4 MiB (~60–90 µs at 400 Gb/s per HCA) ≈
+230–260 µs vs NCCL's 259 µs NVLS_TREE at 2 nodes (§5.5) — parity within the
+noise, and the dependency on NCCL drops to `ncclAllReduce` on a small
+communicator. Alternative for a fully vendor-free run: stage the shard through
+host memory and gloo (already instantiated in the PG) — ~3.4 MiB × 2 over PCIe
++ TCP, ~1–3 ms per bucket, hidden behind backward for buckets 0–11 but a
+~5–10 ms exposed tail; acceptable for a demo, not for the bar.
+
+## 8. Minimal plan
+
+M1 — intra-node NVIDIA in the PG (3–4 weeks). Extension `eager_kernels/collectives_ops/`
+(receives `_ctx_ptr` + raw pointers like every eager kernel); per-rank
+library-owned region [Signal | in-stage | out-stage] sized to the largest
+bucket (grow-on-demand needs an all-rank sync, m0 issue modular-4);
+`cuIpcGetMemHandle` → 64 bytes through the c10d store key `mojo-ipc-<rank>-<gen>`
+→ `cuIpcOpenMemHandle` at first collective; RS+AG kernel launched capture-free
+on the existing comm `DeviceStream`; `allreduce` (+`broadcast`, `allgather` via
+the same peer-load kernel) for same-node tensors, NCCL untouched for the rest;
+completion via the existing `comm_fence`. Acceptance: 13-bucket step parity
+with NCCL losses, 27 MiB ≤ 210 µs staged / ≤ 175 µs if §5.6 allows direct
+export. Decision gate: ask Modular for `CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR` on
+the arena chunks (§5.6) — direct export removes the staging copies and the
+size cap; the importer code is already written in `proto/vmm_probe.mojo`.
+
+M2 — MI300A (2–3 weeks incl. cluster access). Swap names, uncached staging
+allocation, `hipSetDevice`; tune blocks (32/64/128) and add `s_sleep` backoff;
+validate barrier + IPC on 4 APUs; measure vs RCCL (`NCCL_DEBUG=INFO` for its
+protocol) at 27/168 MiB.
+
+M3 — multi-node (2 weeks): hierarchical RS → NCCL/RCCL shard allreduce → AG,
+on both clusters; keep `TORCH_MOJO_BACKEND_COMM_STREAM`-style kill switch to
+fall back to plain NCCL.
+
+Optional M4 — NVLS in Mojo (2–3 weeks, NVIDIA only): `cuMulticastCreate`
++ `cuMemExportToShareableHandle` fd passing (needs an AF_UNIX `SCM_RIGHTS`
+helper, ~100 lines) + MAX's existing `multimem_ld_reduce` kernel path; only
+worth it for the 168 MiB tail bucket (+0.2 ms/step today).
+
+## 9. Open risks
+
+- Legacy IPC does not accept MAX's allocations (measured); the VMM export path
+  depends on how MAX created its arena (§5.6). If neither works, staging is
+  permanent: +45 µs per 27 MiB bucket, hidden, and the region size caps the
+  largest single collective (step-1's 474 MiB allreduce → chunk it).
+- Cross-process spin barriers have no abort: a dead rank hangs peers in-kernel
+  (NCCL has abort flags, `nccl:src/device/primitives.h:154-164`). Needs a
+  host watchdog + a poisoned generation counter.
+- `Signal` lifetime contract: peers read my region after my kernel retires
+  (m0 issue modular-4); the next start barrier orders reuse, so buffers must
+  never be freed/resized without an all-rank host sync.
+- MAX frees are stream-ordered on the owning stream only (memory note): every
+  user tensor a side-stream collective touches must stay `record_use`-fenced,
+  as the PG does today.
+- `globaltimer`/`s_memrealtime` are per-GPU; never subtract stamps across GPUs.
+- RCCL/MI300A numbers are extrapolated from source (2.30.7 read, 2.22.3 deployed);
+  fine-grained/uncached memory semantics for polled flags on the APU are the
+  first thing to test there.
+- Mojo `std.ffi` has no C struct-by-value ABI; the 64-byte handle shim is
+  x86-64 SysV specific (fine for both clusters, not portable to aarch64 hosts).
+- ptxas 12.8 / driver 570 gate as for every kernel here; SLURM clock pin via
+  `--comment` did not apply — all numbers at boost clock, NVLink-bound so low
+  sensitivity.

--- a/docs/mojo_collectives_kernel_results.md
+++ b/docs/mojo_collectives_kernel_results.md
@@ -3,7 +3,8 @@
 Deliverable: `collectives_kernels.mojo` (this directory). Harness: `harness.mojo`
 + `validate.sbatch` (correctness + the tables below, NCCL legs interleaved),
 `ab.sbatch` (the NCCL A/B alone), `sweep.sbatch` / `tune.sbatch` /
-`diag.sbatch` (the tuning sweeps), `bench.sbatch`, `smoke.sbatch`.
+`diag.sbatch` (the tuning sweeps), `bench.sbatch`, `smoke.sbatch`,
+`split.sbatch` + `split_report.py` (the split allreduce of §10).
 `./build.sh` builds the per-dtype harnesses and the assembly dumps;
 `./build.sh sweeps` also builds the `-D`-tuned variants the sweep scripts
 expect. Raw logs: `/home/gabriel/ddp_work/logs/ccl_*.log`.
@@ -327,6 +328,9 @@ marked as such in the source.
 
 ## 9. What the ABI layer needs to know
 
+(§10 adds three more names for the multi-node path; everything below applies to
+them unchanged.)
+
 Six exported names, matching the contract exactly: `signal_bytes`,
 `error_offset`, `region_init(ctx, region)` (no stream — it blocks),
 `allreduce[dtype](ctx, stream, ...)`, `broadcast(...)`,
@@ -368,3 +372,183 @@ Two notes on the surrounding layer:
   start barrier's whole job is to order one generation's writes after the
   previous generation's reads. A repeated or decreasing generation silently
   passes barriers it should not.
+
+## 10. Split allreduce for the multi-node path (job 233937)
+
+The hierarchical allreduce of §7 of the feasibility study needs the intra-node
+allreduce cut in half so the vendor library can allreduce one shard across
+nodes in between. Three names were added; the six existing exports are
+untouched (their device code is **byte-identical** before and after -- checked
+by diffing `asm/{ar2,ar1,bcast,ag}_{sm_90a,gfx942}.asm` against a build of the
+previous file).
+
+```
+shard_range(numel, world, rank, elem_bytes) -> (offset_elems, count_elems)
+reduce_scatter_stage[dtype](ctx, stream, rank, world, regions, in_ptr,
+                            numel, cap_bytes, generation)
+allgather_finish[dtype](ctx, stream, rank, world, regions, out_ptr,
+                        numel, cap_bytes, scale, generation)
+```
+
+`rank`/`world`/`regions` are the **node-local** group. The sequence per bucket:
+
+```
+reduce_scatter_stage(g)        push + local reduce; my shard, SUM over the
+                               node, unscaled, lands in MY stage_out
+<vendor allreduce, in place>   region + signal_bytes() + cap_bytes
+                               + offset*elem_bytes, count elements, SAME stream
+allgather_finish(g+1)          start barrier, then pull every rank's shard
+                               (mine included) into out_ptr, times `scale`
+```
+
+Preconditions are `allreduce`'s (16-byte aligned buffer, `numel*elem_bytes <=
+cap_bytes`, strictly increasing generation); the pair costs **two**
+generations. `out_ptr` may be the same buffer as `in_ptr`.
+
+### 10.1 Shard placement
+
+`shard_range` is a different partition from the fused kernel's and
+deliberately so: equal shards of `per` elements with `per` rounded up to the
+16-byte vector width, the last non-empty shard short, ranks past the end
+empty. Every offset is therefore 16-byte aligned, every rank derives the same
+table from `(numel, world, elem_bytes)` alone, and the ABI layer can state the
+inter-node collective's arguments in one line. Imbalance against the fused
+kernel's balanced split is at most one 16-byte vector per rank.
+
+The shard sits in stage_out **at its own element offset**, i.e. stage_out is an
+image of the whole buffer of which only my shard is live. The push slots go at
+the base of stage_in and are *compacted* to `world-1` (rank s never writes its
+own slot): `world` uncompacted slots can be up to `16*world` bytes larger than
+stage_in when `numel*elem_bytes == cap_bytes`, which would spill onto rank 0's
+shard in stage_out. Checked exhaustively over every dtype width, world and cap.
+
+### 10.2 The three ordering questions, and why no new protocol was needed
+
+1. **A foreign library rewrites my stage_out shard between the two calls.**
+   `allgather_finish`'s start barrier is the fence: a rank publishes its
+   generation g+1 flags only from inside that kernel, which its stream starts
+   only after its inter-node op completed. Seeing peer p's flag therefore
+   implies p's shard is final.
+2. **Peer p's shard was written by a previous kernel**, not by the thread that
+   publishes the flag. Stream order puts that kernel's writes happen-before the
+   release store, and the release/acquire pair is system-scoped and cumulative,
+   so the acquiring reader sees them (on gfx942 `_sync`'s AMD-only release
+   fence supplies the `buffer_wbl2 sc0 sc1` the workgroup barrier omits). The
+   consequence is worth stating: block-index matching, which the fused kernel
+   needs *within* one launch, is **not** needed across this boundary, so the
+   two halves may be launched with different grids -- and they are.
+3. **Arena reuse after the pulls.** Nothing new: the next collective of any
+   kind opens with a start barrier and a rank reaches it only after its own
+   `allgather_finish` retired, so no generation g+2 write can race a generation
+   g+1 pull. The split pair just spends two generations. The existing
+   buffer-reuse invariant covers it as written -- verified, not assumed, by the
+   extended `mix` below.
+
+### 10.3 Split vs fused, 8xH100 SXM, 1980 MHz (job 233937)
+
+`harness.mojo split` runs, per size, five legs back to back in one process:
+the fused `allreduce`; each half alone (both are legal standalone collectives);
+the stand-in inter-node step alone, so it can be subtracted; and the whole
+pair. Device time from `%globaltimer` stamps on the stream, 20 back-to-back
+launches x 5 reps, median, max over ranks, three interleaved rounds.
+
+fp32, world 8 (us):
+
+| bytes | fused | rs stage | stub | ag finish | **pair** | pair-fused | minus stub |
+|---|---|---|---|---|---|---|---|
+| 4 B | 9.5 | 8.8 | 2.1 | 7.1 | **17.6** | +8.1 | +5.9 |
+| 9 MiB | 64.7 | 36.3 | 3.1 | 35.5 | **74.8** | +10.1 | +7.1 |
+| **27 MiB** | 162.7 | 89.6 | 3.7 | 93.6 | **186.3** | +23.7 | +19.9 |
+| 168 MiB | 935.4 | 507.2 | 9.8 | 492.4 | **1003.9** | +68.5 | +58.8 |
+| 512 MiB | 2777.6 | 1513.2 | 60.7 | 1457.9 | **3025.8** | +248.2 | +187.5 |
+
+bf16, world 8 (us):
+
+| bytes | fused | rs stage | stub | ag finish | **pair** | pair-fused | minus stub |
+|---|---|---|---|---|---|---|---|
+| 4 B | 9.6 | 8.9 | 2.3 | 7.0 | **17.9** | +8.3 | +6.1 |
+| 9 MiB | 64.7 | 36.3 | 3.3 | 35.5 | **74.9** | +10.2 | +6.9 |
+| **27 MiB** | 162.4 | 89.7 | 4.2 | 93.6 | **187.9** | +25.4 | +21.3 |
+| 168 MiB | 935.9 | 503.1 | 11.6 | 491.5 | **1012.2** | +76.3 | +64.7 |
+| 512 MiB | 2778.8 | 1501.4 | 101.2 | 1458.8 | **3057.7** | +278.9 | +177.7 |
+
+The stand-in is a one-pass read-modify-write of the shard on the same stream
+(it adds a rank-independent constant, so the verify can tell "the inter-node
+step ran" from "it was skipped"); a real `ncclAllReduce` over `nNodes` costs
+much more, and these columns exist so it can be substituted rather than
+guessed at.
+
+**Net of the stand-in the pair costs +6 to +8 us up to 9 MiB and +6-7% at
+168-512 MiB**, i.e. the promised "fused plus one launch" at small and medium
+sizes, growing to a percentage at the bandwidth-bound end. Where it goes:
+
+* one extra kernel launch and one extra 8-way start barrier (~6 us, and that
+  is the whole story at 4 B and 9 MiB);
+* `allgather_finish` pulls **`world`** shards, not `world-1`: my own shard has
+  to come back out of my stage_out because the inter-node step rewrote it,
+  where the fused kernel wrote its own shard straight to the user output during
+  the reduce. That is `bytes/world` of extra local read at every size, and it
+  is the term that grows.
+
+Neither half is slow in itself: `ag finish` at 27 MiB (93.6 us) matches the
+standalone `allgather` collective on the same per-rank size (96-98 us, §4), and
+`rs stage` (89.6) is its mirror image. The split simply cannot amortise the
+second launch the way one kernel does. Whether that matters is a question for
+the ABI layer: at the 9 MiB and 27 MiB DDP buckets it is +7 and +20 us against
+an inter-node leg of 60-90 us.
+
+### 10.4 Correctness
+
+`harness.mojo split` verifies against a host reference recomputed from the same
+deterministic splitmix64 fill, with the stand-in's constant folded into the
+expectation -- so a pair that silently skipped the inter-node step fails, and
+does not merely look like a rounding difference. 116 passing cases:
+
+* dtypes float32, bfloat16, float16, int32, int64 at world 8; float32 at world
+  4, 2 and **1**; bfloat16 world 5, int64 world 3, int32 world 7 (odd worlds
+  take the runtime-`world` kernel instantiation).
+* eight sizes per configuration, chosen ragged: 1, 2, 3, 6, 1003, 65537,
+  7079424 (27 MiB) and 16777215 elements at fp32, and the corresponding counts
+  at the other widths -- i.e. non-multiples of the 16-byte vector width, sizes
+  smaller than `world` (so most shards are empty), and `cap-4` bytes.
+* each size also re-checked after the timing legs, whose last leg is the pair
+  with a zero stand-in -- a plain allreduce, checked as one.
+* float32 is checked exactly. bf16/fp16 get a wider band than the fused path
+  and have to: the split stores the node-local sum in the *wire* dtype (the
+  vendor library reduces that buffer, so it cannot stay in fp32) and rounds
+  again on the scaled pull, where the fused kernel rounds once. That is a
+  property of the hierarchical algorithm, not of this implementation -- NCCL's
+  own hierarchical paths do the same.
+* the region's error word is read back after every case (stays 0).
+
+`harness.mojo mix` now rotates **eight** generations per round instead of four:
+4-byte one-shot allreduce, 27 MiB two-shot allreduce, 2000-byte broadcast,
+8-byte allgather, then a 4-byte split pair and a 27 MiB split pair, each with
+the stand-in kernel running between its halves. The split pairs run in place
+with a zero stand-in so they stay idempotent like the fused calls and a single
+corrupted generation anywhere in the run still survives to the final check.
+**200 rounds = 1600 generations**, passing for float32 and bfloat16 at world 8,
+float32 at world 4 and bfloat16 at world 5. This is the test that the
+buffer-reuse invariant of §10.2(3) actually holds with a foreign kernel writing
+the arena mid-collective.
+
+### 10.5 Build
+
+Both new kernels build warning-free for both targets from the same source
+(`./build.sh`, which now also dumps `asm/rs_*.asm` and `asm/agf_*.asm`):
+
+| | sm_90a | gfx942 |
+|---|---|---|
+| `_rs_stage_kernel` payload | 13 `ld.global.v4.b32` / 6 `st.global.v4.b32` | 13 `global_load_dwordx4` / 6 `global_store_dwordx4` |
+| `_ag_finish_kernel` payload | 10 / 10 | 10 / 10 |
+| flags | 3 `st.release.sys.global` + 4 `ld.acquire.sys.global` | `buffer_wbl2 sc0 sc1` / `buffer_inv sc0 sc1` |
+| local/scratch traffic | none | none |
+
+Zero `ld.local` / `scratch_` in either kernel on either target, i.e. the
+MOCO-1431 pointer-array trap of §6 was avoided here too (slot addresses are
+formed arithmetically inside the unrolled loop).
+
+Reproduce: `sbatch split.sbatch`, then
+`python3 split_report.py /home/gabriel/ddp_work/logs/split_<jobid>`.
+Raw logs: `/home/gabriel/ddp_work/logs/ccl_split_233937.log` and
+`/home/gabriel/ddp_work/logs/split_233937/*.txt` (every rank's CSV).

--- a/docs/mojo_collectives_kernel_results.md
+++ b/docs/mojo_collectives_kernel_results.md
@@ -1,0 +1,370 @@
+# Mojo intra-node collectives — measured results
+
+Deliverable: `collectives_kernels.mojo` (this directory). Harness: `harness.mojo`
++ `validate.sbatch` (correctness + the tables below, NCCL legs interleaved),
+`ab.sbatch` (the NCCL A/B alone), `sweep.sbatch` / `tune.sbatch` /
+`diag.sbatch` (the tuning sweeps), `bench.sbatch`, `smoke.sbatch`.
+`./build.sh` builds the per-dtype harnesses and the assembly dumps;
+`./build.sh sweeps` also builds the `-D`-tuned variants the sweep scripts
+expect. Raw logs: `/home/gabriel/ddp_work/logs/ccl_*.log`.
+
+All numbers: 8xH100 SXM (NVSwitch), one process per GPU, regions exchanged with
+`cuIpcGetMemHandle`/`cuIpcOpenMemHandle`, **staged** (user tensors in
+MAX-allocated memory; every copy the design needs is inside the measurement),
+20 back-to-back launches x 5 reps, median, max over ranks. Device time = wall
+over the 20 launches / 20, cross-checked against an in-kernel `globaltimer`
+span recorded by stamp kernels on the same stream (they agree to <0.5%
+everywhere; the CSV prints both). SM clock 1980 MHz (boost, unpinned — the
+SLURM `--comment=gpu_clock` pin does not take on this cluster; checked per job).
+
+Nodes: `cl02s01dgx18`, `cl02s01dgx04`, `cl02s01dgx16`, `cl02s04dgx01`. Node to
+node spread on the same code is ~2%, so cross-job comparisons below are only
+made within a job.
+
+## 1. Headline: same-node A/B against NCCL (job 233776, shipped constants)
+
+Legs interleaved within each round (NCCL NVLS, mojo fp32, mojo bf16, NCCL ring),
+3 rounds, same node, same job. NCCL = stock torch 2.11.0+cu128 / NCCL 2.28.9,
+device time from CUDA events, max over ranks — the same statistic the Mojo
+harness prints.
+
+fp32, world 8 (us):
+
+| bytes | **mojo** | NCCL default (NVLS) | NCCL ring (`NCCL_NVLS_ENABLE=0`) | mojo / NVLS | target |
+|---|---|---|---|---|---|
+| 4 B | **9.4** | 18.4 | 17.5 | 0.51x | <= 25 ✔ |
+| 256 KiB | **15.3** | 19.9 | 19.5 | 0.77x | — |
+| 512 KiB | **21.4** | 19.6 | 19.6 | 1.09x | — |
+| 1 MiB | **23.6** | 24.7 | 25.0 | 0.96x | — |
+| 9 MiB | **64.6** | 85.8 | 76.4 | 0.75x | <= 91 ✔ |
+| **27 MiB** (DDP bucket) | **163.8** | 174.9 | 181.8 | **0.94x** | <= 184 ✔ |
+| 168 MiB (tail bucket) | **958** | 750 | 899 | 1.28x | "as close as unicast gets" |
+| 512 MiB | **2860** | 2146 | 2636 | 1.33x | — |
+
+bf16, world 8: 9.4 / 15.4 / 21.4 / 23.6 / 64.8 / **163.1** / 959 / 2856 us —
+within 0.5% of fp32 at every size (target: 2%).
+
+world 4 (fp32): 8.4 / 10.9 / 14.0 / 18.3 / 56.5 / 135.7 / 814 / 2437 us.
+world 2 (fp32): 8.0 / 8.9 / 10.3 / 15.4 / 40.9 / 101.0 / 623 / 1856 us.
+
+**The three stated targets are met with the staging included**, and the two
+sizes that matter for GPT-2 DDP (9 and 27 MiB) beat NCCL's best algorithm on
+the same node by 25% and 6%. The feasibility study's *direct* kernel (operating
+on library-owned buffers, no user tensors involved) was 66 / 165 us at 9 /
+27 MiB: **the staging now costs nothing measurable**, against +25% (82 /
+210 us) for the naive copy-in/copy-out staging the study measured. The one
+size where NCCL wins below 1 MiB is 512 KiB (21.4 vs 19.6), at the top of the
+one-shot regime.
+
+## 2. Why the staging became free
+
+The user's tensors are MAX-allocated and cannot be exported by IPC, so peers can
+only read the library's region. Instead of copying the input in and the result
+out, the kernel makes the *transfers themselves* do the staging:
+
+* **push** — each rank reads its own input straight from user memory and writes
+  shard *s* into peer *s*'s slot. That write is the copy-in and it is the NVLink
+  transfer the reduce-scatter needed anyway.
+* **reduce** — each rank sums the `world` contributions to its own shard (its own
+  from user memory, the peers' from its region) and writes the result both to
+  its region and to its slice of the user output.
+* **pull** — each rank reads the peers' reduced shards straight into the user
+  output.
+
+NVLink traffic per GPU is `2*(world-1)/world*bytes` — the unicast minimum, the
+same as a direct reduce-scatter + all-gather — and no local byte is copied that
+the direct kernel would not also copy. Three cross-GPU syncs: a start barrier
+(the arena-reuse invariant, see §6) plus one per data dependency.
+
+Messages at or below 512 KiB take a **one-shot** path instead — every rank
+pushes its whole input to every peer and reduces locally, `(world-1)x` the
+NVLink bytes but one data sync instead of two. Measured crossover (one-shot vs
+two-shot, us): 128 KiB 9.3/19.0, 256 KiB 12.3/19.3, 512 KiB 18.1/19.8, 1 MiB
+30.0/20.5 (job 233731, before the start barrier added ~2.5 us to both).
+
+## 3. What tops out where: the unicast ceiling at 168 MiB
+
+At 168 MiB the kernel is 1.07x NCCL ring and 1.28x NCCL NVLS. The decomposition
+below says why, and it is measured, not modelled.
+
+`allgather` with 21 MiB per rank (= 168 MiB output) moves exactly the same
+154 MB of NVLink reads per GPU as the allreduce's pull phase, and nothing else
+except a local 22 MB stage copy: **502-508 us**, i.e. **~305 GB/s per GPU per
+direction**. The allreduce at 168 MiB is 958-990 us for a push (154 MB out)
+plus a pull (154 MB in), i.e. **~315 GB/s per direction** — the same rate. So:
+
+* both NVLink phases already run at the rate a pure peer-copy kernel achieves;
+* the local reduce costs **~30 us of the ~980** (980 - 2x~480), not the ~110 us
+  a naive HBM model predicts — the memory system absorbs it;
+* therefore **pipelining the reduce behind the transfers can win at most ~3%**,
+  and was not implemented (see §6, negative results).
+
+The ceiling for this design is the fabric rate under all-to-all traffic:
+**~310 GB/s per direction per GPU, 69% of NVLink4's 450 GB/s**. NCCL ring gets
+343 GB/s (899 us) with neighbour-only traffic — ~10% better fabric efficiency
+that a direct (all-to-all) reduce-scatter/all-gather does not reach by tuning
+(every knob was swept, §5); closing it needs a different schedule, an
+N-1-step ring, which is a different kernel and would give up the latency win
+at 9-27 MiB that matters more for this workload.
+
+**NCCL NVLS's 750 us is out of reach for any unicast kernel**, and not by a
+small margin of tuning: `multimem.ld_reduce` has the NVSwitch do the reduction,
+so each GPU moves `2*bytes/world` across the fabric instead of
+`2*bytes*(world-1)/world` — 7x fewer bytes at world 8. To match it we would need
+`cuMulticastCreate` + `cuMemExportToShareableHandle` + fd passing over an
+AF_UNIX socket (`SCM_RIGHTS`), and — the part that reaches outside this file —
+the region would have to be allocated with `cuMemCreate`/`cuMemMap` instead of
+`cuMemAlloc` so it can be bound to the multicast object. MAX's
+`DeviceMulticastBuffer` is single-process and cannot be reused across processes.
+That is the exact gap; it was not attempted here because the region allocator
+belongs to the plumbing layer.
+
+Consequences for GPT-2 DDP: buckets 0-11 (9 and 27 MiB) are faster than NCCL and
+overlapped with backward anyway; the exposed 168 MiB tail bucket costs
++0.21 ms/step versus NCCL NVLS, on a ~45 ms step.
+
+## 4. Broadcast and allgather
+
+| collective | size | first design (us) | **shipped design (us)** |
+|---|---|---|---|
+| broadcast | 27 MiB | 552 (root stages, all read) | **154-157** |
+| broadcast | 168 MiB | 3374 | **927-1035** |
+| broadcast | 256 MiB | — | **1436** |
+| allgather | 3.4 MiB/rank (27 MiB out) | — | **96-98** |
+| allgather | 21 MiB/rank (168 MiB out) | — | **502-508** |
+| allgather | 32 MiB/rank (256 MiB out) | — | **778** |
+
+(ranges are across nodes, jobs 233776/233789/233794; world 3 also measured:
+broadcast 27 MiB 118 us, allgather 9 MiB/rank 77 us.)
+
+The first broadcast put `(world−1)·nbytes` on the root's single outbound link
+(552 us at 27 MiB where the fabric can do ~150). The shipped one is **scatter +
+all-gather**: the root scatters shard *p* into rank *p*'s stage (nbytes out of
+the root, spread over the peers), then every non-root rank gathers the `world`
+shards. 3.6× faster, and both phases are permutations, so no link carries more
+than `nbytes`. It is out-of-place capable (ncclBroadcast semantics): only the
+root reads `send_ptr`, everyone writes `recv_ptr`, and when the two differ on
+the root it copies locally instead of gathering its own message back over
+NVLink. Allgather is a local stage + a peer gather — already the unicast
+minimum — and honours a `stride_bytes` that differs from `nbytes_per_rank` so
+the ABI layer can chunk one rank's contribution across calls. DDP's two
+~250 MiB parameter broadcasts cost ~1.4 ms each instead of ~5 ms.
+
+## 5. Tuning sweeps
+
+Grid (blocks of 256 threads), fp32 world 8, µs:
+
+| blocks | 4 B | 1 MiB | 9 MiB | 27 MiB | 168 MiB | 512 MiB |
+|---|---|---|---|---|---|---|
+| 64 | — | — | — | — | 1000 | 2955 |
+| 96 | 6.8 | 20.6 | 63.2 | 177.2 | 991 | 2982 |
+| 128 | 6.7 | 20.6 | 65.7 | 166.9 | **977** | **2826** |
+| 132 | 6.9 | 20.7 | 67.4 | 167.5 | 993 | 2934 |
+| 160 | — | — | — | — | 1104 | 3458 |
+| **216** | 6.8 | 20.5 | **61.1** | 167.4 | 1002 | 3030 |
+| 264 | 6.8 | 20.6 | 66.6 | **164.7** | 951 | 3051 |
+| 432 | 6.9 | 20.7 | 64.0 | 169.8 | 1075 | 3331 |
+| 864 | 6.7 | 20.5 | 63.5 | 175.0 | 1000 | 3168 |
+
+Two regimes, hence the two constants in the file (`_AR_MAX_BLOCKS` = 216 below
+64 MiB, `_AR_BIG_BLOCKS` = 128 at and above it; both fitted on H100 and marked
+as such):
+
+* **small/medium**: more threads win because the transfer is latency-bound —
+  216 blocks is the flat optimum at 9 MiB (61.1 vs 65.7 at 128).
+* **large**: a grid that fits in **one wave** of the 132 SMs wins, because the
+  barrier is per block index: with more blocks than SMs the second wave runs the
+  *whole* collective after the first, on fewer SMs. 128 blocks is 7% faster than
+  216 at 512 MiB (2826 vs 3030). 160 blocks (1.2 waves, a long tail wave) is the
+  worst point measured — 3458 µs, 22% worse than 128.
+
+Unroll (16-byte vectors in flight per thread in the copy loops), fp32 world 8:
+
+| unroll | 9 MiB | 27 MiB | 168 MiB | 512 MiB |
+|---|---|---|---|---|
+| 1 | 62.2 | 168.1 | 1083 | 3222 |
+| 2 | 61.3 | 163.9 | 1025 | 3162 |
+| **4** | 61.5 | 167.1 | **994** | **3078** |
+| 8 | 61.6 | 164.5 | 1026 | 3369 |
+
+Memory-level parallelism matters only in the bandwidth-bound regime (+9% from
+U=1 to U=4 at 168 MiB) and is flat below 27 MiB. U=8 regresses (register
+pressure). `_UNROLL = 4`.
+
+One-shot/two-shot threshold (job 233731, three interleaved rounds, measured
+before the start barrier added ~2.5 us to every leg). Each column is the same
+size run by two builds differing only in `-D ccl_oneshot_max`, so the pair
+isolates the path, not the size:
+
+| bytes | 64 KiB | 128 KiB | 256 KiB | 512 KiB | 1 MiB | 2 MiB | 4 MiB |
+|---|---|---|---|---|---|---|---|
+| one-shot | 7.5 | **9.3** | **12.2** | **18.1** | 30.0 | 51.9 | 97.0 |
+| two-shot | 7.5 | 19.0 | 19.3 | 19.9 | **20.5** | **24.2** | **34.5** |
+
+The crossover sits just above 512 KiB, so `_ONESHOT_MAX_BYTES = 512 KiB`. Below
+256 KiB the one-shot path is 2x faster; above 1 MiB it degrades as
+`(world-1)x` the bytes should.
+
+## 6. Negative results (do not re-explore)
+
+* **Pipelining the local reduce behind the transfers** (chunk the shard, give
+  each chunk its own pair of flags, and run `reduce(c+1)` concurrently with
+  `pull(c)` — half the block's warps on each): designed, costed, **not
+  implemented**, because the measurement in §3 bounds the win. The reduce is
+  worth ~30 µs of the 988 at 168 MiB, and K chunks recover at most
+  `(K−1)/K · 30 µs` while adding `2K` syncs at ~2–3 µs each: K=4 nets ≈ +7 µs,
+  i.e. nothing. The design is sound and written down here so nobody re-derives
+  it: the matching invariant is per *block*, not per thread (block *b* must
+  produce exactly the indices block *b* of its peers consumes, and with a
+  grid-stride loop that set is fixed by the loop shape), so threads inside a
+  block may be split by role as long as every phase keeps the same
+  block→index mapping. Worth revisiting only if the reduce ever gets more
+  expensive (a wider dtype conversion, a fused op).
+* **A stack array of peer pointers in the reduce loop** (`InlineArray[Pointer,
+  MAX_WORLD]`, the natural way to write it, and what MAX's `_multi_gpu_barrier`
+  warns about as MOCO-1431): the array is demoted to **local memory**, so the
+  PTX shows `ld.local.b64` per pointer per iteration and every payload load
+  becomes a generic-address `ld.v4.b32` instead of `ld.global.v4.b32`. Forming
+  the address arithmetically inside the unrolled loop fixes it: 18
+  `ld.global.v4.b32`, zero local traffic.
+* **More blocks**: 432 and 864 are worse everywhere (see the table); the
+  intuition "more blocks fill NVLink better" is wrong once the grid exceeds one
+  or two waves, because the per-block barrier serialises waves.
+* **Broadcast by staging the whole message on the root**: 3.6× slower than
+  scatter + all-gather (552 vs 154 us at 27 MiB). Do not "simplify" it back.
+* **A byte copier that falls back to single bytes when a pointer is
+  misaligned**: `_copy_bytes` chooses 16-byte vectors or a fallback per call,
+  and for a byte collective the writer and the reader are different ranks
+  looking at different pointer pairs (the root's `send` vs a peer's `recv`), so
+  they can disagree. A byte-wise fallback would then give writer and reader
+  different index -> block mappings, and the barrier is per block index: block 3
+  would read a chunk block 0 wrote, with nothing ordering them. Both paths now
+  walk the same 16-byte chunks in the same grid-stride order; only the
+  instructions inside a chunk differ. Found by inspection, not by a failing
+  test — it needs `send` and `recv` to have different 16-byte alignment.
+* **Dropping the start barrier** (two syncs per allreduce instead of three,
+  ordering the arena reuse out of the phase structure alone): measured 2.5–3 µs
+  cheaper at every size, and **wrong**. That argument only holds for a run of
+  identically shaped collectives. DDP interleaves a 4-byte one-shot allreduce
+  and byte collectives with 27 MiB two-shot allreduces, whose staging layouts
+  overlap; with only the data syncs, rank R's push for generation g+1 is
+  concurrent with a slower rank's reads for generation g whenever the two
+  generations lay the arena out differently. The start barrier reduces the
+  whole question to one invariant (§ "Buffer-reuse invariant" in the source),
+  and `harness.mojo mix` — 800 interleaved generations of exactly that pattern,
+  both allreduces in place so a single corrupted generation survives to the end
+  — is the regression test.
+
+## 7. Correctness
+
+`harness.mojo verify` (job 233776, 94 passing cases) checks every result against
+a host reference recomputed from the same deterministic splitmix64 fill (no
+RNG):
+
+* dtypes float32, bfloat16, float16, int32, int64 — world 8; plus float32 world
+  4, 2 and **1**, int64 world 3, bfloat16 world 5, int32 world 7 (odd worlds
+  take the runtime-`world` kernel instantiation; world 1 degenerates to
+  `out = scale * in` and is exercised, not special-cased away).
+* sizes 1, 2, 3, 1003, one page, 65537 and `(cap−1)/element_size` elements — i.e.
+  ragged, non-multiples of the 16-byte vector width, and the 4-byte case.
+* every size run twice: out-of-place and **in-place** (`in_ptr == out_ptr`).
+* float32 is checked **exactly** (the fill is k/128 with |k| ≤ 128, so the sum of
+  8 is exact in fp32 and the ×1/8 scale is a power of two); bf16/fp16 to half a
+  bf16 ulp; **int64 against an Int64 reference with samples of magnitude 2⁵⁶**,
+  which no fp64 reference could verify.
+* the region's error word is read back after every case (it stays 0).
+
+`harness.mojo mix` is the interleaving regression test: 200 rounds x (4-byte
+one-shot allreduce, 27 MiB two-shot allreduce, 2000-byte broadcast, 8-byte
+allgather) = **800 generations** whose staging layouts overlap, both allreduces
+in place with `scale = 1/world` so the value is idempotent once every rank holds
+the mean and a single corrupted generation anywhere in the run is still visible
+in the final buffer. Passes for float32 and bfloat16 at world 8, float32 at world 4 and bfloat16 at
+world 5 (jobs 233776, 233789, 233794). This is the test that the start barrier
+exists for.
+
+Broadcast and allgather results are checked byte-for-byte against the same hash
+(sampled every 997 bytes) in the `ops` suite.
+
+## 8. Build
+
+Both targets build from the one file, no vendor `#ifdef` in the device code:
+
+```
+uv run --no-sync mojo build harness.mojo -I . --target-accelerator sm_90a  -D dtype=float32 -o harness_float32
+uv run --no-sync mojo build harness.mojo -I . --target-accelerator gfx942  -D dtype=float32 -o harness_f32_gfx942
+```
+
+`collectives_kernels.mojo` compiles warning-free on both. The emitted device
+code is what NCCL/RCCL rely on (`asm/` holds the dumps, produced by
+`dump_asm.mojo` with no GPU present):
+
+| | sm_90a | gfx942 |
+|---|---|---|
+| flag publish | `st.release.sys.global.b64` | `global_store … sc0 sc1` + `buffer_wbl2 sc0 sc1` |
+| flag wait | `ld.acquire.sys.global.b64` | `global_load … sc0 sc1` + `buffer_inv sc0 sc1` |
+| payload | `ld/st.global.v4.b32` (18/12 in the allreduce) | `global_load/store_dwordx4` (18/12) |
+| block barrier | `bar.sync` | `s_barrier` |
+| deadline | `%globaltimer` | `s_memrealtime` |
+
+Blocks are 256 threads (RCCL's gfx942 maximum) and every layout is wave-64
+safe. The file has exactly **one** comptime vendor gate, in `_sync`: gfx942
+emits its workgroup barrier as `s_waitcnt lgkmcnt(0); s_barrier`, which does
+*not* wait on vector memory, so another wave's payload stores can still be in
+flight when one thread publishes the flag. RCCL solves this by putting
+`vmcnt(0)` inside its block barrier; the portable spelling is a release fence
+in every thread, which lowers to `s_waitcnt vmcnt(0)` + `buffer_wbl2 sc0 sc1`.
+NVIDIA needs nothing there (`bar.sync` is a CTA-scope fence and the release
+store is cumulative over it — what NCCL's `postPeer` relies on), and the gate
+is comptime, so the sm_90a instruction mix is byte-identical with and without
+it (checked by diffing the dumps).
+
+AMD numbers are unmeasured (no MI300A here). Two things the AMD host side will
+need, from RCCL's source: the region must be allocated **uncached**
+(`hipExtMallocWithFlags(hipDeviceMallocUncached)`) — RCCL's precondition for
+polled flags on MI300 — and the tuning constants above are H100 fits and are
+marked as such in the source.
+
+## 9. What the ABI layer needs to know
+
+Six exported names, matching the contract exactly: `signal_bytes`,
+`error_offset`, `region_init(ctx, region)` (no stream — it blocks),
+`allreduce[dtype](ctx, stream, ...)`, `broadcast(...)`,
+`allgather(..., stride_bytes=-1)`. `MAX_WORLD = 8`. Everything is enqueued on
+the stream passed in and returns right after the enqueue; `ctx` is only the
+compile/cache handle (`DeviceFunction`s are cached process-globally per
+`ctx.id()`, so the per-call cost is the enqueue, not a ~180 us
+`compile_function`).
+
+Preconditions the file enforces by raising, all of them cheap host-side checks:
+
+* `numel * size_of[dtype]() <= cap_bytes`, `nbytes <= cap_bytes`,
+  `nbytes_per_rank <= cap_bytes` — the caller chunks anything larger (it does).
+* **`in_ptr` and `out_ptr` of `allreduce` must be 16-byte aligned.** The payload
+  loops use 16-byte vectors, which fault on a misaligned address. Every
+  allocator-returned pointer satisfies this and so does every chunk offset the
+  ABI layer forms (they are multiples of `cap_bytes`); a mid-tensor *view* may
+  not, and such a tensor must be staged into an aligned buffer by the caller
+  rather than have the kernel guess. `broadcast`/`allgather` need no such rule —
+  the byte copier checks alignment at run time and falls back to a scalar loop.
+* `world` in `1..8` (world 1 works and degenerates to `out = scale * in`),
+  `rank < world`, `generation >= 1`, `cap_bytes` a positive multiple of 4096.
+* `scale` is applied on the final write for floating-point dtypes and ignored
+  for integers (the caller passes 1.0 there, which is what NCCL's `ncclAvg`
+  does anyway).
+
+Two notes on the surrounding layer:
+
+* **The error word is device memory.** `error_offset()` is a byte offset into
+  the region, which is `cuMemAlloc`/`hipMalloc` memory: it cannot be read by
+  dereferencing a host pointer (that faults or reads garbage). Copy it back with
+  `cuMemcpyDtoH` / a one-thread kernel, as `harness.mojo`'s `check_error` does.
+  A nonzero value is `code * 1_000_000 + phase` and means some block gave up
+  waiting for a peer (60 s deadline, measured with the GPU's own timer, never
+  compared across GPUs); the collective's result is undefined from that
+  generation on.
+* `generation` must be strictly increasing per communicator **across all
+  collective kinds** — the flag values are `generation * 8 + phase` and the
+  start barrier's whole job is to order one generation's writes after the
+  previous generation's reads. A repeated or decreasing generation silently
+  passes barriers it should not.

--- a/docs/mojo_collectives_kernel_results.md
+++ b/docs/mojo_collectives_kernel_results.md
@@ -399,7 +399,8 @@ allgather_finish[dtype](ctx, stream, rank, world, regions, out_ptr,
 
 ```
 reduce_scatter_stage(g)        push + local reduce; my shard, SUM over the
-                               node, unscaled, lands in MY stage_out
+                               node times `scale` (default 1), lands in MY
+                               stage_out
 <vendor allreduce, in place>   region + signal_bytes() + cap_bytes
                                + offset*elem_bytes, count elements, SAME stream
 allgather_finish(g+1)          start barrier, then pull every rank's shard

--- a/docs/mojo_collectives_kernel_results.md
+++ b/docs/mojo_collectives_kernel_results.md
@@ -444,6 +444,16 @@ shard in stage_out. Checked exhaustively over every dtype width, world and cap.
    buffer-reuse invariant covers it as written -- verified, not assumed, by the
    extended `mix` below.
 
+The ABI layer now runs several such pairs CONCURRENTLY, to overlap the
+inter-node hop with the intra-node halves of other chunks (see the
+"Multi-node" subsection of `docs/distributed.md`). It needs nothing from this
+file to do it: each in-flight chunk is handed a different arena -- a shifted
+region base and a smaller `cap_bytes`, carved so the arenas are disjoint --
+so every rule above applies per arena, unchanged, and point 3 is what orders
+one arena's reuse `PIPE_ARENAS` chunks later. Generations stay strictly
+increasing globally (two are reserved per chunk, so a chunk's all-gather is
+still its own reduce-scatter's plus one) and therefore per arena.
+
 ### 10.3 Split vs fused, 8xH100 SXM, 1980 MHz (job 233937)
 
 `harness.mojo split` runs, per size, five legs back to back in one process:

--- a/docs/mojo_collectives_kernel_results.md
+++ b/docs/mojo_collectives_kernel_results.md
@@ -118,7 +118,12 @@ the region would have to be allocated with `cuMemCreate`/`cuMemMap` instead of
 `cuMemAlloc` so it can be bound to the multicast object. MAX's
 `DeviceMulticastBuffer` is single-process and cannot be reused across processes.
 That is the exact gap; it was not attempted here because the region allocator
-belongs to the plumbing layer.
+belongs to the plumbing layer. **It has since been closed exactly along those
+lines** — `nvls_kernels.mojo` and `vmm.mojo`, dispatched above 48 MiB, taking
+168 MiB from 990 to 790 us and 512 MiB from 2988 to 2226. Nothing in this file
+changed: the six exported names below are untouched and the unicast kernels
+still carry everything below the crossover. See the "NVLS" subsection of
+docs/distributed.md.
 
 Consequences for GPT-2 DDP: buckets 0-11 (9 and 27 MiB) are faster than NCCL and
 overlapped with backward anyway; the exposed 168 MiB tail bucket costs

--- a/docs/mojo_collectives_nvls_results.md
+++ b/docs/mojo_collectives_nvls_results.md
@@ -29,9 +29,10 @@ kernels of `../kernel`, which are snapshotted read-only in `ref/`),
 * **Crossover 48 MiB.** Below it the unicast push/reduce/pull kernels win and
   must keep the traffic; above it NVLS wins and the margin grows with size.
   GPT-2 DDP's 27 MiB bucket stays unicast, its 168 MiB tail bucket moves.
-* **RDMA registration of the region did not work first try** and there is no
-  dmabuf fallback on this driver -- see §4, it needs one more look before the
-  multi-node path leans on it.
+* **RDMA registration of the region failed for a reason that is now fixed**:
+  the `cuMemCreate` prop lacked `allocFlags.gpuDirectRDMACapable`, which
+  `nvidia_peermem` requires on VMM memory; there is still no dmabuf fallback
+  on this driver -- see §4.
 * **AMD keeps the unicast kernels**: `multimem` is sm_90+ and RCCL has no
   equivalent.
 
@@ -139,15 +140,16 @@ cuMemMap'd unicast mapping:
   loaded on the compute nodes and `CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_SUPPORTED
   = 1`.
 
-The second result is the load-bearing one and it is worth repeating with more
-care before acting on it: the probe registers 512 MiB on `ibv_get_device_list()[0]`,
-which on these nodes is not necessarily the HCA closest to GPU 0, and it does
-not read `errno`. Treat it as "GPUDirect registration of a VMM mapping did not
-work first try on this box", not as a proof that it cannot work. What is solid
-is the dmabuf half: with `DMA_BUF_SUPPORTED = 0` there is no dmabuf fallback,
-so the multi-node path has to make `ibv_reg_mr` work on this mapping — or keep
-the inter-node staging buffer in `cuMemAlloc` memory, which the current
-hierarchical design (`../kernel` §10) already does.
+Resolved (2026-09-09, `issue_repro/gdr_probe.mojo`: H100 node, all 12 mlx5
+HCAs, 64 MiB per buffer): the NULL came from the allocation, not from the HCA
+choice. `nvidia_peermem` only pins a `cuMemCreate` chunk whose prop set
+`allocFlags.gpuDirectRDMACapable = 1`. Without it every HCA returns NULL with
+`errno 14` (EFAULT); with it all 12 register. NCCL sets the flag whenever
+`CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_WITH_CUDA_VMM_SUPPORTED` (110) is 1
+(`nccl:src/include/alloc.h:329`), `vmm.mojo` now does the same, and MAX's own
+arena chunks already carry it: a `DeviceContext` buffer registers on 12/12
+HCAs too. So the multi-node path can register a VMM region; only the dmabuf
+half stays closed on this driver.
 
 ## 5. One kernel, three schedules, and the traffic that decides against unicast
 
@@ -466,7 +468,8 @@ Recorded so the next agent does not re-explore them.
    copy loop).
 7. **`cuMemGetHandleForAddressRange(DMA_BUF_FD)`**: `CUDA_ERROR_NOT_SUPPORTED`
    (801), and `CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED` is 0 on all 8 devices.
-   **`ibv_reg_mr` on the cuMemMap'd unicast mapping**: NULL. §4.
+   **`ibv_reg_mr` on the cuMemMap'd unicast mapping**: NULL until the prop
+   sets `gpuDirectRDMACapable`; fixed. §4.
 8. **The multicast object cannot be small.** `CU_MULTICAST_GRANULARITY_RECOMMENDED`
    is 512 MiB on this hardware, so a 512 MiB payload plus a 4 KiB header
    allocates 1 GiB per rank. `MINIMUM` is 2 MiB and was not measured.

--- a/docs/mojo_collectives_nvls_results.md
+++ b/docs/mojo_collectives_nvls_results.md
@@ -1,0 +1,493 @@
+# NVLS (NVSwitch multicast) allreduce in Mojo — measured results
+
+Standalone multi-process prototype under `nvls/`, 8xH100 80GB HBM3 + NVSwitch
+(kyutai partition, driver 570.211.01, CUDA 12.8 toolchain, MAX 26.5 / Mojo 1.0).
+One process per GPU (the torchrun model), no NCCL, no MAX multicast API — the
+driver is called through `OwnedDLHandle("libcuda.so.1")`.
+
+Sources: `mcsetup.mojo` (host: VMM + multicast bring-up, fd transport),
+`mckernels.mojo` (device: the allreduce and the barrier), `mcharness.mojo`
+(probe / verify / timing), `abharness.mojo` (ABBA A/B against the unicast
+kernels of `../kernel`, which are snapshotted read-only in `ref/`),
+`build.sh`, `run.sh`, `bench.sbatch`, `sweep.sbatch`, `crossover.sbatch`,
+`report.py`, `nccl_sizes.py`, `dump_asm.mojo`, and the emitted PTX in `asm/`.
+
+## 0. Verdict
+
+* **NVLS works on these nodes** from Mojo, multi-process, with no MAX multicast
+  API and no NCCL: every device reports `CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED
+  = 1`, the whole `cuMulticast*` sequence returns 0, and the kernel verifies
+  against an fp64 host reference at every size and world from 1 element to
+  512 MiB, in place and out of place, fp32 and bf16.
+* **The target is met, on the line at 168 MiB.** Staged (user tensors copied
+  in and out), fp32, 8xH100, same node and same job as the reference:
+  **785.7-788.3 us at 168 MiB against NCCL's 748.6-749.9** (1.048x and 1.053x
+  in two independent jobs, budget 790) and **2217 us at 512 MiB against 2143**
+  (1.035x, budget 2250). So 512 MiB is comfortably inside 5% and 168 MiB
+  straddles it; §7.5 names the ~60 us of barrier that would settle it. Against
+  the shipped unicast kernels the same numbers are 0.82x and 0.77x.
+* **Crossover 48 MiB.** Below it the unicast push/reduce/pull kernels win and
+  must keep the traffic; above it NVLS wins and the margin grows with size.
+  GPT-2 DDP's 27 MiB bucket stays unicast, its 168 MiB tail bucket moves.
+* **RDMA registration of the region did not work first try** and there is no
+  dmabuf fallback on this driver -- see §4, it needs one more look before the
+  multi-node path leans on it.
+* **AMD keeps the unicast kernels**: `multimem` is sm_90+ and RCCL has no
+  equivalent.
+
+## 1. Does multicast work on these nodes?
+
+**Yes.** Every device reports the capability and the whole sequence runs:
+
+```
+ATTR dev0..7  multicast=1  vmm=1  posix_fd=1  fabric=1  dmabuf=0  gdr=1
+```
+
+(`cuDeviceGetAttribute` 132 / 102 / 103 / 128 / 124 / 116.) `cuMulticastCreate`,
+`cuMulticastAddDevice` on all 8, `cuMulticastBindMem` and the dual mapping all
+return 0, and an 8-rank `multimem.ld_reduce` + `multimem.st` allreduce verifies
+against an fp64 host reference. No fabric manager configuration was needed
+beyond what the nodes already run.
+
+Granularity (`cuMulticastGetGranularity`): **MINIMUM 2 MiB, RECOMMENDED 512
+MiB**; `cuMemGetAllocationGranularity(RECOMMENDED)` is 2 MiB. NCCL uses
+RECOMMENDED, which means the smallest multicast object on this hardware is
+512 MiB; a 512 MiB payload plus the 4 KiB header therefore rounds up to a
+1 GiB allocation per rank. Using MINIMUM instead is possible and was not
+measured.
+
+## 2. The setup recipe that worked
+
+Ordering matters in exactly two places: every device must be in the team
+before any memory is bound, and every rank must have mapped before any rank
+issues a multimem instruction.
+
+1. `cuDeviceGetAttribute(CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED)` on every
+   device; bail out to the unicast kernels if any says 0.
+2. Rank 0: `CUmulticastObjectProp{numDevices=world, size, handleTypes=
+   CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, flags=0}` →
+   `cuMulticastGetGranularity(RECOMMENDED)` → round `size` up →
+   `cuMulticastCreate` → `cuMemExportToShareableHandle(&fd, mc,
+   POSIX_FILE_DESCRIPTOR, 0)`.
+3. Send `fd` to the other ranks (see §3). Each of them
+   `cuMemImportFromShareableHandle(&mc, (void*)fd, POSIX_FILE_DESCRIPTOR)`.
+4. Every rank: `cuMulticastAddDevice(mc, myDev)`.
+5. **Barrier.**
+6. Every rank: `cuMemCreate` its own physical memory with
+   `CUmemAllocationProp{type=PINNED, location={DEVICE,myDev},
+   requestedHandleTypes=POSIX_FILE_DESCRIPTOR}`, then
+   `cuMulticastBindMem(mc, 0, mine, 0, size, 0)` — every rank binds at
+   multicast offset 0, so one multicast address covers eight distinct physical
+   allocations.
+7. Every rank: `cuMemAddressReserve`/`cuMemMap`/`cuMemSetAccess` **twice** —
+   once against the multicast handle (the address `multimem.*` takes) and once
+   against its own memory handle (ordinary loads and stores; this is what the
+   copy-in, the copy-out and the flag spin use).
+8. **Barrier.** Zero the header (cuMemCreate memory is not guaranteed clean).
+
+The peers never import each other's *unicast* memory — that is the structural
+difference from the `cuIpc` path of `../kernel`. Only the multicast handle
+crosses processes, i.e. 7 fd sends instead of 56 handle exchanges.
+
+Setup cost, one-off, 512 MiB object (median of the ranks):
+
+| step | us |
+|---|---|
+| `cuMulticastCreate` (rank 0) | 88 |
+| export + fd transport + `cuMemImportFromShareableHandle` (peers) | 54 |
+| `cuMemCreate` + `cuMulticastBindMem` | 10 000 - 32 000 |
+| `cuMemAddressReserve`/`Map`/`SetAccess` x2 | 27 000 - 63 000 |
+| **total including the two file barriers** | **150 000 - 230 000** |
+
+`cuMulticastBindMem` and the mappings dominate and are wildly variable; NCCL
+sees the same thing (its source calls bind "where we normally see issues if the
+system NVLS/Multicast support is broken", `nccl:src/transport/nvls.cc:369`).
+150-230 ms is a communicator-creation cost, paid once.
+
+## 3. Passing the fd: SCM_RIGHTS vs pidfd_getfd
+
+Both were implemented and both work here (`-D`-free, selected by the
+harness's last argument).
+
+* **`SCM_RIGHTS` over an AF_UNIX `SOCK_DGRAM` socket** — what NCCL does
+  (`nccl:src/os/linux_ipcsocket.cc:171-245`, reached through its proxy thread,
+  `nccl:src/proxy.cc:1572-1595`). Works regardless of
+  `/proc/sys/kernel/yama/ptrace_scope`. ~70 lines of hand-laid-out `msghdr` /
+  `cmsghdr` in Mojo because `std.ffi` has no C-struct ABI.
+  One trap, found the hard way: the rendezvous file barrier must not use the
+  same path as the bound socket — `open()` on a bound unix socket fails with
+  ENXIO.
+* **`pidfd_open` + `pidfd_getfd`** — 10 lines, reusing `proto/vmm_probe.mojo`'s
+  shim, but it needs `PTRACE_MODE_ATTACH`. It works on these nodes only because
+  `ptrace_scope` is 0.
+
+**Recommendation for the library: SCM_RIGHTS.** `ptrace_scope` is 1 on stock
+Ubuntu and 2 or 3 on hardened images, and a collective that silently loses NVLS
+because of a sysctl is worse than 70 lines of `sendmsg`.
+
+## 4. RDMA registration of the region (for the multi-node path)
+
+On these nodes, **neither** of the two registration paths worked on the
+cuMemMap'd unicast mapping:
+
+* `cuMemGetHandleForAddressRange(..., CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD)` →
+  **rc 801, `CUDA_ERROR_NOT_SUPPORTED`**, consistent with
+  `CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED = 0` on every device. So NCCL's
+  `ibv_reg_dmabuf_mr` fallback is unavailable here.
+* `ibv_reg_mr(pd, ucVA, size, LOCAL_WRITE|REMOTE_WRITE|REMOTE_READ)` on the
+  first HCA → **NULL** (after 1.3-6.8 ms), even though `nvidia_peermem` is
+  loaded on the compute nodes and `CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_SUPPORTED
+  = 1`.
+
+The second result is the load-bearing one and it is worth repeating with more
+care before acting on it: the probe registers 512 MiB on `ibv_get_device_list()[0]`,
+which on these nodes is not necessarily the HCA closest to GPU 0, and it does
+not read `errno`. Treat it as "GPUDirect registration of a VMM mapping did not
+work first try on this box", not as a proof that it cannot work. What is solid
+is the dmabuf half: with `DMA_BUF_SUPPORTED = 0` there is no dmabuf fallback,
+so the multi-node path has to make `ibv_reg_mr` work on this mapping — or keep
+the inter-node staging buffer in `cuMemAlloc` memory, which the current
+hierarchical design (`../kernel` §10) already does.
+
+## 5. One kernel, three schedules, and the traffic that decides against unicast
+
+Both stage: the user's tensors are MAX-allocated and cannot be bound to a
+multicast object, so every byte is copied into the bound region and back out.
+That staging is part of every number below.
+
+Per GPU, for an allreduce of `N` bytes at world 8:
+
+| | NVLink out | NVLink in | HBM |
+|---|---|---|---|
+| unicast push/reduce/pull (`../kernel`) | 7N/4 | 7N/4 | ~4N |
+| NVLS | N (7N/8 serving peers' `ld_reduce` + N/8 of `multimem.st`) | N (N/8 of results + 7N/8 of peers' `st`) | ~6N (2N copy-in, N served, N received, 2N copy-out) |
+
+NVLS moves **1.75x fewer NVLink bytes** and ~1.5x more HBM bytes. That is the
+whole trade, and it is why NVLS only wins once the message is big enough for
+the fabric rather than the launch to dominate.
+
+**`nvls_allreduce_multimem_<dtype>`, three-phase (default).** One kernel:
+copy-in of the whole message, barrier, `multimem.ld_reduce` + `multimem.st`
+over this rank's 1/8 slice, barrier, copy-out of the whole message. 216 blocks
+x 512 threads, 16-byte operands (`.v4.f32` / `.acc::f32.v4.bf16x2`), 40
+registers.
+
+**`-D nvls_pipe=1`, split grid (the shipped shape).** Same work, but the grid
+is split: the low `nvls_reduce_pct`% of the blocks only drive the switch and the
+rest only drive HBM, and the message is cut into `nvls_chunk_kib` chunks so that
+chunk c's reduction runs at the same time as chunk c+1's copy-in and chunk c-1's
+copy-out. One barrier per chunk covers all three because they touch disjoint
+byte ranges. Tuned: 216 blocks x 256 threads, 25% reducers, 43 MiB chunks
+(100 registers, so `nvvm.minctasm=2` at 256 threads; see §7.4).
+
+**`-D nvls_pipe=2`, fused.** Same chunk schedule, but every thread does both:
+a thread that owns reduce vector j also moves `world` copy-in and `world`
+copy-out vectors, issued between that vector's `multimem.ld_reduce` and its
+`multimem.st` so they run inside the switch round trip. Neither side gives up
+threads. It is 6% slower than the tuned split grid; §6.3 says why.
+
+## 6. Results
+
+All on one 8xH100 SXM node, SM clock unpinned (1980 MHz under load), 20
+back-to-back launches x 5 repetitions, median, device time from the GPU's own
+`globaltimer` across the burst. NCCL is stock torch 2.11.0+cu128 / NCCL 2.28.9,
+device time from CUDA events, max over ranks -- and it is measured **in the same
+job on the same node** as the Mojo numbers, not quoted from an earlier run.
+
+### 6.1 First cut: the untuned schedules, everything in one job
+
+Job 234239, node cl02s01dgx05, fp32 world 8, us. The "split grid" column here
+is the *untuned* 60%/21 MiB setting; §6.4 has the tuned one.
+
+| MiB | unicast (`../kernel`) | NVLS 3-phase | NVLS split grid (untuned) | NCCL NVLS | NCCL ring |
+|---|---|---|---|---|---|
+| 1 | 23.5 | 24.4 | 24.5 | 25.3 | 30.4 |
+| 4 | 37.6 | 42.8 | 43.5 | 52.7 | 47.6 |
+| 9 | **64.7** | 75.6 | 76.5 | 88.4 | 75.8 |
+| 16 | **104.2** | 127.4 | 122.8 | 118.7 | 117.1 |
+| 27 (DDP bucket) | **162.2** | 203.9 | 181.7 | 175.3 | 183.2 |
+| 64 | 374.0 | 403.3 | 378.2 | **323.8** | 366.4 |
+| 128 | 737.4 | 744.4 | 712.1 | **585.7** | 703.8 |
+| 168 (tail bucket) | 963.3 | 957.0 | 927.0 | **748.7** | 903.5 |
+| 256 | 1440.8 | 1420.8 | 1384.1 | **1107.6** | 1354.9 |
+| 512 | 2874.2 | 2772.3 | 2741.1 | **2143.4** | 2637.3 |
+
+bf16 is within 0.5% of fp32 at every size for all three Mojo variants.
+
+### 6.2 Where the time goes (phase builds, `-D nvls_phase=`)
+
+The three-phase kernel splits cleanly, and the split says the whole gap to NCCL
+is the staging:
+
+| MiB | copies only | switch only | sum | measured full |
+|---|---|---|---|---|
+| 27 | 56.3 | 166.3 | 222.6 | 203.9 |
+| 168 | 275.0 | 707.2 | 982.2 | 957.0 |
+| 512 | 795.3 | 2005.3 | 2800.6 | 2772.3 |
+
+At 132 blocks x 512 threads the switch phase is faster still -- **684 us** at
+168 MiB and **1982 us** at 512 MiB -- and the copies are unchanged (271 us at
+168 MiB). So:
+
+* the **switch phase alone already beats NCCL's whole allreduce**: 684 vs 749
+  at 168 MiB, 1982 vs 2143 at 512 MiB;
+* the copies are 275 us of pure addition on top, which is exactly the 1.24x;
+* NCCL is therefore overlapping its staging almost perfectly, and any Mojo
+  kernel that does the same lands at 0.91-0.93x NCCL.
+
+Effective fabric rate in the switch phase is 250-270 GB/s per direction against
+NVLink4's 450, and it does **not** improve with more multimem loads in flight
+(`-D nvls_mm_unroll`: at 168 MiB the switch phase is 684 us with 2 in flight,
+726 with 4, 777 with 8) -- so it is a switch/reduction throughput limit, not a
+latency-hiding problem, and NCCL sees the same ceiling.
+
+### 6.3 Tuning the overlap (job 234241 sweep + jobs 234244/234249/234252/234253)
+
+fp32, us, at the two sizes that matter. "split" = schedule 1 (a fraction of the
+blocks on the switch), "fused" = schedule 2 (every thread does both).
+
+| variant | 168 MiB | 512 MiB |
+|---|---|---|
+| three phases, 216x512 | 957 | 2772 |
+| split, 60% reducers, 21 MiB chunks, 216x256 | 927 | 2745 |
+| split, 50% | 877 | 2574 |
+| split, 40% | 843 | 2472 |
+| split, 30% | 824 | 2422 |
+| split, 25% | 819 | 2404 |
+| split, 20% | 805 | 2371 |
+| **split, 25%, 43 MiB chunks** | **786** | **2217** |
+| split, 25%, 86 MiB chunks | 826 | 2191 |
+| fused, 132x512, 21 MiB chunks | 894 | 2645 |
+| fused, 132x512, 43 MiB chunks | 830 | 2392 |
+| fused, 216x256, 43 MiB chunks | 824 | 2368 |
+| NCCL NVLS (same node, same job) | 749 | 2145 |
+
+Two things the sweep settles:
+
+* **Fewer blocks on the switch, more on HBM.** The switch phase saturates at
+  about 33k threads (the whole-grid sweep of the three-phase kernel moves only
+  2% between 64 and 264 blocks); the copies want every thread they can get.
+  Hence 25%, not the 60% a naive "the fabric is the slow half" split suggests.
+* **Chunks want to be big.** 43 MiB is best at 168 MiB (4 chunks) and 86 MiB is
+  best at 512 MiB (6 chunks) -- i.e. about `bytes/4` to `bytes/6`, floor 21 MiB.
+  Smaller chunks lose to the barrier: 5 MiB chunks cost 1163 us at 168 MiB
+  against 927 for 21 MiB, which prices the two-level barrier at roughly 10 us.
+
+The fused schedule was built to avoid the split's thread starvation -- every
+thread reduces *and* copies, with the copies issued between a chunk's
+`ld_reduce` and its `st` so they run inside the switch round trip -- and it does
+beat the split grid at the same chunk size when the split is badly tuned, but it
+loses to a well-tuned split (830 vs 786). The reason is visible in the source:
+the `world` copy pairs a thread does per reduce are a chain of dependent
+load-then-store pairs, so they serialize on HBM latency instead of pipelining.
+Hoisting all `world` loads before all `world` stores would fix it and costs 64
+more registers, which at 94 already is not affordable. Left as the obvious next
+step.
+
+### 6.4 Headline: the tuned NVLS against both references, same node, same job
+
+fp32, world 8, us. NVLS and NCCL are both from job 234253; the unicast column
+is from job 234239 on a different node of the same model (it reproduces
+`../kernel`'s recorded numbers to within 1%).
+
+| MiB | unicast | **NVLS (split 25%, 43 MiB chunks)** | NCCL NVLS | NVLS / NCCL |
+|---|---|---|---|---|
+| 27 (DDP bucket) | **162** | 172.0 | 175.2 | **0.98** |
+| 64 | 374 | 339.1 | 325.6 | 1.04 |
+| 128 | 737 | 620.5 | 585.8 | 1.06 |
+| **168 (tail bucket)** | 963 | **785.7** | 749.9 | **1.048** |
+| 256 | 1441 | 1153.5 | 1109.1 | 1.04 |
+| **512** | 2874 | **2217.1** | 2143.1 | **1.035** |
+
+bf16 at the same configuration: 171.7 / 338.3 / 621.8 / **785.2** / 1152.0 /
+**2216.3** us -- within 0.2% of fp32 everywhere. NCCL's bf16 is 1-2% faster
+than its fp32 at the big sizes (739.0 / 2115.3), so the bf16 ratios are 1.063
+at 168 MiB and 1.048 at 512 MiB.
+
+**The stated goal is met in fp32**: 785.7 us at 168 MiB against a 790 us budget
+(NCCL + 5%), and 2217 us at 512 MiB against 2250. Staging is included in both.
+A second independent job (234256, the shipped binaries straight out of
+`build.sh`) gives 788.3 and 2217.0 against an NCCL of 748.6 in that same job --
+1.053x and 1.035x. So 512 MiB is inside 5% by a clear margin and 168 MiB sits
+on the line, moving 0.5 points between runs. bf16 tracks fp32 to within 0.2%,
+but NCCL's bf16 is 1-2% faster than its fp32 at these sizes (739.0 / 2115.3),
+so the bf16 ratios are 1.063 at 168 MiB and 1.048 at 512 MiB.
+
+### 6.5 Crossover, and what the library should dispatch on
+
+`abharness.mojo` runs both kernels in one process set over the same user
+tensors, interleaved ABBA inside every repetition (nvls,uni | uni,nvls) so a
+monotonic clock or thermal ramp cancels to first order. Job 234254, tuned NVLS
+(split 25%, 43 MiB chunks), fp32, us. Job 234256 reproduces the two end points
+from a fresh `build.sh` on another node to within 0.1% (786.2 / 963.3 and
+2218.6 / 2872.1):
+
+| MiB | NVLS | unicast | NVLS / unicast |
+|---|---|---|---|
+| 16 | 109.1 | 103.6 | 1.053 |
+| 24 | 155.1 | 148.5 | 1.045 |
+| 27 | 172.2 | 163.7 | 1.052 |
+| 32 | 200.0 | 190.2 | 1.052 |
+| 40 | 244.6 | 234.7 | 1.043 |
+| **48** | **271.3** | **281.7** | **0.963** |
+| 64 | 338.8 | 372.6 | 0.909 |
+| 96 | 469.2 | 553.9 | 0.847 |
+| 128 | 620.4 | 735.6 | 0.843 |
+| 168 | 786.2 | 963.1 | 0.816 |
+| 256 | 1153.1 | 1445.2 | 0.798 |
+| 512 | 2218.3 | 2871.5 | 0.773 |
+
+bf16 lands on the same crossover to within 0.3% at every size (1.051 / 1.048 /
+1.050 / 1.053 / 1.043 / **0.961** / 0.903 / 0.842 / 0.840 / 0.814 / 0.796 /
+0.772), so one constant covers both dtypes.
+
+**The crossover is between 40 and 48 MiB**, and it is sharp -- 4% the wrong
+side at 40 MiB, 4% the right side at 48. `NVLS_MIN_BYTES = 48 MiB` is the
+dispatch constant; below it the unicast push/reduce/pull kernels keep the
+traffic, above it NVLS takes it and the margin grows monotonically with size.
+
+For GPT-2 DDP that puts the 27 MiB bucket on the unicast path (where it already
+beats NCCL by 7%) and moves the 168 MiB tail bucket to NVLS, taking it from
+1.29x NCCL to 1.05x.
+
+## 7. What this changes in the library
+
+### 7.1 Region allocation
+
+`region_init` today takes a `cuMemAlloc`/`hipMalloc` base. NVLS needs the
+region to be VMM memory bound to a multicast object, so the allocation moves
+into the library:
+
+* NVIDIA sm_90+: the §2 sequence. The region gets **two** base pointers, `mc`
+  and `uc`; every existing kernel keeps using `uc` unchanged (it is ordinary
+  device memory), and only the NVLS kernel needs `mc`.
+* Everything else (sm_80 and below, all AMD): `cuMemAlloc`/`hipMalloc` exactly
+  as now. `multimem` is an sm_90+ instruction and RCCL has no equivalent, so
+  **AMD keeps the unicast kernels**, with no source-level fork beyond the
+  existing `comptime if has_amd_gpu_accelerator()` and a runtime capability
+  check.
+* Granularity forces the region to a multiple of 512 MiB (or 2 MiB with
+  `CU_MULTICAST_GRANULARITY_MINIMUM`). The library's `cap_bytes` should be
+  chosen with that in mind rather than allocating a fresh object per bucket —
+  bind cost alone is 10-30 ms.
+
+### 7.2 The IPC import path becomes a VMM import
+
+For the unicast kernels the peers still need each other's regions. Two ways to
+get there, both already exercised in this tree:
+
+* keep `cuIpcGetMemHandle`/`cuIpcOpenMemHandle` on a **separate**
+  `cuMemAlloc` region (what `abharness.mojo` does: the two legs own two
+  regions), or
+* export each rank's `cuMemCreate` handle with
+  `cuMemExportToShareableHandle` and import it with the same fd transport as
+  the multicast handle (`cuMemImportFromShareableHandle` +
+  `cuMemAddressReserve`/`Map`/`SetAccess`), which is what `proto/vmm_probe.mojo`
+  established and what NCCL does for its P2P transport with driver >= 12.0
+  (`nccl:src/transport/p2p.cc:267-327`). This is the better end state: one
+  region, one allocation, both kernel families over it, and the fd machinery is
+  written once.
+
+Either way the c10d store carries a rendezvous, not a handle: the fd itself
+must travel over an AF_UNIX socket, so the store holds the socket path.
+
+### 7.3 Kernel dispatch by size
+
+The library gains a third allreduce route next to one-shot and two-shot. The
+switch is a pure size comparison on the same region, so it is a `if nbytes >=
+NVLS_MIN_BYTES and have_multicast` in the existing dispatcher — no new
+protocol, no new flags, and the generation counter keeps advancing across all
+three (the NVLS kernel consumes a known number of barrier slots per call, see
+`barriers_per_call`).
+
+### 7.4 Two footguns the prototype found
+
+* **The barrier must be a full barrier.** The unicast kernels match blocks by
+  index (block b only consumes what block b of a peer produced). The NVLS
+  kernel cannot: the reduce phase reads a contiguous slice that *every* block
+  of every peer helped stage. The block-index-matched barrier passes the small
+  cases and fails from n=65537 up, which is exactly the kind of bug that ships.
+  The prototype uses a two-level barrier (device-scope arrival counter, then
+  one `multimem.red.release.sys.global.add.u32` from the last block to arrive),
+  and pays for it with the next footgun.
+* **A full barrier requires the whole grid to be resident.** The three-phase
+  kernel uses 40 registers, so 216 blocks of 512 threads fit on 132 SMs; the
+  pipelined one uses 100, which is one block per SM, and it deadlocked until
+  the block size dropped to 256 with `nvvm.minctasm=2`. A library must either
+  pin the launch geometry to a measured occupancy, or go back to index-matched
+  barriers by giving block b the *same* sub-range in all three phases (copy-in
+  writes, for each rank s, only `[s*per + b*per/NB, ...)`; reduce and copy-out
+  address the same sub-ranges). The second is the better answer for shipped
+  code and is not implemented here.
+
+### 7.5 Two constants the library has to carry
+
+* `NVLS_MIN_BYTES = 48 MiB` (§6.5), one value for fp32 and bf16.
+* The pipeline chunk should scale with the message, not be fixed: 43 MiB is
+  best at 168 MiB (4 chunks) and 86 MiB at 512 MiB (6 chunks), while 5 MiB
+  costs 48% at 168 MiB. `chunk = clamp(bytes / 4, 21 MiB, 86 MiB)` fits every
+  point measured. The reason is the barrier: one per chunk at roughly 10 us,
+  which is also the number to attack first (§7.4 second bullet) -- an
+  index-matched barrier would be worth about 60 us at 168 MiB, i.e. the rest
+  of the gap to NCCL.
+
+## 8. What did not work, with numbers
+
+Recorded so the next agent does not re-explore them.
+
+1. **Block-index-matched barrier** (the one the unicast kernels use, and the
+   first thing tried because it is 20 us cheaper). Passes every small case and
+   fails from **n = 65537** up: 3-6 wrong elements out of 65537, every rank, at
+   scattered indices. The reduce phase reads a contiguous slice that every
+   block of every peer staged, so block b of rank r consumes bytes block b' != b
+   of a peer produced. See §7.4.
+2. **A grid that is not fully resident deadlocks**, because the two-level
+   barrier waits for every block. Measured, all at 216 blocks: 512 threads x 40
+   registers (three-phase) is fine, but 640 threads (58 registers, 1 block/SM),
+   `-D nvls_unroll=4` (88 registers), `-D nvls_mm_unroll=4/8` (72/116
+   registers) and the pipelined kernel at 512 threads (100 registers) all hang
+   until the 15 s in-kernel deadline. 396 blocks x 512 x 40 registers hangs too
+   -- exactly at the 3-blocks-per-SM boundary, so the boundary is not usable.
+   Every one of these runs fine once the grid drops to 132 blocks.
+3. **More multimem loads in flight does not help.** The switch-only phase at
+   168 MiB: 684 us with 2 loads in flight, 726 with 4, 777 with 8 (132 blocks x
+   512). At 27 MiB the order reverses (150 / 148 / 135), so the deeper unroll
+   is a small-message optimization only. The fabric is at a throughput ceiling
+   of 250-270 GB/s per direction, not a latency wall.
+4. **`multimem` with `.gpu` scope instead of `.sys`**: 960 us at 168 MiB
+   against 957 for `.sys` -- no gain, and `.sys` is the correct scope for eight
+   devices, so there is nothing to trade.
+5. **Small pipeline chunks.** 2.6 MiB chunks cost 1374 us at 168 MiB, 5 MiB
+   1163, 10 MiB 1030, 21 MiB 927, 43 MiB 924 (all at the untuned 60% split).
+   The barrier is worth about 10 us and there is one per chunk.
+6. **The fused schedule**, which was supposed to beat the split grid by not
+   giving up threads on either side: 830 us at 168 MiB against 786 for the
+   tuned split. §6.3 says why (dependent load-store chains in the per-thread
+   copy loop).
+7. **`cuMemGetHandleForAddressRange(DMA_BUF_FD)`**: `CUDA_ERROR_NOT_SUPPORTED`
+   (801), and `CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED` is 0 on all 8 devices.
+   **`ibv_reg_mr` on the cuMemMap'd unicast mapping**: NULL. §4.
+8. **The multicast object cannot be small.** `CU_MULTICAST_GRANULARITY_RECOMMENDED`
+   is 512 MiB on this hardware, so a 512 MiB payload plus a 4 KiB header
+   allocates 1 GiB per rank. `MINIMUM` is 2 MiB and was not measured.
+
+## 9. Reproducing
+
+```bash
+# login node, no GPU: cross-compile everything (add `sweeps` for the variants)
+nvls/build.sh sweeps
+
+# one node, 8 GPUs: probe + correctness + timing + both references + ABBA A/B
+sbatch nvls/bench.sbatch
+# tuning sweeps (grid, block size, unroll, scope, chunk, reducer share)
+sbatch nvls/sweep.sbatch
+
+# tables out of any of those logs
+uv run --no-sync python nvls/report.py /home/gabriel/ddp_work/logs/nvls_bench_<job>.log
+```
+
+`run.sh <binary> <world> <suite> <iters> <reps> <cap_mib> <transport> [sizes]`
+runs one process per rank under one flock of the node's GPU lock and kills the
+group on `RUN_TIMEOUT` (default 420 s) so a wedged rank cannot eat the job.
+Note that a clean run still prints `RUN_RC=143`: the inner `trap 'kill 0' EXIT`
+signals its own process group on the way out. It is not a timeout.

--- a/tests/ddp_worker.py
+++ b/tests/ddp_worker.py
@@ -450,6 +450,28 @@ def _stress_broadcast_allgather_edges(failures: list[str], rank: int, world: int
     dist.barrier()
 
 
+def _stress_avg_overflow(failures: list[str], rank: int, world: int):
+    """AVG over half dtypes must never hold the unscaled sum in the wire dtype.
+
+    Every rank contributes 32768: `world` of them sum past fp16's 65504 while
+    the average is exact, so a path that scales after a narrow store reads
+    inf (NCCL pre-multiplies, `ncclDevPreMulSum`). Two sizes: 1003 elements
+    for the small-message kernels, and 24M elements -- 48 MiB of fp16, the
+    NVLS floor on one node and the pipelined hierarchical path on several.
+    """
+    for dtype in (torch.float16, torch.bfloat16):
+        for n in (1003, 24 * 1024 * 1024):
+            x = torch.full((n,), 32768.0, dtype=dtype, device="mojo")
+            dist.all_reduce(x, op=dist.ReduceOp.AVG)
+            want = torch.full((n,), 32768.0, dtype=dtype)
+            _check(
+                failures,
+                f"stress.avg_overflow.{dtype}.n{n}",
+                torch.equal(x.cpu(), want),
+            )
+    dist.barrier()
+
+
 def run_stress(failures: list[str]):
     rank = dist.get_rank()
     world = dist.get_world_size()
@@ -461,6 +483,7 @@ def run_stress(failures: list[str]):
     _stress_mix(failures, rank, world)
     _stress_verify_matrix(failures, rank, world)
     _stress_broadcast_allgather_edges(failures, rank, world)
+    _stress_avg_overflow(failures, rank, world)
 
 
 def main():

--- a/tests/ddp_worker.py
+++ b/tests/ddp_worker.py
@@ -6,8 +6,10 @@ without a GPU: everything device-touching happens inside main().
 """
 
 # ruff: noqa: E402 -- use_local_rank_gpu() must run before torch/MAX initialize
+import ctypes
 import os
 import sys
+import time
 
 # One GPU per rank, decided before anything can initialize CUDA/MAX.
 from torch_mojo_backend.distributed import use_local_rank_gpu
@@ -505,6 +507,109 @@ def run_stress(failures: list[str]):
     _stress_avg_overflow(failures, rank, world)
 
 
+# ncclResult_t values ncclCommAbort's contract is asserted against.
+_NCCL_SUCCESS = 0
+_NCCL_INVALID_USAGE = 5
+
+# What abort is allowed to take. mojoccl's ABORT_QUIESCE_TIMEOUT_S is 5 s: if
+# the spinning kernels had NOT left, abort would poll the streams for the
+# whole 5 s and then keep the region, so landing under 4 s is itself the
+# evidence that the device really quiesced -- and it is far under the 60 s
+# barrier deadline that would otherwise have released those kernels.
+_ABORT_BOUND_S = 4.0
+
+
+def run_abort(failures: list[str]):
+    """`ncclCommAbort`'s contract, from the outside.
+
+    Rank 0 stays out of a 27 MiB allreduce every other rank enqueues, so their
+    start barrier waits on a flag nobody will ever publish -- the shape of a
+    rank that died mid-step. Every rank then aborts. A pass is: abort returns,
+    the device is idle, and both happen in a fraction of the barrier's own
+    `MOJOCCL_IB_TIMEOUT_S` deadline, which only the abort word can do. The
+    aborted communicator must then report an error, refuse further
+    collectives, and survive a `ncclCommDestroy`.
+
+    Vendor NCCL/RCCL is skipped: same contract, different timing, and this
+    asserts on timing.
+    """
+    rank = dist.get_rank()
+    world = dist.get_world_size()
+    if not _MOJO_CCL:
+        print(f"[rank {rank}] SKIP abort (mojoccl-only timing)", flush=True)
+        return
+    if world < 2:
+        print(f"[rank {rank}] SKIP abort (needs 2+ ranks)", flush=True)
+        return
+    spin_deadline = float(os.environ.get("MOJOCCL_IB_TIMEOUT_S", "60"))
+
+    pg = dist.group.WORLD
+    assert isinstance(pg, MojoProcessGroup)
+    n = (27 * 1024 * 1024) // 4
+    x = torch.full((n,), float(rank + 1), device="mojo")
+    comm, stream = _pg_comm(x)
+    lib = comm._ccl._lib
+    handle = comm._handle
+    torch_mojo_device_module.synchronize()
+
+    dist.barrier()
+    if rank != 0:
+        comm.all_reduce(
+            _ptr_of(x),
+            _ptr_of(x),
+            n,
+            _nccl_dtype(torch.float32),
+            _nccl_red_op(dist.ReduceOp.SUM),
+            stream,
+        )
+    # Long enough that the kernels are certainly spinning, and the gloo
+    # barrier after it puts every rank's abort within milliseconds of every
+    # other's -- so no rank frees its region while a peer still reads it.
+    time.sleep(2.0)
+    dist.barrier()
+
+    t0 = time.monotonic()
+    pg.abort()
+    torch_mojo_device_module.synchronize()
+    elapsed = time.monotonic() - t0
+    print(f"[rank {rank}] abort released the device in {elapsed:.3f}s", flush=True)
+    _check(
+        failures,
+        "abort.releases_the_device_promptly",
+        elapsed < min(_ABORT_BOUND_S, spin_deadline / 4.0),
+    )
+
+    err = ctypes.c_int(0)
+    rc = lib.ncclCommGetAsyncError(ctypes.c_void_p(handle), ctypes.byref(err))
+    _check(
+        failures,
+        "abort.async_error_reports_failure",
+        rc == _NCCL_SUCCESS and err.value != _NCCL_SUCCESS,
+    )
+
+    _check(
+        failures,
+        "abort.refuses_further_collectives",
+        lib.ncclAllReduce(
+            _ptr_of(x),
+            _ptr_of(x),
+            n,
+            _nccl_dtype(torch.float32),
+            _nccl_red_op(dist.ReduceOp.SUM),
+            handle,
+            stream,
+        )
+        == _NCCL_INVALID_USAGE,
+    )
+
+    _check(
+        failures,
+        "abort.destroy_after_abort_is_a_no_op",
+        lib.ncclCommDestroy(ctypes.c_void_p(handle)) == _NCCL_SUCCESS,
+    )
+    dist.barrier()
+
+
 def main():
     mode = sys.argv[1]
 
@@ -519,6 +624,8 @@ def main():
         run_lazy_fence(failures)
     elif mode == "stress":
         run_stress(failures)
+    elif mode == "abort":
+        run_abort(failures)
     else:
         raise ValueError(f"unknown mode {mode}")
     dist.destroy_process_group()

--- a/tests/ddp_worker.py
+++ b/tests/ddp_worker.py
@@ -21,6 +21,14 @@ import torch.distributed as dist
 from torch.nn.parallel import DistributedDataParallel as DDP
 
 from torch_mojo_backend import register_mojo_devices
+from torch_mojo_backend.distributed import nccl
+from torch_mojo_backend.distributed.process_group import (
+    MojoProcessGroup,
+    _nccl_dtype,
+    _nccl_red_op,
+    _ptr_of,
+)
+from torch_mojo_backend.mojo_device import torch_mojo_device_module
 
 # mojoccl (torch_mojo_backend/distributed/mojoccl) implements AllReduce/
 # Broadcast/AllGather only -- Reduce/ReduceScatter/Send/Recv return
@@ -236,6 +244,225 @@ def run_lazy_fence(failures: list[str]):
     dist.barrier()
 
 
+# ---------------------------------------------------------------------------
+# stress: mojoccl-only regression coverage ported from the kernel harness
+# (/home/gabriel/ddp_work/mojo_collectives/kernel/harness.mojo `mix` and
+# `verify`) into the real torchrun/c10d path -- vendor NCCL/RCCL never see
+# this mode (nothing here would fail against them; it exists to catch
+# mojoccl-specific ABI bugs like the interleaving bug RESULTS.md §6 found).
+# ---------------------------------------------------------------------------
+
+_VERIFY_DTYPES: list[torch.dtype] = [
+    torch.float32,
+    torch.float16,
+    torch.bfloat16,
+    torch.int32,
+    torch.int64,
+]
+_INT_DTYPES = (torch.int32, torch.int64)
+
+
+def _fill(dtype: torch.dtype, rank: int, n: int) -> torch.Tensor:
+    """Deterministic per-(rank, index) values, no RNG, on the CPU.
+
+    Integers land in [-128, 127]: exact CPU references, no overflow summing
+    up to 8 ranks. Floats are k/128 with |k| <= 128: exactly representable
+    in fp16/bf16/fp32 (<= 8 significant bits), so only the cross-rank SUM can
+    round, never the fill itself -- the same trick harness.mojo's _val_f64
+    uses and for the same reason.
+    """
+    idx = torch.arange(n, dtype=torch.int64)
+    h = (rank * 1000003 + idx * 2654435761) & 0xFF
+    if dtype in _INT_DTYPES:
+        return (h - 128).to(dtype)
+    return ((h.to(torch.float64) - 128.0) / 128.0).to(dtype)
+
+
+def _reference(dtype: torch.dtype, world: int, n: int, avg: bool) -> torch.Tensor:
+    """The CPU sum (or, for floats, AVG) of `_fill(dtype, r, n)` over every
+    rank r, accumulated wide (int64 / float64) then rounded once to `dtype`
+    -- mojoccl ignores `scale` for integer dtypes (collectives_kernels.mojo's
+    allreduce docstring: "ignored for integer dtypes"), so AVG on int32/int64
+    is SUM, matching what the library actually computes, not what real NCCL's
+    ncclAvg would do.
+    """
+    acc_dtype = torch.int64 if dtype in _INT_DTYPES else torch.float64
+    acc = torch.zeros(n, dtype=acc_dtype)
+    for r in range(world):
+        acc += _fill(dtype, r, n).to(acc_dtype)
+    if avg and dtype not in _INT_DTYPES:
+        acc = acc / world
+    return acc.to(dtype)
+
+
+def _matches(dtype: torch.dtype, got: torch.Tensor, want: torch.Tensor) -> bool:
+    """Exact for float32/int32/int64; half a bf16 ulp for fp16/bf16 -- the
+    same tolerance harness.mojo's verify_ar uses, validated there against
+    this exact kernel (RESULTS.md §7)."""
+    if dtype in (torch.float16, torch.bfloat16):
+        got64 = got.to(torch.float64)
+        want64 = want.to(torch.float64)
+        tol = 0.004 * torch.clamp(want64.abs(), min=1.0)
+        return bool((got64 - want64).abs().le(tol).all())
+    return torch.equal(got, want)
+
+
+def _pg_comm(tensor: torch.Tensor) -> tuple[nccl.NcclComm, int]:
+    """(NcclComm, default-stream handle) for `tensor`'s device, bypassing
+    dist.all_reduce's always-in-place call shape (process_group.py always
+    passes the same pointer as sendbuff and recvbuff) so the verify matrix
+    below can also exercise a genuine sendbuff != recvbuff ncclAllReduce.
+    `dist.group.WORLD` is this backend's own `MojoProcessGroup` instance
+    directly -- no C++ PG wraps it (see MojoProcessGroup.__init__).
+
+    Callers MUST synchronize the device before enqueuing on the returned
+    stream if a prior collective on this comm went through dist.all_reduce:
+    that path can run on a side comm-stream (TORCH_MOJO_BACKEND_COMM_STREAM,
+    the default), and NCCL/RCCL-style comms require every op on a
+    communicator to execute in issue order across ranks
+    (process_group.py's `_fence_default` exists for exactly this) -- this
+    raw call bypasses that fencing, so the caller re-establishes the
+    ordering with a full sync instead.
+    """
+    pg = dist.group.WORLD
+    assert isinstance(pg, MojoProcessGroup)
+    comm, stream, _ = pg._device_state(tensor)
+    return comm, stream
+
+
+def _stress_mix(failures: list[str], rank: int, world: int):
+    """Port of `harness.mojo mix`: several hundred generations interleaving a
+    4-byte one-shot allreduce, a 27 MiB two-shot allreduce, a broadcast and
+    an allgather, all sharing mojoccl's staging arena with different
+    layouts -- the pattern that found the interleaving bug (RESULTS.md §6).
+    The two allreduces run in place with AVG, which is idempotent once every
+    rank holds the mean, so a single corrupted generation anywhere in the
+    200 rounds (800 generations) still shows up in the final check. The
+    broadcast/allgather payloads are cheap (2 KiB, 8 B/rank) and change every
+    round, so they are verified every round instead.
+    """
+    rounds = 200
+    big_n = (27 * 1024 * 1024) // 4  # 27 MiB of float32
+
+    a_small = torch.full((1,), float(rank + 1), device="mojo")
+    a_big = torch.full((big_n,), float(rank + 1), device="mojo")
+    bcast_n = 500  # 2000 bytes of float32
+    bcast_buf = torch.zeros(bcast_n, device="mojo")
+    ag_per_rank = 2
+    ag_in = torch.zeros(ag_per_rank, device="mojo")
+    ag_out = torch.zeros(world * ag_per_rank, device="mojo")
+
+    bcast_ok = True
+    gather_ok = True
+    for r in range(rounds):
+        dist.all_reduce(a_small, op=dist.ReduceOp.AVG)
+        dist.all_reduce(a_big, op=dist.ReduceOp.AVG)
+
+        bval = float((r % 97) + 1) * 0.25
+        if rank == 0:
+            bcast_buf.fill_(bval)
+        dist.broadcast(bcast_buf, src=0)
+        if not bool((bcast_buf.cpu() == bval).all()):
+            bcast_ok = False
+
+        ag_in.fill_(float(r * 1000 + rank))
+        dist.all_gather_into_tensor(ag_out, ag_in)
+        want = torch.cat(
+            [torch.full((ag_per_rank,), float(r * 1000 + p)) for p in range(world)]
+        )
+        if not torch.equal(ag_out.cpu(), want):
+            gather_ok = False
+
+    _check(failures, "stress.mix.broadcast", bcast_ok)
+    _check(failures, "stress.mix.allgather", gather_ok)
+
+    expected_mean = float(world + 1) / 2.0
+    small_ok = bool(torch.allclose(a_small.cpu(), torch.full((1,), expected_mean)))
+    big_ok = bool(torch.allclose(a_big.cpu(), torch.full((big_n,), expected_mean)))
+    _check(failures, "stress.mix.allreduce_4B", small_ok)
+    _check(failures, "stress.mix.allreduce_27MiB", big_ok)
+    dist.barrier()
+
+
+def _stress_verify_matrix(failures: list[str], rank: int, world: int):
+    """dtypes x ragged sizes x {SUM, AVG} x {in place, out of place}.
+
+    Sizes: 1, 1003 (not a multiple of the 16-byte vector width), a size one
+    element short of the region cap, and one element past it (forces the ABI
+    layer's chunking loop). MOJOCCL_REGION_MB is set small for this mode (see
+    test_distributed.py) specifically so "past the cap" stays a small tensor.
+    """
+    cap_bytes = int(os.environ.get("MOJOCCL_REGION_MB", "256")) * 1024 * 1024
+
+    for dtype in _VERIFY_DTYPES:
+        item_bytes = torch.zeros((), dtype=dtype).element_size()
+        max_elems = cap_bytes // item_bytes
+        sizes = [1, 1003, max(1, (cap_bytes - 1) // item_bytes), max_elems + 1]
+        for n in sizes:
+            for op, avg in ((dist.ReduceOp.SUM, False), (dist.ReduceOp.AVG, True)):
+                want = _reference(dtype, world, n, avg)
+                tag = f"stress.verify.{dtype}.n{n}.{op.name}"
+
+                x = _fill(dtype, rank, n).to("mojo")
+                dist.all_reduce(x, op=op)
+                _check(failures, f"{tag}.inplace", _matches(dtype, x.cpu(), want))
+
+                # Full sync: the in-place step above may have run on the
+                # comm side-stream: see _pg_comm's docstring.
+                torch_mojo_device_module.synchronize()
+                src = _fill(dtype, rank, n).to("mojo")
+                dst = torch.zeros(n, dtype=dtype, device="mojo")
+                comm, stream = _pg_comm(src)
+                comm.all_reduce(
+                    _ptr_of(src),
+                    _ptr_of(dst),
+                    n,
+                    _nccl_dtype(dtype),
+                    _nccl_red_op(op),
+                    stream,
+                )
+                _check(failures, f"{tag}.outofplace", _matches(dtype, dst.cpu(), want))
+    dist.barrier()
+
+
+def _stress_broadcast_allgather_edges(failures: list[str], rank: int, world: int):
+    """Broadcast from a non-zero root; allgather with a per-rank size that is
+    not a multiple of 16 bytes (12 bytes of float32)."""
+    root = world - 1
+    n = 777
+    buf = torch.zeros(n, device="mojo")
+    if rank == root:
+        buf.copy_(_fill(torch.float32, root, n).to("mojo"))
+    dist.broadcast(buf, src=root)
+    want_bcast = _fill(torch.float32, root, n)
+    _check(
+        failures, "stress.broadcast_nonzero_root", torch.equal(buf.cpu(), want_bcast)
+    )
+
+    per_rank = 3  # 12 bytes -- not a multiple of 16
+    mine = _fill(torch.float32, rank, per_rank).to("mojo")
+    out = torch.zeros(world * per_rank, device="mojo")
+    dist.all_gather_into_tensor(out, mine)
+    want_gather = torch.cat([_fill(torch.float32, r, per_rank) for r in range(world)])
+    _check(
+        failures, "stress.allgather_non16_per_rank", torch.equal(out.cpu(), want_gather)
+    )
+    dist.barrier()
+
+
+def run_stress(failures: list[str]):
+    rank = dist.get_rank()
+    world = dist.get_world_size()
+    if not _MOJO_CCL:
+        print(
+            f"[rank {rank}] SKIP stress (mojoccl-only regression coverage)", flush=True
+        )
+        return
+    _stress_mix(failures, rank, world)
+    _stress_verify_matrix(failures, rank, world)
+    _stress_broadcast_allgather_edges(failures, rank, world)
+
+
 def main():
     mode = sys.argv[1]
 
@@ -248,6 +475,8 @@ def main():
         run_ddp_parity(failures)
     elif mode == "lazy_fence":
         run_lazy_fence(failures)
+    elif mode == "stress":
+        run_stress(failures)
     else:
         raise ValueError(f"unknown mode {mode}")
     dist.destroy_process_group()

--- a/tests/ddp_worker.py
+++ b/tests/ddp_worker.py
@@ -295,15 +295,26 @@ def _reference(dtype: torch.dtype, world: int, n: int, avg: bool) -> torch.Tenso
     return acc.to(dtype)
 
 
-def _matches(dtype: torch.dtype, got: torch.Tensor, want: torch.Tensor) -> bool:
+def _matches(
+    dtype: torch.dtype, got: torch.Tensor, want: torch.Tensor, avg: bool, world: int
+) -> bool:
     """Exact for float32/int32/int64; half a bf16 ulp for fp16/bf16 -- the
     same tolerance harness.mojo's verify_ar uses, validated there against
-    this exact kernel (RESULTS.md §7)."""
+    this exact kernel (RESULTS.md §7).
+
+    One exception: a float32 AVG over a world that is not a power of two.
+    1/world is then inexact in fp32, so both NCCL (PreMulSum) and mojoccl
+    round it into each input before summing and the result is a few fp32
+    ulps off the fp64 reference -- seen at 24 ranks, never at 8 or 16, where
+    every step is exact. A few ulps of slack there, not a wider band.
+    """
     if dtype in (torch.float16, torch.bfloat16):
         got64 = got.to(torch.float64)
         want64 = want.to(torch.float64)
         tol = 0.004 * torch.clamp(want64.abs(), min=1.0)
         return bool((got64 - want64).abs().le(tol).all())
+    if dtype == torch.float32 and avg and world & (world - 1):
+        return torch.allclose(got, want, rtol=1e-6, atol=1e-6)
     return torch.equal(got, want)
 
 
@@ -405,7 +416,11 @@ def _stress_verify_matrix(failures: list[str], rank: int, world: int):
 
                 x = _fill(dtype, rank, n).to("mojo")
                 dist.all_reduce(x, op=op)
-                _check(failures, f"{tag}.inplace", _matches(dtype, x.cpu(), want))
+                _check(
+                    failures,
+                    f"{tag}.inplace",
+                    _matches(dtype, x.cpu(), want, avg, world),
+                )
 
                 # Full sync: the in-place step above may have run on the
                 # comm side-stream: see _pg_comm's docstring.
@@ -421,7 +436,11 @@ def _stress_verify_matrix(failures: list[str], rank: int, world: int):
                     _nccl_red_op(op),
                     stream,
                 )
-                _check(failures, f"{tag}.outofplace", _matches(dtype, dst.cpu(), want))
+                _check(
+                    failures,
+                    f"{tag}.outofplace",
+                    _matches(dtype, dst.cpu(), want, avg, world),
+                )
     dist.barrier()
 
 

--- a/tests/ddp_worker.py
+++ b/tests/ddp_worker.py
@@ -552,6 +552,19 @@ def run_abort(failures: list[str]):
     handle = comm._handle
     torch_mojo_device_module.synchronize()
 
+    # The healthy path of the poll first -- one device read per pipeline
+    # arena through the communicator's cached scratch, which nothing else in
+    # the suite exercises.
+    dist.all_reduce(torch.ones(1024, device="mojo"))
+    torch_mojo_device_module.synchronize()
+    clean = ctypes.c_int(-1)
+    clean_rc = lib.ncclCommGetAsyncError(ctypes.c_void_p(handle), ctypes.byref(clean))
+    _check(
+        failures,
+        "abort.async_error_clean_before_abort",
+        clean_rc == _NCCL_SUCCESS and clean.value == _NCCL_SUCCESS,
+    )
+
     dist.barrier()
     if rank != 0:
         comm.all_reduce(

--- a/tests/ddp_worker.py
+++ b/tests/ddp_worker.py
@@ -22,6 +22,12 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 
 from torch_mojo_backend import register_mojo_devices
 
+# mojoccl (torch_mojo_backend/distributed/mojoccl) implements AllReduce/
+# Broadcast/AllGather only -- Reduce/ReduceScatter/Send/Recv return
+# ncclInvalidUsage (DDP on GPT-2 needs only the first three). Skip the
+# checks that need the unimplemented ops rather than fail on them.
+_MOJO_CCL = os.environ.get("TORCH_MOJO_BACKEND_CCL") == "mojo"
+
 
 class ElemwiseNet(torch.nn.Module):
     """Matmul-free so it runs even where GEMM routes are unavailable."""
@@ -78,13 +84,21 @@ def run_collectives(failures: list[str]):
     )
     _check(failures, "all_gather_into_tensor", ok)
 
-    src = torch.arange(world * 3, dtype=torch.float32, device="mojo")
-    out = torch.zeros(3, device="mojo")
-    dist.reduce_scatter_tensor(out, src)
-    exp = (
-        torch.arange(world * 3, dtype=torch.float32)[rank * 3 : (rank + 1) * 3] * world
-    )
-    _check(failures, "reduce_scatter_tensor", bool((out.cpu() == exp).all()))
+    if _MOJO_CCL:
+        print(
+            f"[rank {rank}] SKIP reduce_scatter_tensor "
+            "(mojoccl does not implement ncclReduceScatter)",
+            flush=True,
+        )
+    else:
+        src = torch.arange(world * 3, dtype=torch.float32, device="mojo")
+        out = torch.zeros(3, device="mojo")
+        dist.reduce_scatter_tensor(out, src)
+        exp = (
+            torch.arange(world * 3, dtype=torch.float32)[rank * 3 : (rank + 1) * 3]
+            * world
+        )
+        _check(failures, "reduce_scatter_tensor", bool((out.cpu() == exp).all()))
 
     objs: list[dict[str, int] | None] = [None] * world
     dist.all_gather_object(objs, {"rank": rank})
@@ -99,19 +113,26 @@ def run_collectives(failures: list[str]):
     )
 
     if world > 1:
-        s = torch.full((7,), float(rank), device="mojo")
-        r = torch.zeros(7, device="mojo")
-        if rank % 2 == 0:
-            dist.send(s, (rank + 1) % world)
-            dist.recv(r, (rank - 1) % world)
+        if _MOJO_CCL:
+            print(
+                f"[rank {rank}] SKIP send_recv_ring "
+                "(mojoccl does not implement ncclSend/ncclRecv)",
+                flush=True,
+            )
         else:
-            dist.recv(r, (rank - 1) % world)
-            dist.send(s, (rank + 1) % world)
-        _check(
-            failures,
-            "send_recv_ring",
-            bool((r.cpu() == float((rank - 1) % world)).all()),
-        )
+            s = torch.full((7,), float(rank), device="mojo")
+            r = torch.zeros(7, device="mojo")
+            if rank % 2 == 0:
+                dist.send(s, (rank + 1) % world)
+                dist.recv(r, (rank - 1) % world)
+            else:
+                dist.recv(r, (rank - 1) % world)
+                dist.send(s, (rank + 1) % world)
+            _check(
+                failures,
+                "send_recv_ring",
+                bool((r.cpu() == float((rank - 1) % world)).all()),
+            )
 
     dist.barrier()
 

--- a/tests/multinode/README.md
+++ b/tests/multinode/README.md
@@ -57,14 +57,30 @@ iteration is skipped outright, and phases B and C run their vendor leg(s)
 only (no ABBA — there is nothing to interleave against). Default
 (`RUN_MOJO=1` or unset) attempts every leg.
 
-As of this writing `torch_mojo_backend/distributed/mojoccl/` is intra-node
-only (its rendezvous is a `/dev/shm` directory, `MAX_WORLD = 8`) — multi-node
-transport is being implemented on this same branch
-(`mojo-collectives-multinode`) in parallel. **Use `RUN_MOJO=0` until that
-lands**: without it, every mojo leg at 16 ranks will fail or hang up to
-`ddp_worker.py`'s 300 s `init_process_group` timeout, burning the job's time
-budget for no signal. Once the transport lands, drop `RUN_MOJO=0` (or set
-`RUN_MOJO=1`) to exercise it end to end.
+`torch_mojo_backend/distributed/mojoccl/` supports multiple nodes:
+`ncclGetUniqueId` encodes a TCP rendezvous (`{ipv4, port, magic}` of a
+listening socket this library opens itself, not a `/dev/shm` path), and the
+inter-node hop is GPUDirect RDMA written directly over libibverbs
+(`bootstrap.mojo`/`ibverbs.mojo`/`internode.mojo`) — no vendor collective
+library at any level. See the "Multi-node" subsection of
+`docs/distributed.md` for the design. `RUN_MOJO` therefore **defaults to
+`1`**: leave it unset to exercise the mojo legs end to end at 16 ranks.
+`RUN_MOJO=0` still exists to get a vendor-only NCCL reference run without
+spending the job's time budget on the mojo legs (useful when only NCCL's
+numbers are wanted, or while iterating on something unrelated to mojoccl).
+
+## GPU-free self-tests
+
+`tests/multinode/selftest/` holds two standalone Mojo programs
+(`bs_test.mojo`, `ib_bringup.mojo`) that exercise the TCP bootstrap and the
+whole libibverbs RDMA transport between processes on any host with
+InfiniBand — the SLURM **login node** included, so they run in seconds
+without a GPU or a job allocation. They caught six real bugs (bootstrap/QP
+wiring, resource leaks on a failed `ib_setup`, a silently-misread port LID)
+before any GPU time was spent chasing them; run them before and after any
+change to `torch_mojo_backend/distributed/mojoccl/{bootstrap,ibverbs,
+internode}.mojo`. See `tests/multinode/selftest/README.md` for build and run
+commands.
 
 ## Output
 

--- a/tests/multinode/README.md
+++ b/tests/multinode/README.md
@@ -1,0 +1,109 @@
+# Two-node mojoccl validation and bench
+
+`run_two_node_checks.sbatch` is a 2-node x 8-GPU (16-rank) SLURM job that
+exercises the mojo distributed backend (`torch_mojo_backend/distributed/`)
+both with real NCCL (`TORCH_MOJO_BACKEND_CCL` unset, called "vendor" below)
+and with `mojoccl` (`TORCH_MOJO_BACKEND_CCL=mojo`, the in-repo Mojo
+re-implementation of NCCL's C ABI — see the "Mojo collectives" section of
+`docs/distributed.md`). Background reading: `AGENTS.md`, `docs/distributed.md`,
+`docs/mojo_collectives_feasibility.md` (especially §2 traffic profile, §5.1
+and §5.5 for the single- and two-node NCCL reference numbers, and §7/§8 for
+the multi-node design this job is meant to validate once it lands).
+
+## What it runs
+
+One `sbatch` job, three phases, always in this order:
+
+**A. `tests/ddp_worker.py`, 16 ranks.** For each `ccl` in `vendor`, `mojo`:
+run modes `collectives`, `ddp_parity`, `stress` (one `torchrun
+--nnodes=2 --nproc-per-node=8` launch per mode). `stress` is a no-op PASS
+under vendor NCCL (it self-skips — see `run_stress` in `ddp_worker.py`); it
+is mojoccl-specific regression coverage ported from the kernel harness.
+
+**B. `ar_bench_gpt2.py` allreduce bench, ABBA order:** `vendor, mojo, mojo,
+vendor` — the AGENTS.md-documented ordering that cancels a thermal/clock
+ramp to first order. Prints one `RESULT ccl=... dtype=... size_mib=...
+median_us=... min_us=... busbw_gbs=...` line per (ccl, dtype, size) at 1,
+9, 27, 168, 512 MiB, fp32 and bf16. Only the vendor legs run with
+`NCCL_DEBUG=INFO NCCL_DEBUG_SUBSYS=TUNING` (algo/protocol choices — the
+mojo legs don't go through NCCL's tuner, and mojo's `TORCH_MOJO_BACKEND_CCL`
+path talks to `libmojoccl.so`, not NCCL, so the flag can't tell us anything
+about it).
+
+**C. `demo_scripts/nanogpt_ddp.py --device mojo`, 40 steps, ABBA order,**
+same shape as B: `vendor, mojo, mojo, vendor`. Fixed args:
+`--nanogpt-path /home/gabriel/ddp_work/nanoGPT --data-dir
+/home/gabriel/ddp_work/nanoGPT/data/shakespeare --log-interval 1
+--eval-iters 10 --seed 1337 --max-iters 40 --eval-interval 40` (an eval,
+hence a val-loss line, is printed once at step 40).
+
+Every leg is a single `torchrun` launch spanning both nodes
+(`--rdzv-backend=c10d`, `MASTER_ADDR` from `scontrol show hostnames`), run
+through `srun bash -c "... flock /tmp/gpu_lock_0.lock uv run --no-sync
+torchrun ..."` — `srun` puts one such shell on each node (`--ntasks-per-node=1`
+from the `#SBATCH` header), so the flock is local to that node's `/tmp` and
+guards that node's 8 GPUs against any other job touching them concurrently.
+`PYTHONPATH` is pinned to this worktree
+(`/home/gabriel/ddp_work/mojo_coll_mn`) so `ar_bench_gpt2.py`, which lives
+outside the repo under `/home/gabriel/ddp_work/mojo_collectives/`, resolves
+`torch_mojo_backend` from here rather than whatever else might be on the
+path.
+
+## RUN_MOJO
+
+`RUN_MOJO=0` (env var, e.g. `sbatch --export=ALL,RUN_MOJO=0
+run_two_node_checks.sbatch`) skips every mojo-ccl leg: phase A's `ccl=mojo`
+iteration is skipped outright, and phases B and C run their vendor leg(s)
+only (no ABBA — there is nothing to interleave against). Default
+(`RUN_MOJO=1` or unset) attempts every leg.
+
+As of this writing `torch_mojo_backend/distributed/mojoccl/` is intra-node
+only (its rendezvous is a `/dev/shm` directory, `MAX_WORLD = 8`) — multi-node
+transport is being implemented on this same branch
+(`mojo-collectives-multinode`) in parallel. **Use `RUN_MOJO=0` until that
+lands**: without it, every mojo leg at 16 ranks will fail or hang up to
+`ddp_worker.py`'s 300 s `init_process_group` timeout, burning the job's time
+budget for no signal. Once the transport lands, drop `RUN_MOJO=0` (or set
+`RUN_MOJO=1`) to exercise it end to end.
+
+## Output
+
+`-o /home/gabriel/ddp_work/logs/mojoccl_2node_%j.log` is the **job log** —
+node names, per-node SM clock, branch/commit, then, per leg, a `===
+<phase> ccl=... ... ===` header, a filtered view of that leg's output
+(`[rank N] OK/FAIL ...` lines for ddp_worker, `RESULT ...` lines for the
+bench, `step ...`/`val loss ...` lines for training), and a `=== <phase>
+ccl=... ... exit: N ===` trailer with that leg's `torchrun` exit code. This
+is the file `summarize.py` reads.
+
+Each leg's **full, unfiltered** output (including every per-step line and,
+for the vendor bench legs, the full `NCCL_DEBUG=INFO` tuning log) is also
+saved to its own file under `/home/gabriel/ddp_work/logs/`, e.g.
+`mojoccl_2node_<jobid>_worker_vendor_collectives.log`,
+`mojoccl_2node_<jobid>_arbench_vendor_leg1.log`,
+`mojoccl_2node_<jobid>_nanogpt_mojo_leg2.log`.
+
+## summarize.py
+
+```bash
+uv run --no-sync python tests/multinode/summarize.py \
+    /home/gabriel/ddp_work/logs/mojoccl_2node_<jobid>.log
+```
+
+Stdlib only (no torch import — runs fine on the login node). Parses the job
+log's `RESULT`/`=== ... ===`/`step ...` lines (regexes at the top of the
+file) into one markdown report with three tables: allreduce bench (per
+dtype/size, vendor and mojo median device time and the mojo/vendor ratio —
+median-of-medians if a ccl has more than one ABBA leg at that size), the six
+`ddp_worker` pass/fail results, and the training runs' step-40 loss, val
+loss and tok/s with pass/fail. Pass `--out FILE` to write the report to a
+file instead of stdout; multiple log paths may be given (e.g. to merge a
+job log with one of the per-leg logs) and are concatenated before parsing.
+
+## Vendor-only NCCL reference
+
+The first run of this job should be `RUN_MOJO=0`, to establish the current
+NCCL reference numbers at 16 ranks before the mojoccl transport exists —
+see `/home/gabriel/ddp_work/mojo_collectives/mn/NCCL_REFERENCE_16.md` for
+node names, SM clock, NCCL algo/protocol choices and the resulting numbers
+from that run.

--- a/tests/multinode/README.md
+++ b/tests/multinode/README.md
@@ -71,16 +71,19 @@ numbers are wanted, or while iterating on something unrelated to mojoccl).
 
 ## GPU-free self-tests
 
-`tests/multinode/selftest/` holds two standalone Mojo programs
-(`bs_test.mojo`, `ib_bringup.mojo`) that exercise the TCP bootstrap and the
-whole libibverbs RDMA transport between processes on any host with
-InfiniBand — the SLURM **login node** included, so they run in seconds
-without a GPU or a job allocation. They caught six real bugs (bootstrap/QP
-wiring, resource leaks on a failed `ib_setup`, a silently-misread port LID)
-before any GPU time was spent chasing them; run them before and after any
-change to `torch_mojo_backend/distributed/mojoccl/{bootstrap,ibverbs,
-internode}.mojo`. See `tests/multinode/selftest/README.md` for build and run
-commands.
+`tests/multinode/selftest/` holds four standalone Mojo programs that
+exercise the TCP bootstrap (`bs_test.mojo`), the libibverbs RDMA transport
+(`ib_bringup.mojo`), the pipelined transport and its credit-based flow
+control (`ib_pipeline.mojo`) and the region geometry
+(`geometry_test.mojo`) — the first three between processes on any host with
+InfiniBand, the SLURM **login node** included, and the last one needing
+nothing at all, so they run in seconds without a GPU or a job allocation.
+They caught six real bugs (bootstrap/QP wiring, resource leaks on a failed
+`ib_setup`, a silently-misread port LID) before any GPU time was spent
+chasing them; run them before and after any change to
+`torch_mojo_backend/distributed/mojoccl/{bootstrap,ibverbs,internode}.mojo`
+or to the region layout in `mojoccl.mojo`. See
+`tests/multinode/selftest/README.md` for build and run commands.
 
 ## Output
 

--- a/tests/multinode/rank_bind.py
+++ b/tests/multinode/rank_bind.py
@@ -1,0 +1,15 @@
+"""Bind this torchrun rank to a compact slice of the task's CPU mask, then exec the demo."""
+
+import os
+import sys
+
+lr = int(os.environ["LOCAL_RANK"])
+lw = int(os.environ["LOCAL_WORLD_SIZE"])
+cpus = sorted(os.sched_getaffinity(0))
+per = len(cpus) // lw
+mine = cpus[lr * per : (lr + 1) * per]
+os.sched_setaffinity(0, mine)
+print(
+    f"rank_bind: local_rank {lr} -> cpus {mine[0]}-{mine[-1]} ({len(mine)})", flush=True
+)
+os.execv(sys.executable, [sys.executable, "demo_scripts/nanogpt_ddp.py", *sys.argv[1:]])

--- a/tests/multinode/run_two_node_checks.sbatch
+++ b/tests/multinode/run_two_node_checks.sbatch
@@ -41,7 +41,14 @@
 set -x
 : "${RUN_MOJO:=1}"
 
-REPO=/home/gabriel/ddp_work/mojo_coll_mn
+# The checkout to test. Defaults to the directory sbatch was run from, so a
+# worktree tests its own code; `REPO=<path> sbatch ...` overrides it. SLURM
+# copies this script to its spool directory, so $0 says nothing useful.
+: "${REPO:=${SLURM_SUBMIT_DIR:-$PWD}}"
+if [ ! -d "$REPO/torch_mojo_backend/distributed/mojoccl" ]; then
+  echo "REPO=$REPO is not a torch-mojo-backend checkout" >&2
+  exit 1
+fi
 LOGDIR=/home/gabriel/ddp_work/logs
 NANOGPT=/home/gabriel/ddp_work/nanoGPT
 mkdir -p "$LOGDIR"

--- a/tests/multinode/run_two_node_checks.sbatch
+++ b/tests/multinode/run_two_node_checks.sbatch
@@ -24,12 +24,11 @@
 #      first order (see AGENTS.md "Benchmark harness notes").
 #   C. demo_scripts/nanogpt_ddp.py, 40 steps, ABBA order, under both ccls.
 #
-# RUN_MOJO=0 (default 1): skip every mojo-ccl leg. Multi-node mojoccl
-# transport is not implemented yet (torch_mojo_backend/distributed/mojoccl/
-# is intra-node-only as of this writing: rendezvous is a /dev/shm directory,
-# one node only) -- use RUN_MOJO=0 to get the vendor-only NCCL reference
-# numbers without burning the job's time budget on mojo legs that will
-# fail/hang until the transport agent's work lands on this branch.
+# RUN_MOJO=0 (default 1): skip every mojo-ccl leg. mojoccl's multi-node
+# transport (TCP bootstrap carried in the unique id, GPUDirect RDMA over
+# libibverbs -- see the "Multi-node" subsection of docs/distributed.md) is
+# exercised by default; RUN_MOJO=0 instead gets a vendor-only NCCL reference
+# run without spending the job's time budget on the mojo legs.
 #
 # Every leg is one torchrun launch across both nodes (--nnodes=2
 # --nproc-per-node=8), guarded per node by `flock /tmp/gpu_lock_0.lock`

--- a/tests/multinode/run_two_node_checks.sbatch
+++ b/tests/multinode/run_two_node_checks.sbatch
@@ -1,0 +1,152 @@
+#!/bin/bash
+#SBATCH -p kyutai_debug
+#SBATCH -N 2
+#SBATCH --ntasks-per-node=1
+#SBATCH --gres=gpu:8
+#SBATCH -c 64
+#SBATCH --mem=256G
+#SBATCH -t 1:30:00
+#SBATCH -J mojoccl_2node
+#SBATCH --exclude=par2dc5-ai-prd-cl02s03dgx01
+#SBATCH -o /home/gabriel/ddp_work/logs/mojoccl_2node_%j.log
+#
+# 2-node x 8-GPU (16-rank) validation + bench for mojoccl
+# (torch_mojo_backend/distributed/mojoccl/), the Mojo re-implementation of
+# NCCL's C ABI selected with TORCH_MOJO_BACKEND_CCL=mojo. "vendor" below
+# means that variable left UNSET (real NCCL). See tests/multinode/README.md
+# for the full leg-by-leg description and RUN_MOJO=0/1 semantics.
+#
+# Three phases, in order:
+#   A. tests/ddp_worker.py collectives/ddp_parity/stress at 16 ranks, once
+#      per ccl.
+#   B. ar_bench_gpt2.py (allreduce device-time bench) in ABBA order
+#      (vendor, mojo, mojo, vendor) so a thermal/clock ramp cancels to
+#      first order (see AGENTS.md "Benchmark harness notes").
+#   C. demo_scripts/nanogpt_ddp.py, 40 steps, ABBA order, under both ccls.
+#
+# RUN_MOJO=0 (default 1): skip every mojo-ccl leg. Multi-node mojoccl
+# transport is not implemented yet (torch_mojo_backend/distributed/mojoccl/
+# is intra-node-only as of this writing: rendezvous is a /dev/shm directory,
+# one node only) -- use RUN_MOJO=0 to get the vendor-only NCCL reference
+# numbers without burning the job's time budget on mojo legs that will
+# fail/hang until the transport agent's work lands on this branch.
+#
+# Every leg is one torchrun launch across both nodes (--nnodes=2
+# --nproc-per-node=8), guarded per node by `flock /tmp/gpu_lock_0.lock`
+# inside the srun'd command (srun runs one task per node; that task's
+# flock is local to that node's /tmp). Each leg's full output goes to its
+# own log under /home/gabriel/ddp_work/logs/; a filtered view (result
+# lines, per-rank OK/FAIL, step lines, errors) is echoed to this job's
+# main -o log, which is what tests/multinode/summarize.py reads.
+
+set -x
+: "${RUN_MOJO:=1}"
+
+REPO=/home/gabriel/ddp_work/mojo_coll_mn
+LOGDIR=/home/gabriel/ddp_work/logs
+NANOGPT=/home/gabriel/ddp_work/nanoGPT
+mkdir -p "$LOGDIR"
+
+export MODULAR_NVPTX_COMPILER_PATH=/usr/local/cuda/bin/ptxas
+export PATH=$HOME/.local/bin:$PATH
+export OMP_NUM_THREADS=4
+export PYTHONPATH=$REPO
+cd "$REPO"
+
+echo "=== nodes ==="
+scontrol show hostnames "$SLURM_JOB_NODELIST"
+echo "=== per-node SM clock ==="
+srun --ntasks-per-node=1 bash -c 'hostname; nvidia-smi --query-gpu=clocks.sm --format=csv,noheader'
+echo "=== branch/commit ==="
+git rev-parse --abbrev-ref HEAD; git log --oneline -1
+echo "=== RUN_MOJO=$RUN_MOJO ==="
+
+MASTER_ADDR=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -1)
+export MASTER_ADDR
+
+set_ccl() {  # $1 = vendor|mojo
+  if [ "$1" = "mojo" ]; then
+    export TORCH_MOJO_BACKEND_CCL=mojo
+  else
+    unset TORCH_MOJO_BACKEND_CCL
+  fi
+}
+
+run_worker() {  # $1 = ccl, $2 = mode
+  local ccl=$1 mode=$2
+  echo "=== ddp_worker ccl=$ccl mode=$mode (16 ranks) ==="
+  set_ccl "$ccl"
+  local log="$LOGDIR/mojoccl_2node_${SLURM_JOB_ID}_worker_${ccl}_${mode}.log"
+  srun bash -c "flock /tmp/gpu_lock_0.lock uv run --no-sync torchrun \
+      --nnodes=\$SLURM_NNODES --nproc-per-node=8 --rdzv-backend=c10d \
+      --rdzv-endpoint=$MASTER_ADDR:29601 --rdzv-id=\$SLURM_JOB_ID \
+      tests/ddp_worker.py $mode" \
+    2>&1 | tee "$log" | grep -iE "^\[rank|FAILURES|Error|Traceback"
+  echo "=== ddp_worker ccl=$ccl mode=$mode exit: ${PIPESTATUS[0]} ==="
+}
+
+run_bench() {  # $1 = ccl, $2 = leg number (label only)
+  local ccl=$1 leg=$2
+  echo "=== ar_bench_gpt2 ccl=$ccl leg=$leg ==="
+  set_ccl "$ccl"
+  local log="$LOGDIR/mojoccl_2node_${SLURM_JOB_ID}_arbench_${ccl}_leg${leg}.log"
+  local dbg_prefix=""
+  # Algo/protocol choices only need capturing on the real-NCCL legs.
+  [ "$ccl" = "vendor" ] && dbg_prefix="NCCL_DEBUG=INFO NCCL_DEBUG_SUBSYS=TUNING"
+  srun bash -c "$dbg_prefix flock /tmp/gpu_lock_0.lock uv run --no-sync torchrun \
+      --nnodes=\$SLURM_NNODES --nproc-per-node=8 --rdzv-backend=c10d \
+      --rdzv-endpoint=$MASTER_ADDR:29602 --rdzv-id=\$SLURM_JOB_ID \
+      /home/gabriel/ddp_work/mojo_collectives/ar_bench_gpt2.py" \
+    2>&1 | tee "$log" | grep -E "^RESULT|Bytes -> Algo|Error|Traceback"
+  echo "=== ar_bench_gpt2 ccl=$ccl leg=$leg exit: ${PIPESTATUS[0]} ==="
+}
+
+run_train() {  # $1 = ccl, $2 = leg number (label only)
+  local ccl=$1 leg=$2
+  echo "=== nanogpt_ddp ccl=$ccl leg=$leg ==="
+  set_ccl "$ccl"
+  local log="$LOGDIR/mojoccl_2node_${SLURM_JOB_ID}_nanogpt_${ccl}_leg${leg}.log"
+  local common="--nanogpt-path $NANOGPT --data-dir $NANOGPT/data/shakespeare --log-interval 1 --eval-iters 10 --seed 1337 --max-iters 40 --eval-interval 40"
+  srun bash -c "flock /tmp/gpu_lock_0.lock uv run --no-sync torchrun \
+      --nnodes=\$SLURM_NNODES --nproc-per-node=8 --rdzv-backend=c10d \
+      --rdzv-endpoint=$MASTER_ADDR:29603 --rdzv-id=\$SLURM_JOB_ID \
+      demo_scripts/nanogpt_ddp.py --device mojo $common" \
+    2>&1 | tee "$log" | grep -E "^step|val loss|^done:|Error|Traceback"
+  echo "=== nanogpt_ddp ccl=$ccl leg=$leg exit: ${PIPESTATUS[0]} ==="
+}
+
+# --- Phase A: ddp_worker checks, 16 ranks, per ccl -------------------------
+for ccl in vendor mojo; do
+  if [ "$ccl" = "mojo" ] && [ "$RUN_MOJO" = "0" ]; then
+    echo "=== SKIP ddp_worker ccl=mojo (RUN_MOJO=0) ==="
+    continue
+  fi
+  for mode in collectives ddp_parity stress; do
+    run_worker "$ccl" "$mode"
+  done
+done
+
+# --- Phase B: allreduce bench, ABBA order -----------------------------------
+if [ "$RUN_MOJO" = "0" ]; then
+  echo "=== SKIP ar_bench_gpt2 ccl=mojo (RUN_MOJO=0) ==="
+  run_bench vendor 1
+  run_bench vendor 2
+else
+  run_bench vendor 1
+  run_bench mojo 1
+  run_bench mojo 2
+  run_bench vendor 2
+fi
+
+# --- Phase C: nanoGPT DDP training, 40 steps, under both ccls --------------
+if [ "$RUN_MOJO" = "0" ]; then
+  echo "=== SKIP nanogpt_ddp ccl=mojo (RUN_MOJO=0) ==="
+  run_train vendor 1
+else
+  run_train vendor 1
+  run_train mojo 1
+  run_train mojo 2
+  run_train vendor 2
+fi
+
+echo "=== 2-NODE CHECKS DONE ==="

--- a/tests/multinode/run_two_node_checks.sbatch
+++ b/tests/multinode/run_two_node_checks.sbatch
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH -p kyutai_debug
+#SBATCH -p kyutai
 #SBATCH -N 2
 #SBATCH --ntasks-per-node=1
 #SBATCH --gres=gpu:8

--- a/tests/multinode/selftest/README.md
+++ b/tests/multinode/selftest/README.md
@@ -1,0 +1,60 @@
+# mojoccl transport self-tests that need no GPU
+
+Two standalone Mojo programs that exercise
+`torch_mojo_backend/distributed/mojoccl/{bootstrap,ibverbs,internode}.mojo`
+on any host with InfiniBand — the SLURM **login node** included, which is
+what makes them cheap enough to run on every change. They caught six real
+bugs (bootstrap/QP/immediate wiring, resource leaks on a failed `ib_setup`,
+a silently-misread port LID) before any GPU time was spent chasing them.
+
+Build (from a checkout of this repo, no accelerator needed):
+
+    uv run --no-sync mojo build tests/multinode/selftest/bs_test.mojo \
+        -I torch_mojo_backend/distributed/mojoccl -o /tmp/bs_test
+    uv run --no-sync mojo build tests/multinode/selftest/ib_bringup.mojo \
+        -I torch_mojo_backend/distributed/mojoccl -o /tmp/ib_bringup
+
+## `bs_test.mojo` — the TCP bootstrap
+
+`bs_test <rank> <nranks> <uid-file> <fake-host-index>`. Rank 0 writes the
+128-byte unique id to `<uid-file>`; the rest poll for it. Each rank adds
+`<fake-host-index>` to its host hash, so one box can pretend to be several
+nodes and the derived node/local_rank table can be checked against a known
+answer. Runs both blob rounds (16-byte and 256-byte, payload verified) and
+the closing barrier.
+
+    for r in $(seq 0 15); do /tmp/bs_test $r 16 /tmp/uid.txt $((r/8)) & done; wait
+
+Exercised: 8 ranks/1 node, 16/2, 6/3.
+
+## `ib_bringup.mojo` — the RDMA transport
+
+`ib_bringup <rank> <nranks> <uid-file>`. Every rank is its own "node"
+(local_world 1), so `nranks-1` queue pairs are created per rank. Registers
+host memory as the region, runs the bootstrap, moves every QP to RTS, then
+runs 400 exchanges through `internode.ib_exchange_now` — the inline
+equivalent of the stream callback — alternating inbox halves and verifying
+every peer's slot against a rank/sequence-derived pattern.
+
+    for r in 0 1 2 3; do
+        MOJOCCL_IB_PROXY=0 /tmp/ib_bringup $r 4 /tmp/uid4.txt &
+    done; wait
+
+`MOJOCCL_IB_PROXY=0` is required here and only here: the progress thread's
+mailbox is pinned, device-mapped host memory, which needs a driver that can
+allocate it, and this host has no GPU. Without it `ib_setup` fails with
+"symbol not found: cuMemHostAlloc" -- which is the honest answer, not
+something to paper over, since on a real node that symbol is always there.
+
+400 exchanges is deliberately past `RECV_DEPTH` (64): a receive WR that is
+consumed and not reposted shows up as a hang rather than as wrong data.
+
+Covered by these and NOT by anything that needs a GPU: interface selection,
+the unique-id encoding, the two-round rendezvous, topology derivation, HCA
+and port selection, `ibv_reg_mr`, QP INIT/RTR/RTS with NCCL's attribute
+values, the ops-table dispatch for post_send/post_recv/poll_cq, the
+immediate's parity tagging, recv reposting, the self-QP GPUDirect flush, and
+`ib_setup`'s unwind of partially-created resources on a failure path. NOT
+covered: registration of *device* memory (needs nvidia_peermem and a GPU),
+the progress thread and its two spin kernels (they need pinned host memory
+and a stream), and everything in `mojoccl.mojo` above the transport.

--- a/tests/multinode/selftest/README.md
+++ b/tests/multinode/selftest/README.md
@@ -1,11 +1,12 @@
 # mojoccl transport self-tests that need no GPU
 
-Four standalone Mojo programs that exercise
-`torch_mojo_backend/distributed/mojoccl/{bootstrap,ibverbs,internode}.mojo`
+Five standalone Mojo programs that exercise
+`torch_mojo_backend/distributed/mojoccl/{bootstrap,ibverbs,internode,vmm}.mojo`
 on any host with InfiniBand — the SLURM **login node** included, which is
 what makes them cheap enough to run on every change. They caught six real
 bugs (bootstrap/QP/immediate wiring, resource leaks on a failed `ib_setup`,
 a silently-misread port LID) before any GPU time was spent chasing them.
+`geometry_test` and `fd_exchange` need no InfiniBand either.
 
 Build (from a checkout of this repo, no accelerator needed):
 
@@ -17,6 +18,8 @@ Build (from a checkout of this repo, no accelerator needed):
         -I torch_mojo_backend/distributed/mojoccl -o /tmp/ib_pipeline
     uv run --no-sync mojo build tests/multinode/selftest/geometry_test.mojo \
         -I torch_mojo_backend/distributed/mojoccl -o /tmp/geometry_test
+    uv run --no-sync mojo build tests/multinode/selftest/fd_exchange.mojo \
+        -I torch_mojo_backend/distributed/mojoccl -o /tmp/fd_exchange
 
 ## `bs_test.mojo` — the TCP bootstrap
 
@@ -87,14 +90,36 @@ inside stage_in, chunk offsets 16-byte aligned, the staging total not
 growing, and a single-node region byte-identical to the pre-pipeline one.
 ~99k cases, under a second.
 
+## `fd_exchange.mojo` — the SCM_RIGHTS fd transport of the NVLS bring-up
+
+`fd_exchange <local_rank> <local_world> <dir> <magic>`. `vmm.mojo` hands the
+multicast object and every rank's own VMM handle to its node-mates as file
+descriptors over an AF_UNIX `SOCK_DGRAM` socket, with the msghdr / cmsghdr /
+sockaddr_un structs laid out by hand over `UInt64` words because `std.ffi`
+has no C-struct ABI. A wrong offset there does not fail loudly — `sendmsg`
+succeeds and the control message is silently dropped, or a descriptor arrives
+that belongs to something else — so this runs the shipped functions
+(`socket_path`, `scm_bind`, `scm_send`, `scm_recv`, `scm_unbind`) over
+ordinary file descriptors and checks that what the receiver reads *through*
+the descriptor is what the sender wrote.
+
+    rm -rf /tmp/fdx && mkdir -p /tmp/fdx
+    for r in $(seq 0 7); do /tmp/fd_exchange $r 8 /tmp/fdx 987654321 & done; wait
+
+Same two rounds and the same `(kind, tag)` dispatch as production: rank 0's
+"multicast" descriptor one-to-all, then every rank's own descriptor
+all-to-all, where datagrams from several senders arrive in an arbitrary order
+and the tag is the only thing that says whose region one is. No GPU, no
+InfiniBand, no multicast hardware. Exercised at 2 and 8 ranks.
+
 Covered by these and NOT by anything that needs a GPU: interface selection,
 the unique-id encoding, the two-round rendezvous, topology derivation, HCA
 and port selection, `ibv_reg_mr`, QP INIT/RTR/RTS with NCCL's attribute
 values, the ops-table dispatch for post_send/post_recv/poll_cq, the
 immediate's sequence and credit tagging, recv reposting, the self-QP
 GPUDirect flush, the credit-based flow control with several exchanges in
-flight, the region geometry, and `ib_setup`'s unwind of partially-created
-resources on a failure path. NOT covered: registration of *device* memory
+flight, the region geometry, the SCM_RIGHTS fd transport, and `ib_setup`'s
+unwind of partially-created resources on a failure path. NOT covered: registration of *device* memory
 (needs nvidia_peermem and a GPU), the progress thread and its two spin
 kernels (they need pinned host memory and a stream), and everything in
 `mojoccl.mojo` above the transport.

--- a/tests/multinode/selftest/README.md
+++ b/tests/multinode/selftest/README.md
@@ -1,12 +1,13 @@
 # mojoccl transport self-tests that need no GPU
 
-Five standalone Mojo programs that exercise
+Six standalone Mojo programs that exercise
 `torch_mojo_backend/distributed/mojoccl/{bootstrap,ibverbs,internode,vmm}.mojo`
 on any host with InfiniBand — the SLURM **login node** included, which is
 what makes them cheap enough to run on every change. They caught six real
 bugs (bootstrap/QP/immediate wiring, resource leaks on a failed `ib_setup`,
 a silently-misread port LID) before any GPU time was spent chasing them.
-`geometry_test` and `fd_exchange` need no InfiniBand either.
+`geometry_test`, `fd_exchange` and `sock_deadline` need no InfiniBand
+either, and `sock_deadline` needs no peer processes at all.
 
 Build (from a checkout of this repo, no accelerator needed):
 
@@ -20,6 +21,8 @@ Build (from a checkout of this repo, no accelerator needed):
         -I torch_mojo_backend/distributed/mojoccl -o /tmp/geometry_test
     uv run --no-sync mojo build tests/multinode/selftest/fd_exchange.mojo \
         -I torch_mojo_backend/distributed/mojoccl -o /tmp/fd_exchange
+    uv run --no-sync mojo build tests/multinode/selftest/sock_deadline.mojo \
+        -I torch_mojo_backend/distributed/mojoccl -o /tmp/sock_deadline
 
 ## `bs_test.mojo` — the TCP bootstrap
 
@@ -99,18 +102,35 @@ sockaddr_un structs laid out by hand over `UInt64` words because `std.ffi`
 has no C-struct ABI. A wrong offset there does not fail loudly — `sendmsg`
 succeeds and the control message is silently dropped, or a descriptor arrives
 that belongs to something else — so this runs the shipped functions
-(`socket_path`, `scm_bind`, `scm_send`, `scm_recv`, `scm_unbind`) over
-ordinary file descriptors and checks that what the receiver reads *through*
+(`socket_path`, `scm_bind`, `scm_send`, `scm_recv`, `scm_exchange_fds`,
+`scm_unbind`) over ordinary file descriptors and checks that what the receiver reads *through*
 the descriptor is what the sender wrote.
 
     rm -rf /tmp/fdx && mkdir -p /tmp/fdx
     for r in $(seq 0 7); do /tmp/fd_exchange $r 8 /tmp/fdx 987654321 & done; wait
 
-Same two rounds and the same `(kind, tag)` dispatch as production: rank 0's
+The same `(kind, tag)` dispatch as production, in three rounds: rank 0's
 "multicast" descriptor one-to-all, then every rank's own descriptor
-all-to-all, where datagrams from several senders arrive in an arbitrary order
-and the tag is the only thing that says whose region one is. No GPU, no
-InfiniBand, no multicast hardware. Exercised at 2 and 8 ranks.
+all-to-all sending everything before receiving anything, then that same
+all-to-all through `scm_exchange_fds`, which interleaves the two halves and
+is what `nvls_bind_and_map` calls. Datagrams from several senders arrive in
+an arbitrary order, so the tag is the only thing that says whose region one
+is. No GPU, no InfiniBand, no multicast hardware. Exercised at 2 and 8 ranks.
+
+## `sock_deadline.mojo` — the deadlines, with the peers deliberately absent
+
+`sock_deadline`, no arguments, no peers, no IB, ~8 s. Five calls that must
+FAIL, each near its 1.5 s deadline: the bootstrap root with a rank that never
+connects, a connect to a port nothing listens on, a connect to an unroutable
+address (TEST-NET-3), `scm_send` into an AF_UNIX datagram queue filled to
+`net.unix.max_dgram_qlen`, and `scm_exchange_fds` with a peer that never
+binds. Coming back too early fails the case (the deadline is not being
+honoured) and so does taking much longer — the second is the bug it exists
+for: against the code before it, the unroutable connect returned after
+**129.5 s** on a 1.5 s deadline, because `connect` blocked in the kernel and
+the deadline was only read after it came back. It is 1.50 s now.
+
+    /tmp/sock_deadline
 
 Covered by these and NOT by anything that needs a GPU: interface selection,
 the unique-id encoding, the two-round rendezvous, topology derivation, HCA
@@ -118,7 +138,8 @@ and port selection, `ibv_reg_mr`, QP INIT/RTR/RTS with NCCL's attribute
 values, the ops-table dispatch for post_send/post_recv/poll_cq, the
 immediate's sequence and credit tagging, recv reposting, the self-QP
 GPUDirect flush, the credit-based flow control with several exchanges in
-flight, the region geometry, the SCM_RIGHTS fd transport, and `ib_setup`'s
+flight, the region geometry, the SCM_RIGHTS fd transport (both its shapes),
+the socket deadlines, and `ib_setup`'s
 unwind of partially-created resources on a failure path. NOT covered: registration of *device* memory
 (needs nvidia_peermem and a GPU), the progress thread and its two spin
 kernels (they need pinned host memory and a stream), and everything in

--- a/tests/multinode/selftest/README.md
+++ b/tests/multinode/selftest/README.md
@@ -1,6 +1,6 @@
 # mojoccl transport self-tests that need no GPU
 
-Two standalone Mojo programs that exercise
+Four standalone Mojo programs that exercise
 `torch_mojo_backend/distributed/mojoccl/{bootstrap,ibverbs,internode}.mojo`
 on any host with InfiniBand — the SLURM **login node** included, which is
 what makes them cheap enough to run on every change. They caught six real
@@ -13,6 +13,10 @@ Build (from a checkout of this repo, no accelerator needed):
         -I torch_mojo_backend/distributed/mojoccl -o /tmp/bs_test
     uv run --no-sync mojo build tests/multinode/selftest/ib_bringup.mojo \
         -I torch_mojo_backend/distributed/mojoccl -o /tmp/ib_bringup
+    uv run --no-sync mojo build tests/multinode/selftest/ib_pipeline.mojo \
+        -I torch_mojo_backend/distributed/mojoccl -o /tmp/ib_pipeline
+    uv run --no-sync mojo build tests/multinode/selftest/geometry_test.mojo \
+        -I torch_mojo_backend/distributed/mojoccl -o /tmp/geometry_test
 
 ## `bs_test.mojo` — the TCP bootstrap
 
@@ -49,12 +53,48 @@ something to paper over, since on a real node that symbol is always there.
 400 exchanges is deliberately past `RECV_DEPTH` (64): a receive WR that is
 consumed and not reposted shows up as a hang rather than as wrong data.
 
+## `ib_pipeline.mojo` — several exchanges in flight, and the credits
+
+`ib_pipeline <rank> <nranks> <uid-file> [nslots] [depth] [nexchanges]`
+(defaults 5, 4, 200 — the shipped `INBOX_SLOTS` and `PIPE_ARENAS`).
+Reproduces the GPU schedule of `mojoccl._do_allreduce` exactly — submit
+chunk k, consume chunk k-(depth-1) — with the calling thread standing in
+for the stream, so `credit_upto` takes the values it takes in production.
+
+    for r in 0 1 2 3; do
+        MOJOCCL_IB_PROXY=0 /tmp/ib_pipeline $r 4 /tmp/uidp.txt 5 4 200 &
+    done; wait
+
+It catches the two failures the credit protocol can have, and they look
+different: a slot group rewritten before its consumer read it is wrong bytes
+(the payload pattern carries the sequence number), while a credit never sent
+or never counted is a **hang**, which is why the run goes well past
+`nslots` exchanges. Exercised at `nslots depth` of `5 4` (shipped), `5 5`
+and `2 2` (the tight window, where a rank blocks until a peer's credit
+arrives), `1 1` (fully serial) and `8 4`, at 4 and 6 ranks.
+
+## `geometry_test.mojo` — the region carving, GPU-free and peer-free
+
+`geometry_test`, no arguments. Sweeps `mojoccl`'s own layout arithmetic
+(`region_layout`, `inbox_group_bytes`, `max_chunk_bytes`,
+`pipeline_chunk_bytes` — the communicator calls these through one-line
+wrappers, so this checks the shipped code and not a copy) over region sizes
+1 MiB–1 GiB, `local_world` 1–8, 2–16 nodes, every allreduce dtype width and
+message sizes from one element to four chunk caps, and asserts that every
+address a collective forms stays inside the area it belongs to: inbox slots
+inside their group, the shard inside stage_out, the compacted push slots
+inside stage_in, chunk offsets 16-byte aligned, the staging total not
+growing, and a single-node region byte-identical to the pre-pipeline one.
+~99k cases, under a second.
+
 Covered by these and NOT by anything that needs a GPU: interface selection,
 the unique-id encoding, the two-round rendezvous, topology derivation, HCA
 and port selection, `ibv_reg_mr`, QP INIT/RTR/RTS with NCCL's attribute
 values, the ops-table dispatch for post_send/post_recv/poll_cq, the
-immediate's parity tagging, recv reposting, the self-QP GPUDirect flush, and
-`ib_setup`'s unwind of partially-created resources on a failure path. NOT
-covered: registration of *device* memory (needs nvidia_peermem and a GPU),
-the progress thread and its two spin kernels (they need pinned host memory
-and a stream), and everything in `mojoccl.mojo` above the transport.
+immediate's sequence and credit tagging, recv reposting, the self-QP
+GPUDirect flush, the credit-based flow control with several exchanges in
+flight, the region geometry, and `ib_setup`'s unwind of partially-created
+resources on a failure path. NOT covered: registration of *device* memory
+(needs nvidia_peermem and a GPU), the progress thread and its two spin
+kernels (they need pinned host memory and a stream), and everything in
+`mojoccl.mojo` above the transport.

--- a/tests/multinode/selftest/bs_test.mojo
+++ b/tests/multinode/selftest/bs_test.mojo
@@ -17,7 +17,9 @@ from bootstrap import (
 
 
 def _p8(n: Int) -> Pointer[UInt8, MutAnyOrigin]:
-    return Pointer[UInt8, MutAnyOrigin](unsafe_from_address=Int(unsafe_alloc[UInt8](n)))
+    return Pointer[UInt8, MutAnyOrigin](
+        unsafe_from_address=Int(unsafe_alloc[UInt8](n))
+    )
 
 
 def main() raises:

--- a/tests/multinode/selftest/bs_test.mojo
+++ b/tests/multinode/selftest/bs_test.mojo
@@ -1,0 +1,98 @@
+from std.ffi import external_call
+from std.memory.alloc import unsafe_alloc
+from std.sys import argv
+from std.time import sleep
+
+from bootstrap import (
+    UID_BYTES,
+    bootstrap_allgather,
+    bootstrap_barrier,
+    bootstrap_connect,
+    derive_topology,
+    format_ipv4,
+    host_hash,
+    local_ipv4,
+    make_unique_id,
+)
+
+
+def _p8(n: Int) -> Pointer[UInt8, MutAnyOrigin]:
+    return Pointer[UInt8, MutAnyOrigin](unsafe_from_address=Int(unsafe_alloc[UInt8](n)))
+
+
+def main() raises:
+    var a = argv()
+    var rank = Int(String(a[1]))
+    var nranks = Int(String(a[2]))
+    var uid_path = String(a[3])
+    var fake_host = Int(String(a[4]))  # pretend-node index for topology tests
+
+    var uid = _p8(UID_BYTES)
+    if rank == 0:
+        make_unique_id(uid)
+        var s = String("")
+        for i in range(UID_BYTES):
+            s += String(Int(uid[unsafe_offset=i])) + " "
+        with open(uid_path, "w") as f:
+            f.write(s)
+        print("rank 0 ip", format_ipv4(local_ipv4()))
+    else:
+        while True:
+            try:
+                var text: String
+                with open(uid_path, "r") as f:
+                    text = f.read()
+                var k = 0
+                for part in text.split(" "):
+                    if String(part).byte_length() == 0:
+                        continue
+                    uid[unsafe_offset=k] = UInt8(Int(String(part)))
+                    k += 1
+                if k == UID_BYTES:
+                    break
+            except:
+                pass
+            sleep(0.02)
+
+    var conn = bootstrap_connect(uid, rank, nranks, 30.0)
+    # round 1: host hash (faked so one box can pretend to be several nodes)
+    var blob = _p8(16)
+    var bw = blob.unsafe_bitcast[UInt64]()
+    bw[unsafe_offset=0] = host_hash() + UInt64(fake_host)
+    bw[unsafe_offset=1] = UInt64(rank)
+    var all = _p8(16 * nranks)
+    bootstrap_allgather(conn, blob, 16, all, 30.0)
+    var aw = all.unsafe_bitcast[UInt64]()
+    var hashes = List[UInt64]()
+    for r in range(nranks):
+        hashes.append(aw[unsafe_offset=2 * r])
+        if Int(aw[unsafe_offset=2 * r + 1]) != r:
+            raise Error("rank mismatch in gathered table at " + String(r))
+    var topo = derive_topology(hashes, rank)
+    # round 2: a 256-byte blob, checked
+    var b2 = _p8(256)
+    for i in range(256):
+        b2[unsafe_offset=i] = UInt8((rank * 7 + i) & 0xFF)
+    var a2 = _p8(256 * nranks)
+    bootstrap_allgather(conn, b2, 256, a2, 30.0)
+    for r in range(nranks):
+        for i in range(256):
+            if Int(a2[unsafe_offset=r * 256 + i]) != ((r * 7 + i) & 0xFF):
+                raise Error("round-2 payload mismatch")
+    bootstrap_barrier(conn, 30.0)
+    conn.close()
+    print(
+        "rank",
+        rank,
+        "nnodes",
+        topo.nnodes,
+        "local_world",
+        topo.local_world,
+        "my_node",
+        topo.my_node,
+        "my_local_rank",
+        topo.my_local_rank,
+        "rank_at[0]",
+        topo.rank_at[0],
+        "OK",
+    )

--- a/tests/multinode/selftest/fd_exchange.mojo
+++ b/tests/multinode/selftest/fd_exchange.mojo
@@ -1,0 +1,155 @@
+# The AF_UNIX SCM_RIGHTS fd transport, without a GPU.
+#
+# `vmm.mojo` hands the multicast object and every rank's own VMM handle to its
+# node-mates as file descriptors over an AF_UNIX SOCK_DGRAM socket, with the
+# msghdr / cmsghdr / sockaddr_un structs laid out by hand over UInt64 words
+# because `std.ffi` has no C-struct ABI. Getting one of those offsets wrong
+# does not fail loudly -- `sendmsg` succeeds and the control message is
+# dropped, or an fd arrives that belongs to something else -- so it is worth a
+# test that needs neither CUDA nor a multicast-capable machine.
+#
+# This runs the shipped functions (`socket_path`, `scm_bind`, `scm_send`,
+# `scm_recv`, `scm_unbind`) over ordinary file descriptors and checks that what
+# the receiver reads THROUGH the descriptor is what the sender wrote, in the
+# same two rounds and with the same (kind, tag) dispatch production uses:
+# one-to-all for the multicast handle, then all-to-all for the unicast ones.
+#
+#   uv run --no-sync mojo build tests/multinode/selftest/fd_exchange.mojo \
+#       -I torch_mojo_backend/distributed/mojoccl -o /tmp/fd_exchange
+#   for r in 0 1 2 3 4 5 6 7; do /tmp/fd_exchange $r 8 /tmp/fdx 1234 & done; wait
+
+from std.ffi import OwnedDLHandle
+from std.memory.alloc import unsafe_alloc
+from std.pathlib import Path
+from std.sys import argv
+from std.time import perf_counter_ns, sleep
+
+from vmm import (
+    MSG_KIND_MC,
+    MSG_KIND_UC,
+    scm_bind,
+    scm_recv,
+    scm_send,
+    scm_unbind,
+    socket_path,
+)
+
+comptime TIMEOUT_S: Float64 = 30.0
+comptime PAYLOAD = 64
+
+
+def _barrier(dir: String, tag: String, rank: Int, world: Int) raises:
+    """File rendezvous. Deliberately not the socket path: `open()` on a bound
+    unix socket fails with ENXIO, which is how the prototype first lost an
+    afternoon."""
+    with open(dir + "/" + tag + String(rank), "w") as f:
+        f.write(String("1"))
+    var t0 = perf_counter_ns()
+    for r in range(world):
+        while not Path(dir + "/" + tag + String(r)).exists():
+            sleep(0.01)
+            if perf_counter_ns() - t0 > 60_000_000_000:
+                raise Error("barrier " + tag + " timed out")
+
+
+def _make_fd(libc: OwnedDLHandle, path: String, fill: Int) raises -> Int:
+    """A file of `PAYLOAD` bytes of `fill`, opened read-only; its fd is what
+    travels. `fill` stays ASCII: `chr` encodes as UTF-8, so 0xA5 would be
+    written as two bytes and the check would fail on the test, not on the
+    transport."""
+    var buf = String("")
+    for _ in range(PAYLOAD):
+        buf += chr(fill)
+    with open(path, "w") as f:
+        f.write(buf)
+    var cpath = unsafe_alloc[UInt8](len(path.as_bytes()) + 1)
+    for i in range(len(path.as_bytes())):
+        cpath[unsafe_offset=i] = path.as_bytes()[i]
+    cpath[unsafe_offset=len(path.as_bytes())] = 0
+    var fd = libc.get_function[Int32]("open")(cpath, Int32(0))  # O_RDONLY
+    if fd < 0:
+        raise Error("open(" + path + ") failed")
+    return Int(fd)
+
+
+def _read_fd(libc: OwnedDLHandle, fd: Int) raises -> Int:
+    """First byte behind `fd`, read through the descriptor itself."""
+    var buf = unsafe_alloc[UInt8](PAYLOAD)
+    buf[unsafe_offset=0] = 0
+    var n = libc.get_function[Int]("pread")(Int32(fd), buf, PAYLOAD, Int(0))
+    if n <= 0:
+        raise Error("pread through the received fd returned " + String(n))
+    return Int(buf[unsafe_offset=0])
+
+
+def main() raises:
+    var a = argv()
+    var rank = Int(String(a[1]))
+    var world = Int(String(a[2]))
+    var dir = String(a[3])
+    var magic = UInt64(Int(String(a[4])))
+    var libc = OwnedDLHandle("libc.so.6")
+    var bad = 0
+
+    var spath = socket_path(dir, magic, rank)
+    var sock = scm_bind(libc, spath, TIMEOUT_S)
+    _barrier(dir, "bound", rank, world)
+
+    # Round 1: rank 0's "multicast" fd to everyone, one to all.
+    comptime MC_FILL = 0x5A  # "Z"
+    if rank == 0:
+        var fd = _make_fd(libc, dir + "/mcfile", MC_FILL)
+        for r in range(1, world):
+            scm_send(
+                libc, socket_path(dir, magic, r), fd, MSG_KIND_MC, 0, TIMEOUT_S
+            )
+        _ = libc.get_function[Int32]("close")(Int32(fd))
+    else:
+        var got = scm_recv(libc, sock)
+        if got[1] != MSG_KIND_MC:
+            print("rank", rank, "round 1 kind", got[1], "expected", MSG_KIND_MC)
+            bad += 1
+        var v = _read_fd(libc, got[0])
+        if v != MC_FILL:
+            print("rank", rank, "round 1 payload", v, "expected", MC_FILL)
+            bad += 1
+        _ = libc.get_function[Int32]("close")(Int32(got[0]))
+    _barrier(dir, "round1", rank, world)
+
+    # Round 2: every rank's own fd to every other rank, all to all, with the
+    # sender's identity carried in the tag -- datagrams from several senders
+    # arrive in an arbitrary order, so the tag is the only thing that says
+    # whose region a descriptor is.
+    var mine = _make_fd(libc, dir + "/ucfile" + String(rank), 0x41 + rank)
+    for r in range(world):
+        if r == rank:
+            continue
+        scm_send(
+            libc, socket_path(dir, magic, r), mine, MSG_KIND_UC, rank, TIMEOUT_S
+        )
+    var seen = List[Int](length=world, fill=0)
+    for _ in range(world - 1):
+        var got = scm_recv(libc, sock)
+        if got[1] != MSG_KIND_UC or got[2] < 0 or got[2] >= world:
+            print("rank", rank, "round 2 kind", got[1], "tag", got[2])
+            bad += 1
+            continue
+        var v = _read_fd(libc, got[0])
+        if v != 0x41 + got[2]:
+            print("rank", rank, "got", v, "from tag", got[2])
+            bad += 1
+        seen[got[2]] += 1
+        _ = libc.get_function[Int32]("close")(Int32(got[0]))
+    for r in range(world):
+        var want = 0 if r == rank else 1
+        if seen[r] != want:
+            print("rank", rank, "saw", seen[r], "descriptors from", r)
+            bad += 1
+    _ = libc.get_function[Int32]("close")(Int32(mine))
+
+    scm_unbind(libc, sock, spath)
+    if bad == 0:
+        print("rank", rank, "PASS")
+    else:
+        print("rank", rank, "FAIL", bad)
+        raise Error("fd_exchange failed on rank " + String(rank))

--- a/tests/multinode/selftest/fd_exchange.mojo
+++ b/tests/multinode/selftest/fd_exchange.mojo
@@ -9,10 +9,16 @@
 # test that needs neither CUDA nor a multicast-capable machine.
 #
 # This runs the shipped functions (`socket_path`, `scm_bind`, `scm_send`,
-# `scm_recv`, `scm_unbind`) over ordinary file descriptors and checks that what
-# the receiver reads THROUGH the descriptor is what the sender wrote, in the
-# same two rounds and with the same (kind, tag) dispatch production uses:
-# one-to-all for the multicast handle, then all-to-all for the unicast ones.
+# `scm_recv`, `scm_exchange_fds`, `scm_unbind`) over ordinary file descriptors
+# and checks that what the receiver reads THROUGH the descriptor is what the
+# sender wrote, in the same rounds and with the same (kind, tag) dispatch
+# production uses: one-to-all for the multicast handle, then all-to-all for
+# the unicast ones -- round 2 sending everything before receiving anything,
+# round 3 through `scm_exchange_fds`, which interleaves the two and is what
+# `nvls_bind_and_map` actually calls. Round 3 is the shape that survives a
+# host whose `net.unix.max_dgram_qlen` is smaller than `local_world`; that a
+# full queue makes the send fail rather than block is checked, deterministic
+# and peer-free, by sock_deadline.mojo.
 #
 #   uv run --no-sync mojo build tests/multinode/selftest/fd_exchange.mojo \
 #       -I torch_mojo_backend/distributed/mojoccl -o /tmp/fd_exchange
@@ -28,6 +34,7 @@ from vmm import (
     MSG_KIND_MC,
     MSG_KIND_UC,
     scm_bind,
+    scm_exchange_fds,
     scm_recv,
     scm_send,
     scm_unbind,
@@ -145,6 +152,41 @@ def main() raises:
         if seen[r] != want:
             print("rank", rank, "saw", seen[r], "descriptors from", r)
             bad += 1
+    _barrier(dir, "round2", rank, world)
+
+    # Round 3: the same all-to-all through the shipped helper, which sends and
+    # receives at the same time. `_barrier` first, so every rank is listening
+    # before any starts -- the helper's own deadline is what covers a peer
+    # that never binds, and that case belongs to sock_deadline.mojo, not here.
+    var paths = List[String]()
+    for r in range(world):
+        if r != rank:
+            paths.append(socket_path(dir, magic, r))
+    var got3 = scm_exchange_fds(
+        libc, sock, paths, mine, MSG_KIND_UC, rank, TIMEOUT_S
+    )
+    if len(got3) != world - 1:
+        print("rank", rank, "round 3 got", len(got3), "want", world - 1)
+        bad += 1
+    var seen3 = List[Int](length=world, fill=0)
+    for i in range(len(got3)):
+        var g = got3[i]
+        if g[1] != MSG_KIND_UC or g[2] < 0 or g[2] >= world:
+            print("rank", rank, "round 3 kind", g[1], "tag", g[2])
+            bad += 1
+            continue
+        var v = _read_fd(libc, g[0])
+        if v != 0x41 + g[2]:
+            print("rank", rank, "round 3 got", v, "from tag", g[2])
+            bad += 1
+        seen3[g[2]] += 1
+        _ = libc.get_function[Int32]("close")(Int32(g[0]))
+    for r in range(world):
+        var want3 = 0 if r == rank else 1
+        if seen3[r] != want3:
+            print("rank", rank, "round 3 saw", seen3[r], "from", r)
+            bad += 1
+
     _ = libc.get_function[Int32]("close")(Int32(mine))
 
     scm_unbind(libc, sock, spath)

--- a/tests/multinode/selftest/geometry_test.mojo
+++ b/tests/multinode/selftest/geometry_test.mojo
@@ -1,0 +1,181 @@
+# Region-geometry sweep: no GPU, no InfiniBand, no peers. Checks that every
+# address a multi-node collective forms stays inside the area it belongs to,
+# over the whole configuration matrix this library claims to support --
+# region 1 MiB..1 GiB, local_world 1..8, 2..16 nodes, every allreduce dtype
+# width, and message sizes from 4 bytes to the chunk cap.
+#
+# The arithmetic is the library's own (`mojoccl.region_layout` and friends,
+# which the communicator calls through one-line wrappers), so this is a check
+# of the shipped code and not of a copy of it.
+from std.sys import size_of
+
+from collectives_kernels import MAX_WORLD, shard_range, signal_bytes
+from internode import CREDIT_AREA_BYTES, CREDIT_SLOT_BYTES, MAX_NODES
+from mojoccl import (
+    EMPTY_SHARD_BYTES,
+    INBOX_SLOTS,
+    PIPE_ARENAS,
+    inbox_group_bytes,
+    max_chunk_bytes,
+    net_stage_bytes,
+    pipeline_chunk_bytes,
+    region_layout,
+)
+
+
+def _align_up(x: Int, a: Int) -> Int:
+    return (x + a - 1) // a * a
+
+
+def _check(ok: Bool, what: String, mut bad: Int):
+    if not ok:
+        bad += 1
+        if bad < 20:
+            print("FAIL:", what)
+
+
+def main() raises:
+    var caps = List[Int]()
+    var mb = 1
+    while mb <= 1024:
+        caps.append(mb * 1024 * 1024)
+        mb *= 2
+    # A few non-power-of-two region sizes too: MOJOCCL_REGION_MB takes any
+    # 4 KiB multiple.
+    caps.append(3 * 1024 * 1024)
+    caps.append(48 * 1024 * 1024)
+    caps.append(200 * 1024 * 1024)
+    caps.append(768 * 1024 * 1024)
+
+    var widths = List[Int]()
+    widths.append(1)
+    widths.append(2)
+    widths.append(4)
+    widths.append(8)
+
+    var bad = 0
+    var cases = 0
+    for ci in range(len(caps)):
+        var cap = caps[ci]
+        for nnodes in range(1, MAX_NODES + 1):
+            var lay = region_layout(cap, nnodes)
+            var narenas = lay[0]
+            var arena_cap = lay[1]
+            var stride = lay[2]
+            var region_bytes = lay[3]
+            var net_off = narenas * stride
+            _check(
+                narenas == (PIPE_ARENAS if nnodes > 1 else 1),
+                "arena count",
+                bad,
+            )
+            _check(arena_cap % 4096 == 0 and arena_cap > 0, "arena_cap page", bad)
+            _check(
+                stride == signal_bytes() + 2 * arena_cap, "arena stride", bad
+            )
+            _check(
+                region_bytes == net_off + (cap if nnodes > 1 else 0),
+                "region size",
+                bad,
+            )
+            # The staging total must not grow: that is what keeps the region
+            # the size it was before the pipeline.
+            _check(
+                narenas * 2 * arena_cap <= 2 * cap, "staging total", bad
+            )
+            if nnodes == 1:
+                _check(arena_cap == cap, "single node keeps the old cap", bad)
+                _check(region_bytes == signal_bytes() + 2 * cap, "single node region", bad)
+                continue
+
+            var group = inbox_group_bytes(cap, INBOX_SLOTS)
+            _check(group > 0, "inbox group nonempty", bad)
+            _check(
+                INBOX_SLOTS * group <= cap // 2, "inbox groups fit", bad
+            )
+            _check(
+                CREDIT_AREA_BYTES + net_stage_bytes(cap) <= cap // 2,
+                "credits + staging fit the first half",
+                bad,
+            )
+            _check(
+                (MAX_NODES - 1) * CREDIT_SLOT_BYTES <= CREDIT_AREA_BYTES,
+                "credit slots fit the credit area",
+                bad,
+            )
+            var npeers = nnodes - 1
+            for li in range(1, MAX_WORLD + 1):
+                var lw = li
+                var maxchunk = max_chunk_bytes(
+                    cap, arena_cap, INBOX_SLOTS, lw, nnodes
+                )
+                _check(maxchunk % 4096 == 0, "chunk page aligned", bad)
+                for wi in range(len(widths)):
+                    var item = widths[wi]
+                    # Message sizes: tiny, ragged, and right at the cap.
+                    var sizes = List[Int]()
+                    sizes.append(item)
+                    sizes.append(3 * item)
+                    sizes.append(1003 * item)
+                    sizes.append(maxchunk // 2 + item)
+                    sizes.append(maxchunk - item)
+                    sizes.append(maxchunk)
+                    sizes.append(4 * maxchunk + 7 * item)
+                    for si in range(len(sizes)):
+                        var total = sizes[si]
+                        var chunk_bytes = pipeline_chunk_bytes(
+                            maxchunk, lw, total
+                        )
+                        _check(chunk_bytes <= maxchunk, "chunk <= max", bad)
+                        _check(
+                            chunk_bytes <= arena_cap, "chunk fits an arena", bad
+                        )
+                        _check(
+                            chunk_bytes % 4096 == 0, "chunk page aligned", bad
+                        )
+                        var chunk_elems = max(1, chunk_bytes // item)
+                        var count = max(1, total // item)
+                        var nchunks = (count + chunk_elems - 1) // chunk_elems
+                        _check(nchunks >= 1, "at least one chunk", bad)
+                        for k in range(nchunks):
+                            var off = k * chunk_elems
+                            var cnt = min(chunk_elems, count - off)
+                            # Every chunk offset must stay 16-byte aligned:
+                            # the split kernels use 16-byte vectors.
+                            _check(
+                                (off * item) % 16 == 0, "chunk offset align", bad
+                            )
+                            _check(
+                                cnt * item <= arena_cap,
+                                "chunk elems fit the arena cap",
+                                bad,
+                            )
+                            for r in range(lw):
+                                var sr = shard_range(cnt, lw, r, item)
+                                var nbytes = sr[1] * item
+                                var slot = _align_up(
+                                    max(nbytes, EMPTY_SHARD_BYTES), 16
+                                )
+                                _check(
+                                    npeers * slot <= group,
+                                    "inbox slots fit the group",
+                                    bad,
+                                )
+                                # The shard lives in stage_out at its own
+                                # element offset; it must stay inside it.
+                                _check(
+                                    sr[0] * item + nbytes <= arena_cap,
+                                    "shard inside stage_out",
+                                    bad,
+                                )
+                                # Compacted push slots at the base of
+                                # stage_in (RESULTS.md 10.1).
+                                var per = shard_range(cnt, lw, 0, item)[1]
+                                _check(
+                                    (lw - 1) * per * item <= arena_cap,
+                                    "push slots inside stage_in",
+                                    bad,
+                                )
+                            cases += 1
+    print("geometry cases", cases, "failures", bad)
+    print("PASS" if bad == 0 else "FAIL")

--- a/tests/multinode/selftest/geometry_test.mojo
+++ b/tests/multinode/selftest/geometry_test.mojo
@@ -69,7 +69,9 @@ def main() raises:
                 "arena count",
                 bad,
             )
-            _check(arena_cap % 4096 == 0 and arena_cap > 0, "arena_cap page", bad)
+            _check(
+                arena_cap % 4096 == 0 and arena_cap > 0, "arena_cap page", bad
+            )
             _check(
                 stride == signal_bytes() + 2 * arena_cap, "arena stride", bad
             )
@@ -80,19 +82,19 @@ def main() raises:
             )
             # The staging total must not grow: that is what keeps the region
             # the size it was before the pipeline.
-            _check(
-                narenas * 2 * arena_cap <= 2 * cap, "staging total", bad
-            )
+            _check(narenas * 2 * arena_cap <= 2 * cap, "staging total", bad)
             if nnodes == 1:
                 _check(arena_cap == cap, "single node keeps the old cap", bad)
-                _check(region_bytes == signal_bytes() + 2 * cap, "single node region", bad)
+                _check(
+                    region_bytes == signal_bytes() + 2 * cap,
+                    "single node region",
+                    bad,
+                )
                 continue
 
             var group = inbox_group_bytes(cap, INBOX_SLOTS)
             _check(group > 0, "inbox group nonempty", bad)
-            _check(
-                INBOX_SLOTS * group <= cap // 2, "inbox groups fit", bad
-            )
+            _check(INBOX_SLOTS * group <= cap // 2, "inbox groups fit", bad)
             _check(
                 CREDIT_AREA_BYTES + net_stage_bytes(cap) <= cap // 2,
                 "credits + staging fit the first half",
@@ -143,7 +145,9 @@ def main() raises:
                             # Every chunk offset must stay 16-byte aligned:
                             # the split kernels use 16-byte vectors.
                             _check(
-                                (off * item) % 16 == 0, "chunk offset align", bad
+                                (off * item) % 16 == 0,
+                                "chunk offset align",
+                                bad,
                             )
                             _check(
                                 cnt * item <= arena_cap,

--- a/tests/multinode/selftest/ib_bringup.mojo
+++ b/tests/multinode/selftest/ib_bringup.mojo
@@ -81,7 +81,7 @@ def main() raises:
     bootstrap_allgather(conn, b1, 16, t1, 30.0)
     var hashes = List[UInt64]()
     for r in range(nranks):
-        hashes.append(t1.unsafe_bitcast[UInt64]()[unsafe_offset = 2 * r])
+        hashes.append(t1.unsafe_bitcast[UInt64]()[unsafe_offset=2 * r])
     var topo = derive_topology(hashes, rank)
     print("rank", rank, "nnodes", topo.nnodes, "local_world", topo.local_world)
 
@@ -94,8 +94,15 @@ def main() raises:
     # this test stays a transport test. The credit protocol proper (several
     # exchanges in flight, reuse gated on a peer's credit) is ib_pipeline.
     var ib = ib_setup(
-        driver, 0, topo.my_local_rank, topo.my_node, topo.nnodes, Int(region),
-        region_bytes, 2, net_off,
+        driver,
+        0,
+        topo.my_local_rank,
+        topo.my_node,
+        topo.nnodes,
+        Int(region),
+        region_bytes,
+        2,
+        net_off,
     )
     var lid = ib_port_lid(ib)
     var mtu = ib_port_mtu(ib)
@@ -122,7 +129,9 @@ def main() raises:
     var nseq = 401
     for seq in range(1, nseq):
         for i in range(nbytes):
-            region[unsafe_offset = src + i] = UInt8((rank * 31 + seq * 7 + i) & 0xFF)
+            region[unsafe_offset=src + i] = UInt8(
+                (rank * 31 + seq * 7 + i) & 0xFF
+            )
         var inbox_base = inbox0 + (seq % 2) * half
         ib_exchange_now(
             ib,
@@ -140,10 +149,15 @@ def main() raises:
             var sender = j if j < topo.my_node else j + 1
             for i in range(nbytes):
                 var want = UInt8((sender * 31 + seq * 7 + i) & 0xFF)
-                if region[unsafe_offset = inbox_base + j * slot_bytes + i] != want:
+                if (
+                    region[unsafe_offset=inbox_base + j * slot_bytes + i]
+                    != want
+                ):
                     bad += 1
         if seq % 100 == 0 or seq < 3:
-            print("rank", rank, "seq", seq, "checked", npeers, "slots, bad", bad)
+            print(
+                "rank", rank, "seq", seq, "checked", npeers, "slots, bad", bad
+            )
     ib_teardown(ib)
     conn.close()
     print("rank", rank, "PASS" if bad == 0 else "FAIL")

--- a/tests/multinode/selftest/ib_bringup.mojo
+++ b/tests/multinode/selftest/ib_bringup.mojo
@@ -1,0 +1,142 @@
+# Two-process bring-up self-test for bootstrap + ibverbs + internode, on a
+# host that has InfiniBand but no GPU: the "region" is registered host
+# memory and the exchange runs inline instead of from a stream callback.
+from std.ffi import OwnedDLHandle, external_call
+from std.memory.alloc import unsafe_alloc
+from std.sys import argv
+from std.time import sleep
+
+from bootstrap import (
+    UID_BYTES,
+    bootstrap_allgather,
+    bootstrap_barrier,
+    bootstrap_connect,
+    derive_topology,
+    host_hash,
+    make_unique_id,
+)
+from internode import (
+    IB_BLOB_BYTES,
+    ib_connect,
+    ib_exchange_now,
+    ib_local_info,
+    ib_npeers,
+    ib_port_lid,
+    ib_port_mtu,
+    ib_setup,
+    ib_teardown,
+)
+
+comptime P8 = Pointer[UInt8, MutAnyOrigin]
+comptime CAP = 1 << 20
+comptime SIGNAL = 128 * 1024
+
+
+def _p(n: Int) -> P8:
+    var p = P8(unsafe_from_address=Int(unsafe_alloc[UInt8](n)))
+    for i in range(n):
+        p[unsafe_offset=i] = 0
+    return p
+
+
+def main() raises:
+    var a = argv()
+    var rank = Int(String(a[1]))
+    var nranks = Int(String(a[2]))
+    var uid_path = String(a[3])
+
+    var uid = _p(UID_BYTES)
+    if rank == 0:
+        make_unique_id(uid)
+        var t = String("")
+        for i in range(UID_BYTES):
+            t += String(Int(uid[unsafe_offset=i])) + " "
+        with open(uid_path, "w") as f:
+            f.write(t)
+    else:
+        while True:
+            try:
+                var text: String
+                with open(uid_path, "r") as f:
+                    text = f.read()
+                var k = 0
+                for part in text.split(" "):
+                    if String(part).byte_length() == 0:
+                        continue
+                    uid[unsafe_offset=k] = UInt8(Int(String(part)))
+                    k += 1
+                if k == UID_BYTES:
+                    break
+            except:
+                pass
+            sleep(0.02)
+
+    var conn = bootstrap_connect(uid, rank, nranks, 30.0)
+    # Pretend each rank is its own node (that is what an inter-node QP set
+    # needs); local_world == 1.
+    var b1 = _p(16)
+    b1.unsafe_bitcast[UInt64]()[unsafe_offset=0] = host_hash() + UInt64(rank)
+    var t1 = _p(16 * nranks)
+    bootstrap_allgather(conn, b1, 16, t1, 30.0)
+    var hashes = List[UInt64]()
+    for r in range(nranks):
+        hashes.append(t1.unsafe_bitcast[UInt64]()[unsafe_offset = 2 * r])
+    var topo = derive_topology(hashes, rank)
+    print("rank", rank, "nnodes", topo.nnodes, "local_world", topo.local_world)
+
+    var region_bytes = SIGNAL + 3 * CAP
+    var region = _p(region_bytes)
+    var driver = OwnedDLHandle("libc.so.6")  # no GPU here; PCI probe just fails
+    var ib = ib_setup(
+        driver, 0, topo.my_local_rank, topo.my_node, topo.nnodes, Int(region),
+        region_bytes,
+    )
+    var lid = ib_port_lid(ib)
+    var mtu = ib_port_mtu(ib)
+    var b2 = _p(IB_BLOB_BYTES)
+    ib_local_info(ib, b2, lid, mtu)
+    var t2 = _p(IB_BLOB_BYTES * nranks)
+    bootstrap_allgather(conn, b2, IB_BLOB_BYTES, t2, 30.0)
+    var peer_rank_of_node = List[Int]()
+    for j in range(topo.nnodes):
+        peer_rank_of_node.append(topo.rank_at[j * topo.local_world])
+    ib_connect(ib, t2, IB_BLOB_BYTES, peer_rank_of_node, mtu)
+    bootstrap_barrier(conn, 30.0)
+    print("rank", rank, "lid", lid, "mtu", mtu, "peers", ib_npeers(ib), "RTS")
+
+    # Many exchanges, alternating inbox halves and payload sizes, well past
+    # RECV_DEPTH so a leaked recv WR would show up as a hang.
+    var npeers = ib_npeers(ib)
+    var nbytes = 64 * 1024
+    var net_off = SIGNAL + 2 * CAP
+    var slot_bytes = nbytes
+    var half = npeers * slot_bytes
+    var src = net_off + 2 * half  # scratch above both inbox halves
+    var bad = 0
+    var nseq = 401
+    for seq in range(1, nseq):
+        for i in range(nbytes):
+            region[unsafe_offset = src + i] = UInt8((rank * 31 + seq * 7 + i) & 0xFF)
+        var inbox_base = net_off + (seq & 1) * half
+        ib_exchange_now(
+            ib,
+            Int(region) + src,
+            nbytes,
+            inbox_base,
+            slot_bytes,
+            True,
+            npeers,
+            Int(region) + inbox_base,
+            seq,
+        )
+        for j in range(npeers):
+            var sender = j if j < topo.my_node else j + 1
+            for i in range(nbytes):
+                var want = UInt8((sender * 31 + seq * 7 + i) & 0xFF)
+                if region[unsafe_offset = inbox_base + j * slot_bytes + i] != want:
+                    bad += 1
+        if seq % 100 == 0 or seq < 3:
+            print("rank", rank, "seq", seq, "checked", npeers, "slots, bad", bad)
+    ib_teardown(ib)
+    conn.close()
+    print("rank", rank, "PASS" if bad == 0 else "FAIL")

--- a/tests/multinode/selftest/ib_bringup.mojo
+++ b/tests/multinode/selftest/ib_bringup.mojo
@@ -16,6 +16,7 @@ from bootstrap import (
     make_unique_id,
 )
 from internode import (
+    CREDIT_AREA_BYTES,
     IB_BLOB_BYTES,
     ib_connect,
     ib_exchange_now,
@@ -86,10 +87,15 @@ def main() raises:
 
     var region_bytes = SIGNAL + 3 * CAP
     var region = _p(region_bytes)
+    var net_off = SIGNAL + 2 * CAP
     var driver = OwnedDLHandle("libc.so.6")  # no GPU here; PCI probe just fails
+    # Two inbox slot groups: enough that consecutive exchanges alternate, and
+    # the credit for e-2 is always in hand by the time e is submitted, so
+    # this test stays a transport test. The credit protocol proper (several
+    # exchanges in flight, reuse gated on a peer's credit) is ib_pipeline.
     var ib = ib_setup(
         driver, 0, topo.my_local_rank, topo.my_node, topo.nnodes, Int(region),
-        region_bytes,
+        region_bytes, 2, net_off,
     )
     var lid = ib_port_lid(ib)
     var mtu = ib_port_mtu(ib)
@@ -108,16 +114,16 @@ def main() raises:
     # RECV_DEPTH so a leaked recv WR would show up as a hang.
     var npeers = ib_npeers(ib)
     var nbytes = 64 * 1024
-    var net_off = SIGNAL + 2 * CAP
+    var inbox0 = net_off + CREDIT_AREA_BYTES
     var slot_bytes = nbytes
     var half = npeers * slot_bytes
-    var src = net_off + 2 * half  # scratch above both inbox halves
+    var src = inbox0 + 2 * half  # scratch above both slot groups
     var bad = 0
     var nseq = 401
     for seq in range(1, nseq):
         for i in range(nbytes):
             region[unsafe_offset = src + i] = UInt8((rank * 31 + seq * 7 + i) & 0xFF)
-        var inbox_base = net_off + (seq & 1) * half
+        var inbox_base = inbox0 + (seq % 2) * half
         ib_exchange_now(
             ib,
             Int(region) + src,
@@ -128,6 +134,7 @@ def main() raises:
             npeers,
             Int(region) + inbox_base,
             seq,
+            seq - 1,  # the previous exchange was checked before this one
         )
         for j in range(npeers):
             var sender = j if j < topo.my_node else j + 1

--- a/tests/multinode/selftest/ib_bringup.mojo
+++ b/tests/multinode/selftest/ib_bringup.mojo
@@ -97,6 +97,7 @@ def main() raises:
         driver,
         0,
         topo.my_local_rank,
+        topo.local_world,
         topo.my_node,
         topo.nnodes,
         Int(region),

--- a/tests/multinode/selftest/ib_pipeline.mojo
+++ b/tests/multinode/selftest/ib_pipeline.mojo
@@ -110,6 +110,7 @@ def main() raises:
         driver,
         0,
         topo.my_local_rank,
+        topo.local_world,
         topo.my_node,
         topo.nnodes,
         Int(region),

--- a/tests/multinode/selftest/ib_pipeline.mojo
+++ b/tests/multinode/selftest/ib_pipeline.mojo
@@ -1,0 +1,175 @@
+# Self-test for the pipelined transport: several exchanges in flight at once,
+# inbox slot groups reused only against an explicit credit, on a host with
+# InfiniBand and no GPU. The GPU schedule of `mojoccl._do_allreduce` is
+# reproduced exactly -- submit chunk k, consume chunk k-(depth-1) -- with the
+# calling thread standing in for the stream, so `credit_upto` takes the same
+# values it does in production.
+#
+# What this catches that ib_bringup cannot: a slot group rewritten before its
+# consumer read it (wrong bytes, since the pattern carries the sequence
+# number), and a credit that is never sent or never counted (a hang, which is
+# why the run is bounded well past `nslots` exchanges).
+from std.ffi import OwnedDLHandle
+from std.memory.alloc import unsafe_alloc
+from std.sys import argv
+from std.time import sleep
+
+from bootstrap import (
+    UID_BYTES,
+    bootstrap_allgather,
+    bootstrap_barrier,
+    bootstrap_connect,
+    derive_topology,
+    host_hash,
+    make_unique_id,
+)
+from internode import (
+    CREDIT_AREA_BYTES,
+    IB_BLOB_BYTES,
+    ib_connect,
+    ib_local_info,
+    ib_npeers,
+    ib_port_lid,
+    ib_port_mtu,
+    ib_setup,
+    ib_submit_now,
+    ib_teardown,
+    ib_wait_now,
+)
+
+comptime P8 = Pointer[UInt8, MutAnyOrigin]
+
+
+def _p(n: Int) -> P8:
+    var p = P8(unsafe_from_address=Int(unsafe_alloc[UInt8](n)))
+    for i in range(n):
+        p[unsafe_offset=i] = 0
+    return p
+
+
+def main() raises:
+    var a = argv()
+    var rank = Int(String(a[1]))
+    var nranks = Int(String(a[2]))
+    var uid_path = String(a[3])
+    var nslots = Int(String(a[4])) if len(a) > 4 else 5
+    var depth = Int(String(a[5])) if len(a) > 5 else 4
+    var nexch = Int(String(a[6])) if len(a) > 6 else 200
+    if depth > nslots:
+        raise Error("depth must be <= nslots or the credit window deadlocks")
+
+    var uid = _p(UID_BYTES)
+    if rank == 0:
+        make_unique_id(uid)
+        var t = String("")
+        for i in range(UID_BYTES):
+            t += String(Int(uid[unsafe_offset=i])) + " "
+        with open(uid_path, "w") as f:
+            f.write(t)
+    else:
+        while True:
+            try:
+                var text: String
+                with open(uid_path, "r") as f:
+                    text = f.read()
+                var k = 0
+                for part in text.split(" "):
+                    if String(part).byte_length() == 0:
+                        continue
+                    uid[unsafe_offset=k] = UInt8(Int(String(part)))
+                    k += 1
+                if k == UID_BYTES:
+                    break
+            except:
+                pass
+            sleep(0.02)
+
+    var conn = bootstrap_connect(uid, rank, nranks, 30.0)
+    # One "node" per rank, as in ib_bringup: that is what gives every rank a
+    # queue pair to every other.
+    var b1 = _p(16)
+    b1.unsafe_bitcast[UInt64]()[unsafe_offset=0] = host_hash() + UInt64(rank)
+    var t1 = _p(16 * nranks)
+    bootstrap_allgather(conn, b1, 16, t1, 30.0)
+    var hashes = List[UInt64]()
+    for r in range(nranks):
+        hashes.append(t1.unsafe_bitcast[UInt64]()[unsafe_offset = 2 * r])
+    var topo = derive_topology(hashes, rank)
+
+    var nbytes = 16 * 1024
+    var slot_bytes = nbytes
+    var npeers_max = nranks - 1
+    var group = npeers_max * slot_bytes
+    var credit_off = 0
+    var inbox0 = CREDIT_AREA_BYTES
+    var src = inbox0 + nslots * group
+    var region_bytes = src + depth * nbytes + 4096
+    var region = _p(region_bytes)
+    var driver = OwnedDLHandle("libc.so.6")
+    var ib = ib_setup(
+        driver, 0, topo.my_local_rank, topo.my_node, topo.nnodes,
+        Int(region), region_bytes, nslots, credit_off,
+    )
+    var lid = ib_port_lid(ib)
+    var mtu = ib_port_mtu(ib)
+    var b2 = _p(IB_BLOB_BYTES)
+    ib_local_info(ib, b2, lid, mtu)
+    var t2 = _p(IB_BLOB_BYTES * nranks)
+    bootstrap_allgather(conn, b2, IB_BLOB_BYTES, t2, 30.0)
+    var peer_rank_of_node = List[Int]()
+    for j in range(topo.nnodes):
+        peer_rank_of_node.append(topo.rank_at[j * topo.local_world])
+    ib_connect(ib, t2, IB_BLOB_BYTES, peer_rank_of_node, mtu)
+    bootstrap_barrier(conn, 30.0)
+    var npeers = ib_npeers(ib)
+    print(
+        "rank", rank, "peers", npeers, "slots", nslots, "depth", depth,
+        "exchanges", nexch, "RTS",
+    )
+
+    # Each in-flight exchange gets its own send buffer, the way each pipeline
+    # chunk gets its own arena: the NIC may still be reading chunk k's bytes
+    # while chunk k+1 is being filled.
+    var bad = 0
+    var consumed = 0
+    for k in range(nexch + depth - 1):
+        if k < nexch:
+            var seq = k + 1
+            var sbuf = src + (k % depth) * nbytes
+            for i in range(nbytes):
+                region[unsafe_offset = sbuf + i] = UInt8(
+                    (rank * 31 + seq * 7 + i) & 0xFF
+                )
+            var inbox_base = inbox0 + (seq % nslots) * group
+            ib_submit_now(
+                ib,
+                Int(region) + sbuf,
+                nbytes,
+                inbox_base,
+                slot_bytes,
+                True,
+                npeers,
+                Int(region) + inbox_base,
+                seq,
+                consumed,
+            )
+        var j = k - (depth - 1)
+        if j >= 0:
+            var seq = j + 1
+            var inbox_base = inbox0 + (seq % nslots) * group
+            ib_wait_now(ib, seq)
+            for q in range(npeers):
+                var sender = q if q < topo.my_node else q + 1
+                for i in range(nbytes):
+                    var want = UInt8((sender * 31 + seq * 7 + i) & 0xFF)
+                    if (
+                        region[unsafe_offset = inbox_base + q * slot_bytes + i]
+                        != want
+                    ):
+                        bad += 1
+            consumed = seq
+            if seq % 50 == 0 or seq < 3:
+                print("rank", rank, "consumed", seq, "bad", bad)
+    ib_teardown(ib)
+    conn.close()
+    print("rank", rank, "PASS" if bad == 0 else "FAIL")

--- a/tests/multinode/selftest/ib_pipeline.mojo
+++ b/tests/multinode/selftest/ib_pipeline.mojo
@@ -93,7 +93,7 @@ def main() raises:
     bootstrap_allgather(conn, b1, 16, t1, 30.0)
     var hashes = List[UInt64]()
     for r in range(nranks):
-        hashes.append(t1.unsafe_bitcast[UInt64]()[unsafe_offset = 2 * r])
+        hashes.append(t1.unsafe_bitcast[UInt64]()[unsafe_offset=2 * r])
     var topo = derive_topology(hashes, rank)
 
     var nbytes = 16 * 1024
@@ -107,8 +107,15 @@ def main() raises:
     var region = _p(region_bytes)
     var driver = OwnedDLHandle("libc.so.6")
     var ib = ib_setup(
-        driver, 0, topo.my_local_rank, topo.my_node, topo.nnodes,
-        Int(region), region_bytes, nslots, credit_off,
+        driver,
+        0,
+        topo.my_local_rank,
+        topo.my_node,
+        topo.nnodes,
+        Int(region),
+        region_bytes,
+        nslots,
+        credit_off,
     )
     var lid = ib_port_lid(ib)
     var mtu = ib_port_mtu(ib)
@@ -123,8 +130,17 @@ def main() raises:
     bootstrap_barrier(conn, 30.0)
     var npeers = ib_npeers(ib)
     print(
-        "rank", rank, "peers", npeers, "slots", nslots, "depth", depth,
-        "exchanges", nexch, "RTS",
+        "rank",
+        rank,
+        "peers",
+        npeers,
+        "slots",
+        nslots,
+        "depth",
+        depth,
+        "exchanges",
+        nexch,
+        "RTS",
     )
 
     # Each in-flight exchange gets its own send buffer, the way each pipeline
@@ -137,7 +153,7 @@ def main() raises:
             var seq = k + 1
             var sbuf = src + (k % depth) * nbytes
             for i in range(nbytes):
-                region[unsafe_offset = sbuf + i] = UInt8(
+                region[unsafe_offset=sbuf + i] = UInt8(
                     (rank * 31 + seq * 7 + i) & 0xFF
                 )
             var inbox_base = inbox0 + (seq % nslots) * group
@@ -163,7 +179,7 @@ def main() raises:
                 for i in range(nbytes):
                     var want = UInt8((sender * 31 + seq * 7 + i) & 0xFF)
                     if (
-                        region[unsafe_offset = inbox_base + q * slot_bytes + i]
+                        region[unsafe_offset=inbox_base + q * slot_bytes + i]
                         != want
                     ):
                         bad += 1

--- a/tests/multinode/selftest/sock_deadline.mojo
+++ b/tests/multinode/selftest/sock_deadline.mojo
@@ -1,0 +1,252 @@
+# The bootstrap and fd-transport deadlines, without a GPU, without IB and
+# without a peer.
+#
+# Both transports wait on sockets, and both used to run a BLOCKING syscall
+# first and check the deadline only after it returned. A dropped SYN keeps
+# `connect` inside the kernel for over two minutes whatever
+# MOJOCCL_BOOTSTRAP_TIMEOUT_S says, and a `sendmsg` into a full AF_UNIX
+# datagram queue never returns at all -- which is how eight ranks that all
+# send before they receive wedge an NVLS bring-up on a host with a small
+# `net.unix.max_dgram_qlen`.
+#
+# Every case here is "this call must FAIL, and it must fail near its
+# deadline": too fast is a bug (the deadline is not being honoured), too slow
+# is the bug these cases exist for (a syscall the deadline cannot reach).
+# Nothing needs a peer -- the peers are deliberately absent -- so this runs
+# anywhere, in one process, in a few seconds.
+#
+#   uv run --no-sync mojo build tests/multinode/selftest/sock_deadline.mojo \
+#       -I torch_mojo_backend/distributed/mojoccl -o /tmp/sock_deadline
+#   /tmp/sock_deadline
+
+from std.ffi import OwnedDLHandle, external_call
+from std.memory.alloc import unsafe_alloc
+from std.random import random_ui64
+from std.time import perf_counter_ns
+
+from bootstrap import (
+    UID_BYTES,
+    _encode_id,
+    bootstrap_connect,
+    local_ipv4,
+    make_unique_id,
+)
+from vmm import (
+    MSG_KIND_UC,
+    _fd_msghdr,
+    _send_once,
+    _send_socket,
+    _sockaddr,
+    scm_bind,
+    scm_exchange_fds,
+    scm_send,
+    scm_unbind,
+    socket_path,
+)
+
+comptime DEADLINE_S: Float64 = 1.5
+"""Short on purpose: every case below is expected to reach it."""
+
+comptime SLACK_S: Float64 = 5.0
+"""How far past the deadline a bounded failure may still land. Generous --
+the point is to separate "bounded" from "blocked in a syscall for minutes",
+not to measure the scheduler."""
+
+comptime BLACKHOLE_IP = "203.0.113.9"
+"""TEST-NET-3 (RFC 5737): reserved for documentation, so nothing routes it.
+Whether the SYN is dropped or refused depends on the network in front of the
+test, and either is fine here: `bootstrap_connect` retries until its deadline
+in both cases, so the expected elapsed time is the same one."""
+
+
+def _elapsed_s(t0: Int) -> Float64:
+    return Float64(perf_counter_ns() - t0) / 1.0e9
+
+
+def _check_bounded(mut bad: Int, name: String, t: Float64):
+    """A case passes when it came back, and came back near the deadline."""
+    if t < DEADLINE_S * 0.5:
+        print("FAIL", name, "returned after", t, "s, before its deadline")
+        bad += 1
+    elif t > DEADLINE_S + SLACK_S:
+        print("FAIL", name, "took", t, "s -- the deadline did not bound it")
+        bad += 1
+    else:
+        print("ok  ", name, t, "s")
+
+
+def _ipv4_be(dotted: String) raises -> UInt32:
+    """`inet_addr(3)`: a dotted quad as the network-order u32 the unique id
+    carries."""
+    var b = dotted.as_bytes()
+    var c = unsafe_alloc[UInt8](len(b) + 1)
+    for i in range(len(b)):
+        c[unsafe_offset=i] = b[i]
+    c[unsafe_offset = len(b)] = 0
+    return external_call["inet_addr", UInt32](c)
+
+
+def _closed_port_be() raises -> UInt16:
+    """A port nothing listens on: bind one, read it back, close it."""
+    comptime AF_INET: Int32 = 2
+    comptime SOCK_STREAM: Int32 = 1
+    var fd = external_call["socket", Int32](AF_INET, SOCK_STREAM, Int32(0))
+    if fd < 0:
+        raise Error("socket() failed")
+    var sa = unsafe_alloc[UInt8](16)
+    for i in range(16):
+        sa[unsafe_offset=i] = 0
+    sa[unsafe_offset=0] = 2
+    if external_call["bind", Int32](fd, sa, UInt32(16)) != 0:
+        _ = external_call["close", Int32](fd)
+        raise Error("bind() failed")
+    var slen = unsafe_alloc[UInt32](1)
+    slen[unsafe_offset=0] = 16
+    if external_call["getsockname", Int32](fd, sa, slen) != 0:
+        _ = external_call["close", Int32](fd)
+        raise Error("getsockname() failed")
+    var port = sa.unsafe_bitcast[UInt16]()[unsafe_offset=1]
+    _ = external_call["close", Int32](fd)
+    return port
+
+
+def _uid_pointing_at(addr_be: UInt32, port_be: UInt16) -> Int:
+    """A well-formed unique id for an endpoint of this test's choosing. The
+    magic is random and belongs to no listener in this process, so
+    `bootstrap_connect` takes the non-root path and really connects."""
+    var uid = unsafe_alloc[UInt8](UID_BYTES)
+    var p = Pointer[UInt8, MutAnyOrigin](unsafe_from_address=Int(uid))
+    _encode_id(p, addr_be, port_be, random_ui64(1, UInt64.MAX))
+    return Int(uid)
+
+
+def _case_root_never_reached(mut bad: Int) raises:
+    """Rank 0 of a two-rank communicator, with rank 1 never launched: the
+    accept loop must give up at the deadline."""
+    var uid = unsafe_alloc[UInt8](UID_BYTES)
+    var p = Pointer[UInt8, MutAnyOrigin](unsafe_from_address=Int(uid))
+    make_unique_id(p)
+    var t0 = perf_counter_ns()
+    try:
+        var conn = bootstrap_connect(p, 0, 2, DEADLINE_S)
+        conn.close()
+        print("FAIL root-never-reached returned a connection")
+        bad += 1
+        return
+    except:
+        pass
+    _check_bounded(bad, "root: peer never connects", _elapsed_s(t0))
+
+
+def _case_connect(mut bad: Int, name: String, addr_be: UInt32, port: UInt16) raises:
+    var p = Pointer[UInt8, MutAnyOrigin](
+        unsafe_from_address=_uid_pointing_at(addr_be, port)
+    )
+    var t0 = perf_counter_ns()
+    try:
+        var conn = bootstrap_connect(p, 1, 2, DEADLINE_S)
+        conn.close()
+        print("FAIL", name, "connected to an endpoint that does not exist")
+        bad += 1
+        return
+    except:
+        pass
+    _check_bounded(bad, name, _elapsed_s(t0))
+
+
+def _fill_queue(libc: OwnedDLHandle, path: String) raises -> Int:
+    """Fill `path`'s receive queue to `net.unix.max_dgram_qlen`, the state a
+    node with few free slots is in when eight ranks all send at once.
+
+    It takes several sending sockets: a datagram in flight is charged to its
+    SENDER's send buffer, so one socket runs out (a few hundred here) long
+    before the receiver's queue does. A brand-new socket that cannot push a
+    single datagram is the signal that the limit reached is the receiver's.
+    The sockets are deliberately left open -- closing them would give the
+    charge back and drain the very condition the case needs.
+    """
+    var fd = libc.get_function[Int32]("dup")(Int32(0))
+    var n = 0
+    for _ in range(16):
+        var sock = _send_socket(libc, 1.0)
+        var msg = _fd_msghdr(_sockaddr(path), Int(fd), MSG_KIND_UC, 0)
+        var pushed = 0
+        while pushed < 100000 and _send_once(libc, sock, msg) == 0:
+            pushed += 1
+        n += pushed
+        if pushed == 0:
+            break
+    _ = libc.get_function[Int32]("close")(fd)
+    return n
+
+
+def _case_full_queue(mut bad: Int) raises:
+    """`scm_send` into a queue nobody drains. It must time out; a blocking
+    `sendmsg` here waits for room that is never coming."""
+    var libc = OwnedDLHandle("libc.so.6")
+    var magic = random_ui64(1, UInt64.MAX)
+    var path = socket_path("/tmp", magic, 0)
+    var sock = scm_bind(libc, path, DEADLINE_S)
+    var filled = _fill_queue(libc, path)
+    if filled == 0:
+        print("FAIL full-queue could not fill the receive queue at all")
+        bad += 1
+        scm_unbind(libc, sock, path)
+        return
+    var fd = libc.get_function[Int32]("dup")(Int32(0))
+    var t0 = perf_counter_ns()
+    try:
+        scm_send(libc, path, Int(fd), MSG_KIND_UC, 0, DEADLINE_S)
+        print("FAIL full-queue accepted a send into a full queue")
+        bad += 1
+    except:
+        _check_bounded(
+            bad, "scm_send: receiver queue full (" + String(filled) + ")",
+            _elapsed_s(t0),
+        )
+    _ = libc.get_function[Int32]("close")(fd)
+    scm_unbind(libc, sock, path)
+
+
+def _case_exchange_no_peer(mut bad: Int) raises:
+    """`scm_exchange_fds` with a peer that never binds its socket: bounded,
+    and it says how far it got."""
+    var libc = OwnedDLHandle("libc.so.6")
+    var magic = random_ui64(1, UInt64.MAX)
+    var path = socket_path("/tmp", magic, 0)
+    var sock = scm_bind(libc, path, DEADLINE_S)
+    var paths = List[String]()
+    paths.append(socket_path("/tmp", magic, 1))  # nobody ever binds this
+    var fd = libc.get_function[Int32]("dup")(Int32(0))
+    var t0 = perf_counter_ns()
+    try:
+        var got = scm_exchange_fds(
+            libc, sock, paths, Int(fd), MSG_KIND_UC, 0, DEADLINE_S
+        )
+        print("FAIL exchange-no-peer returned", len(got), "descriptors")
+        bad += 1
+    except:
+        _check_bounded(bad, "scm_exchange_fds: peer never binds", _elapsed_s(t0))
+    _ = libc.get_function[Int32]("close")(fd)
+    scm_unbind(libc, sock, path)
+
+
+def main() raises:
+    var bad = 0
+    _case_root_never_reached(bad)
+    _case_connect(
+        bad, "connect: nothing listening", local_ipv4(), _closed_port_be()
+    )
+    _case_connect(
+        bad,
+        "connect: unroutable address",
+        _ipv4_be(BLACKHOLE_IP),
+        UInt16(0x3930),  # port 12345, network order
+    )
+    _case_full_queue(bad)
+    _case_exchange_no_peer(bad)
+    if bad == 0:
+        print("sock_deadline PASS")
+    else:
+        print("sock_deadline FAIL", bad)
+        raise Error("sock_deadline: " + String(bad) + " case(s) failed")

--- a/tests/multinode/selftest/sock_deadline.mojo
+++ b/tests/multinode/selftest/sock_deadline.mojo
@@ -138,7 +138,9 @@ def _case_root_never_reached(mut bad: Int) raises:
     _check_bounded(bad, "root: peer never connects", _elapsed_s(t0))
 
 
-def _case_connect(mut bad: Int, name: String, addr_be: UInt32, port: UInt16) raises:
+def _case_connect(
+    mut bad: Int, name: String, addr_be: UInt32, port: UInt16
+) raises:
     var p = Pointer[UInt8, MutAnyOrigin](
         unsafe_from_address=_uid_pointing_at(addr_be, port)
     )
@@ -226,7 +228,9 @@ def _case_exchange_no_peer(mut bad: Int) raises:
         print("FAIL exchange-no-peer returned", len(got), "descriptors")
         bad += 1
     except:
-        _check_bounded(bad, "scm_exchange_fds: peer never binds", _elapsed_s(t0))
+        _check_bounded(
+            bad, "scm_exchange_fds: peer never binds", _elapsed_s(t0)
+        )
     _ = libc.get_function[Int32]("close")(fd)
     scm_unbind(libc, sock, path)
 

--- a/tests/multinode/selftest/sock_deadline.mojo
+++ b/tests/multinode/selftest/sock_deadline.mojo
@@ -82,7 +82,7 @@ def _ipv4_be(dotted: String) raises -> UInt32:
     var c = unsafe_alloc[UInt8](len(b) + 1)
     for i in range(len(b)):
         c[unsafe_offset=i] = b[i]
-    c[unsafe_offset = len(b)] = 0
+    c[unsafe_offset=len(b)] = 0
     return external_call["inet_addr", UInt32](c)
 
 
@@ -203,7 +203,8 @@ def _case_full_queue(mut bad: Int) raises:
         bad += 1
     except:
         _check_bounded(
-            bad, "scm_send: receiver queue full (" + String(filled) + ")",
+            bad,
+            "scm_send: receiver queue full (" + String(filled) + ")",
             _elapsed_s(t0),
         )
     _ = libc.get_function[Int32]("close")(fd)

--- a/tests/multinode/summarize.py
+++ b/tests/multinode/summarize.py
@@ -58,11 +58,11 @@ TrainKey = tuple[str, str]  # (ccl, leg)
 
 
 def parse(lines: list[str]) -> dict[str, object]:
-    bench: dict[BenchKey, list[float]] = {}
-    worker: dict[WorkerKey, int | None] = {}
-    train: dict[TrainKey, dict[str, float | int | None]] = {}
-    skipped: list[str] = []
-    current_train: TrainKey | None = None
+    bench = dict[BenchKey, list[float]]()
+    worker = dict[WorkerKey, int | None]()
+    train = dict[TrainKey, dict[str, float | int | None]]()
+    skipped = list[str]()
+    current_train = None
 
     for raw in lines:
         line = raw.rstrip("\n")
@@ -143,7 +143,7 @@ def _fmt(x: float | int | None, spec: str = ".1f") -> str:
 
 
 def render_bench(bench: dict[BenchKey, list[float]]) -> str:
-    sizes: dict[tuple[str, int], dict[str, float]] = {}
+    sizes = dict[tuple[str, int], dict[str, float]]()
     for (ccl, dtype, mib), medians in bench.items():
         sizes.setdefault((dtype, mib), {})[ccl] = statistics.median(medians)
 
@@ -220,7 +220,7 @@ def render(parsed: dict[str, object], source: str) -> str:
     return "\n".join(parts)
 
 
-def main() -> None:
+def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "logs",
@@ -233,7 +233,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    lines: list[str] = []
+    lines = list[str]()
     for path in args.logs:
         lines.extend(path.read_text(errors="replace").splitlines())
 

--- a/tests/multinode/summarize.py
+++ b/tests/multinode/summarize.py
@@ -23,8 +23,7 @@ import argparse
 import statistics
 import sys
 from pathlib import Path
-from re import Pattern
-from re import compile as re_compile
+from re import Pattern, compile as re_compile
 
 _RESULT_RE: Pattern[str] = re_compile(
     r"^RESULT ccl=(?P<ccl>\S+) dtype=(?P<dtype>\S+) size_mib=\s*(?P<mib>\d+) "

--- a/tests/multinode/summarize.py
+++ b/tests/multinode/summarize.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Summarize a tests/multinode/run_two_node_checks.sbatch job log.
+
+Reads the SLURM job log named by that sbatch script's ``-o`` (e.g.
+``/home/gabriel/ddp_work/logs/mojoccl_2node_<jobid>.log``) and prints one
+markdown report with three tables:
+
+- allreduce bench (``ar_bench_gpt2.py`` ``RESULT ...`` lines): per dtype and
+  size, the vendor/mojo median device time and the mojo/vendor ratio.
+- ddp_worker checks (``=== ddp_worker ccl=... mode=... exit: N ===``): per
+  (ccl, mode) pass/fail, from the leg's exit code.
+- nanoGPT DDP training (``=== nanogpt_ddp ccl=... leg=... ===`` plus the
+  script's own ``step NNNNN | ...`` lines): per (ccl, leg) the last logged
+  step's loss and tok/s, the val loss if an eval ran, and pass/fail.
+
+Stdlib only: this runs on the SLURM login node (no GPU, no torch import).
+
+    uv run --no-sync python tests/multinode/summarize.py \\
+        /home/gabriel/ddp_work/logs/mojoccl_2node_<jobid>.log
+"""
+
+import argparse
+import statistics
+import sys
+from pathlib import Path
+from re import Pattern
+from re import compile as re_compile
+
+_RESULT_RE: Pattern[str] = re_compile(
+    r"^RESULT ccl=(?P<ccl>\S+) dtype=(?P<dtype>\S+) size_mib=\s*(?P<mib>\d+) "
+    r"median_us=\s*(?P<median>[\d.]+) min_us=\s*(?P<min>[\d.]+) "
+    r"busbw_gbs=\s*(?P<busbw>[\d.]+)"
+)
+_WORKER_HEADER_RE: Pattern[str] = re_compile(
+    r"^=== ddp_worker ccl=(?P<ccl>\S+) mode=(?P<mode>\S+) \(16 ranks\) ===$"
+)
+_WORKER_EXIT_RE: Pattern[str] = re_compile(
+    r"^=== ddp_worker ccl=(?P<ccl>\S+) mode=(?P<mode>\S+) exit: (?P<rc>\d+) ===$"
+)
+_TRAIN_HEADER_RE: Pattern[str] = re_compile(
+    r"^=== nanogpt_ddp ccl=(?P<ccl>\S+) leg=(?P<leg>\S+) ===$"
+)
+_TRAIN_EXIT_RE: Pattern[str] = re_compile(
+    r"^=== nanogpt_ddp ccl=(?P<ccl>\S+) leg=(?P<leg>\S+) exit: (?P<rc>\d+) ===$"
+)
+_STEP_RE: Pattern[str] = re_compile(
+    r"^step\s+(?P<step>\d+)\s*\|\s*loss\s+(?P<loss>-?[\d.]+)\s*\|\s*"
+    r"(?P<toks>[\d.]+)k tok/s\s*\|\s*(?P<secs>[\d.]+)s"
+)
+_VAL_RE: Pattern[str] = re_compile(
+    r"^step\s+(?P<step>\d+)\s*\|\s*val loss\s+(?P<val>-?[\d.]+)"
+)
+_SKIP_RE: Pattern[str] = re_compile(r"^=== SKIP (?P<what>.+) \(RUN_MOJO=0\) ===$")
+
+BenchKey = tuple[str, str, int]  # (ccl, dtype, size_mib)
+WorkerKey = tuple[str, str]  # (ccl, mode)
+TrainKey = tuple[str, str]  # (ccl, leg)
+
+
+def parse(lines: list[str]) -> dict[str, object]:
+    bench: dict[BenchKey, list[float]] = {}
+    worker: dict[WorkerKey, int | None] = {}
+    train: dict[TrainKey, dict[str, float | int | None]] = {}
+    skipped: list[str] = []
+    current_train: TrainKey | None = None
+
+    for raw in lines:
+        line = raw.rstrip("\n")
+
+        m = _SKIP_RE.match(line)
+        if m:
+            skipped.append(m.group("what"))
+            continue
+
+        m = _RESULT_RE.match(line)
+        if m:
+            key = (m.group("ccl"), m.group("dtype"), int(m.group("mib")))
+            bench.setdefault(key, []).append(float(m.group("median")))
+            continue
+
+        m = _WORKER_HEADER_RE.match(line)
+        if m:
+            worker.setdefault((m.group("ccl"), m.group("mode")), None)
+            continue
+        m = _WORKER_EXIT_RE.match(line)
+        if m:
+            worker[(m.group("ccl"), m.group("mode"))] = int(m.group("rc"))
+            continue
+
+        m = _TRAIN_HEADER_RE.match(line)
+        if m:
+            key = (m.group("ccl"), m.group("leg"))
+            train.setdefault(
+                key,
+                {
+                    "rc": None,
+                    "step": None,
+                    "loss": None,
+                    "toks": None,
+                    "val_loss": None,
+                },
+            )
+            current_train = key
+            continue
+        m = _TRAIN_EXIT_RE.match(line)
+        if m:
+            key = (m.group("ccl"), m.group("leg"))
+            train.setdefault(
+                key,
+                {
+                    "rc": None,
+                    "step": None,
+                    "loss": None,
+                    "toks": None,
+                    "val_loss": None,
+                },
+            )
+            train[key]["rc"] = int(m.group("rc"))
+            if current_train == key:
+                current_train = None
+            continue
+
+        if current_train is not None:
+            m = _STEP_RE.match(line)
+            if m:
+                step = int(m.group("step"))
+                d = train[current_train]
+                if d["step"] is None or step >= d["step"]:
+                    d["step"] = step
+                    d["loss"] = float(m.group("loss"))
+                    d["toks"] = float(m.group("toks"))
+                continue
+            m = _VAL_RE.match(line)
+            if m:
+                train[current_train]["val_loss"] = float(m.group("val"))
+                continue
+
+    return {"bench": bench, "worker": worker, "train": train, "skipped": skipped}
+
+
+def _fmt(x: float | int | None, spec: str = ".1f") -> str:
+    return format(x, spec) if isinstance(x, (int, float)) else "N/A"
+
+
+def render_bench(bench: dict[BenchKey, list[float]]) -> str:
+    sizes: dict[tuple[str, int], dict[str, float]] = {}
+    for (ccl, dtype, mib), medians in bench.items():
+        sizes.setdefault((dtype, mib), {})[ccl] = statistics.median(medians)
+
+    lines = [
+        "| dtype | size (MiB) | vendor median (us) | mojo median (us) | mojo/vendor |",
+        "|---|---|---|---|---|",
+    ]
+    for dtype, mib in sorted(sizes, key=lambda k: (k[0], k[1])):
+        cell = sizes[(dtype, mib)]
+        vendor = cell.get("vendor")
+        mojo = cell.get("mojo")
+        ratio = mojo / vendor if (vendor and mojo) else None
+        lines.append(
+            f"| {dtype} | {mib} | {_fmt(vendor)} | {_fmt(mojo)} | {_fmt(ratio, '.3f')} |"
+        )
+    if len(lines) == 2:
+        lines.append("| _(no RESULT lines found)_ | | | | |")
+    return "\n".join(lines)
+
+
+def render_worker(worker: dict[WorkerKey, int | None]) -> str:
+    lines = ["| ccl | mode | result |", "|---|---|---|"]
+    for ccl, mode in sorted(worker):
+        rc = worker[(ccl, mode)]
+        status = "PASS" if rc == 0 else ("FAIL" if rc is not None else "NO EXIT LOGGED")
+        lines.append(
+            f"| {ccl} | {mode} | {status} (rc={_fmt(rc, 'd') if rc is not None else 'N/A'}) |"
+        )
+    if len(lines) == 2:
+        lines.append("| _(no ddp_worker legs found)_ | | |")
+    return "\n".join(lines)
+
+
+def render_train(train: dict[TrainKey, dict[str, float | int | None]]) -> str:
+    lines = [
+        "| ccl | leg | step | loss | val loss | tok/s | result |",
+        "|---|---|---|---|---|---|---|",
+    ]
+    for ccl, leg in sorted(train):
+        d = train[(ccl, leg)]
+        rc = d["rc"]
+        status = "PASS" if rc == 0 else ("FAIL" if rc is not None else "NO EXIT LOGGED")
+        toks = f"{d['toks']:.1f}k" if isinstance(d["toks"], (int, float)) else "N/A"
+        lines.append(
+            f"| {ccl} | {leg} | {_fmt(d['step'], 'd') if d['step'] is not None else 'N/A'} "
+            f"| {_fmt(d['loss'], '.4f')} | {_fmt(d['val_loss'], '.4f')} | {toks} | {status} |"
+        )
+    if len(lines) == 2:
+        lines.append("| _(no nanogpt_ddp legs found)_ | | | | | | |")
+    return "\n".join(lines)
+
+
+def render(parsed: dict[str, object], source: str) -> str:
+    bench = parsed["bench"]
+    worker = parsed["worker"]
+    train = parsed["train"]
+    skipped = parsed["skipped"]
+    assert isinstance(bench, dict)
+    assert isinstance(worker, dict)
+    assert isinstance(train, dict)
+    assert isinstance(skipped, list)
+
+    parts = [f"# mojoccl two-node summary\n\nSource: `{source}`\n"]
+    if skipped:
+        parts.append(
+            "Skipped legs (RUN_MOJO=0): " + ", ".join(sorted(set(skipped))) + "\n"
+        )
+    parts.append("## Allreduce bench (ar_bench_gpt2.py)\n")
+    parts.append(render_bench(bench) + "\n")
+    parts.append("## ddp_worker checks (16 ranks)\n")
+    parts.append(render_worker(worker) + "\n")
+    parts.append("## nanoGPT DDP training (40 steps)\n")
+    parts.append(render_train(train) + "\n")
+    return "\n".join(parts)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "logs",
+        nargs="+",
+        type=Path,
+        help="job log path(s) from the sbatch job's -o file",
+    )
+    parser.add_argument(
+        "--out", type=Path, default=None, help="write markdown here instead of stdout"
+    )
+    args = parser.parse_args()
+
+    lines: list[str] = []
+    for path in args.logs:
+        lines.extend(path.read_text(errors="replace").splitlines())
+
+    parsed = parse(lines)
+    report = render(parsed, ", ".join(str(p) for p in args.logs))
+
+    if args.out is not None:
+        args.out.write_text(report)
+    else:
+        sys.stdout.write(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/nvls_check.py
+++ b/tests/nvls_check.py
@@ -1,0 +1,72 @@
+"""mojoccl's NVLS allreduce, at world sizes and sizes ddp_worker misses.
+
+`ddp_worker stress` verifies the multicast path at 8 ranks and 256 MiB.
+This runs the same kind of check at whatever `WORLD_SIZE` torchrun gives it
+-- 2 and 4 are the interesting ones, since the reducer/copy block split and
+the per-rank slice arithmetic are both functions of `world` -- over sizes
+that straddle the `MOJOCCL_NVLS_MIN_MB` dispatch threshold and the staging
+arena, including one element past it so the ABI layer's chunking loop runs.
+
+    TORCH_MOJO_BACKEND_CCL=mojo torchrun --nproc-per-node=2 tests/nvls_check.py
+
+Exits nonzero on the first mismatch. It is not a pytest module (it needs
+torchrun, like tests/ddp_worker.py) and pytest does not collect it.
+"""
+
+# ruff: noqa: E402 -- use_local_rank_gpu() must run before torch/MAX initialize
+import os
+
+# One GPU per rank, decided before anything can initialize CUDA/MAX.
+from torch_mojo_backend.distributed import use_local_rank_gpu
+
+use_local_rank_gpu()
+
+import torch
+import torch.distributed as dist
+
+from torch_mojo_backend import register_mojo_devices
+
+register_mojo_devices()
+
+RANK = int(os.environ["RANK"])
+WORLD = int(os.environ["WORLD_SIZE"])
+
+
+def main():
+    dist.init_process_group(backend="mojo")
+    cap = int(os.environ.get("MOJOCCL_REGION_MB", "256")) * 1024 * 1024
+    bad = 0
+    for dtype in (torch.float32, torch.bfloat16):
+        item = torch.zeros((), dtype=dtype).element_size()
+        for n in (
+            47 * 1024 * 1024 // item,  # just below the NVLS floor
+            48 * 1024 * 1024 // item,  # just at it
+            64 * 1024 * 1024 // item + 3,  # ragged, above it
+            2 * cap // item + 1,  # one element past the NVLS staging arena
+        ):
+            for op, avg in ((dist.ReduceOp.SUM, False), (dist.ReduceOp.AVG, True)):
+                x = torch.full((n,), float(RANK + 1), dtype=dtype, device="mojo")
+                dist.all_reduce(x, op=op)
+                want = WORLD * (WORLD + 1) / 2
+                if avg:
+                    want /= WORLD
+                got = x.cpu()
+                ok = bool((got == torch.tensor(want, dtype=dtype)).all())
+                tag = f"world{WORLD}.{dtype}.n{n}.{op.name}"
+                if not ok:
+                    bad += 1
+                    print(
+                        f"[rank {RANK}] FAIL {tag} first={got[0]} want={want}",
+                        flush=True,
+                    )
+                else:
+                    print(f"[rank {RANK}] OK   {tag}", flush=True)
+                del x, got
+    dist.barrier()
+    dist.destroy_process_group()
+    print(f"[rank {RANK}] {'PASS' if bad == 0 else 'FAILURES ' + str(bad)}", flush=True)
+    raise SystemExit(1 if bad else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/nvls_check.py
+++ b/tests/nvls_check.py
@@ -36,7 +36,17 @@ def main():
     dist.init_process_group(backend="mojo")
     cap = int(os.environ.get("MOJOCCL_REGION_MB", "256")) * 1024 * 1024
     bad = 0
-    for dtype in (torch.float32, torch.bfloat16):
+    # (op, fill, expected). The third case fills every rank with 32768: the
+    # unscaled sum overflows fp16 (world x 32768 > 65504) while the average is
+    # exact, so it fails unless AVG's 1/world is applied to the inputs before
+    # the switch narrows the sum (NCCL's PreMulSum), and it is the reason
+    # fp16 is in the dtype list.
+    cases = (
+        (dist.ReduceOp.SUM, float(RANK + 1), WORLD * (WORLD + 1) / 2),
+        (dist.ReduceOp.AVG, float(RANK + 1), (WORLD + 1) / 2),
+        (dist.ReduceOp.AVG, 32768.0, 32768.0),
+    )
+    for dtype in (torch.float32, torch.float16, torch.bfloat16):
         item = torch.zeros((), dtype=dtype).element_size()
         for n in (
             47 * 1024 * 1024 // item,  # just below the NVLS floor
@@ -44,15 +54,12 @@ def main():
             64 * 1024 * 1024 // item + 3,  # ragged, above it
             2 * cap // item + 1,  # one element past the NVLS staging arena
         ):
-            for op, avg in ((dist.ReduceOp.SUM, False), (dist.ReduceOp.AVG, True)):
-                x = torch.full((n,), float(RANK + 1), dtype=dtype, device="mojo")
+            for op, fill, want in cases:
+                x = torch.full((n,), fill, dtype=dtype, device="mojo")
                 dist.all_reduce(x, op=op)
-                want = WORLD * (WORLD + 1) / 2
-                if avg:
-                    want /= WORLD
                 got = x.cpu()
                 ok = bool((got == torch.tensor(want, dtype=dtype)).all())
-                tag = f"world{WORLD}.{dtype}.n{n}.{op.name}"
+                tag = f"world{WORLD}.{dtype}.n{n}.{op.name}.fill{int(fill)}"
                 if not ok:
                     bad += 1
                     print(

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -342,7 +342,9 @@ def _run_torchrun(nproc: int, mode: str, extra_env: dict[str, str] | None = None
 
 @pytest.mark.parametrize("ccl", ["vendor", "mojo"])
 @pytest.mark.parametrize("comm_stream", ["1", "0"], ids=["side-stream", "same-stream"])
-@pytest.mark.parametrize("mode", ["collectives", "ddp_parity", "lazy_fence", "stress"])
+@pytest.mark.parametrize(
+    "mode", ["collectives", "ddp_parity", "lazy_fence", "stress", "abort"]
+)
 def test_two_rank_nccl(mode: str, comm_stream: str, ccl: str):
     """`ccl="mojo"` runs the same workers against mojoccl
     (torch_mojo_backend/distributed/mojoccl), the in-repo NCCL-API library,
@@ -358,11 +360,15 @@ def test_two_rank_nccl(mode: str, comm_stream: str, ccl: str):
     NCCL/RCCL doesn't already cover elsewhere, so it only runs for
     `ccl="mojo"`. MOJOCCL_REGION_MB is pinned small so its "past the region
     cap" cases stay cheap tensors instead of needing a real 256 MiB region.
+
+    `mode="abort"` is likewise mojoccl-only: it asserts that ncclCommAbort
+    releases the spinning kernels and the region in a fraction of the
+    barrier deadline, which is a timing claim about this library.
     """
     if _gpu_count() < 2:
         pytest.skip("needs at least 2 GPUs")
-    if mode == "stress" and ccl != "mojo":
-        pytest.skip("stress is mojoccl-only regression coverage")
+    if mode in ("stress", "abort") and ccl != "mojo":
+        pytest.skip(f"{mode} is mojoccl-only regression coverage")
     extra_env = {"TORCH_MOJO_BACKEND_COMM_STREAM": comm_stream}
     if ccl == "mojo":
         extra_env["TORCH_MOJO_BACKEND_CCL"] = "mojo"

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -340,12 +340,23 @@ def _run_torchrun(nproc: int, mode: str, extra_env: dict[str, str] | None = None
         )
 
 
+@pytest.mark.parametrize("ccl", ["vendor", "mojo"])
 @pytest.mark.parametrize("comm_stream", ["1", "0"], ids=["side-stream", "same-stream"])
 @pytest.mark.parametrize("mode", ["collectives", "ddp_parity", "lazy_fence"])
-def test_two_rank_nccl(mode: str, comm_stream: str):
+def test_two_rank_nccl(mode: str, comm_stream: str, ccl: str):
+    """`ccl="mojo"` runs the same workers against mojoccl
+    (torch_mojo_backend/distributed/mojoccl), the in-repo NCCL-API library,
+    instead of vendor NCCL/RCCL -- same process_group.py, same ddp_worker.py,
+    only the loaded .so differs (nccl.py's `load()`). ddp_worker.py itself
+    skips the two collectives mojoccl does not implement yet
+    (ReduceScatter, Send/Recv) when this is set.
+    """
     if _gpu_count() < 2:
         pytest.skip("needs at least 2 GPUs")
-    _run_torchrun(2, mode, {"TORCH_MOJO_BACKEND_COMM_STREAM": comm_stream})
+    extra_env = {"TORCH_MOJO_BACKEND_COMM_STREAM": comm_stream}
+    if ccl == "mojo":
+        extra_env["TORCH_MOJO_BACKEND_CCL"] = "mojo"
+    _run_torchrun(2, mode, extra_env)
 
 
 def _measure_overhead_microseconds(no_hook: bool) -> dict[str, float]:

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -342,7 +342,7 @@ def _run_torchrun(nproc: int, mode: str, extra_env: dict[str, str] | None = None
 
 @pytest.mark.parametrize("ccl", ["vendor", "mojo"])
 @pytest.mark.parametrize("comm_stream", ["1", "0"], ids=["side-stream", "same-stream"])
-@pytest.mark.parametrize("mode", ["collectives", "ddp_parity", "lazy_fence"])
+@pytest.mark.parametrize("mode", ["collectives", "ddp_parity", "lazy_fence", "stress"])
 def test_two_rank_nccl(mode: str, comm_stream: str, ccl: str):
     """`ccl="mojo"` runs the same workers against mojoccl
     (torch_mojo_backend/distributed/mojoccl), the in-repo NCCL-API library,
@@ -350,12 +350,24 @@ def test_two_rank_nccl(mode: str, comm_stream: str, ccl: str):
     only the loaded .so differs (nccl.py's `load()`). ddp_worker.py itself
     skips the two collectives mojoccl does not implement yet
     (ReduceScatter, Send/Recv) when this is set.
+
+    `mode="stress"` is mojoccl-specific regression coverage ported from the
+    kernel harness (docs/mojo_collectives_kernel_results.md §6-7): the
+    interleaving pattern that found a silent-corruption bug, plus a
+    dtype/size/op/placement verify matrix. It exercises nothing vendor
+    NCCL/RCCL doesn't already cover elsewhere, so it only runs for
+    `ccl="mojo"`. MOJOCCL_REGION_MB is pinned small so its "past the region
+    cap" cases stay cheap tensors instead of needing a real 256 MiB region.
     """
     if _gpu_count() < 2:
         pytest.skip("needs at least 2 GPUs")
+    if mode == "stress" and ccl != "mojo":
+        pytest.skip("stress is mojoccl-only regression coverage")
     extra_env = {"TORCH_MOJO_BACKEND_COMM_STREAM": comm_stream}
     if ccl == "mojo":
         extra_env["TORCH_MOJO_BACKEND_CCL"] = "mojo"
+    if mode == "stress":
+        extra_env["MOJOCCL_REGION_MB"] = "4"
     _run_torchrun(2, mode, extra_env)
 
 

--- a/torch_mojo_backend/distributed/mojoccl/bootstrap.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/bootstrap.mojo
@@ -81,15 +81,13 @@ def _alloc[T: AnyType](n: Int) -> Pointer[T, MutAnyOrigin]:
     one `ncclCommInitRank`, and is handed to libc by address; rebinding to
     `MutAnyOrigin` once here keeps the call sites free of casts.
     """
-    return Pointer[T, MutAnyOrigin](
-        unsafe_from_address=Int(unsafe_alloc[T](n))
-    )
+    return Pointer[T, MutAnyOrigin](unsafe_from_address=Int(unsafe_alloc[T](n)))
 
 
 def _errno() -> Int32:
-    return external_call[
-        "__errno_location", Pointer[Int32, MutAnyOrigin]
-    ]()[unsafe_offset=0]
+    return external_call["__errno_location", Pointer[Int32, MutAnyOrigin]]()[
+        unsafe_offset=0
+    ]
 
 
 def _close(fd: Int32):
@@ -106,7 +104,9 @@ def _set_timeout(fd: Int32, optname: Int32, seconds: Int64) raises:
         fd, SOL_SOCKET, optname, tv, UInt32(16)
     )
     if rc != 0:
-        raise Error("mojoccl: setsockopt(timeout) failed, errno=" + String(_errno()))
+        raise Error(
+            "mojoccl: setsockopt(timeout) failed, errno=" + String(_errno())
+        )
 
 
 def _get_int_opt(fd: Int32, level: Int32, optname: Int32) raises -> Int32:
@@ -115,9 +115,7 @@ def _get_int_opt(fd: Int32, level: Int32, optname: Int32) raises -> Int32:
     var l = _alloc[UInt32](1)
     l[unsafe_offset=0] = 4
     if external_call["getsockopt", Int32](fd, level, optname, v, l) != 0:
-        raise Error(
-            "mojoccl: getsockopt failed, errno=" + String(_errno())
-        )
+        raise Error("mojoccl: getsockopt failed, errno=" + String(_errno()))
     return v[unsafe_offset=0]
 
 
@@ -156,9 +154,7 @@ def _connect_deadline(
     then `SO_ERROR` for the verdict -- the three steps a bounded TCP connect
     needs. False means "not connected" (refused, unreachable, or out of
     time); the caller decides whether to retry or to give up."""
-    var rc = external_call["connect", Int32](
-        fd, sa, UInt32(SOCKADDR_IN_BYTES)
-    )
+    var rc = external_call["connect", Int32](fd, sa, UInt32(SOCKADDR_IN_BYTES))
     if rc == 0:
         return True
     var e = _errno()
@@ -202,8 +198,7 @@ def _fill_sockaddr(
 
 
 def _ipv4_of_iface(name: String) -> UInt32:
-    """SIOCGIFADDR on a throwaway UDP socket; 0 if the interface has no IPv4.
-    """
+    """SIOCGIFADDR on a throwaway UDP socket; 0 if the interface has no IPv4."""
     if name.byte_length() == 0 or name.byte_length() > 15:
         return 0
     var fd = external_call["socket", Int32](AF_INET, SOCK_DGRAM, Int32(0))
@@ -281,7 +276,9 @@ def local_ipv4() raises -> UInt32:
         var a = _ipv4_of_iface(want)
         if a == 0:
             raise Error(
-                "mojoccl: MOJOCCL_SOCKET_IFNAME=" + want + " has no IPv4 address"
+                "mojoccl: MOJOCCL_SOCKET_IFNAME="
+                + want
+                + " has no IPv4 address"
             )
         return a
     for n in _default_route_ifaces():
@@ -411,8 +408,7 @@ def _take_root(magic: UInt64) -> Int32:
 
 
 def make_unique_id(out_bytes: Pointer[UInt8, MutAnyOrigin]) raises:
-    """Bind a listening socket and encode where it is (ncclGetUniqueId).
-    """
+    """Bind a listening socket and encode where it is (ncclGetUniqueId)."""
     var addr = local_ipv4()
     var fd = external_call["socket", Int32](
         AF_INET, SOCK_STREAM | SOCK_NONBLOCK, Int32(0)
@@ -423,9 +419,7 @@ def make_unique_id(out_bytes: Pointer[UInt8, MutAnyOrigin]) raises:
         _set_int_opt(fd, SOL_SOCKET, SO_REUSEADDR, 1)
         var sa = _alloc[UInt8](SOCKADDR_IN_BYTES)
         _fill_sockaddr(sa, addr, 0)  # port 0: let the kernel choose
-        if external_call["bind", Int32](
-            fd, sa, UInt32(SOCKADDR_IN_BYTES)
-        ) != 0:
+        if external_call["bind", Int32](fd, sa, UInt32(SOCKADDR_IN_BYTES)) != 0:
             raise Error("mojoccl: bind() failed, errno=" + String(_errno()))
         # A backlog of 1024 covers every rank connecting at once (NCCL uses
         # 16384, nccl:src/misc/socket.cc:571; 1024 is far past 8 nodes x 8).
@@ -459,7 +453,9 @@ struct BootstrapConn(Movable):
     var listen_fd: Int32
     var fds: List[Int32]
 
-    def __init__(out self, rank: Int, nranks: Int, is_root: Bool, listen_fd: Int32):
+    def __init__(
+        out self, rank: Int, nranks: Int, is_root: Bool, listen_fd: Int32
+    ):
         self.rank = rank
         self.nranks = nranks
         self.is_root = is_root
@@ -485,9 +481,7 @@ def _send_all(
             raise Error("mojoccl: bootstrap send timed out")
         var n = external_call["send", Int64](
             fd,
-            Pointer[UInt8, MutAnyOrigin](
-                unsafe_from_address=Int(buf) + done
-            ),
+            Pointer[UInt8, MutAnyOrigin](unsafe_from_address=Int(buf) + done),
             UInt64(nbytes - done),
             MSG_NOSIGNAL,
         )
@@ -511,9 +505,7 @@ def _recv_all(
             raise Error("mojoccl: bootstrap recv timed out")
         var n = external_call["recv", Int64](
             fd,
-            Pointer[UInt8, MutAnyOrigin](
-                unsafe_from_address=Int(buf) + done
-            ),
+            Pointer[UInt8, MutAnyOrigin](unsafe_from_address=Int(buf) + done),
             UInt64(nbytes - done),
             Int32(0),
         )
@@ -551,8 +543,9 @@ def bootstrap_connect(
     var listen_fd = _take_root(magic)
     var conn = BootstrapConn(rank, nranks, listen_fd >= 0, listen_fd)
     try:
-        _rendezvous(conn, rank, nranks, addr_be, port_be, magic, deadline_ns,
-                    timeout_s)
+        _rendezvous(
+            conn, rank, nranks, addr_be, port_be, magic, deadline_ns, timeout_s
+        )
     except e:
         # Every exit that is not the happy one closes the sockets here: this
         # function's caller never sees the `BootstrapConn` when it raises, so
@@ -726,9 +719,9 @@ struct Topology(Movable):
     var local_world: Int
     var my_node: Int
     var my_local_rank: Int
-    var node_of: List[Int]        # global rank -> node index
+    var node_of: List[Int]  # global rank -> node index
     var local_rank_of: List[Int]  # global rank -> local rank
-    var rank_at: List[Int]        # node * local_world + local_rank -> global rank
+    var rank_at: List[Int]  # node * local_world + local_rank -> global rank
 
     def __init__(out self, nranks: Int):
         self.nnodes = 1
@@ -740,9 +733,7 @@ struct Topology(Movable):
         self.rank_at = List[Int](length=nranks, fill=0)
 
 
-def derive_topology(
-    host_hashes: List[UInt64], rank: Int
-) raises -> Topology:
+def derive_topology(host_hashes: List[UInt64], rank: Int) raises -> Topology:
     """Node index = order of first appearance scanning ranks 0..n-1; local
     rank = how many earlier ranks share the host. Pure function of the
     gathered table, so every rank computes the same answer with no round

--- a/torch_mojo_backend/distributed/mojoccl/bootstrap.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/bootstrap.mojo
@@ -1,0 +1,149 @@
+# /dev/shm rendezvous bootstrap for mojoccl's ncclCommInitRank.
+#
+# Real NCCL exchanges per-rank IPC handles over its own bootstrap socket,
+# whose address is encoded in the 128-byte ncclUniqueId. This library has no
+# socket bootstrap yet, so it stands in with a directory: the rank that calls
+# ncclGetUniqueId creates a fresh dir under /dev/shm and encodes its path in
+# the id (that id then travels through the caller's OWN rendezvous -- for
+# this repo, the c10d store in distributed/process_group.py, unchanged).
+# Every rank's ncclCommInitRank decodes the path back out, atomically writes
+# its own `rank<r>.handle` file there, and polls for the rest.
+#
+# This is intra-node only. The design leaves room for a multi-node TCP
+# bootstrap later (encode "host:port" instead of a path, listen instead of
+# mkdir) without changing ncclCommInitRank's call shape.
+
+from std.ffi import OwnedDLHandle, CStringSlice
+from std.memory.alloc import unsafe_alloc
+from std.pathlib import Path
+from std.tempfile import mkdtemp
+from std.time import sleep, perf_counter_ns
+from std.collections.string import chr
+
+comptime UID_BYTES = 128
+comptime HANDLE_BYTES = 64
+
+
+def create_rendezvous_dir() raises -> String:
+    """Called once, by the rank that generates the unique id."""
+    return mkdtemp(prefix="mojoccl-", dir="/dev/shm")
+
+
+def encode_dir(dir: String, out_bytes: Pointer[UInt8, MutAnyOrigin]) raises:
+    """Writes `dir`'s UTF-8 bytes, NUL-padded, into the 128-byte unique id."""
+    for i in range(UID_BYTES):
+        out_bytes[unsafe_offset=i] = 0
+    var db = dir.as_bytes()
+    if len(db) > UID_BYTES - 2:
+        raise Error(
+            "mojoccl: rendezvous directory path too long for the 128-byte"
+            " unique id"
+        )
+    for i in range(len(db)):
+        out_bytes[unsafe_offset=i] = db[i]
+
+
+def decode_dir(in_bytes: Pointer[UInt8, MutAnyOrigin]) raises -> String:
+    """The inverse of `encode_dir`, reading up to the first NUL byte."""
+    var n = 0
+    while n < UID_BYTES and Int(in_bytes[unsafe_offset=n]) != 0:
+        n += 1
+    if n == 0:
+        raise Error("mojoccl: empty rendezvous directory in the unique id")
+    var s = String(capacity=n)
+    for i in range(n):
+        s += chr(Int(in_bytes[unsafe_offset=i]))
+    return s^
+
+
+def _to_cstr(s: String) -> Pointer[Int8, ImmutAnyOrigin]:
+    """A heap copy of `s`'s bytes plus a trailing NUL.
+
+    `CStringSlice`'s constructors only VALIDATE an existing terminator
+    (`std.ffi.cstring._validate_bytes`); neither copies. A plain `String`'s
+    backing storage carries no such terminator (measured: both the
+    `StringSlice` and `Span[Byte]` constructors raise "CStringSlice is not
+    nul-terminated" on one), so this builds the terminated buffer by hand.
+    """
+    var src = s.as_bytes()
+    var n = len(src)
+    var buf = unsafe_alloc[UInt8](n + 1)
+    for i in range(n):
+        buf[unsafe_offset=i] = src[i]
+    buf[unsafe_offset=n] = 0
+    return Pointer[Int8, ImmutAnyOrigin](unsafe_from_address=Int(buf))
+
+
+def _rename(old: String, new: String) raises:
+    """POSIX rename(2) via libc -- the atomic-publish half of the handle
+    write. Not in std.os yet, so called directly (the same OwnedDLHandle +
+    get_function shape as every other FFI call in this library)."""
+    var libc = OwnedDLHandle("libc.so.6")
+    var old_c = CStringSlice(unsafe_from_ptr=_to_cstr(old))
+    var new_c = CStringSlice(unsafe_from_ptr=_to_cstr(new))
+    var rc = libc.get_function[Int32]("rename")(
+        old_c.unsafe_ptr(), new_c.unsafe_ptr()
+    )
+    if rc != 0:
+        raise Error("mojoccl: rename to " + new + " failed, rc=" + String(rc))
+
+
+def write_rank_handle(
+    dir: String, rank: Int, ordinal: Int, handle: Pointer[UInt8, MutAnyOrigin]
+) raises:
+    """Atomically publishes this rank's (device ordinal, IPC handle) pair.
+
+    Written as space-separated decimal integers (matches
+    proto/ipc_probe.mojo's handle-file convention) so there is no binary
+    layout to keep in sync between writer and reader.
+    """
+    var final_path = dir + "/rank" + String(rank) + ".handle"
+    var tmp_path = dir + "/.rank" + String(rank) + ".handle.tmp"
+    var s = String(ordinal)
+    for i in range(HANDLE_BYTES):
+        s += " " + String(Int(handle[unsafe_offset=i]))
+    with open(tmp_path, "w") as f:
+        f.write(s)
+    _rename(tmp_path, final_path)
+
+
+def read_rank_handle(
+    dir: String, rank: Int, out_handle: Pointer[UInt8, MutAnyOrigin]
+) raises -> Int:
+    """Reads a published handle file; returns the peer's device ordinal and
+    fills `out_handle[0:64]`."""
+    var path = dir + "/rank" + String(rank) + ".handle"
+    var s: String
+    with open(path, "r") as f:
+        s = f.read()
+    var k = 0
+    var ordinal = -1
+    for part in s.split(" "):
+        if part.byte_length() == 0:
+            continue
+        if ordinal == -1:
+            ordinal = Int(part)
+        else:
+            out_handle[unsafe_offset=k] = UInt8(Int(part))
+            k += 1
+    if k != HANDLE_BYTES or ordinal == -1:
+        raise Error("mojoccl: malformed handle file " + path)
+    return ordinal
+
+
+def wait_for_rank(dir: String, rank: Int, timeout_s: Float64) raises:
+    """Blocks until `rank`'s handle file exists, or raises past the timeout."""
+    var path = dir + "/rank" + String(rank) + ".handle"
+    var t0 = perf_counter_ns()
+    var deadline_ns = Int(timeout_s * 1.0e9)
+    while not Path(path).exists():
+        if perf_counter_ns() - t0 > deadline_ns:
+            raise Error(
+                "mojoccl: timeout after "
+                + String(timeout_s)
+                + "s waiting for rank "
+                + String(rank)
+                + " at "
+                + dir
+            )
+        sleep(0.02)

--- a/torch_mojo_backend/distributed/mojoccl/bootstrap.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/bootstrap.mojo
@@ -48,6 +48,19 @@ comptime MSG_NOSIGNAL: Int32 = 0x4000
 comptime EINTR: Int32 = 4
 comptime EAGAIN: Int32 = 11
 comptime ECONNREFUSED: Int32 = 111
+comptime SO_ERROR: Int32 = 4
+comptime EINPROGRESS: Int32 = 115
+comptime EALREADY: Int32 = 114
+comptime EISCONN: Int32 = 106
+# SOCK_NONBLOCK, the Linux flag `socket(2)` and `accept4(2)` take in their
+# type argument. Every socket this module opens carries it, so no blocking
+# syscall can outlive the deadline the caller set: the wait happens in
+# `poll(2)` with a computed timeout instead, and SO_RCVTIMEO/SO_SNDTIMEO stay
+# on as a backstop for the cases poll cannot see (a socket wedged in the
+# kernel, a revents race).
+comptime SOCK_NONBLOCK: Int32 = 0x800
+comptime POLLIN: Int32 = 1
+comptime POLLOUT: Int32 = 4
 # sizeof(struct sockaddr_in) == 16: sin_family u16 @0, sin_port u16 @2 (both
 # network order), sin_addr u32 @4, 8 zero bytes. sizeof(struct ifreq) == 40:
 # ifr_name[16] @0, then the sockaddr at 16 (so the IPv4 word is at 20).
@@ -94,6 +107,68 @@ def _set_timeout(fd: Int32, optname: Int32, seconds: Int64) raises:
     )
     if rc != 0:
         raise Error("mojoccl: setsockopt(timeout) failed, errno=" + String(_errno()))
+
+
+def _get_int_opt(fd: Int32, level: Int32, optname: Int32) raises -> Int32:
+    var v = _alloc[Int32](1)
+    v[unsafe_offset=0] = 0
+    var l = _alloc[UInt32](1)
+    l[unsafe_offset=0] = 4
+    if external_call["getsockopt", Int32](fd, level, optname, v, l) != 0:
+        raise Error(
+            "mojoccl: getsockopt failed, errno=" + String(_errno())
+        )
+    return v[unsafe_offset=0]
+
+
+def _wait_ready(fd: Int32, events: Int32, deadline_ns: Int) raises -> Bool:
+    """Wait until `fd` is ready (or its peer hung up), bounded by an ABSOLUTE
+    deadline. False means the deadline passed.
+
+    This is what bounds the blocking, rather than a check after the syscall
+    came back: `connect` on a dropped SYN retries inside the kernel for over
+    two minutes, and by the time it returns, a shorter bootstrap deadline has
+    long expired. `struct pollfd` is {i32 fd, i16 events, i16 revents}.
+    """
+    var pfd = _alloc[Int32](2)
+    while True:
+        var left = deadline_ns - perf_counter_ns()
+        if left <= 0:
+            return False
+        var ms = left // 1_000_000 + 1
+        if ms > Int(SOCK_SLICE_S) * 1000:
+            ms = Int(SOCK_SLICE_S) * 1000
+        pfd[unsafe_offset=0] = fd
+        pfd[unsafe_offset=1] = events & 0xFFFF
+        var rc = external_call["poll", Int32](pfd, UInt64(1), Int32(ms))
+        if rc > 0:
+            return True
+        if rc < 0:
+            var e = _errno()
+            if e != EINTR:
+                raise Error("mojoccl: poll() failed, errno=" + String(e))
+
+
+def _connect_deadline(
+    fd: Int32, sa: Pointer[UInt8, MutAnyOrigin], deadline_ns: Int
+) raises -> Bool:
+    """Non-blocking `connect`, `poll` for writability inside the deadline,
+    then `SO_ERROR` for the verdict -- the three steps a bounded TCP connect
+    needs. False means "not connected" (refused, unreachable, or out of
+    time); the caller decides whether to retry or to give up."""
+    var rc = external_call["connect", Int32](
+        fd, sa, UInt32(SOCKADDR_IN_BYTES)
+    )
+    if rc == 0:
+        return True
+    var e = _errno()
+    if e == EISCONN:
+        return True
+    if e != EINPROGRESS and e != EALREADY and e != EINTR:
+        return False
+    if not _wait_ready(fd, POLLOUT, deadline_ns):
+        return False
+    return _get_int_opt(fd, SOL_SOCKET, SO_ERROR) == 0
 
 
 def _set_int_opt(fd: Int32, level: Int32, optname: Int32, value: Int32) raises:
@@ -339,7 +414,9 @@ def make_unique_id(out_bytes: Pointer[UInt8, MutAnyOrigin]) raises:
     """Bind a listening socket and encode where it is (ncclGetUniqueId).
     """
     var addr = local_ipv4()
-    var fd = external_call["socket", Int32](AF_INET, SOCK_STREAM, Int32(0))
+    var fd = external_call["socket", Int32](
+        AF_INET, SOCK_STREAM | SOCK_NONBLOCK, Int32(0)
+    )
     if fd < 0:
         raise Error("mojoccl: socket() failed, errno=" + String(_errno()))
     try:
@@ -402,6 +479,10 @@ def _send_all(
 ) raises:
     var done = 0
     while done < nbytes:
+        # Checked before every syscall, not only when one returns EAGAIN: a
+        # peer trickling bytes makes progress forever otherwise.
+        if not _wait_ready(fd, POLLOUT, deadline_ns):
+            raise Error("mojoccl: bootstrap send timed out")
         var n = external_call["send", Int64](
             fd,
             Pointer[UInt8, MutAnyOrigin](
@@ -426,6 +507,8 @@ def _recv_all(
 ) raises:
     var done = 0
     while done < nbytes:
+        if not _wait_ready(fd, POLLIN, deadline_ns):
+            raise Error("mojoccl: bootstrap recv timed out")
         var n = external_call["recv", Int64](
             fd,
             Pointer[UInt8, MutAnyOrigin](
@@ -467,32 +550,55 @@ def bootstrap_connect(
     var deadline_ns = perf_counter_ns() + Int(timeout_s * 1.0e9)
     var listen_fd = _take_root(magic)
     var conn = BootstrapConn(rank, nranks, listen_fd >= 0, listen_fd)
+    try:
+        _rendezvous(conn, rank, nranks, addr_be, port_be, magic, deadline_ns,
+                    timeout_s)
+    except e:
+        # Every exit that is not the happy one closes the sockets here: this
+        # function's caller never sees the `BootstrapConn` when it raises, so
+        # a listener left open holds the unique id's port for the life of the
+        # process and a per-rank socket leaves its peer blocked until its own
+        # deadline instead of failing fast on a closed connection.
+        conn.close()
+        raise e
+    return conn^
 
+
+def _rendezvous(
+    mut conn: BootstrapConn,
+    rank: Int,
+    nranks: Int,
+    addr_be: UInt32,
+    port_be: UInt16,
+    magic: UInt64,
+    deadline_ns: Int,
+    timeout_s: Float64,
+) raises:
+    """`bootstrap_connect`'s body, split out so one `except` closes every
+    socket on every failure path."""
     var hello = _alloc[UInt8](16)
     var hw = hello.unsafe_bitcast[UInt64]()
 
     if conn.is_root:
-        _set_timeout(listen_fd, SO_RCVTIMEO, SOCK_SLICE_S)
+        _set_timeout(conn.listen_fd, SO_RCVTIMEO, SOCK_SLICE_S)
         var got = 0
         while got < nranks - 1:
-            var cfd = external_call["accept", Int32](
-                listen_fd, Int64(0), Int64(0)
+            if not _wait_ready(conn.listen_fd, POLLIN, deadline_ns):
+                raise Error(
+                    "mojoccl: bootstrap timed out with "
+                    + String(got + 1)
+                    + " of "
+                    + String(nranks)
+                    + " ranks connected"
+                )
+            var cfd = external_call["accept4", Int32](
+                conn.listen_fd, Int64(0), Int64(0), SOCK_NONBLOCK
             )
             if cfd < 0:
                 var e = _errno()
                 if e == EINTR or e == EAGAIN:
-                    if perf_counter_ns() > deadline_ns:
-                        conn.close()
-                        raise Error(
-                            "mojoccl: bootstrap timed out with "
-                            + String(got + 1)
-                            + " of "
-                            + String(nranks)
-                            + " ranks connected"
-                        )
                     continue
-                conn.close()
-                raise Error("mojoccl: accept() failed, errno=" + String(e))
+                raise Error("mojoccl: accept4() failed, errno=" + String(e))
             try:
                 _set_timeout(cfd, SO_RCVTIMEO, SOCK_SLICE_S)
                 _set_timeout(cfd, SO_SNDTIMEO, SOCK_SLICE_S)
@@ -500,7 +606,6 @@ def bootstrap_connect(
                 _recv_all(cfd, hello, 16, deadline_ns)
             except e:
                 _close(cfd)
-                conn.close()
                 raise e
             var peer_magic = hw[unsafe_offset=0]
             var peer_rank = Int(hw[unsafe_offset=1])
@@ -509,33 +614,42 @@ def bootstrap_connect(
                 continue  # not ours: another communicator's straggler
             if conn.fds[peer_rank] >= 0:
                 _close(cfd)
-                conn.close()
                 raise Error(
                     "mojoccl: two ranks announced rank " + String(peer_rank)
                 )
             conn.fds[peer_rank] = cfd
             got += 1
-        return conn^
+        return
 
     # Non-root: connect, retrying while the root is still coming up.
     while True:
-        var fd = external_call["socket", Int32](AF_INET, SOCK_STREAM, Int32(0))
+        var fd = external_call["socket", Int32](
+            AF_INET, SOCK_STREAM | SOCK_NONBLOCK, Int32(0)
+        )
         if fd < 0:
             raise Error("mojoccl: socket() failed, errno=" + String(_errno()))
         var sa = _alloc[UInt8](SOCKADDR_IN_BYTES)
         _fill_sockaddr(sa, addr_be, port_be)
-        var rc = external_call["connect", Int32](
-            fd, sa, UInt32(SOCKADDR_IN_BYTES)
-        )
-        if rc == 0:
-            _set_timeout(fd, SO_RCVTIMEO, SOCK_SLICE_S)
-            _set_timeout(fd, SO_SNDTIMEO, SOCK_SLICE_S)
-            _set_int_opt(fd, IPPROTO_TCP, TCP_NODELAY, 1)
+        var connected = False
+        try:
+            connected = _connect_deadline(fd, sa, deadline_ns)
+        except e:
+            _close(fd)
+            raise e
+        if connected:
+            try:
+                _set_timeout(fd, SO_RCVTIMEO, SOCK_SLICE_S)
+                _set_timeout(fd, SO_SNDTIMEO, SOCK_SLICE_S)
+                _set_int_opt(fd, IPPROTO_TCP, TCP_NODELAY, 1)
+            except e:
+                _close(fd)
+                raise e
             conn.fds[0] = fd
             hw[unsafe_offset=0] = magic
             hw[unsafe_offset=1] = UInt64(rank)
             _send_all(fd, hello, 16, deadline_ns)
-            return conn^
+            return
+        var err = _errno()
         _close(fd)
         if perf_counter_ns() > deadline_ns:
             raise Error(
@@ -546,7 +660,7 @@ def bootstrap_connect(
                 + " within "
                 + String(timeout_s)
                 + "s (errno="
-                + String(_errno())
+                + String(err)
                 + "); check MOJOCCL_SOCKET_IFNAME reaches every node"
             )
         sleep(0.02)

--- a/torch_mojo_backend/distributed/mojoccl/bootstrap.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/bootstrap.mojo
@@ -1,199 +1,678 @@
-# /dev/shm rendezvous bootstrap for mojoccl's ncclCommInitRank.
+# TCP socket bootstrap for mojoccl's ncclCommInitRank -- single node and
+# multi node alike (it replaced the /dev/shm rendezvous directory, which
+# could never span hosts).
 #
-# Real NCCL exchanges per-rank IPC handles over its own bootstrap socket,
-# whose address is encoded in the 128-byte ncclUniqueId. This library has no
-# socket bootstrap yet, so it stands in with a directory: the rank that calls
-# ncclGetUniqueId creates a fresh dir under /dev/shm and encodes its path in
-# the id (that id then travels through the caller's OWN rendezvous -- for
-# this repo, the c10d store in distributed/process_group.py, unchanged).
-# Every rank's ncclCommInitRank decodes the path back out, atomically writes
-# its own `rank<r>.handle` file there, and polls for the rest.
+# Shape copied from NCCL: the process that calls ncclGetUniqueId opens a
+# listening socket and encodes {ipv4, port, random magic} in the 128-byte
+# ncclUniqueId (nccl:src/bootstrap.cc:495-529 puts the root's
+# ncclSocketAddress + a magic in the id the same way); that id then travels
+# through the caller's OWN rendezvous -- here the c10d store in
+# distributed/process_group.py, unchanged. Every rank's ncclCommInitRank
+# decodes it, connects to the root, and the root relays.
 #
-# This is intra-node only. The design leaves room for a multi-node TCP
-# bootstrap later (encode "host:port" instead of a path, listen instead of
-# mkdir) without changing ncclCommInitRank's call shape.
+# One primitive is enough: `bootstrap_allgather` of a fixed-size blob. Round
+# 1 gathers host identity so every rank derives the same node/local_rank
+# table by itself (no root-side decision to broadcast); round 2 gathers the
+# IPC handle + IB connection data; round 3 is a 4-byte barrier that closes
+# init. NCCL's root does one allgather too (`bootstrapAllGather`,
+# nccl:src/bootstrap.cc:1080) -- it just runs a ring, which is not worth the
+# code at 16 ranks of 256 bytes.
 
-from std.ffi import OwnedDLHandle, CStringSlice
+from std.ffi import _get_global_or_null, external_call
 from std.memory.alloc import unsafe_alloc
-from std.os import remove, rmdir
-from std.pathlib import Path
-from std.tempfile import mkdtemp
-from std.time import sleep, perf_counter_ns
-from std.collections.string import chr
+from std.os import getenv, listdir
+from std.random import random_ui64
+from std.time import perf_counter_ns, sleep
 
 comptime UID_BYTES = 128
 comptime HANDLE_BYTES = 64
 
+# "MOJOCCL2" -- the id format tag. Bumped from the /dev/shm-path id (which
+# carried no tag at all), so a stale id from a mismatched build is rejected
+# with a message instead of being parsed as an address.
+comptime UID_TAG: UInt64 = 0x4D_4F_4A_4F_43_43_4C_32
 
-def create_rendezvous_dir() raises -> String:
-    """Called once, by the rank that generates the unique id."""
-    return mkdtemp(prefix="mojoccl-", dir="/dev/shm")
+# <sys/socket.h>, <netinet/in.h>, <netinet/tcp.h>, <sys/ioctl.h>: verified on
+# this machine with a gcc offsetof/value dump rather than taken from memory.
+comptime AF_INET: Int32 = 2
+comptime SOCK_STREAM: Int32 = 1
+comptime SOCK_DGRAM: Int32 = 2
+comptime SOL_SOCKET: Int32 = 1
+comptime SO_REUSEADDR: Int32 = 2
+comptime SO_RCVTIMEO: Int32 = 20
+comptime SO_SNDTIMEO: Int32 = 21
+comptime IPPROTO_TCP: Int32 = 6
+comptime TCP_NODELAY: Int32 = 1
+comptime SIOCGIFADDR: UInt64 = 0x8915
+comptime MSG_NOSIGNAL: Int32 = 0x4000
+comptime EINTR: Int32 = 4
+comptime EAGAIN: Int32 = 11
+comptime ECONNREFUSED: Int32 = 111
+# sizeof(struct sockaddr_in) == 16: sin_family u16 @0, sin_port u16 @2 (both
+# network order), sin_addr u32 @4, 8 zero bytes. sizeof(struct ifreq) == 40:
+# ifr_name[16] @0, then the sockaddr at 16 (so the IPv4 word is at 20).
+comptime SOCKADDR_IN_BYTES = 16
+comptime IFREQ_BYTES = 40
+
+# Per-socket send/recv timeout. Short enough that a wedged peer is noticed
+# quickly, long enough that a slice is not spent on syscall churn; the loops
+# below re-arm it until the caller's own deadline expires.
+comptime SOCK_SLICE_S: Int64 = 5
 
 
-def encode_dir(dir: String, out_bytes: Pointer[UInt8, MutAnyOrigin]) raises:
-    """Writes `dir`'s UTF-8 bytes, NUL-padded, into the 128-byte unique id."""
-    for i in range(UID_BYTES):
-        out_bytes[unsafe_offset=i] = 0
-    var db = dir.as_bytes()
-    if len(db) > UID_BYTES - 2:
-        raise Error(
-            "mojoccl: rendezvous directory path too long for the 128-byte"
-            " unique id"
-        )
-    for i in range(len(db)):
-        out_bytes[unsafe_offset=i] = db[i]
+@always_inline
+def _alloc[T: AnyType](n: Int) -> Pointer[T, MutAnyOrigin]:
+    """`unsafe_alloc` with the origin the FFI signatures here declare.
 
-
-def decode_dir(in_bytes: Pointer[UInt8, MutAnyOrigin]) raises -> String:
-    """The inverse of `encode_dir`, reading up to the first NUL byte."""
-    var n = 0
-    while n < UID_BYTES and Int(in_bytes[unsafe_offset=n]) != 0:
-        n += 1
-    if n == 0:
-        raise Error("mojoccl: empty rendezvous directory in the unique id")
-    var s = String(capacity=n)
-    for i in range(n):
-        s += chr(Int(in_bytes[unsafe_offset=i]))
-    return s^
-
-
-def _to_cstr(s: String) -> Pointer[Int8, ImmutAnyOrigin]:
-    """A heap copy of `s`'s bytes plus a trailing NUL.
-
-    `CStringSlice`'s constructors only VALIDATE an existing terminator
-    (`std.ffi.cstring._validate_bytes`); neither copies. A plain `String`'s
-    backing storage carries no such terminator (measured: both the
-    `StringSlice` and `Span[Byte]` constructors raise "CStringSlice is not
-    nul-terminated" on one), so this builds the terminated buffer by hand.
+    Every buffer this module allocates is small, lives for the duration of
+    one `ncclCommInitRank`, and is handed to libc by address; rebinding to
+    `MutAnyOrigin` once here keeps the call sites free of casts.
     """
-    var src = s.as_bytes()
-    var n = len(src)
-    var buf = unsafe_alloc[UInt8](n + 1)
-    for i in range(n):
-        buf[unsafe_offset=i] = src[i]
-    buf[unsafe_offset=n] = 0
-    return Pointer[Int8, ImmutAnyOrigin](unsafe_from_address=Int(buf))
+    return Pointer[T, MutAnyOrigin](
+        unsafe_from_address=Int(unsafe_alloc[T](n))
+    )
 
 
-def _rename(old: String, new: String) raises:
-    """POSIX rename(2) via libc -- the atomic-publish half of the handle
-    write. Not in std.os yet, so called directly (the same OwnedDLHandle +
-    get_function shape as every other FFI call in this library)."""
-    var libc = OwnedDLHandle("libc.so.6")
-    var old_c = CStringSlice(unsafe_from_ptr=_to_cstr(old))
-    var new_c = CStringSlice(unsafe_from_ptr=_to_cstr(new))
-    var rc = libc.get_function[Int32]("rename")(
-        old_c.unsafe_ptr(), new_c.unsafe_ptr()
+def _errno() -> Int32:
+    return external_call[
+        "__errno_location", Pointer[Int32, MutAnyOrigin]
+    ]()[unsafe_offset=0]
+
+
+def _close(fd: Int32):
+    if fd >= 0:
+        _ = external_call["close", Int32](fd)
+
+
+def _set_timeout(fd: Int32, optname: Int32, seconds: Int64) raises:
+    """SO_RCVTIMEO / SO_SNDTIMEO: struct timeval {i64 tv_sec, i64 tv_usec}."""
+    var tv = _alloc[Int64](2)
+    tv[unsafe_offset=0] = seconds
+    tv[unsafe_offset=1] = 0
+    var rc = external_call["setsockopt", Int32](
+        fd, SOL_SOCKET, optname, tv, UInt32(16)
     )
     if rc != 0:
-        raise Error("mojoccl: rename to " + new + " failed, rc=" + String(rc))
+        raise Error("mojoccl: setsockopt(timeout) failed, errno=" + String(_errno()))
 
 
-def _atomic_write(final_path: String, tmp_path: String, content: String) raises:
-    """write+rename: readers never observe a partially written file."""
-    with open(tmp_path, "w") as f:
-        f.write(content)
-    _rename(tmp_path, final_path)
+def _set_int_opt(fd: Int32, level: Int32, optname: Int32, value: Int32) raises:
+    var v = _alloc[Int32](1)
+    v[unsafe_offset=0] = value
+    var rc = external_call["setsockopt", Int32](
+        fd, level, optname, v, UInt32(4)
+    )
+    if rc != 0:
+        raise Error("mojoccl: setsockopt failed, errno=" + String(_errno()))
 
 
-def write_rank_handle(
-    dir: String, rank: Int, ordinal: Int, handle: Pointer[UInt8, MutAnyOrigin]
-) raises:
-    """Atomically publishes this rank's (device ordinal, IPC handle) pair.
+def _fill_sockaddr(
+    sa: Pointer[UInt8, MutAnyOrigin], addr_be: UInt32, port_be: UInt16
+):
+    for i in range(SOCKADDR_IN_BYTES):
+        sa[unsafe_offset=i] = 0
+    # sin_family is host-order u16; AF_INET == 2 fits in the low byte on the
+    # little-endian targets this library builds for.
+    sa[unsafe_offset=0] = 2
+    sa[unsafe_offset=1] = 0
+    var p = sa.unsafe_bitcast[UInt16]()
+    p[unsafe_offset=1] = port_be
+    var a = sa.unsafe_bitcast[UInt32]()
+    a[unsafe_offset=1] = addr_be
 
-    Written as space-separated decimal integers (matches
-    proto/ipc_probe.mojo's handle-file convention) so there is no binary
-    layout to keep in sync between writer and reader.
+
+# ===-------------------------------------------------------------------=== #
+# Local IPv4 discovery (NCCL_SOCKET_IFNAME's analogue)
+# ===-------------------------------------------------------------------=== #
+
+
+def _ipv4_of_iface(name: String) -> UInt32:
+    """SIOCGIFADDR on a throwaway UDP socket; 0 if the interface has no IPv4.
     """
-    var s = String(ordinal)
-    for i in range(HANDLE_BYTES):
-        s += " " + String(Int(handle[unsafe_offset=i]))
-    _atomic_write(
-        dir + "/rank" + String(rank) + ".handle",
-        dir + "/.rank" + String(rank) + ".handle.tmp",
-        s,
-    )
+    if name.byte_length() == 0 or name.byte_length() > 15:
+        return 0
+    var fd = external_call["socket", Int32](AF_INET, SOCK_DGRAM, Int32(0))
+    if fd < 0:
+        return 0
+    var req = _alloc[UInt8](IFREQ_BYTES)
+    for i in range(IFREQ_BYTES):
+        req[unsafe_offset=i] = 0
+    var nb = name.as_bytes()
+    for i in range(len(nb)):
+        req[unsafe_offset=i] = nb[i]
+    var rc = external_call["ioctl", Int32](fd, SIOCGIFADDR, req)
+    _close(fd)
+    if rc != 0:
+        return 0
+    return req.unsafe_bitcast[UInt32]()[unsafe_offset=5]  # byte 20
 
 
-def write_rank_done(dir: String, rank: Int) raises:
-    """Atomically publishes that this rank has opened every peer's IPC
-    handle. Rank 0 waits for every rank's marker (`wait_for_done`) before
-    removing `dir` (`remove_rendezvous_dir`) -- see ncclCommInitRank."""
-    _atomic_write(
-        dir + "/rank" + String(rank) + ".done",
-        dir + "/.rank" + String(rank) + ".done.tmp",
-        "1",
-    )
-
-
-def read_rank_handle(
-    dir: String, rank: Int, out_handle: Pointer[UInt8, MutAnyOrigin]
-) raises -> Int:
-    """Reads a published handle file; returns the peer's device ordinal and
-    fills `out_handle[0:64]`."""
-    var path = dir + "/rank" + String(rank) + ".handle"
-    var s: String
-    with open(path, "r") as f:
-        s = f.read()
-    var k = 0
-    var ordinal = -1
-    for part in s.split(" "):
-        if part.byte_length() == 0:
+def _default_route_ifaces() -> List[String]:
+    """Interfaces carrying a default route, from /proc/net/route (columns:
+    Iface Destination Gateway ...; Destination 00000000 == default)."""
+    var out = List[String]()
+    var text: String
+    try:
+        with open("/proc/net/route", "r") as f:
+            text = f.read()
+    except:
+        return out^
+    var first = True
+    for line in text.split("\n"):
+        if first:
+            first = False  # header
             continue
-        if ordinal == -1:
-            ordinal = Int(part)
-        else:
-            out_handle[unsafe_offset=k] = UInt8(Int(part))
-            k += 1
-    if k != HANDLE_BYTES or ordinal == -1:
-        raise Error("mojoccl: malformed handle file " + path)
-    return ordinal
+        var cols = List[String]()
+        for c in String(line).split("\t"):
+            if String(c).byte_length() > 0:
+                cols.append(String(c))
+        if len(cols) < 2:
+            continue
+        if cols[1] == "00000000":
+            out.append(cols[0])
+    return out^
 
 
-def _wait_for_file(path: String, rank: Int, timeout_s: Float64, dir: String) raises:
-    var t0 = perf_counter_ns()
-    var deadline_ns = Int(timeout_s * 1.0e9)
-    while not Path(path).exists():
-        if perf_counter_ns() - t0 > deadline_ns:
+def _up_ifaces() -> List[String]:
+    var out = List[String]()
+    var names: List[String]
+    try:
+        names = listdir("/sys/class/net")
+    except:
+        return out^
+    for n in names:
+        if String(n) == "lo":
+            continue
+        try:
+            with open("/sys/class/net/" + String(n) + "/operstate", "r") as f:
+                if String(f.read().strip()) != "up":
+                    continue
+        except:
+            continue
+        out.append(String(n))
+    return out^
+
+
+def local_ipv4() raises -> UInt32:
+    """The address this rank publishes in the unique id, network order.
+
+    MOJOCCL_SOCKET_IFNAME wins (NCCL_SOCKET_IFNAME's analogue, without the
+    ^/= prefix grammar); otherwise the first UP non-loopback interface that
+    carries a default route and has an IPv4 address; otherwise any UP
+    non-loopback IPv4 interface.
+    """
+    var want = getenv("MOJOCCL_SOCKET_IFNAME", "")
+    if want.byte_length() > 0:
+        var a = _ipv4_of_iface(want)
+        if a == 0:
             raise Error(
-                "mojoccl: timeout after "
+                "mojoccl: MOJOCCL_SOCKET_IFNAME=" + want + " has no IPv4 address"
+            )
+        return a
+    for n in _default_route_ifaces():
+        var a = _ipv4_of_iface(String(n))
+        if a != 0:
+            return a
+    for n in _up_ifaces():
+        var a = _ipv4_of_iface(String(n))
+        if a != 0:
+            return a
+    raise Error(
+        "mojoccl: no usable IPv4 interface found; set MOJOCCL_SOCKET_IFNAME"
+    )
+
+
+def format_ipv4(addr_be: UInt32) -> String:
+    var b = (addr_be >> 0) & 0xFF
+    var c = (addr_be >> 8) & 0xFF
+    var d = (addr_be >> 16) & 0xFF
+    var e = (addr_be >> 24) & 0xFF
+    return String(b) + "." + String(c) + "." + String(d) + "." + String(e)
+
+
+# ===-------------------------------------------------------------------=== #
+# Host identity
+# ===-------------------------------------------------------------------=== #
+
+
+def host_hash() -> UInt64:
+    """A 64-bit id of this physical host, equal on every rank of a node and
+    different across nodes. /etc/machine-id first (stable, always present on
+    these images), boot_id next, hostname last."""
+    var text = String("")
+    for p in ["/etc/machine-id", "/proc/sys/kernel/random/boot_id"]:
+        try:
+            with open(String(p), "r") as f:
+                text = String(f.read().strip())
+            if text.byte_length() > 0:
+                break
+        except:
+            continue
+    if text.byte_length() == 0:
+        var buf = _alloc[UInt8](256)
+        for i in range(256):
+            buf[unsafe_offset=i] = 0
+        _ = external_call["gethostname", Int32](buf, UInt64(255))
+        var n = 0
+        while n < 255 and buf[unsafe_offset=n] != 0:
+            n += 1
+        text = String(capacity=n)
+        for i in range(n):
+            text += chr(Int(buf[unsafe_offset=i]))
+    # FNV-1a: any stable 64-bit mix is fine, this one needs no table.
+    var h: UInt64 = 0xCBF29CE484222325
+    for byte in text.as_bytes():
+        h = (h ^ UInt64(byte)) * 0x100000001B3
+    return h
+
+
+# ===-------------------------------------------------------------------=== #
+# The 128-byte unique id
+# ===-------------------------------------------------------------------=== #
+
+
+def _encode_id(
+    out_bytes: Pointer[UInt8, MutAnyOrigin],
+    addr_be: UInt32,
+    port_be: UInt16,
+    magic: UInt64,
+):
+    for i in range(UID_BYTES):
+        out_bytes[unsafe_offset=i] = 0
+    var w = out_bytes.unsafe_bitcast[UInt64]()
+    w[unsafe_offset=0] = UID_TAG
+    w[unsafe_offset=1] = magic
+    out_bytes.unsafe_bitcast[UInt32]()[unsafe_offset=4] = addr_be
+    out_bytes.unsafe_bitcast[UInt16]()[unsafe_offset=10] = port_be
+
+
+def decode_id(
+    in_bytes: Pointer[UInt8, MutAnyOrigin],
+) raises -> Tuple[UInt32, UInt16, UInt64]:
+    """`(addr_be, port_be, magic)` out of a unique id."""
+    var w = in_bytes.unsafe_bitcast[UInt64]()
+    if w[unsafe_offset=0] != UID_TAG:
+        raise Error(
+            "mojoccl: unique id is not this library's (tag mismatch); a stale"
+            " id or one from a different CCL implementation"
+        )
+    return Tuple(
+        in_bytes.unsafe_bitcast[UInt32]()[unsafe_offset=4],
+        in_bytes.unsafe_bitcast[UInt16]()[unsafe_offset=10],
+        w[unsafe_offset=1],
+    )
+
+
+def _root_global_name(magic: UInt64) -> String:
+    return String("MOJOCCL_ROOT_") + String(magic)
+
+
+def _remember_root(magic: UInt64, fd: Int32):
+    """The listening socket ncclGetUniqueId opened has to survive until this
+    process's own ncclCommInitRank runs (a different call, no shared state
+    otherwise). Stashed in the compiler-runtime global table, the same
+    process-global mechanism collectives_kernels.mojo caches DeviceFunctions
+    in, keyed by the id's magic so several communicators can be in flight."""
+    var slot = _alloc[Int64](1)
+    slot[unsafe_offset=0] = Int64(fd)
+    var name = _root_global_name(magic)
+    external_call["KGEN_CompilerRT_InsertGlobal", NoneType](
+        StringSlice(name), slot.unsafe_bitcast[NoneType]()
+    )
+
+
+def _take_root(magic: UInt64) -> Int32:
+    """The listening fd for `magic` if this process created the id, else -1.
+    Consumed: the slot is set to -1 so a second communicator on the same id
+    cannot re-accept on it."""
+    var name = _root_global_name(magic)
+    var g = _get_global_or_null(name)
+    if not g:
+        return -1
+    var slot = g.value().unsafe_bitcast[Int64]()
+    var fd = Int32(slot[unsafe_offset=0])
+    slot[unsafe_offset=0] = -1
+    return fd
+
+
+def make_unique_id(out_bytes: Pointer[UInt8, MutAnyOrigin]) raises:
+    """Bind a listening socket and encode where it is (ncclGetUniqueId).
+    """
+    var addr = local_ipv4()
+    var fd = external_call["socket", Int32](AF_INET, SOCK_STREAM, Int32(0))
+    if fd < 0:
+        raise Error("mojoccl: socket() failed, errno=" + String(_errno()))
+    try:
+        _set_int_opt(fd, SOL_SOCKET, SO_REUSEADDR, 1)
+        var sa = _alloc[UInt8](SOCKADDR_IN_BYTES)
+        _fill_sockaddr(sa, addr, 0)  # port 0: let the kernel choose
+        if external_call["bind", Int32](
+            fd, sa, UInt32(SOCKADDR_IN_BYTES)
+        ) != 0:
+            raise Error("mojoccl: bind() failed, errno=" + String(_errno()))
+        # A backlog of 1024 covers every rank connecting at once (NCCL uses
+        # 16384, nccl:src/misc/socket.cc:571; 1024 is far past 8 nodes x 8).
+        if external_call["listen", Int32](fd, Int32(1024)) != 0:
+            raise Error("mojoccl: listen() failed, errno=" + String(_errno()))
+        var slen = _alloc[UInt32](1)
+        slen[unsafe_offset=0] = UInt32(SOCKADDR_IN_BYTES)
+        if external_call["getsockname", Int32](fd, sa, slen) != 0:
+            raise Error("mojoccl: getsockname() failed")
+        var port_be = sa.unsafe_bitcast[UInt16]()[unsafe_offset=1]
+        var magic = random_ui64(1, UInt64.MAX)
+        _encode_id(out_bytes, addr, port_be, magic)
+        _remember_root(magic, fd)
+    except e:
+        _close(fd)
+        raise e
+
+
+# ===-------------------------------------------------------------------=== #
+# The connection
+# ===-------------------------------------------------------------------=== #
+
+
+struct BootstrapConn(Movable):
+    """Root: `fds[r]` is the socket to rank r (own slot -1) and `listen_fd`
+    is still open. Non-root: `fds` holds the one socket to the root."""
+
+    var rank: Int
+    var nranks: Int
+    var is_root: Bool
+    var listen_fd: Int32
+    var fds: List[Int32]
+
+    def __init__(out self, rank: Int, nranks: Int, is_root: Bool, listen_fd: Int32):
+        self.rank = rank
+        self.nranks = nranks
+        self.is_root = is_root
+        self.listen_fd = listen_fd
+        self.fds = List[Int32](length=nranks if is_root else 1, fill=-1)
+
+    def close(mut self):
+        for i in range(len(self.fds)):
+            _close(self.fds[i])
+            self.fds[i] = -1
+        _close(self.listen_fd)
+        self.listen_fd = -1
+
+
+def _send_all(
+    fd: Int32, buf: Pointer[UInt8, MutAnyOrigin], nbytes: Int, deadline_ns: Int
+) raises:
+    var done = 0
+    while done < nbytes:
+        var n = external_call["send", Int64](
+            fd,
+            Pointer[UInt8, MutAnyOrigin](
+                unsafe_from_address=Int(buf) + done
+            ),
+            UInt64(nbytes - done),
+            MSG_NOSIGNAL,
+        )
+        if n > 0:
+            done += Int(n)
+            continue
+        var e = _errno()
+        if n < 0 and (e == EINTR or e == EAGAIN):
+            if perf_counter_ns() > deadline_ns:
+                raise Error("mojoccl: bootstrap send timed out")
+            continue
+        raise Error("mojoccl: bootstrap send failed, errno=" + String(e))
+
+
+def _recv_all(
+    fd: Int32, buf: Pointer[UInt8, MutAnyOrigin], nbytes: Int, deadline_ns: Int
+) raises:
+    var done = 0
+    while done < nbytes:
+        var n = external_call["recv", Int64](
+            fd,
+            Pointer[UInt8, MutAnyOrigin](
+                unsafe_from_address=Int(buf) + done
+            ),
+            UInt64(nbytes - done),
+            Int32(0),
+        )
+        if n > 0:
+            done += Int(n)
+            continue
+        if n == 0:
+            raise Error("mojoccl: bootstrap peer closed the connection")
+        var e = _errno()
+        if e == EINTR or e == EAGAIN:
+            if perf_counter_ns() > deadline_ns:
+                raise Error("mojoccl: bootstrap recv timed out")
+            continue
+        raise Error("mojoccl: bootstrap recv failed, errno=" + String(e))
+
+
+def bootstrap_connect(
+    uid: Pointer[UInt8, MutAnyOrigin],
+    rank: Int,
+    nranks: Int,
+    timeout_s: Float64,
+) raises -> BootstrapConn:
+    """Every rank's first act in ncclCommInitRank: reach the root.
+
+    Non-root ranks connect and announce {magic, rank}; the root accepts
+    `nranks - 1` of those and files each fd by the rank it announced. A
+    mismatched magic is refused rather than trusted -- two communicators
+    bootstrapping at once on one node would otherwise cross wires.
+    """
+    var decoded = decode_id(uid)
+    var addr_be = decoded[0]
+    var port_be = decoded[1]
+    var magic = decoded[2]
+    var deadline_ns = perf_counter_ns() + Int(timeout_s * 1.0e9)
+    var listen_fd = _take_root(magic)
+    var conn = BootstrapConn(rank, nranks, listen_fd >= 0, listen_fd)
+
+    var hello = _alloc[UInt8](16)
+    var hw = hello.unsafe_bitcast[UInt64]()
+
+    if conn.is_root:
+        _set_timeout(listen_fd, SO_RCVTIMEO, SOCK_SLICE_S)
+        var got = 0
+        while got < nranks - 1:
+            var cfd = external_call["accept", Int32](
+                listen_fd, Int64(0), Int64(0)
+            )
+            if cfd < 0:
+                var e = _errno()
+                if e == EINTR or e == EAGAIN:
+                    if perf_counter_ns() > deadline_ns:
+                        conn.close()
+                        raise Error(
+                            "mojoccl: bootstrap timed out with "
+                            + String(got + 1)
+                            + " of "
+                            + String(nranks)
+                            + " ranks connected"
+                        )
+                    continue
+                conn.close()
+                raise Error("mojoccl: accept() failed, errno=" + String(e))
+            try:
+                _set_timeout(cfd, SO_RCVTIMEO, SOCK_SLICE_S)
+                _set_timeout(cfd, SO_SNDTIMEO, SOCK_SLICE_S)
+                _set_int_opt(cfd, IPPROTO_TCP, TCP_NODELAY, 1)
+                _recv_all(cfd, hello, 16, deadline_ns)
+            except e:
+                _close(cfd)
+                conn.close()
+                raise e
+            var peer_magic = hw[unsafe_offset=0]
+            var peer_rank = Int(hw[unsafe_offset=1])
+            if peer_magic != magic or peer_rank < 0 or peer_rank >= nranks:
+                _close(cfd)
+                continue  # not ours: another communicator's straggler
+            if conn.fds[peer_rank] >= 0:
+                _close(cfd)
+                conn.close()
+                raise Error(
+                    "mojoccl: two ranks announced rank " + String(peer_rank)
+                )
+            conn.fds[peer_rank] = cfd
+            got += 1
+        return conn^
+
+    # Non-root: connect, retrying while the root is still coming up.
+    while True:
+        var fd = external_call["socket", Int32](AF_INET, SOCK_STREAM, Int32(0))
+        if fd < 0:
+            raise Error("mojoccl: socket() failed, errno=" + String(_errno()))
+        var sa = _alloc[UInt8](SOCKADDR_IN_BYTES)
+        _fill_sockaddr(sa, addr_be, port_be)
+        var rc = external_call["connect", Int32](
+            fd, sa, UInt32(SOCKADDR_IN_BYTES)
+        )
+        if rc == 0:
+            _set_timeout(fd, SO_RCVTIMEO, SOCK_SLICE_S)
+            _set_timeout(fd, SO_SNDTIMEO, SOCK_SLICE_S)
+            _set_int_opt(fd, IPPROTO_TCP, TCP_NODELAY, 1)
+            conn.fds[0] = fd
+            hw[unsafe_offset=0] = magic
+            hw[unsafe_offset=1] = UInt64(rank)
+            _send_all(fd, hello, 16, deadline_ns)
+            return conn^
+        _close(fd)
+        if perf_counter_ns() > deadline_ns:
+            raise Error(
+                "mojoccl: could not reach the bootstrap root at "
+                + format_ipv4(addr_be)
+                + ":"
+                + String(Int(port_be >> 8) | (Int(port_be & 0xFF) << 8))
+                + " within "
                 + String(timeout_s)
-                + "s waiting for rank "
-                + String(rank)
-                + " at "
-                + dir
+                + "s (errno="
+                + String(_errno())
+                + "); check MOJOCCL_SOCKET_IFNAME reaches every node"
             )
         sleep(0.02)
 
 
-def wait_for_rank(dir: String, rank: Int, timeout_s: Float64) raises:
-    """Blocks until `rank`'s handle file exists, or raises past the timeout."""
-    _wait_for_file(dir + "/rank" + String(rank) + ".handle", rank, timeout_s, dir)
+def bootstrap_allgather(
+    mut conn: BootstrapConn,
+    blob: Pointer[UInt8, MutAnyOrigin],
+    nbytes: Int,
+    all_out: Pointer[UInt8, MutAnyOrigin],
+    timeout_s: Float64,
+) raises:
+    """`all_out[r*nbytes : (r+1)*nbytes]` gets rank r's `blob`, on every rank.
 
-
-def wait_for_done(dir: String, rank: Int, timeout_s: Float64) raises:
-    """Blocks until `rank`'s done marker (`write_rank_done`) exists, or
-    raises past the timeout."""
-    _wait_for_file(dir + "/rank" + String(rank) + ".done", rank, timeout_s, dir)
-
-
-def remove_rendezvous_dir(dir: String, nranks: Int) raises:
-    """Removes every rank's handle/done file, then the directory itself.
-
-    Called once, by rank 0, once every rank's done marker has landed
-    (normal completion) or on an init failure rank 0 hit after creating
-    `dir` (`ncclGetUniqueId`). Per-file removal is best-effort -- a file a
-    peer never got around to writing is not an error here -- but the final
-    `rmdir` is not: a non-empty directory after every known file was
-    cleared means something unexpected is in there, worth surfacing.
+    Root-relayed: N-1 sends in, one N*nbytes table out. At 16 ranks x 256 B
+    that is 4 KiB per rank, three times per communicator.
     """
-    for r in range(nranks):
-        try:
-            remove(dir + "/rank" + String(r) + ".handle")
-        except:
-            pass
-        try:
-            remove(dir + "/rank" + String(r) + ".done")
-        except:
-            pass
-    rmdir(dir)
+    var deadline_ns = perf_counter_ns() + Int(timeout_s * 1.0e9)
+    var total = conn.nranks * nbytes
+    if conn.is_root:
+        for i in range(nbytes):
+            all_out[unsafe_offset=conn.rank * nbytes + i] = blob[
+                unsafe_offset=i
+            ]
+        for r in range(conn.nranks):
+            if r == conn.rank:
+                continue
+            _recv_all(
+                conn.fds[r],
+                Pointer[UInt8, MutAnyOrigin](
+                    unsafe_from_address=Int(all_out) + r * nbytes
+                ),
+                nbytes,
+                deadline_ns,
+            )
+        for r in range(conn.nranks):
+            if r != conn.rank:
+                _send_all(conn.fds[r], all_out, total, deadline_ns)
+    else:
+        _send_all(conn.fds[0], blob, nbytes, deadline_ns)
+        _recv_all(conn.fds[0], all_out, total, deadline_ns)
+
+
+def bootstrap_barrier(mut conn: BootstrapConn, timeout_s: Float64) raises:
+    """A 4-byte allgather used for what its bytes are not: everyone has
+    arrived. Init's last step -- after it, a peer's region is zeroed, its IPC
+    handles are open and its QPs are in RTS, so the first collective may
+    write flags into it."""
+    var one = _alloc[UInt8](4)
+    for i in range(4):
+        one[unsafe_offset=i] = UInt8(1)
+    var all = _alloc[UInt8](4 * conn.nranks)
+    bootstrap_allgather(conn, one, 4, all, timeout_s)
+
+
+# ===-------------------------------------------------------------------=== #
+# Topology, derived identically on every rank from the round-1 table
+# ===-------------------------------------------------------------------=== #
+
+
+struct Topology(Movable):
+    var nnodes: Int
+    var local_world: Int
+    var my_node: Int
+    var my_local_rank: Int
+    var node_of: List[Int]        # global rank -> node index
+    var local_rank_of: List[Int]  # global rank -> local rank
+    var rank_at: List[Int]        # node * local_world + local_rank -> global rank
+
+    def __init__(out self, nranks: Int):
+        self.nnodes = 1
+        self.local_world = nranks
+        self.my_node = 0
+        self.my_local_rank = 0
+        self.node_of = List[Int](length=nranks, fill=0)
+        self.local_rank_of = List[Int](length=nranks, fill=0)
+        self.rank_at = List[Int](length=nranks, fill=0)
+
+
+def derive_topology(
+    host_hashes: List[UInt64], rank: Int
+) raises -> Topology:
+    """Node index = order of first appearance scanning ranks 0..n-1; local
+    rank = how many earlier ranks share the host. Pure function of the
+    gathered table, so every rank computes the same answer with no round
+    trip -- and the DDP invariant (equal ranks per node) is checked here,
+    where the error message can name the offending node."""
+    var n = len(host_hashes)
+    var topo = Topology(n)
+    var node_hash = List[UInt64]()
+    topo.nnodes = 0
+    for r in range(n):
+        var h = host_hashes[r]
+        var idx = -1
+        for j in range(len(node_hash)):
+            if node_hash[j] == h:
+                idx = j
+                break
+        if idx < 0:
+            idx = len(node_hash)
+            node_hash.append(h)
+        topo.node_of[r] = idx
+    topo.nnodes = len(node_hash)
+    var counts = List[Int](length=topo.nnodes, fill=0)
+    for r in range(n):
+        var nd = topo.node_of[r]
+        topo.local_rank_of[r] = counts[nd]
+        counts[nd] += 1
+    topo.local_world = counts[0]
+    for j in range(topo.nnodes):
+        if counts[j] != topo.local_world:
+            raise Error(
+                "mojoccl: every node must contribute the same number of ranks"
+                " (node 0 has "
+                + String(topo.local_world)
+                + ", node "
+                + String(j)
+                + " has "
+                + String(counts[j])
+                + "); launch with a uniform --nproc-per-node"
+            )
+    topo.my_node = topo.node_of[rank]
+    topo.my_local_rank = topo.local_rank_of[rank]
+    topo.rank_at = List[Int](length=topo.nnodes * topo.local_world, fill=0)
+    for r in range(n):
+        topo.rank_at[
+            topo.node_of[r] * topo.local_world + topo.local_rank_of[r]
+        ] = r
+    return topo^

--- a/torch_mojo_backend/distributed/mojoccl/bootstrap.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/bootstrap.mojo
@@ -15,6 +15,7 @@
 
 from std.ffi import OwnedDLHandle, CStringSlice
 from std.memory.alloc import unsafe_alloc
+from std.os import remove, rmdir
 from std.pathlib import Path
 from std.tempfile import mkdtemp
 from std.time import sleep, perf_counter_ns
@@ -88,6 +89,13 @@ def _rename(old: String, new: String) raises:
         raise Error("mojoccl: rename to " + new + " failed, rc=" + String(rc))
 
 
+def _atomic_write(final_path: String, tmp_path: String, content: String) raises:
+    """write+rename: readers never observe a partially written file."""
+    with open(tmp_path, "w") as f:
+        f.write(content)
+    _rename(tmp_path, final_path)
+
+
 def write_rank_handle(
     dir: String, rank: Int, ordinal: Int, handle: Pointer[UInt8, MutAnyOrigin]
 ) raises:
@@ -97,14 +105,25 @@ def write_rank_handle(
     proto/ipc_probe.mojo's handle-file convention) so there is no binary
     layout to keep in sync between writer and reader.
     """
-    var final_path = dir + "/rank" + String(rank) + ".handle"
-    var tmp_path = dir + "/.rank" + String(rank) + ".handle.tmp"
     var s = String(ordinal)
     for i in range(HANDLE_BYTES):
         s += " " + String(Int(handle[unsafe_offset=i]))
-    with open(tmp_path, "w") as f:
-        f.write(s)
-    _rename(tmp_path, final_path)
+    _atomic_write(
+        dir + "/rank" + String(rank) + ".handle",
+        dir + "/.rank" + String(rank) + ".handle.tmp",
+        s,
+    )
+
+
+def write_rank_done(dir: String, rank: Int) raises:
+    """Atomically publishes that this rank has opened every peer's IPC
+    handle. Rank 0 waits for every rank's marker (`wait_for_done`) before
+    removing `dir` (`remove_rendezvous_dir`) -- see ncclCommInitRank."""
+    _atomic_write(
+        dir + "/rank" + String(rank) + ".done",
+        dir + "/.rank" + String(rank) + ".done.tmp",
+        "1",
+    )
 
 
 def read_rank_handle(
@@ -131,9 +150,7 @@ def read_rank_handle(
     return ordinal
 
 
-def wait_for_rank(dir: String, rank: Int, timeout_s: Float64) raises:
-    """Blocks until `rank`'s handle file exists, or raises past the timeout."""
-    var path = dir + "/rank" + String(rank) + ".handle"
+def _wait_for_file(path: String, rank: Int, timeout_s: Float64, dir: String) raises:
     var t0 = perf_counter_ns()
     var deadline_ns = Int(timeout_s * 1.0e9)
     while not Path(path).exists():
@@ -147,3 +164,36 @@ def wait_for_rank(dir: String, rank: Int, timeout_s: Float64) raises:
                 + dir
             )
         sleep(0.02)
+
+
+def wait_for_rank(dir: String, rank: Int, timeout_s: Float64) raises:
+    """Blocks until `rank`'s handle file exists, or raises past the timeout."""
+    _wait_for_file(dir + "/rank" + String(rank) + ".handle", rank, timeout_s, dir)
+
+
+def wait_for_done(dir: String, rank: Int, timeout_s: Float64) raises:
+    """Blocks until `rank`'s done marker (`write_rank_done`) exists, or
+    raises past the timeout."""
+    _wait_for_file(dir + "/rank" + String(rank) + ".done", rank, timeout_s, dir)
+
+
+def remove_rendezvous_dir(dir: String, nranks: Int) raises:
+    """Removes every rank's handle/done file, then the directory itself.
+
+    Called once, by rank 0, once every rank's done marker has landed
+    (normal completion) or on an init failure rank 0 hit after creating
+    `dir` (`ncclGetUniqueId`). Per-file removal is best-effort -- a file a
+    peer never got around to writing is not an error here -- but the final
+    `rmdir` is not: a non-empty directory after every known file was
+    cleared means something unexpected is in there, worth surfacing.
+    """
+    for r in range(nranks):
+        try:
+            remove(dir + "/rank" + String(r) + ".handle")
+        except:
+            pass
+        try:
+            remove(dir + "/rank" + String(r) + ".done")
+        except:
+            pass
+    rmdir(dir)

--- a/torch_mojo_backend/distributed/mojoccl/bootstrap.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/bootstrap.mojo
@@ -150,7 +150,9 @@ def read_rank_handle(
     return ordinal
 
 
-def _wait_for_file(path: String, rank: Int, timeout_s: Float64, dir: String) raises:
+def _wait_for_file(
+    path: String, rank: Int, timeout_s: Float64, dir: String
+) raises:
     var t0 = perf_counter_ns()
     var deadline_ns = Int(timeout_s * 1.0e9)
     while not Path(path).exists():
@@ -168,7 +170,9 @@ def _wait_for_file(path: String, rank: Int, timeout_s: Float64, dir: String) rai
 
 def wait_for_rank(dir: String, rank: Int, timeout_s: Float64) raises:
     """Blocks until `rank`'s handle file exists, or raises past the timeout."""
-    _wait_for_file(dir + "/rank" + String(rank) + ".handle", rank, timeout_s, dir)
+    _wait_for_file(
+        dir + "/rank" + String(rank) + ".handle", rank, timeout_s, dir
+    )
 
 
 def wait_for_done(dir: String, rank: Int, timeout_s: Float64) raises:
@@ -182,18 +186,16 @@ def remove_rendezvous_dir(dir: String, nranks: Int) raises:
 
     Called once, by rank 0, once every rank's done marker has landed
     (normal completion) or on an init failure rank 0 hit after creating
-    `dir` (`ncclGetUniqueId`). Per-file removal is best-effort -- a file a
-    peer never got around to writing is not an error here -- but the final
-    `rmdir` is not: a non-empty directory after every known file was
-    cleared means something unexpected is in there, worth surfacing.
+    `dir` (`ncclGetUniqueId`). A file a peer never got around to writing is
+    not an error here and is skipped; any other failure propagates, and so
+    does the final `rmdir`: a non-empty directory after every known file
+    was cleared means something unexpected is in there, worth surfacing.
     """
     for r in range(nranks):
-        try:
-            remove(dir + "/rank" + String(r) + ".handle")
-        except:
-            pass
-        try:
-            remove(dir + "/rank" + String(r) + ".done")
-        except:
-            pass
+        var handle = dir + "/rank" + String(r) + ".handle"
+        if Path(handle).exists():
+            remove(handle)
+        var done = dir + "/rank" + String(r) + ".done"
+        if Path(done).exists():
+            remove(done)
     rmdir(dir)

--- a/torch_mojo_backend/distributed/mojoccl/collectives_kernels.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/collectives_kernels.mojo
@@ -923,6 +923,7 @@ def _rs_stage_kernel[
     world_i: Int32,
     rank_i: Int32,
     flag_base: UInt64,
+    scale: Float32,
     timeout_ns: UInt64,
 ):
     comptime accum = DType.float32 if (
@@ -966,9 +967,12 @@ def _rs_stage_kernel[
         return
 
     # --- phase 2: sum the `world` contributions to my shard into stage_out --
-    # SUM only, unscaled: the caller's inter-node step reduces the same shard
-    # again, so any averaging has to happen once, at the end, in
-    # `allgather_finish`.
+    # Times `scale`, applied in the fp32 accumulator BEFORE the store narrows
+    # to the wire dtype: the inter-node step sums these node partials again in
+    # that dtype, and an unscaled fp16 sum of 8 x 10000 is already inf. This
+    # is NCCL's PreMulSum for AVG (nccl:src/enqueue/enqueue.cc:2517), and for
+    # a power-of-two communicator x/world is exact, so it rounds no more than
+    # the plain sum would. `allgather_finish` then runs with scale 1.
     var my_off = _shard_off(n, per, rank)
     var my_cnt = _shard_cnt(n, per, rank)
     if my_cnt <= 0:
@@ -1011,6 +1015,8 @@ def _rs_stage_kernel[
                     .unsafe_load[width=W, alignment=16](v * W)
                     .cast[accum]()
                 )
+        comptime if accum.is_floating_point():
+            acc *= SIMD[accum, W](scale.cast[accum]())
         shard.unsafe_store[width=W, alignment=16](v * W, acc.cast[dtype]())
 
     for i in range(tid, my_cnt - my_vc * W, stride):
@@ -1025,6 +1031,8 @@ def _rs_stage_kernel[
                 .unsafe_bitcast[Scalar[dtype]]()[unsafe_offset=k]
                 .cast[accum]()
             )
+        comptime if accum.is_floating_point():
+            a *= scale.cast[accum]()
         shard[unsafe_offset=k] = a.cast[dtype]()
 
 
@@ -1566,6 +1574,7 @@ def _launch_rs_stage[
     rank: Int,
     cap_bytes: Int,
     generation: Int,
+    scale: Float32,
 ) raises:
     _enqueue_cached[_rs_stage_kernel[dtype, W, _UNROLL, NW]](
         ctx,
@@ -1582,6 +1591,7 @@ def _launch_rs_stage[
         Int32(world),
         Int32(rank),
         _flag_target(generation, 0),
+        scale,
         UInt64(DEFAULT_TIMEOUT_NS),
     )
 
@@ -1632,16 +1642,22 @@ def reduce_scatter_stage[
     numel: Int,
     cap_bytes: Int,
     generation: Int,
+    scale: Float32 = Float32(1.0),
 ) raises:
     """First half of a hierarchical allreduce: push + local reduce, on `stream`.
 
     When the enqueued work completes, this rank's shard --
-    `shard_range(numel, world, rank, size_of[dtype]())` -- summed (SUM,
-    **unscaled**) over the `world` node-local ranks, sits in this rank's own
-    stage_out, at element offset `offset` from `region + signal_bytes() +
-    cap_bytes`. The caller then runs the inter-node collective in place on
-    exactly that range, on this same stream, and calls `allgather_finish` with
-    `generation + 1`.
+    `shard_range(numel, world, rank, size_of[dtype]())` -- summed over the
+    `world` node-local ranks and multiplied by `scale` (ignored for integer
+    dtypes), sits in this rank's own stage_out, at element offset `offset`
+    from `region + signal_bytes() + cap_bytes`. The caller then runs the
+    inter-node collective in place on exactly that range, on this same
+    stream, and calls `allgather_finish` with `generation + 1` and scale 1.
+
+    `scale` goes here rather than into `allgather_finish` so that an AVG never
+    stores an unscaled sum in a narrow wire dtype (NCCL's PreMulSum); pass
+    the communicator-wide 1/world, and the inter-node SUM of the node
+    partials is the average.
 
     `rank` / `world` / `regions` are the node-local group. Preconditions are
     `allreduce`'s: 16-byte aligned `in_ptr`, `numel * size_of[dtype]() <=
@@ -1658,19 +1674,23 @@ def reduce_scatter_stage[
     # self-rendezvous and the reduce copies the input into stage_out.
     if world == 8:
         _launch_rs_stage[dtype, W, 8](
-            ctx, stream, rp, in_ptr, numel, per, world, rank, cap_bytes, generation
+            ctx, stream, rp, in_ptr, numel, per, world, rank, cap_bytes,
+            generation, scale,
         )
     elif world == 4:
         _launch_rs_stage[dtype, W, 4](
-            ctx, stream, rp, in_ptr, numel, per, world, rank, cap_bytes, generation
+            ctx, stream, rp, in_ptr, numel, per, world, rank, cap_bytes,
+            generation, scale,
         )
     elif world == 2:
         _launch_rs_stage[dtype, W, 2](
-            ctx, stream, rp, in_ptr, numel, per, world, rank, cap_bytes, generation
+            ctx, stream, rp, in_ptr, numel, per, world, rank, cap_bytes,
+            generation, scale,
         )
     else:
         _launch_rs_stage[dtype, W, 0](
-            ctx, stream, rp, in_ptr, numel, per, world, rank, cap_bytes, generation
+            ctx, stream, rp, in_ptr, numel, per, world, rank, cap_bytes,
+            generation, scale,
         )
 
 

--- a/torch_mojo_backend/distributed/mojoccl/collectives_kernels.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/collectives_kernels.mojo
@@ -1,0 +1,423 @@
+# STAND-IN collectives kernel for mojoccl.
+#
+# Correctness over speed, as directed: single-thread-block copy/reduce
+# kernels plus a page-sized signal area and a generation-based barrier built
+# on plain system-scope Atomic release/acquire (the flag pattern
+# proto/ipc_probe.mojo measured working, PASS at §5.3 of
+# docs/mojo_collectives_feasibility.md in the main worktree) -- not MAX's
+# comm.Signal, whose embedded Lamport region alone is ~24.75 MiB/rank, far
+# more than this needs. This file is expected to be replaced wholesale by
+# the production kernel (kernel/collectives_kernels.mojo, written in
+# parallel against this same function-signature contract); nothing outside
+# this file should need to change on that swap.
+#
+# Region layout per rank (see mojoccl.mojo): [0, signal_bytes()) signal area,
+# then stage_in of cap_bytes, then stage_out of cap_bytes. `regions[r]` is
+# rank r's region base as mapped in THIS process (own allocation for
+# r == rank, an opened IPC mapping otherwise).
+
+from std.atomic import Atomic, Ordering
+from std.builtin.device_passable import DevicePassable
+from std.ffi import _get_global_or_null, external_call
+from max.gpu.sync import barrier
+from std.gpu import thread_idx, MAX_THREADS_PER_BLOCK_METADATA
+from std.memory.alloc import unsafe_alloc
+from std.sys import get_accum_type
+from std.time import global_perf_counter_ns
+from std.utils import StaticTuple
+from max.gpu.host import DeviceContext, DeviceStream, DeviceBuffer
+
+from driver import zero_bytes
+
+comptime MAX_WORLD = 8
+comptime BLOCK = 256
+# One page: [0] error word (UInt64), [8] barrier counter (UInt64), padding.
+comptime SIG_BYTES = 4096
+comptime ERR_OFF = 0
+comptime BAR_OFF = 8
+comptime BARRIER_TIMEOUT_NS: UInt64 = 30_000_000_000
+
+
+def signal_bytes() -> Int:
+    return SIG_BYTES
+
+
+def error_offset() -> Int:
+    return ERR_OFF
+
+
+def region_init(ctx: DeviceContext, region: Int) raises:
+    """Zeros the signal area of a freshly allocated region.
+
+    No `stream` parameter (unlike the collectives below): this runs once per
+    rank at communicator creation, on `ctx`'s own queue, before any user
+    stream touches the region -- zero_bytes blocks, so every later
+    collective (issued on the caller's external stream) is guaranteed to see
+    the zeroed area.
+    """
+    zero_bytes(ctx, region, SIG_BYTES)
+
+
+@always_inline
+def _err_ptr(region: Int64) -> Pointer[UInt64, MutAnyOrigin]:
+    return Pointer[UInt64, MutAnyOrigin](
+        unsafe_from_address=Int(region) + ERR_OFF
+    )
+
+
+@always_inline
+def _bar_ptr(region: Int64) -> Pointer[UInt64, MutAnyOrigin]:
+    return Pointer[UInt64, MutAnyOrigin](
+        unsafe_from_address=Int(region) + BAR_OFF
+    )
+
+
+@always_inline
+def _gen_barrier(
+    regions: StaticTuple[Int64, MAX_WORLD],
+    rank: Int32,
+    world: Int32,
+    target: UInt64,
+):
+    """A full, symmetric cross-rank barrier: every participant publishes
+    `target` into its own region and waits for every OTHER participant to
+    reach at least `target` too, before any of them may proceed.
+
+    Symmetric on purpose (publish AND wait, both phases of every call): a
+    one-way "publish and move on" would let a fast rank start overwriting
+    its stage buffers for the NEXT generation while a slow peer is still
+    reading THIS generation's data out of them. `target` is derived from the
+    caller-supplied generation counter, strictly increasing per
+    communicator, so no double-buffering of the counter itself is needed --
+    every call in the process's lifetime gets a fresh target.
+    """
+    if thread_idx.x == 0:
+        Atomic[DType.uint64].store[ordering=Ordering.RELEASE](
+            _bar_ptr(regions[Int(rank)]), target
+        )
+    if Int(thread_idx.x) < Int(world):
+        var peer_ptr = _bar_ptr(regions[Int(thread_idx.x)])
+        var t0 = global_perf_counter_ns()
+        while (
+            Atomic[DType.uint64].load[ordering=Ordering.ACQUIRE](peer_ptr)
+            < target
+        ):
+            if global_perf_counter_ns() - t0 > BARRIER_TIMEOUT_NS:
+                Atomic[DType.uint64].store[ordering=Ordering.RELEASE](
+                    _err_ptr(regions[Int(rank)]), UInt64(1)
+                )
+                break
+    barrier()
+
+
+@always_inline
+def _enqueue_cached_stream[
+    declared_arg_types: TypeList[Trait=AnyType, ...],
+    //,
+    func: def(* args: * declared_arg_types) thin -> None,
+    *Ts: DevicePassable,
+](
+    ctx: DeviceContext,
+    stream: DeviceStream,
+    key: String,
+    threads: Int,
+    *args: *Ts,
+) raises:
+    """Enqueue `func` (grid of 1 block) on the caller's `stream`, compiling
+    it at most once per process and context.
+
+    Self-contained copy of eager_kernels/op_utils's `_enqueue_cached`
+    pattern (this library builds and loads standalone, outside that
+    package): compile once via `ctx`, cache the `DeviceFunction` in the
+    process-global registry, enqueue onto `stream` on every call after.
+    """
+    var name = String(t"MOJOCCL_KERNEL_{key}_{ctx.id()}")
+    comptime FuncT = type_of(ctx.compile_function[func]())
+    var global_ptr = _get_global_or_null(name)
+    if global_ptr:
+        var fptr = global_ptr.value().unsafe_bitcast[FuncT]()
+        stream.enqueue_function(
+            fptr[], *args, grid_dim=(1, 1, 1), block_dim=(threads,)
+        )
+        return
+    var compiled = ctx.compile_function[func]()
+    var fptr = unsafe_alloc[FuncT](1)
+    fptr.unsafe_write(compiled^)
+    external_call["KGEN_CompilerRT_InsertGlobal", NoneType](
+        StringSlice(name), fptr.unsafe_bitcast[NoneType]()
+    )
+    stream.enqueue_function(
+        fptr[], *args, grid_dim=(1, 1, 1), block_dim=(threads,)
+    )
+
+
+# ---------------------------------------------------------------------------
+# allreduce: copy-in, barrier, every rank independently sums every peer's
+# stage_in (no reduce-scatter partitioning -- simplest correct thing, per
+# "plain copy-in / RS+AG / copy-out is fine"), barrier, copy-out. Generic
+# Float64 accumulation covers all five dtypes with one code path; SUM is
+# exact for the small integer values these tests use, AVG divides via
+# `scale`.
+# ---------------------------------------------------------------------------
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(BLOCK))
+)
+def _allreduce_kernel[
+    dtype: DType
+](
+    regions: StaticTuple[Int64, MAX_WORLD],
+    rank: Int32,
+    world: Int32,
+    in_ptr: Int64,
+    out_ptr: Int64,
+    numel: Int32,
+    cap_bytes: Int32,
+    scale: Float32,
+    generation: UInt64,
+):
+    var my_region = Int(regions[Int(rank)])
+    var stage_in = Pointer[Scalar[dtype], MutAnyOrigin](
+        unsafe_from_address=my_region + SIG_BYTES
+    )
+    var src = Pointer[Scalar[dtype], MutAnyOrigin](
+        unsafe_from_address=Int(in_ptr)
+    )
+    var n = Int(numel)
+    var tid = Int(thread_idx.x)
+    for i in range(tid, n, BLOCK):
+        stage_in[unsafe_offset=i] = src[unsafe_offset=i]
+
+    _gen_barrier(regions, rank, world, 2 * generation)
+
+    var stage_out = Pointer[Scalar[dtype], MutAnyOrigin](
+        unsafe_from_address=my_region + SIG_BYTES + Int(cap_bytes)
+    )
+    var w = Int(world)
+    var fscale = Float64(scale)
+    for i in range(tid, n, BLOCK):
+        var acc: Float64 = 0
+        for p in range(w):
+            var peer_in = Pointer[Scalar[dtype], MutAnyOrigin](
+                unsafe_from_address=Int(regions[p]) + SIG_BYTES
+            )
+            acc += Float64(peer_in[unsafe_offset=i])
+        stage_out[unsafe_offset=i] = Scalar[dtype](acc * fscale)
+
+    _gen_barrier(regions, rank, world, 2 * generation + 1)
+
+    var dst = Pointer[Scalar[dtype], MutAnyOrigin](
+        unsafe_from_address=Int(out_ptr)
+    )
+    for i in range(tid, n, BLOCK):
+        dst[unsafe_offset=i] = stage_out[unsafe_offset=i]
+
+
+def allreduce[
+    dtype: DType
+](
+    ctx: DeviceContext,
+    stream: DeviceStream,
+    rank: Int,
+    world: Int,
+    regions: StaticTuple[Int, MAX_WORLD],
+    in_ptr: Int,
+    out_ptr: Int,
+    numel: Int,
+    cap_bytes: Int,
+    scale: Float32,
+    generation: Int,
+) raises:
+    var regions64 = StaticTuple[Int64, MAX_WORLD](fill=0)
+    for i in range(MAX_WORLD):
+        regions64[i] = Int64(regions[i])
+    comptime kern = _allreduce_kernel[dtype]
+    _enqueue_cached_stream[kern](
+        ctx,
+        stream,
+        String("allreduce_") + String(dtype),
+        BLOCK,
+        regions64,
+        Int32(rank),
+        Int32(world),
+        Int64(in_ptr),
+        Int64(out_ptr),
+        Int32(numel),
+        Int32(cap_bytes),
+        scale,
+        UInt64(generation),
+    )
+
+
+# ---------------------------------------------------------------------------
+# broadcast: root copies its send buffer into its own stage_in, barrier,
+# every rank (root included) copies root's stage_in into its own recv
+# buffer, barrier. Byte-granular: NCCL's broadcast moves opaque bytes, no
+# reduction, so there is no dtype to specialize on.
+# ---------------------------------------------------------------------------
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(BLOCK))
+)
+def _broadcast_kernel(
+    regions: StaticTuple[Int64, MAX_WORLD],
+    rank: Int32,
+    root: Int32,
+    world: Int32,
+    send_ptr: Int64,
+    recv_ptr: Int64,
+    nbytes: Int32,
+    generation: UInt64,
+):
+    var my_region = Int(regions[Int(rank)])
+    var stage = Pointer[UInt8, MutAnyOrigin](
+        unsafe_from_address=my_region + SIG_BYTES
+    )
+    var n = Int(nbytes)
+    var tid = Int(thread_idx.x)
+    if rank == root:
+        var src = Pointer[UInt8, MutAnyOrigin](
+            unsafe_from_address=Int(send_ptr)
+        )
+        for i in range(tid, n, BLOCK):
+            stage[unsafe_offset=i] = src[unsafe_offset=i]
+
+    _gen_barrier(regions, rank, world, 2 * generation)
+
+    var root_stage = Pointer[UInt8, MutAnyOrigin](
+        unsafe_from_address=Int(regions[Int(root)]) + SIG_BYTES
+    )
+    var dst = Pointer[UInt8, MutAnyOrigin](unsafe_from_address=Int(recv_ptr))
+    for i in range(tid, n, BLOCK):
+        dst[unsafe_offset=i] = root_stage[unsafe_offset=i]
+
+    _gen_barrier(regions, rank, world, 2 * generation + 1)
+
+
+def broadcast(
+    ctx: DeviceContext,
+    stream: DeviceStream,
+    rank: Int,
+    root: Int,
+    world: Int,
+    regions: StaticTuple[Int, MAX_WORLD],
+    send_ptr: Int,
+    recv_ptr: Int,
+    nbytes: Int,
+    cap_bytes: Int,
+    generation: Int,
+) raises:
+    if nbytes > cap_bytes:
+        raise Error("mojoccl: broadcast nbytes exceeds the region capacity")
+    var regions64 = StaticTuple[Int64, MAX_WORLD](fill=0)
+    for i in range(MAX_WORLD):
+        regions64[i] = Int64(regions[i])
+    comptime kern = _broadcast_kernel
+    _enqueue_cached_stream[kern](
+        ctx,
+        stream,
+        String("broadcast"),
+        BLOCK,
+        regions64,
+        Int32(rank),
+        Int32(root),
+        Int32(world),
+        Int64(send_ptr),
+        Int64(recv_ptr),
+        Int32(nbytes),
+        UInt64(generation),
+    )
+
+
+# ---------------------------------------------------------------------------
+# allgather: every rank copies its chunk into its own stage_in, barrier,
+# every rank copies every peer's stage_in into the right slice of its own
+# output, barrier.
+# ---------------------------------------------------------------------------
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(BLOCK))
+)
+def _allgather_kernel(
+    regions: StaticTuple[Int64, MAX_WORLD],
+    rank: Int32,
+    world: Int32,
+    in_ptr: Int64,
+    out_ptr: Int64,
+    nbytes: Int32,
+    stride_bytes: Int32,
+    generation: UInt64,
+):
+    var my_region = Int(regions[Int(rank)])
+    var stage = Pointer[UInt8, MutAnyOrigin](
+        unsafe_from_address=my_region + SIG_BYTES
+    )
+    var src = Pointer[UInt8, MutAnyOrigin](unsafe_from_address=Int(in_ptr))
+    var n = Int(nbytes)
+    var tid = Int(thread_idx.x)
+    for i in range(tid, n, BLOCK):
+        stage[unsafe_offset=i] = src[unsafe_offset=i]
+
+    _gen_barrier(regions, rank, world, 2 * generation)
+
+    var dst = Pointer[UInt8, MutAnyOrigin](unsafe_from_address=Int(out_ptr))
+    var w = Int(world)
+    var stride = Int(stride_bytes)
+    for p in range(w):
+        var peer_stage = Pointer[UInt8, MutAnyOrigin](
+            unsafe_from_address=Int(regions[p]) + SIG_BYTES
+        )
+        var base = p * stride
+        for i in range(tid, n, BLOCK):
+            dst[unsafe_offset=base + i] = peer_stage[unsafe_offset=i]
+
+    _gen_barrier(regions, rank, world, 2 * generation + 1)
+
+
+def allgather(
+    ctx: DeviceContext,
+    stream: DeviceStream,
+    rank: Int,
+    world: Int,
+    regions: StaticTuple[Int, MAX_WORLD],
+    in_ptr: Int,
+    out_ptr: Int,
+    nbytes_per_rank: Int,
+    cap_bytes: Int,
+    generation: Int,
+    stride_bytes: Int = -1,
+) raises:
+    """`stride_bytes` (default `nbytes_per_rank`) is the OUTPUT layout's true
+    per-rank size, in bytes, separate from `nbytes_per_rank` (how much THIS
+    call moves). They differ only when the caller chunks one rank's
+    contribution across several calls: each chunk still lands at
+    `peer * stride_bytes + chunk_offset` in the flat `[rank0 | rank1 | ...]`
+    output, never at `peer * nbytes_per_rank`. A one-call (unchunked)
+    allgather needs no stride argument at all.
+    """
+    if nbytes_per_rank > cap_bytes:
+        raise Error(
+            "mojoccl: allgather nbytes_per_rank exceeds the region capacity"
+        )
+    var stride = nbytes_per_rank if stride_bytes < 0 else stride_bytes
+    var regions64 = StaticTuple[Int64, MAX_WORLD](fill=0)
+    for i in range(MAX_WORLD):
+        regions64[i] = Int64(regions[i])
+    comptime kern = _allgather_kernel
+    _enqueue_cached_stream[kern](
+        ctx,
+        stream,
+        String("allgather"),
+        BLOCK,
+        regions64,
+        Int32(rank),
+        Int32(world),
+        Int64(in_ptr),
+        Int64(out_ptr),
+        Int32(nbytes_per_rank),
+        Int32(stride),
+        UInt64(generation),
+    )

--- a/torch_mojo_backend/distributed/mojoccl/collectives_kernels.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/collectives_kernels.mojo
@@ -246,7 +246,7 @@ def _record_error(
 ):
     """Publish a failure in my own region's error word (host-readable)."""
     if thread_idx.x == 0:
-        Atomic[DType.uint64].store[ordering = Ordering.RELEASE](
+        Atomic[DType.uint64].store[ordering=Ordering.RELEASE](
             regions[rank].unsafe_bitcast[UInt64](),
             UInt64(code) * 1_000_000 + UInt64(phase),
         )
@@ -276,7 +276,7 @@ def _sync(
     learns that through shared memory so no thread is left inside a `barrier()`.
     """
     var failed = stack_allocation[
-        1, DType.uint32, address_space = AddressSpace.SHARED
+        1, DType.uint32, address_space=AddressSpace.SHARED
     ]()
     if thread_idx.x == 0:
         failed[unsafe_offset=0] = 0
@@ -289,21 +289,20 @@ def _sync(
         # `s_waitcnt vmcnt(0)` + `buffer_wbl2 sc0 sc1`). NVIDIA needs nothing:
         # `bar.sync` is a CTA-scope fence and the release store below is
         # cumulative over it, which is what NCCL's postPeer relies on.
-        fence[ordering = Ordering.RELEASE]()
+        fence[ordering=Ordering.RELEASE]()
     barrier()
 
     if Int(thread_idx.x) < world:
         var peer = Int(thread_idx.x)
         var bid = Int(block_idx.x)
-        Atomic[DType.uint64].store[ordering = Ordering.RELEASE](
+        Atomic[DType.uint64].store[ordering=Ordering.RELEASE](
             _flags(regions[peer]).unsafe_offset(bid * MAX_WORLD + rank),
             target,
         )
         var mine = _flags(regions[rank]).unsafe_offset(bid * MAX_WORLD + peer)
         var spins = 0
         while (
-            Atomic[DType.uint64].load[ordering = Ordering.ACQUIRE](mine)
-            < target
+            Atomic[DType.uint64].load[ordering=Ordering.ACQUIRE](mine) < target
         ):
             spins += 1
             if spins >= _SPIN_CHECK:
@@ -365,7 +364,7 @@ def _copy_scalar_tail[
 ):
     """The `numel % W` elements a 16-byte vector loop cannot cover."""
     for i in range(tid, count, stride):
-        dst[unsafe_offset = base + i] = src[unsafe_offset = base + i]
+        dst[unsafe_offset=base + i] = src[unsafe_offset=base + i]
 
 
 @always_inline
@@ -394,7 +393,7 @@ def _copy_bytes[
     else:
         for v in range(tid, nvec, stride):
             comptime for j in range(16):
-                dst[unsafe_offset = v * 16 + j] = src[unsafe_offset = v * 16 + j]
+                dst[unsafe_offset=v * 16 + j] = src[unsafe_offset=v * 16 + j]
     _copy_scalar_tail(dst, src, nvec * 16, nbytes - nvec * 16, tid, stride)
 
 
@@ -492,9 +491,11 @@ def _ar_twoshot_kernel[
             s -= world
         var src = in_ptr.unsafe_offset(_vstart(s, q, rem) * W)
         var vc = _vcount(s, q, rem)
-        var dst = regions[s].unsafe_offset(
-            push_off + slot_stride * rank
-        ).unsafe_bitcast[Scalar[dtype]]()
+        var dst = (
+            regions[s]
+            .unsafe_offset(push_off + slot_stride * rank)
+            .unsafe_bitcast[Scalar[dtype]]()
+        )
         _copy_vec[dtype, W, U](dst, src, vc, tid, stride)
         if tail > 0 and s == world - 1:
             _copy_scalar_tail(dst, src, vc * W, tail, tid, stride)
@@ -509,9 +510,9 @@ def _ar_twoshot_kernel[
     var my_tail = tail if rank == world - 1 else 0
     var uin = in_ptr.unsafe_offset(my_vs * W)
     var uout = out_ptr.unsafe_offset(my_vs * W)
-    var shard = regions[rank].unsafe_offset(shard_off).unsafe_bitcast[
-        Scalar[dtype]
-    ]()
+    var shard = (
+        regions[rank].unsafe_offset(shard_off).unsafe_bitcast[Scalar[dtype]]()
+    )
 
     # Slot pointers are formed by arithmetic inside the unrolled loop, never
     # held in an array: a stack array of `world` pointers is demoted to local
@@ -577,9 +578,9 @@ def _ar_twoshot_kernel[
             p -= world
         var vs = _vstart(p, q, rem)
         var vc = _vcount(p, q, rem)
-        var src = regions[p].unsafe_offset(shard_off).unsafe_bitcast[
-            Scalar[dtype]
-        ]()
+        var src = (
+            regions[p].unsafe_offset(shard_off).unsafe_bitcast[Scalar[dtype]]()
+        )
         var dst = out_ptr.unsafe_offset(vs * W)
         _copy_vec[dtype, W, U](dst, src, vc, tid, stride)
         if tail > 0 and p == world - 1:
@@ -636,9 +637,11 @@ def _ar_oneshot_kernel[
         var s = rank + i
         if s >= world:
             s -= world
-        var dst = regions[s].unsafe_offset(
-            push_off + slot_stride * rank
-        ).unsafe_bitcast[Scalar[dtype]]()
+        var dst = (
+            regions[s]
+            .unsafe_offset(push_off + slot_stride * rank)
+            .unsafe_bitcast[Scalar[dtype]]()
+        )
         _copy_vec[dtype, W, U](dst, in_ptr, nvec, tid, stride)
         if tail > 0:
             _copy_scalar_tail(dst, in_ptr, nvec * W, tail, tid, stride)
@@ -872,8 +875,9 @@ def _zero_kernel(ptr: Pointer[UInt32, MutAnyOrigin], nwords: Int32):
 
 @always_inline
 def _enqueue_cached[
-    declared_arg_types: TypeList[Trait=AnyType, ...], //,
-    func: def (*args: *declared_arg_types) thin -> None,
+    declared_arg_types: TypeList[Trait=AnyType, ...],
+    //,
+    func: def(* args: * declared_arg_types) thin -> None,
     *Ts: DevicePassable,
 ](
     ctx: DeviceContext,
@@ -984,12 +988,8 @@ def _launch_allreduce[
     var esize = size_of[dtype]()
     var nvec = numel // W
     var tail = numel - nvec * W
-    var ip = Pointer[Scalar[dtype], MutAnyOrigin](
-        unsafe_from_address=in_ptr
-    )
-    var op = Pointer[Scalar[dtype], MutAnyOrigin](
-        unsafe_from_address=out_ptr
-    )
+    var ip = Pointer[Scalar[dtype], MutAnyOrigin](unsafe_from_address=in_ptr)
+    var op = Pointer[Scalar[dtype], MutAnyOrigin](unsafe_from_address=out_ptr)
 
     if one_shot:
         # `world` slots, each a whole message, at the base of the arena. They
@@ -1000,9 +1000,7 @@ def _launch_allreduce[
         if world * slot > 2 * cap_bytes:
             raise Error("collectives: one-shot slots exceed the region")
         var push_off = arena
-        var blocks = min(
-            _AR_MAX_BLOCKS, max(1, (nvec + BLOCK - 1) // BLOCK)
-        )
+        var blocks = min(_AR_MAX_BLOCKS, max(1, (nvec + BLOCK - 1) // BLOCK))
         _enqueue_cached[_ar_oneshot_kernel[dtype, W, _UNROLL, NW]](
             ctx,
             stream,
@@ -1024,9 +1022,7 @@ def _launch_allreduce[
 
     var q = nvec // world
     var rem = nvec % world
-    var max_shard_elems = max(
-        (q + (1 if rem > 0 else 0)) * W, q * W + tail
-    )
+    var max_shard_elems = max((q + (1 if rem > 0 else 0)) * W, q * W + tail)
     var slot = _align_up(max_shard_elems * esize, 16)
     var push_off = arena
     var shard_off = arena + world * slot
@@ -1105,23 +1101,63 @@ def allreduce[
 
     if world == 8:
         _launch_allreduce[dtype, W, 8](
-            ctx, stream, rp, in_ptr, out_ptr, numel, world, rank, cap_bytes, scale,
-            generation, one_shot,
+            ctx,
+            stream,
+            rp,
+            in_ptr,
+            out_ptr,
+            numel,
+            world,
+            rank,
+            cap_bytes,
+            scale,
+            generation,
+            one_shot,
         )
     elif world == 4:
         _launch_allreduce[dtype, W, 4](
-            ctx, stream, rp, in_ptr, out_ptr, numel, world, rank, cap_bytes, scale,
-            generation, one_shot,
+            ctx,
+            stream,
+            rp,
+            in_ptr,
+            out_ptr,
+            numel,
+            world,
+            rank,
+            cap_bytes,
+            scale,
+            generation,
+            one_shot,
         )
     elif world == 2:
         _launch_allreduce[dtype, W, 2](
-            ctx, stream, rp, in_ptr, out_ptr, numel, world, rank, cap_bytes, scale,
-            generation, one_shot,
+            ctx,
+            stream,
+            rp,
+            in_ptr,
+            out_ptr,
+            numel,
+            world,
+            rank,
+            cap_bytes,
+            scale,
+            generation,
+            one_shot,
         )
     else:
         _launch_allreduce[dtype, W, 0](
-            ctx, stream, rp, in_ptr, out_ptr, numel, world, rank, cap_bytes, scale,
-            generation, one_shot,
+            ctx,
+            stream,
+            rp,
+            in_ptr,
+            out_ptr,
+            numel,
+            world,
+            rank,
+            cap_bytes,
+            scale,
+            generation,
+            one_shot,
         )
 
 

--- a/torch_mojo_backend/distributed/mojoccl/collectives_kernels.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/collectives_kernels.mojo
@@ -321,7 +321,7 @@ def _abort_raised(region: Pointer[UInt8, MutAnyOrigin]) -> Bool:
     if addr == 0:
         return False
     return (
-        Atomic[DType.uint64].load[ordering = Ordering.ACQUIRE](
+        Atomic[DType.uint64].load[ordering=Ordering.ACQUIRE](
             Pointer[UInt64, MutAnyOrigin](unsafe_from_address=addr)
         )
         != 0
@@ -337,7 +337,7 @@ def _record_error(
 ):
     """Publish a failure in my own region's error word (host-readable)."""
     if thread_idx.x == 0:
-        Atomic[DType.uint64].store[ordering = Ordering.RELEASE](
+        Atomic[DType.uint64].store[ordering=Ordering.RELEASE](
             regions[rank].unsafe_bitcast[UInt64](),
             UInt64(code) * 1_000_000 + UInt64(phase),
         )
@@ -367,7 +367,7 @@ def _sync(
     learns that through shared memory so no thread is left inside a `barrier()`.
     """
     var failed = stack_allocation[
-        1, DType.uint32, address_space = AddressSpace.SHARED
+        1, DType.uint32, address_space=AddressSpace.SHARED
     ]()
     if thread_idx.x == 0:
         failed[unsafe_offset=0] = 0
@@ -380,21 +380,20 @@ def _sync(
         # `s_waitcnt vmcnt(0)` + `buffer_wbl2 sc0 sc1`). NVIDIA needs nothing:
         # `bar.sync` is a CTA-scope fence and the release store below is
         # cumulative over it, which is what NCCL's postPeer relies on.
-        fence[ordering = Ordering.RELEASE]()
+        fence[ordering=Ordering.RELEASE]()
     barrier()
 
     if Int(thread_idx.x) < world:
         var peer = Int(thread_idx.x)
         var bid = Int(block_idx.x)
-        Atomic[DType.uint64].store[ordering = Ordering.RELEASE](
+        Atomic[DType.uint64].store[ordering=Ordering.RELEASE](
             _flags(regions[peer]).unsafe_offset(bid * MAX_WORLD + rank),
             target,
         )
         var mine = _flags(regions[rank]).unsafe_offset(bid * MAX_WORLD + peer)
         var spins = 0
         while (
-            Atomic[DType.uint64].load[ordering = Ordering.ACQUIRE](mine)
-            < target
+            Atomic[DType.uint64].load[ordering=Ordering.ACQUIRE](mine) < target
         ):
             spins += 1
             if spins >= _SPIN_CHECK:
@@ -459,7 +458,7 @@ def _copy_scalar_tail[
 ):
     """The `numel % W` elements a 16-byte vector loop cannot cover."""
     for i in range(tid, count, stride):
-        dst[unsafe_offset = base + i] = src[unsafe_offset = base + i]
+        dst[unsafe_offset=base + i] = src[unsafe_offset=base + i]
 
 
 @always_inline
@@ -488,7 +487,7 @@ def _copy_bytes[
     else:
         for v in range(tid, nvec, stride):
             comptime for j in range(16):
-                dst[unsafe_offset = v * 16 + j] = src[unsafe_offset = v * 16 + j]
+                dst[unsafe_offset=v * 16 + j] = src[unsafe_offset=v * 16 + j]
     _copy_scalar_tail(dst, src, nvec * 16, nbytes - nvec * 16, tid, stride)
 
 
@@ -726,9 +725,11 @@ def _ar_twoshot_kernel[
             s -= world
         var src = in_ptr.unsafe_offset(_vstart(s, q, rem) * W)
         var vc = _vcount(s, q, rem)
-        var dst = regions[s].unsafe_offset(
-            push_off + slot_stride * rank
-        ).unsafe_bitcast[Scalar[dtype]]()
+        var dst = (
+            regions[s]
+            .unsafe_offset(push_off + slot_stride * rank)
+            .unsafe_bitcast[Scalar[dtype]]()
+        )
         _copy_vec[dtype, W, U](dst, src, vc, tid, stride)
         if tail > 0 and s == world - 1:
             _copy_scalar_tail(dst, src, vc * W, tail, tid, stride)
@@ -743,9 +744,9 @@ def _ar_twoshot_kernel[
     var my_tail = tail if rank == world - 1 else 0
     var uin = in_ptr.unsafe_offset(my_vs * W)
     var uout = out_ptr.unsafe_offset(my_vs * W)
-    var shard = regions[rank].unsafe_offset(shard_off).unsafe_bitcast[
-        Scalar[dtype]
-    ]()
+    var shard = (
+        regions[rank].unsafe_offset(shard_off).unsafe_bitcast[Scalar[dtype]]()
+    )
 
     # Slot pointers are formed by arithmetic inside the unrolled loop, never
     # held in an array: a stack array of `world` pointers is demoted to local
@@ -811,9 +812,9 @@ def _ar_twoshot_kernel[
             p -= world
         var vs = _vstart(p, q, rem)
         var vc = _vcount(p, q, rem)
-        var src = regions[p].unsafe_offset(shard_off).unsafe_bitcast[
-            Scalar[dtype]
-        ]()
+        var src = (
+            regions[p].unsafe_offset(shard_off).unsafe_bitcast[Scalar[dtype]]()
+        )
         var dst = out_ptr.unsafe_offset(vs * W)
         _copy_vec[dtype, W, U](dst, src, vc, tid, stride)
         if tail > 0 and p == world - 1:
@@ -870,9 +871,11 @@ def _ar_oneshot_kernel[
         var s = rank + i
         if s >= world:
             s -= world
-        var dst = regions[s].unsafe_offset(
-            push_off + slot_stride * rank
-        ).unsafe_bitcast[Scalar[dtype]]()
+        var dst = (
+            regions[s]
+            .unsafe_offset(push_off + slot_stride * rank)
+            .unsafe_bitcast[Scalar[dtype]]()
+        )
         _copy_vec[dtype, W, U](dst, in_ptr, nvec, tid, stride)
         if tail > 0:
             _copy_scalar_tail(dst, in_ptr, nvec * W, tail, tid, stride)
@@ -1036,9 +1039,13 @@ def _rs_stage_kernel[
         var cnt = _shard_cnt(n, per, s)
         if cnt <= 0:
             continue
-        var dst = regions[s].unsafe_offset(
-            push_off + slot_stride * (rank if rank < s else rank - 1)
-        ).unsafe_bitcast[Scalar[dtype]]()
+        var dst = (
+            regions[s]
+            .unsafe_offset(
+                push_off + slot_stride * (rank if rank < s else rank - 1)
+            )
+            .unsafe_bitcast[Scalar[dtype]]()
+        )
         _copy_span[dtype, W, U](
             dst, in_ptr.unsafe_offset(off), cnt, tid, stride
         )
@@ -1059,9 +1066,11 @@ def _rs_stage_kernel[
     if my_cnt <= 0:
         return
     var uin = in_ptr.unsafe_offset(my_off)
-    var shard = regions[rank].unsafe_offset(
-        out_off + my_off * esize
-    ).unsafe_bitcast[Scalar[dtype]]()
+    var shard = (
+        regions[rank]
+        .unsafe_offset(out_off + my_off * esize)
+        .unsafe_bitcast[Scalar[dtype]]()
+    )
     # Slot pointers are formed arithmetically, never held in a stack array:
     # such an array is demoted to local memory (MOCO-1431) and every payload
     # load becomes a generic-address `ld.v4.b32` plus an `ld.local.b64`.
@@ -1163,9 +1172,11 @@ def _ag_finish_kernel[
         var cnt = _shard_cnt(n, per, p)
         if cnt <= 0:
             continue
-        var src = regions[p].unsafe_offset(out_off + off * esize).unsafe_bitcast[
-            Scalar[dtype]
-        ]()
+        var src = (
+            regions[p]
+            .unsafe_offset(out_off + off * esize)
+            .unsafe_bitcast[Scalar[dtype]]()
+        )
         _copy_span_scaled[dtype, W, U](
             out_ptr.unsafe_offset(off), src, cnt, tid, stride, scale
         )
@@ -1358,8 +1369,9 @@ def _store_u64_kernel(dst: Pointer[UInt64, MutAnyOrigin], value: UInt64):
 
 @always_inline
 def _enqueue_cached[
-    declared_arg_types: TypeList[Trait=AnyType, ...], //,
-    func: def (*args: *declared_arg_types) thin -> None,
+    declared_arg_types: TypeList[Trait=AnyType, ...],
+    //,
+    func: def(* args: * declared_arg_types) thin -> None,
     *Ts: DevicePassable,
 ](
     ctx: DeviceContext,
@@ -1493,12 +1505,8 @@ def _launch_allreduce[
     var esize = size_of[dtype]()
     var nvec = numel // W
     var tail = numel - nvec * W
-    var ip = Pointer[Scalar[dtype], MutAnyOrigin](
-        unsafe_from_address=in_ptr
-    )
-    var op = Pointer[Scalar[dtype], MutAnyOrigin](
-        unsafe_from_address=out_ptr
-    )
+    var ip = Pointer[Scalar[dtype], MutAnyOrigin](unsafe_from_address=in_ptr)
+    var op = Pointer[Scalar[dtype], MutAnyOrigin](unsafe_from_address=out_ptr)
 
     if one_shot:
         # `world` slots, each a whole message, at the base of the arena. They
@@ -1509,9 +1517,7 @@ def _launch_allreduce[
         if world * slot > 2 * cap_bytes:
             raise Error("collectives: one-shot slots exceed the region")
         var push_off = arena
-        var blocks = min(
-            _AR_MAX_BLOCKS, max(1, (nvec + BLOCK - 1) // BLOCK)
-        )
+        var blocks = min(_AR_MAX_BLOCKS, max(1, (nvec + BLOCK - 1) // BLOCK))
         _enqueue_cached[_ar_oneshot_kernel[dtype, W, _UNROLL, NW]](
             ctx,
             stream,
@@ -1533,9 +1539,7 @@ def _launch_allreduce[
 
     var q = nvec // world
     var rem = nvec % world
-    var max_shard_elems = max(
-        (q + (1 if rem > 0 else 0)) * W, q * W + tail
-    )
+    var max_shard_elems = max((q + (1 if rem > 0 else 0)) * W, q * W + tail)
     var slot = _align_up(max_shard_elems * esize, 16)
     var push_off = arena
     var shard_off = arena + world * slot
@@ -1614,23 +1618,63 @@ def allreduce[
 
     if world == 8:
         _launch_allreduce[dtype, W, 8](
-            ctx, stream, rp, in_ptr, out_ptr, numel, world, rank, cap_bytes, scale,
-            generation, one_shot,
+            ctx,
+            stream,
+            rp,
+            in_ptr,
+            out_ptr,
+            numel,
+            world,
+            rank,
+            cap_bytes,
+            scale,
+            generation,
+            one_shot,
         )
     elif world == 4:
         _launch_allreduce[dtype, W, 4](
-            ctx, stream, rp, in_ptr, out_ptr, numel, world, rank, cap_bytes, scale,
-            generation, one_shot,
+            ctx,
+            stream,
+            rp,
+            in_ptr,
+            out_ptr,
+            numel,
+            world,
+            rank,
+            cap_bytes,
+            scale,
+            generation,
+            one_shot,
         )
     elif world == 2:
         _launch_allreduce[dtype, W, 2](
-            ctx, stream, rp, in_ptr, out_ptr, numel, world, rank, cap_bytes, scale,
-            generation, one_shot,
+            ctx,
+            stream,
+            rp,
+            in_ptr,
+            out_ptr,
+            numel,
+            world,
+            rank,
+            cap_bytes,
+            scale,
+            generation,
+            one_shot,
         )
     else:
         _launch_allreduce[dtype, W, 0](
-            ctx, stream, rp, in_ptr, out_ptr, numel, world, rank, cap_bytes, scale,
-            generation, one_shot,
+            ctx,
+            stream,
+            rp,
+            in_ptr,
+            out_ptr,
+            numel,
+            world,
+            rank,
+            cap_bytes,
+            scale,
+            generation,
+            one_shot,
         )
 
 
@@ -1640,7 +1684,8 @@ def _split_blocks[dtype: DType, W: Int](numel: Int, per: Int) -> Int:
     by the same one-wave rule the fused kernel uses (RESULTS.md block sweep).
     The two halves need not agree -- see ordering note 2 above the kernels."""
     var cap_blocks = (
-        _AR_BIG_BLOCKS if numel * size_of[dtype]() >= _AR_BIG_BYTES else _AR_MAX_BLOCKS
+        _AR_BIG_BLOCKS if numel * size_of[dtype]()
+        >= _AR_BIG_BYTES else _AR_MAX_BLOCKS
     )
     return min(cap_blocks, max(1, (per // W + 1 + BLOCK - 1) // BLOCK))
 
@@ -1787,23 +1832,59 @@ def reduce_scatter_stage[
     # self-rendezvous and the reduce copies the input into stage_out.
     if world == 8:
         _launch_rs_stage[dtype, W, 8](
-            ctx, stream, rp, in_ptr, numel, per, world, rank, cap_bytes,
-            generation, scale,
+            ctx,
+            stream,
+            rp,
+            in_ptr,
+            numel,
+            per,
+            world,
+            rank,
+            cap_bytes,
+            generation,
+            scale,
         )
     elif world == 4:
         _launch_rs_stage[dtype, W, 4](
-            ctx, stream, rp, in_ptr, numel, per, world, rank, cap_bytes,
-            generation, scale,
+            ctx,
+            stream,
+            rp,
+            in_ptr,
+            numel,
+            per,
+            world,
+            rank,
+            cap_bytes,
+            generation,
+            scale,
         )
     elif world == 2:
         _launch_rs_stage[dtype, W, 2](
-            ctx, stream, rp, in_ptr, numel, per, world, rank, cap_bytes,
-            generation, scale,
+            ctx,
+            stream,
+            rp,
+            in_ptr,
+            numel,
+            per,
+            world,
+            rank,
+            cap_bytes,
+            generation,
+            scale,
         )
     else:
         _launch_rs_stage[dtype, W, 0](
-            ctx, stream, rp, in_ptr, numel, per, world, rank, cap_bytes,
-            generation, scale,
+            ctx,
+            stream,
+            rp,
+            in_ptr,
+            numel,
+            per,
+            world,
+            rank,
+            cap_bytes,
+            generation,
+            scale,
         )
 
 
@@ -1847,22 +1928,58 @@ def allgather_finish[
     var rp = _region_ptrs(regions, rank, world)
     if world == 8:
         _launch_ag_finish[dtype, W, 8](
-            ctx, stream, rp, out_ptr, numel, per, world, rank, cap_bytes, scale,
+            ctx,
+            stream,
+            rp,
+            out_ptr,
+            numel,
+            per,
+            world,
+            rank,
+            cap_bytes,
+            scale,
             generation,
         )
     elif world == 4:
         _launch_ag_finish[dtype, W, 4](
-            ctx, stream, rp, out_ptr, numel, per, world, rank, cap_bytes, scale,
+            ctx,
+            stream,
+            rp,
+            out_ptr,
+            numel,
+            per,
+            world,
+            rank,
+            cap_bytes,
+            scale,
             generation,
         )
     elif world == 2:
         _launch_ag_finish[dtype, W, 2](
-            ctx, stream, rp, out_ptr, numel, per, world, rank, cap_bytes, scale,
+            ctx,
+            stream,
+            rp,
+            out_ptr,
+            numel,
+            per,
+            world,
+            rank,
+            cap_bytes,
+            scale,
             generation,
         )
     else:
         _launch_ag_finish[dtype, W, 0](
-            ctx, stream, rp, out_ptr, numel, per, world, rank, cap_bytes, scale,
+            ctx,
+            stream,
+            rp,
+            out_ptr,
+            numel,
+            per,
+            world,
+            rank,
+            cap_bytes,
+            scale,
             generation,
         )
 

--- a/torch_mojo_backend/distributed/mojoccl/collectives_kernels.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/collectives_kernels.mojo
@@ -271,7 +271,7 @@ def spin_timeout_ns() -> UInt64:
             if seconds > 0.0:
                 ns = UInt64(seconds * 1.0e9)
         except:
-            pass
+            ns = UInt64(DEFAULT_TIMEOUT_NS)  # unparsable: keep the default
     var slot = unsafe_alloc[UInt64](1)
     slot[unsafe_offset=0] = ns
     external_call["KGEN_CompilerRT_InsertGlobal", NoneType](

--- a/torch_mojo_backend/distributed/mojoccl/collectives_kernels.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/collectives_kernels.mojo
@@ -75,10 +75,13 @@
 # 3.6x slower.  Allgather is a local stage + a peer gather, which is already
 # the unicast minimum.
 #
-# Every spin is bounded (default 60 s, measured with the GPU's own timer --
-# never compared across GPUs).  On timeout the kernel stores a nonzero code
-# into its own region's error word (byte `error_offset()`) and returns instead
-# of hanging the node.
+# Every spin is bounded (`MOJOCCL_IB_TIMEOUT_S`, default 60 s, measured with
+# the GPU's own timer -- never compared across GPUs).  On timeout the kernel
+# stores a nonzero code into its own region's error word (byte
+# `error_offset()`) and returns instead of hanging the node.  The same spins
+# also leave early when the host raises the communicator's abort word
+# (`install_abort_word`, `ncclCommAbort`), which is what makes abort prompt
+# instead of costing a full deadline.
 #
 # Portability: NVIDIA and AMD share every line of the device code.  Ordering is
 # `Atomic[...].store[RELEASE]` / `load[ACQUIRE]` at default (system) scope,
@@ -133,7 +136,13 @@ comptime MAX_BLOCKS = 1024
 
 comptime _FLAG_BYTE_OFFSET = 4096
 """Start of the flag matrix inside the signal area (the first page holds the
-error word and stays free for future host-visible state)."""
+error word, the NVLS barrier counters and the abort-word pointer)."""
+
+comptime _ABORT_PTR_OFFSET = 256
+"""Header slot holding the DEVICE address of the communicator's pinned host
+abort word. Zero until `install_abort_word` publishes one, and every spin
+reads zero as "this region has no abort word". 64/128/192 are the NVLS
+barrier counters (nvls_kernels.mojo), so 256 is the first free line."""
 
 comptime _SIGNAL_BYTES = 128 * 1024
 """Signal-area size: 4 KiB header + MAX_BLOCKS*MAX_WORLD*8 B of flags = 68 KiB,
@@ -222,6 +231,14 @@ def error_offset() -> Int:
     return 0
 
 
+def abort_ptr_offset() -> Int:
+    """Byte offset, inside the signal area, of the abort-word pointer slot."""
+    comptime assert (
+        _ABORT_PTR_OFFSET + 8 <= _FLAG_BYTE_OFFSET
+    ), "the abort pointer must fit the header page"
+    return _ABORT_PTR_OFFSET
+
+
 @always_inline
 def _align_up(x: Int, a: Int) -> Int:
     return (x + a - 1) // a * a
@@ -248,6 +265,31 @@ def _flags(
 ) -> Pointer[UInt64, MutAnyOrigin]:
     """flags[block][writer_rank], row-major, MAX_WORLD columns."""
     return region.unsafe_offset(_FLAG_BYTE_OFFSET).unsafe_bitcast[UInt64]()
+
+
+@always_inline
+def _abort_raised(region: Pointer[UInt8, MutAnyOrigin]) -> Bool:
+    """Whether the host has raised this communicator's abort word.
+
+    Two dependent loads, and only from the slow path of a spin: the pinned
+    word's device address out of my own region's header (written once at
+    communicator init, never again) and then the word itself, which lives in
+    host memory and is where `ncclCommAbort` stores. A region with no abort
+    word installed reads address zero and never probes further.
+    """
+    var addr = Int(
+        region.unsafe_offset(_ABORT_PTR_OFFSET).unsafe_bitcast[UInt64]()[
+            unsafe_offset=0
+        ]
+    )
+    if addr == 0:
+        return False
+    return (
+        Atomic[DType.uint64].load[ordering = Ordering.ACQUIRE](
+            Pointer[UInt64, MutAnyOrigin](unsafe_from_address=addr)
+        )
+        != 0
+    )
 
 
 @always_inline
@@ -321,6 +363,9 @@ def _sync(
             spins += 1
             if spins >= _SPIN_CHECK:
                 spins = 0
+                if _abort_raised(regions[rank]):
+                    failed[unsafe_offset=0] = 1
+                    break
                 # Same-GPU timer difference only; never compared across GPUs.
                 if global_perf_counter_ns() - t0 > timeout_ns:
                     failed[unsafe_offset=0] = 1
@@ -1261,6 +1306,15 @@ def _zero_kernel(ptr: Pointer[UInt32, MutAnyOrigin], nwords: Int32):
         ptr[unsafe_offset=i] = 0
 
 
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(BLOCK))
+)
+@__name("ccl_store_u64")
+def _store_u64_kernel(dst: Pointer[UInt64, MutAnyOrigin], value: UInt64):
+    if global_idx.x == 0:
+        dst[unsafe_offset=0] = value
+
+
 # ===-------------------------------------------------------------------=== #
 # Cached launch (compile_function costs ~180 us per call; do it once)
 # ===-------------------------------------------------------------------=== #
@@ -1354,6 +1408,29 @@ def region_init(ctx: DeviceContext, region: Int) raises:
         (words + BLOCK - 1) // BLOCK,
         Pointer[UInt32, MutAnyOrigin](unsafe_from_address=region),
         Int32(words),
+    )
+    ctx.synchronize()
+
+
+def install_abort_word(ctx: DeviceContext, region: Int, dev_addr: Int) raises:
+    """Publish the device mapping of the communicator's pinned abort word in
+    this region's header, and block until it has landed.
+
+    The spins read it out of the region rather than take it as a kernel
+    argument because the launcher signatures below are fixed; the region is
+    raw driver memory, so the host cannot poke the slot directly. Called once
+    per arena, right after `region_init` zeroed it and before any peer can
+    reach the region.
+    """
+    _enqueue_cached[_store_u64_kernel](
+        ctx,
+        ctx.stream(),
+        "abortptr",
+        1,
+        Pointer[UInt64, MutAnyOrigin](
+            unsafe_from_address=region + _ABORT_PTR_OFFSET
+        ),
+        UInt64(dev_addr),
     )
     ctx.synchronize()
 

--- a/torch_mojo_backend/distributed/mojoccl/collectives_kernels.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/collectives_kernels.mojo
@@ -1,145 +1,903 @@
-# STAND-IN collectives kernel for mojoccl.
+# Intra-node collectives (allreduce / broadcast / allgather) over IPC-mapped
+# peer regions -- a Mojo replacement for the NCCL/RCCL calls a DDP
+# ProcessGroup makes inside one node.
 #
-# Correctness over speed, as directed: single-thread-block copy/reduce
-# kernels plus a page-sized signal area and a generation-based barrier built
-# on plain system-scope Atomic release/acquire (the flag pattern
-# proto/ipc_probe.mojo measured working, PASS at §5.3 of
-# docs/mojo_collectives_feasibility.md in the main worktree) -- not MAX's
-# comm.Signal, whose embedded Lamport region alone is ~24.75 MiB/rank, far
-# more than this needs. This file is expected to be replaced wholesale by
-# the production kernel (kernel/collectives_kernels.mojo, written in
-# parallel against this same function-signature contract); nothing outside
-# this file should need to change on that swap.
+# One library-owned device allocation per rank ("the region"), shared to the
+# peers by cuIpc/hipIpc (the plumbing layer owns that half), laid out as
 #
-# Region layout per rank (see mojoccl.mojo): [0, signal_bytes()) signal area,
-# then stage_in of cap_bytes, then stage_out of cap_bytes. `regions[r]` is
-# rank r's region base as mapped in THIS process (own allocation for
-# r == rank, an opened IPC mapping otherwise).
+#   [0, SIGNAL_BYTES)                            signal area, zero at creation
+#   [SIGNAL_BYTES, SIGNAL_BYTES + cap)           "stage_in"
+#   [SIGNAL_BYTES + cap, SIGNAL_BYTES + 2*cap)   "stage_out"
+#
+# The two cap-sized halves are library scratch; this file uses them as one
+# 2*cap byte staging arena and places its own sub-areas inside it, always
+# within those bounds:
+#   allreduce two-shot: `world` push slots of max-shard size, then the reduced
+#                       shard (`_launch_allreduce`, which raises if that ever
+#                       fails to fit -- it cannot, since world*shard ~ numel
+#                       <= cap and the arena is 2*cap);
+#   allreduce one-shot: two generation-parity halves of `world` whole-message
+#                       slots (used only when they fit);
+#   broadcast/allgather: the base of the arena, one message-sized stage per
+#                        rank (the caller chunks anything larger than cap).
+#
+# Why the data path looks like it does
+# ------------------------------------
+# The user's tensors live in MAX-allocated memory, which cannot be exported
+# with legacy IPC (measured: `cuIpcGetMemHandle` -> CUDA_ERROR_INVALID_VALUE),
+# so peers can only ever read the region.  The naive way to bridge that -- copy
+# the input into stage_in, run a direct reduce-scatter + all-gather over the
+# regions, copy the result back out -- costs two extra full HBM round trips
+# (+45 us on the 27 MiB GPT-2 bucket, measured in the feasibility study, 210 us
+# vs 165 us direct).  Both copies are avoidable:
+#
+#   phase 1  PUSH   every rank reads its own input straight out of user memory
+#                   and writes shard s into peer s's slot `rank` of the arena.
+#                   That write IS the copy-in, and it travels over NVLink.
+#   phase 2  REDUCE each rank sums the `world` contributions to its own shard
+#                   (its own straight from user memory, the peers' from the
+#                   arena), scales, and writes the result to the arena and to
+#                   its slice of the user output.
+#   phase 3  PULL   each rank reads the other ranks' reduced shards out of
+#                   their arenas directly into its user output.
+#
+# NVLink traffic is 2*(world-1)/world * bytes per GPU -- the unicast minimum,
+# the same as a direct reduce-scatter + all-gather -- and no byte is copied
+# locally that the direct kernel would not also copy.  The staging is free.
+#
+# Synchronisation
+# ---------------
+# The signal area holds one UInt64 flag per (block, writer rank).  Rank r's
+# block b publishes `generation * PHASES_PER_GEN + phase` into every peer's
+# flags[b][r] with a system-scope release store and then waits for its own
+# flags[b][p] to reach that value for every peer p.  Flag values are derived
+# from `generation`, never reset, and compared with `>=`, so a peer that is a
+# whole call ahead can never deadlock a peer that is behind and nothing has to
+# be cleared between calls.  Every collective opens with a start barrier, so
+# one rule covers the whole arena: no generation writes it until every rank has
+# finished reading the previous generation.  That is what lets collectives of
+# different kinds and sizes share the staging area -- see the invariant above
+# `_ar_twoshot_kernel`.
+#
+# Broadcast is scatter + all-gather, not "root stages, everyone reads": the
+# latter puts (world-1) x nbytes on the root's one outbound link and measured
+# 3.6x slower.  Allgather is a local stage + a peer gather, which is already
+# the unicast minimum.
+#
+# Every spin is bounded (default 60 s, measured with the GPU's own timer --
+# never compared across GPUs).  On timeout the kernel stores a nonzero code
+# into its own region's error word (byte `error_offset()`) and returns instead
+# of hanging the node.
+#
+# Portability: NVIDIA and AMD share every line of the device code.  Ordering is
+# `Atomic[...].store[RELEASE]` / `load[ACQUIRE]` at default (system) scope,
+# which lowers to `st.release.sys.global` / `ld.acquire.sys.global` on sm_90a
+# and to `global_store/load ... sc0 sc1` + `buffer_wbl2 sc0 sc1` / `buffer_inv
+# sc0 sc1` on gfx942 -- exactly the instructions RCCL relies on.  Blocks are
+# 256 threads (RCCL's gfx942 maximum) and every layout is wave-64 safe.
+#
+# Every host function takes the DeviceStream to enqueue on (production wraps
+# the caller's foreign cudaStream_t with `DeviceContext.create_external_stream`);
+# `ctx` is only the handle used to compile and cache the DeviceFunction.
+#
+# Builds for both targets:
+#   uv run --no-sync mojo build collectives_kernels.mojo --target-accelerator sm_90a
+#   uv run --no-sync mojo build collectives_kernels.mojo --target-accelerator gfx942
 
-from std.atomic import Atomic, Ordering
+from std.atomic import Atomic, Ordering, fence
 from std.builtin.device_passable import DevicePassable
+from std.collections import InlineArray
 from std.ffi import _get_global_or_null, external_call
+from std.gpu import (
+    MAX_THREADS_PER_BLOCK_METADATA,
+    block_idx,
+    global_idx,
+    grid_dim,
+    thread_idx,
+)
+from max.gpu.host import DeviceContext, DeviceStream
 from max.gpu.sync import barrier
-from std.gpu import thread_idx, MAX_THREADS_PER_BLOCK_METADATA
+from std.memory import AddressSpace, stack_allocation
 from std.memory.alloc import unsafe_alloc
-from std.sys import get_accum_type
+from std.sys import (
+    get_defined_int,
+    has_amd_gpu_accelerator,
+    size_of,
+)
 from std.time import global_perf_counter_ns
 from std.utils import StaticTuple
-from max.gpu.host import DeviceContext, DeviceStream, DeviceBuffer
 
-from driver import zero_bytes
+# ===-------------------------------------------------------------------=== #
+# Compile-time configuration
+# ===-------------------------------------------------------------------=== #
 
 comptime MAX_WORLD = 8
+"""Largest world size a single region can address (one flag column per rank)."""
+
 comptime BLOCK = 256
-# One page: [0] error word (UInt64), [8] barrier counter (UInt64), padding.
-comptime SIG_BYTES = 4096
-comptime ERR_OFF = 0
-comptime BAR_OFF = 8
-comptime BARRIER_TIMEOUT_NS: UInt64 = 30_000_000_000
+"""Threads per block. 256 is RCCL's gfx942 maximum and is wave-64 safe."""
+
+comptime MAX_BLOCKS = 1024
+"""Flag rows in the signal area; every grid this file launches is <= this."""
+
+comptime _FLAG_BYTE_OFFSET = 4096
+"""Start of the flag matrix inside the signal area (the first page holds the
+error word and stays free for future host-visible state)."""
+
+comptime _SIGNAL_BYTES = 128 * 1024
+"""Signal-area size: 4 KiB header + MAX_BLOCKS*MAX_WORLD*8 B of flags = 68 KiB,
+rounded to 128 KiB. Two orders of magnitude below MAX's 24.75 MiB `Signal`."""
+
+comptime PHASES_PER_GEN = 8
+"""Flag values are `generation * PHASES_PER_GEN + phase`; this bounds the
+number of syncs one collective call may perform (three, for the two-shot
+allreduce). Small on purpose: the flag is a UInt64 and the generation counter
+never resets, so headroom costs nothing, but a tight bound documents the
+contract."""
+
+comptime DEFAULT_TIMEOUT_NS = 60_000_000_000
+"""Spin-loop deadline (60 s), measured with this GPU's own timer."""
+
+comptime _SPIN_CHECK = 4096
+"""Spins between two reads of the (not free) global timer."""
+
+# The tuning constants below carry a `-D` override so the benchmark harness
+# can sweep them without editing this file; the defaults are what a plain
+# build (and therefore production) uses.
+
+comptime _UNROLL = get_defined_int["ccl_unroll", 4]()
+"""16-byte vectors in flight per thread in the NVLink copy loops."""
+
+comptime _ONESHOT_MAX_BYTES = get_defined_int["ccl_oneshot_max", 512 * 1024]()
+"""At or below this an allreduce uses the one-shot path: (world-1)x the NVLink
+bytes but one sync instead of two, which wins while the transfer is
+latency-bound. Measured crossover on 8xH100/NVSwitch (us, one-shot vs
+two-shot): 128 KiB 9.3/19.0, 256 KiB 12.3/19.3, 512 KiB 18.1/19.8,
+1 MiB 30.0/20.5 -- so the crossover sits just above 512 KiB. The path is taken
+only if 2*world message-sized slots also fit the region."""
+
+comptime _AR_MAX_BLOCKS = get_defined_int["ccl_ar_blocks", 216]()
+"""Grid cap for allreduce, fitted on H100 (132 SMs) / NVSwitch; see the block
+sweep in RESULTS.md. Not portable: re-fit it on another card."""
+
+comptime _AR_BIG_BYTES = get_defined_int["ccl_ar_big_bytes", 64 * 1024 * 1024]()
+"""Above this message size the allreduce grid drops to `_AR_BIG_BLOCKS`."""
+
+comptime _AR_BIG_BLOCKS = get_defined_int["ccl_ar_big_blocks", 128]()
+"""Grid cap for large allreduces. A grid that fits in one wave of an H100's
+132 SMs measured 8% faster at 512 MiB than 216 blocks (2825 vs 3065 us) and
+the same at 168 MiB, because the barrier is per block index: with more blocks
+than SMs the second wave runs the whole collective after the first, on fewer
+SMs. Fitted on H100 (132 SMs); re-fit on another card."""
+
+comptime _COPY_MAX_BLOCKS = get_defined_int["ccl_copy_blocks", 432]()
+"""Grid cap for the pure-copy collectives (broadcast / allgather)."""
+
+# Error codes written to the region's error word (`error_offset()`).
+comptime ERR_ALLREDUCE_SYNC = 1
+comptime ERR_BROADCAST_SYNC = 2
+comptime ERR_ALLGATHER_SYNC = 3
+
+
+# ===-------------------------------------------------------------------=== #
+# Region geometry (host + device agree; every rank computes the same numbers)
+# ===-------------------------------------------------------------------=== #
 
 
 def signal_bytes() -> Int:
-    return SIG_BYTES
+    """Bytes of signal/flag area at the base of every rank's region."""
+    comptime assert (
+        _AR_MAX_BLOCKS <= MAX_BLOCKS
+        and _AR_BIG_BLOCKS <= MAX_BLOCKS
+        and _COPY_MAX_BLOCKS <= MAX_BLOCKS
+    ), "grid caps must fit the flag matrix"
+    comptime assert BLOCK >= MAX_WORLD, "the sync needs one thread per peer"
+    comptime assert (
+        _FLAG_BYTE_OFFSET + MAX_BLOCKS * MAX_WORLD * 8 <= _SIGNAL_BYTES
+    ), "the flag matrix must fit the signal area"
+    return _SIGNAL_BYTES
 
 
 def error_offset() -> Int:
-    return ERR_OFF
+    """Byte offset, inside the signal area, of the UInt64 error word.
 
-
-def region_init(ctx: DeviceContext, region: Int) raises:
-    """Zeros the signal area of a freshly allocated region.
-
-    No `stream` parameter (unlike the collectives below): this runs once per
-    rank at communicator creation, on `ctx`'s own queue, before any user
-    stream touches the region -- zero_bytes blocks, so every later
-    collective (issued on the caller's external stream) is guaranteed to see
-    the zeroed area.
+    Zero means "no error". A nonzero value is `code * 1_000_000 + phase`, with
+    `code` one of the `ERR_*` constants above; it means some block gave up
+    waiting for a peer and the collective's result is undefined from that
+    generation on.
     """
-    zero_bytes(ctx, region, SIG_BYTES)
+    return 0
 
 
 @always_inline
-def _err_ptr(region: Int64) -> Pointer[UInt64, MutAnyOrigin]:
-    return Pointer[UInt64, MutAnyOrigin](
-        unsafe_from_address=Int(region) + ERR_OFF
-    )
+def _align_up(x: Int, a: Int) -> Int:
+    return (x + a - 1) // a * a
 
 
 @always_inline
-def _bar_ptr(region: Int64) -> Pointer[UInt64, MutAnyOrigin]:
-    return Pointer[UInt64, MutAnyOrigin](
-        unsafe_from_address=Int(region) + BAR_OFF
-    )
+def _flag_target(generation: Int, phase: Int) -> UInt64:
+    """The flag value that marks `phase` of `generation`.
+
+    Strictly increasing in (generation, phase), never reset, so waiters compare
+    with `>=` and a peer running ahead is harmless.
+    """
+    return UInt64(generation) * UInt64(PHASES_PER_GEN) + UInt64(phase)
+
+
+# ===-------------------------------------------------------------------=== #
+# Device-side primitives
+# ===-------------------------------------------------------------------=== #
 
 
 @always_inline
-def _gen_barrier(
-    regions: StaticTuple[Int64, MAX_WORLD],
-    rank: Int32,
-    world: Int32,
-    target: UInt64,
+def _flags(
+    region: Pointer[UInt8, MutAnyOrigin],
+) -> Pointer[UInt64, MutAnyOrigin]:
+    """flags[block][writer_rank], row-major, MAX_WORLD columns."""
+    return region.unsafe_offset(_FLAG_BYTE_OFFSET).unsafe_bitcast[UInt64]()
+
+
+@always_inline
+def _record_error(
+    regions: InlineArray[Pointer[UInt8, MutAnyOrigin], MAX_WORLD],
+    rank: Int,
+    code: Int,
+    phase: Int,
 ):
-    """A full, symmetric cross-rank barrier: every participant publishes
-    `target` into its own region and waits for every OTHER participant to
-    reach at least `target` too, before any of them may proceed.
-
-    Symmetric on purpose (publish AND wait, both phases of every call): a
-    one-way "publish and move on" would let a fast rank start overwriting
-    its stage buffers for the NEXT generation while a slow peer is still
-    reading THIS generation's data out of them. `target` is derived from the
-    caller-supplied generation counter, strictly increasing per
-    communicator, so no double-buffering of the counter itself is needed --
-    every call in the process's lifetime gets a fresh target.
-    """
+    """Publish a failure in my own region's error word (host-readable)."""
     if thread_idx.x == 0:
-        Atomic[DType.uint64].store[ordering=Ordering.RELEASE](
-            _bar_ptr(regions[Int(rank)]), target
+        Atomic[DType.uint64].store[ordering = Ordering.RELEASE](
+            regions[rank].unsafe_bitcast[UInt64](),
+            UInt64(code) * 1_000_000 + UInt64(phase),
         )
-    if Int(thread_idx.x) < Int(world):
-        var peer_ptr = _bar_ptr(regions[Int(thread_idx.x)])
-        var t0 = global_perf_counter_ns()
-        while (
-            Atomic[DType.uint64].load[ordering=Ordering.ACQUIRE](peer_ptr)
-            < target
-        ):
-            if global_perf_counter_ns() - t0 > BARRIER_TIMEOUT_NS:
-                Atomic[DType.uint64].store[ordering=Ordering.RELEASE](
-                    _err_ptr(regions[Int(rank)]), UInt64(1)
-                )
-                break
+
+
+@always_inline
+def _sync(
+    regions: InlineArray[Pointer[UInt8, MutAnyOrigin], MAX_WORLD],
+    world: Int,
+    rank: Int,
+    target: UInt64,
+    t0: UInt64,
+    timeout_ns: UInt64,
+) -> Bool:
+    """Block-scoped barrier across the same block index on every rank.
+
+    Thread `p` (p < world) publishes `target` into peer p's flags[bid][rank]
+    with a release store -- which orders every payload write this block made
+    into peer memory before the flag becomes visible -- then waits for peer p's
+    flag in my own region to reach `target`.
+
+    Blocks are matched by index: every collective in this file gives block b of
+    every rank exactly the same grid-stride slice of the index space, so block b
+    only ever consumes bytes block b of a peer produced.
+
+    Returns False if any participating thread hit the deadline; the whole block
+    learns that through shared memory so no thread is left inside a `barrier()`.
+    """
+    var failed = stack_allocation[
+        1, DType.uint32, address_space = AddressSpace.SHARED
+    ]()
+    if thread_idx.x == 0:
+        failed[unsafe_offset=0] = 0
+    comptime if has_amd_gpu_accelerator():
+        # gfx942's `s_barrier` is emitted with `s_waitcnt lgkmcnt(0)` only, so
+        # another wave's payload stores can still be in flight when one thread
+        # publishes the flag; RCCL puts `vmcnt(0)` inside its block barrier for
+        # exactly this reason (rccl:src/device/prims_simple.h:193-210), and a
+        # release fence in every thread is the portable spelling (it lowers to
+        # `s_waitcnt vmcnt(0)` + `buffer_wbl2 sc0 sc1`). NVIDIA needs nothing:
+        # `bar.sync` is a CTA-scope fence and the release store below is
+        # cumulative over it, which is what NCCL's postPeer relies on.
+        fence[ordering = Ordering.RELEASE]()
     barrier()
 
+    if Int(thread_idx.x) < world:
+        var peer = Int(thread_idx.x)
+        var bid = Int(block_idx.x)
+        Atomic[DType.uint64].store[ordering = Ordering.RELEASE](
+            _flags(regions[peer]).unsafe_offset(bid * MAX_WORLD + rank),
+            target,
+        )
+        var mine = _flags(regions[rank]).unsafe_offset(bid * MAX_WORLD + peer)
+        var spins = 0
+        while (
+            Atomic[DType.uint64].load[ordering = Ordering.ACQUIRE](mine)
+            < target
+        ):
+            spins += 1
+            if spins >= _SPIN_CHECK:
+                spins = 0
+                # Same-GPU timer difference only; never compared across GPUs.
+                if global_perf_counter_ns() - t0 > timeout_ns:
+                    failed[unsafe_offset=0] = 1
+                    break
+    barrier()
+    return failed[unsafe_offset=0] == 0
+
 
 @always_inline
-def _enqueue_cached_stream[
-    declared_arg_types: TypeList[Trait=AnyType, ...],
-    //,
-    func: def(* args: * declared_arg_types) thin -> None,
+def _copy_vec[
+    dtype: DType, W: Int, U: Int
+](
+    dst: Pointer[Scalar[dtype], MutAnyOrigin],
+    src: Pointer[Scalar[dtype], MutAnyOrigin],
+    nvec: Int,
+    tid: Int,
+    stride: Int,
+):
+    """Grid-stride copy of `nvec` 16-byte vectors, `U` of them in flight.
+
+    Both pointers must be 16-byte aligned, which every address this file forms
+    is (region sub-areas are multiples of 16 B from a page-aligned base; user
+    pointers come from MAX's allocator; shard starts are multiples of W).
+    """
+    var v = tid
+    var lim = nvec - (U - 1) * stride
+    while v < lim:
+        var tmp = InlineArray[SIMD[dtype, W], U](uninitialized=True)
+        comptime for u in range(U):
+            tmp[u] = src.unsafe_load[width=W, alignment=16](
+                (v + u * stride) * W
+            )
+        comptime for u in range(U):
+            dst.unsafe_store[width=W, alignment=16](
+                (v + u * stride) * W, tmp[u]
+            )
+        v += U * stride
+    while v < nvec:
+        dst.unsafe_store[width=W, alignment=16](
+            v * W, src.unsafe_load[width=W, alignment=16](v * W)
+        )
+        v += stride
+
+
+@always_inline
+def _copy_scalar_tail[
+    dtype: DType
+](
+    dst: Pointer[Scalar[dtype], MutAnyOrigin],
+    src: Pointer[Scalar[dtype], MutAnyOrigin],
+    base: Int,
+    count: Int,
+    tid: Int,
+    stride: Int,
+):
+    """The `numel % W` elements a 16-byte vector loop cannot cover."""
+    for i in range(tid, count, stride):
+        dst[unsafe_offset = base + i] = src[unsafe_offset = base + i]
+
+
+@always_inline
+def _copy_bytes[
+    U: Int
+](
+    dst: Pointer[UInt8, MutAnyOrigin],
+    src: Pointer[UInt8, MutAnyOrigin],
+    nbytes: Int,
+    tid: Int,
+    stride: Int,
+):
+    """dtype-agnostic byte copy: 16-byte vectors when both sides allow it.
+
+    Both paths walk the *same* 16-byte chunks in the same grid-stride order, so
+    the chunk -> block mapping does not depend on which path a given call takes.
+    That matters: for a byte collective the writer and the reader are different
+    ranks looking at different pointer pairs (the root's `send` and a peer's
+    `recv`), so they can disagree about alignment, and the per-block barrier
+    only orders block b against block b. A fallback that walked single bytes
+    would let block 3 read a chunk block 0 wrote.
+    """
+    var nvec = nbytes // 16
+    if (Int(dst) | Int(src)) % 16 == 0:
+        _copy_vec[DType.uint8, 16, U](dst, src, nvec, tid, stride)
+    else:
+        for v in range(tid, nvec, stride):
+            comptime for j in range(16):
+                dst[unsafe_offset = v * 16 + j] = src[unsafe_offset = v * 16 + j]
+    _copy_scalar_tail(dst, src, nvec * 16, nbytes - nvec * 16, tid, stride)
+
+
+# ===-------------------------------------------------------------------=== #
+# Shard partition. Every rank derives the same table from (numel, world).
+# ===-------------------------------------------------------------------=== #
+
+
+@always_inline
+def _vstart(s: Int, q: Int, rem: Int) -> Int:
+    """First 16-byte vector of rank `s`'s shard."""
+    return s * q + min(s, rem)
+
+
+@always_inline
+def _vcount(s: Int, q: Int, rem: Int) -> Int:
+    """16-byte vectors in rank `s`'s shard (the `numel % W` scalar tail, if
+    any, belongs to the last rank and is counted separately)."""
+    return q + (1 if s < rem else 0)
+
+
+# ===-------------------------------------------------------------------=== #
+# Allreduce -- two-shot (push / reduce / pull)
+# ===-------------------------------------------------------------------=== #
+#
+# Buffer-reuse invariant. Every collective in this file opens with a start
+# barrier, so the whole arena obeys one rule:
+#
+#     no rank writes an arena byte for generation g until every rank has
+#     finished reading arena bytes for generation g-1
+#
+# (a rank reaches generation g's start barrier only after its own generation
+# g-1 work has retired, and nobody passes that barrier until all have arrived).
+# That is what lets collectives of different kinds and sizes share the arena
+# and interleave freely -- which they do: DDP issues a 4-byte one-shot
+# allreduce and an 8-byte allgather in between 27 MiB two-shot allreduces, and
+# their staging layouts overlap. Dropping the start barrier saves ~2.5 us and
+# is only sound for a run of identically shaped collectives; it was measured
+# (166.4 us vs 169 us at 27 MiB) and rejected as a correctness trap.
+#
+# Within a call the two data syncs order the three phases:
+#     start(g) < push(g) < A(g) < reduce(g) < B(g) < pull(g) < start(g+1)
+# and a sync is a full N-way rendezvous of matching block indices. In-place
+# (in_ptr == out_ptr) is safe because the phases are block-matched: block b
+# writes exactly the elements block b read.
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(BLOCK))
+)
+@__name(t"ccl_allreduce_push_reduce_pull_{dtype}_w{NW}")
+def _ar_twoshot_kernel[
+    dtype: DType, W: Int, U: Int, NW: Int
+](
+    regions: InlineArray[Pointer[UInt8, MutAnyOrigin], MAX_WORLD],
+    in_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    numel: Int64,
+    slot_stride_b: Int64,
+    push_off_b: Int64,
+    shard_off_b: Int64,
+    world_i: Int32,
+    rank_i: Int32,
+    flag_base: UInt64,
+    scale: Float32,
+    timeout_ns: UInt64,
+):
+    comptime accum = DType.float32 if (
+        dtype == DType.bfloat16 or dtype == DType.float16
+    ) else dtype
+    var t0 = global_perf_counter_ns()
+    var world = NW if NW > 0 else Int(world_i)
+    var rank = Int(rank_i)
+    var tid = Int(global_idx.x)
+    var stride = Int(grid_dim.x) * BLOCK
+    var n = Int(numel)
+    var nvec = n // W
+    var q = nvec // world
+    var rem = nvec % world
+    var tail = n - nvec * W
+    var slot_stride = Int(slot_stride_b)
+    var push_off = Int(push_off_b)
+    var shard_off = Int(shard_off_b)
+
+    # --- phase 0: start barrier -- nobody writes the arena for generation g
+    # until every rank has finished reading it for generation g-1 ------------
+    if not _sync(regions, world, rank, flag_base, t0, timeout_ns):
+        _record_error(regions, rank, ERR_ALLREDUCE_SYNC, 0)
+        return
+
+    # --- phase 1: push shard s of my input into peer s's slot `rank` --------
+    for i in range(1, world):
+        var s = rank + i
+        if s >= world:
+            s -= world
+        var src = in_ptr.unsafe_offset(_vstart(s, q, rem) * W)
+        var vc = _vcount(s, q, rem)
+        var dst = regions[s].unsafe_offset(
+            push_off + slot_stride * rank
+        ).unsafe_bitcast[Scalar[dtype]]()
+        _copy_vec[dtype, W, U](dst, src, vc, tid, stride)
+        if tail > 0 and s == world - 1:
+            _copy_scalar_tail(dst, src, vc * W, tail, tid, stride)
+
+    if not _sync(regions, world, rank, flag_base + 1, t0, timeout_ns):
+        _record_error(regions, rank, ERR_ALLREDUCE_SYNC, 1)
+        return
+
+    # --- phase 2: reduce my shard, to the arena and to the user output ------
+    var my_vs = _vstart(rank, q, rem)
+    var my_vc = _vcount(rank, q, rem)
+    var my_tail = tail if rank == world - 1 else 0
+    var uin = in_ptr.unsafe_offset(my_vs * W)
+    var uout = out_ptr.unsafe_offset(my_vs * W)
+    var shard = regions[rank].unsafe_offset(shard_off).unsafe_bitcast[
+        Scalar[dtype]
+    ]()
+
+    # Slot pointers are formed by arithmetic inside the unrolled loop, never
+    # held in an array: a stack array of `world` pointers is demoted to local
+    # memory (MOCO-1431) and turns every payload load into a generic-address
+    # `ld.v4.b32` plus an `ld.local.b64` of the pointer itself.
+    var slots = regions[rank].unsafe_offset(push_off)
+
+    for v in range(tid, my_vc, stride):
+        var acc = uin.unsafe_load[width=W, alignment=16](v * W).cast[accum]()
+        comptime if NW > 0:
+            comptime for j in range(1, NW):
+                var p = rank + j
+                if p >= NW:
+                    p -= NW
+                acc += (
+                    slots.unsafe_offset(slot_stride * p)
+                    .unsafe_bitcast[Scalar[dtype]]()
+                    .unsafe_load[width=W, alignment=16](v * W)
+                    .cast[accum]()
+                )
+        else:
+            for j in range(1, world):
+                var p = rank + j
+                if p >= world:
+                    p -= world
+                acc += (
+                    slots.unsafe_offset(slot_stride * p)
+                    .unsafe_bitcast[Scalar[dtype]]()
+                    .unsafe_load[width=W, alignment=16](v * W)
+                    .cast[accum]()
+                )
+        comptime if accum.is_floating_point():
+            acc *= SIMD[accum, W](scale.cast[accum]())
+        var res = acc.cast[dtype]()
+        shard.unsafe_store[width=W, alignment=16](v * W, res)
+        uout.unsafe_store[width=W, alignment=16](v * W, res)
+
+    for i in range(tid, my_tail, stride):
+        var k = my_vc * W + i
+        var a = uin[unsafe_offset=k].cast[accum]()
+        for j in range(1, world):
+            var p = rank + j
+            if p >= world:
+                p -= world
+            a += (
+                slots.unsafe_offset(slot_stride * p)
+                .unsafe_bitcast[Scalar[dtype]]()[unsafe_offset=k]
+                .cast[accum]()
+            )
+        comptime if accum.is_floating_point():
+            a *= scale.cast[accum]()
+        shard[unsafe_offset=k] = a.cast[dtype]()
+        uout[unsafe_offset=k] = a.cast[dtype]()
+
+    if not _sync(regions, world, rank, flag_base + 2, t0, timeout_ns):
+        _record_error(regions, rank, ERR_ALLREDUCE_SYNC, 2)
+        return
+
+    # --- phase 3: pull the peers' reduced shards into the user output -------
+    for i in range(1, world):
+        var p = rank + i
+        if p >= world:
+            p -= world
+        var vs = _vstart(p, q, rem)
+        var vc = _vcount(p, q, rem)
+        var src = regions[p].unsafe_offset(shard_off).unsafe_bitcast[
+            Scalar[dtype]
+        ]()
+        var dst = out_ptr.unsafe_offset(vs * W)
+        _copy_vec[dtype, W, U](dst, src, vc, tid, stride)
+        if tail > 0 and p == world - 1:
+            _copy_scalar_tail(dst, src, vc * W, tail, tid, stride)
+
+
+# ===-------------------------------------------------------------------=== #
+# Allreduce -- one-shot (push whole input / reduce), for small messages
+# ===-------------------------------------------------------------------=== #
+#
+# (world-1)x the NVLink bytes of the two-shot path but one data sync instead of
+# two, which wins while latency dominates: measured 9.3 us against 19.0 us at
+# 128 KiB, with the crossover just above 512 KiB.
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(BLOCK))
+)
+@__name(t"ccl_allreduce_oneshot_{dtype}_w{NW}")
+def _ar_oneshot_kernel[
+    dtype: DType, W: Int, U: Int, NW: Int
+](
+    regions: InlineArray[Pointer[UInt8, MutAnyOrigin], MAX_WORLD],
+    in_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    numel: Int64,
+    slot_stride_b: Int64,
+    push_off_b: Int64,
+    world_i: Int32,
+    rank_i: Int32,
+    flag_base: UInt64,
+    scale: Float32,
+    timeout_ns: UInt64,
+):
+    comptime accum = DType.float32 if (
+        dtype == DType.bfloat16 or dtype == DType.float16
+    ) else dtype
+    var t0 = global_perf_counter_ns()
+    var world = NW if NW > 0 else Int(world_i)
+    var rank = Int(rank_i)
+    var tid = Int(global_idx.x)
+    var stride = Int(grid_dim.x) * BLOCK
+    var n = Int(numel)
+    var nvec = n // W
+    var tail = n - nvec * W
+    var slot_stride = Int(slot_stride_b)
+    var push_off = Int(push_off_b)
+
+    if not _sync(regions, world, rank, flag_base, t0, timeout_ns):
+        _record_error(regions, rank, ERR_ALLREDUCE_SYNC, 0)
+        return
+
+    for i in range(1, world):
+        var s = rank + i
+        if s >= world:
+            s -= world
+        var dst = regions[s].unsafe_offset(
+            push_off + slot_stride * rank
+        ).unsafe_bitcast[Scalar[dtype]]()
+        _copy_vec[dtype, W, U](dst, in_ptr, nvec, tid, stride)
+        if tail > 0:
+            _copy_scalar_tail(dst, in_ptr, nvec * W, tail, tid, stride)
+
+    if not _sync(regions, world, rank, flag_base + 1, t0, timeout_ns):
+        _record_error(regions, rank, ERR_ALLREDUCE_SYNC, 1)
+        return
+
+    var slots = regions[rank].unsafe_offset(push_off)
+
+    for v in range(tid, nvec, stride):
+        var acc = in_ptr.unsafe_load[width=W, alignment=16](v * W).cast[accum]()
+        comptime if NW > 0:
+            comptime for j in range(1, NW):
+                var p = rank + j
+                if p >= NW:
+                    p -= NW
+                acc += (
+                    slots.unsafe_offset(slot_stride * p)
+                    .unsafe_bitcast[Scalar[dtype]]()
+                    .unsafe_load[width=W, alignment=16](v * W)
+                    .cast[accum]()
+                )
+        else:
+            for j in range(1, world):
+                var p = rank + j
+                if p >= world:
+                    p -= world
+                acc += (
+                    slots.unsafe_offset(slot_stride * p)
+                    .unsafe_bitcast[Scalar[dtype]]()
+                    .unsafe_load[width=W, alignment=16](v * W)
+                    .cast[accum]()
+                )
+        comptime if accum.is_floating_point():
+            acc *= SIMD[accum, W](scale.cast[accum]())
+        out_ptr.unsafe_store[width=W, alignment=16](v * W, acc.cast[dtype]())
+
+    for i in range(tid, tail, stride):
+        var k = nvec * W + i
+        var a = in_ptr[unsafe_offset=k].cast[accum]()
+        for j in range(1, world):
+            var p = rank + j
+            if p >= world:
+                p -= world
+            a += (
+                slots.unsafe_offset(slot_stride * p)
+                .unsafe_bitcast[Scalar[dtype]]()[unsafe_offset=k]
+                .cast[accum]()
+            )
+        comptime if accum.is_floating_point():
+            a *= scale.cast[accum]()
+        out_ptr[unsafe_offset=k] = a.cast[dtype]()
+
+
+# ===-------------------------------------------------------------------=== #
+# Broadcast and allgather -- one peer-copy kernel each, chunked to `cap`
+# ===-------------------------------------------------------------------=== #
+#
+# Both walk the buffer in chunks of `cap` bytes and alternate between the two
+# cap-sized halves of the arena, so the write of chunk c races only against
+# reads of chunk c-1 (the other half); reads of chunk c-2 are ordered before
+# it by the sync of chunk c-1. A leading sync separates the first two chunks
+# from the previous call's reads.
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(BLOCK))
+)
+@__name("ccl_broadcast_scatter_gather_bytes")
+def _bcast_kernel[
+    U: Int
+](
+    regions: InlineArray[Pointer[UInt8, MutAnyOrigin], MAX_WORLD],
+    send: Pointer[UInt8, MutAnyOrigin],
+    recv: Pointer[UInt8, MutAnyOrigin],
+    nbytes: Int64,
+    stage_off_b: Int64,
+    world_i: Int32,
+    rank_i: Int32,
+    root_i: Int32,
+    flag_base: UInt64,
+    timeout_ns: UInt64,
+):
+    """Broadcast as scatter + all-gather.
+
+    The obvious design -- root stages the whole message, everybody reads it --
+    puts `(world-1) * nbytes` on the root's single outbound link and measured
+    552 us on 27 MiB where the fabric could do 150. Instead the root scatters
+    shard p into rank p's stage (nbytes out of the root, spread over the peers)
+    and every other rank gathers the `world` shards, so the read side is a
+    permutation too and no link carries more than nbytes.
+
+    Out-of-place capable (ncclBroadcast): the root reads `send`, everyone
+    writes `recv`, and the root copies `send` to `recv` locally when they
+    differ (cheaper than gathering its own message back over NVLink).
+    """
+    var t0 = global_perf_counter_ns()
+    var world = Int(world_i)
+    var rank = Int(rank_i)
+    var root = Int(root_i)
+    var tid = Int(global_idx.x)
+    var stride = Int(grid_dim.x) * BLOCK
+    var n = Int(nbytes)
+    var stage_off = Int(stage_off_b)
+    var nv = n // 16
+    var q = nv // world
+    var rem = nv % world
+    var mtail = n - nv * 16
+
+    if not _sync(regions, world, rank, flag_base, t0, timeout_ns):
+        _record_error(regions, rank, ERR_BROADCAST_SYNC, 0)
+        return
+
+    if rank == root:
+        for i in range(world):
+            var p = root + i
+            if p >= world:
+                p -= world
+            var vc = _vcount(p, q, rem)
+            _copy_bytes[U](
+                regions[p].unsafe_offset(stage_off),
+                send.unsafe_offset(_vstart(p, q, rem) * 16),
+                vc * 16 + (mtail if p == world - 1 else 0),
+                tid,
+                stride,
+            )
+        if Int(send) != Int(recv):
+            _copy_bytes[U](recv, send, n, tid, stride)
+
+    if not _sync(regions, world, rank, flag_base + 1, t0, timeout_ns):
+        _record_error(regions, rank, ERR_BROADCAST_SYNC, 1)
+        return
+
+    if rank != root:
+        for i in range(world):
+            var p = rank + i
+            if p >= world:
+                p -= world
+            var vc = _vcount(p, q, rem)
+            _copy_bytes[U](
+                recv.unsafe_offset(_vstart(p, q, rem) * 16),
+                regions[p].unsafe_offset(stage_off),
+                vc * 16 + (mtail if p == world - 1 else 0),
+                tid,
+                stride,
+            )
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(BLOCK))
+)
+@__name("ccl_allgather_bytes")
+def _allgather_kernel[
+    U: Int
+](
+    regions: InlineArray[Pointer[UInt8, MutAnyOrigin], MAX_WORLD],
+    in_ptr: Pointer[UInt8, MutAnyOrigin],
+    out_ptr: Pointer[UInt8, MutAnyOrigin],
+    nbytes: Int64,
+    stride_b: Int64,
+    stage_off_b: Int64,
+    world_i: Int32,
+    rank_i: Int32,
+    flag_base: UInt64,
+    timeout_ns: UInt64,
+):
+    """Local stage + peer gather -- already the unicast minimum: `nbytes` of
+    local copy and `(world-1)*nbytes` of peer reads per GPU.
+
+    Rank r's contribution lands at `out_ptr + r*stride_b`; `stride_b` is the
+    output layout's true per-rank size, which differs from `nbytes` when the
+    caller splits one rank's contribution across several calls.
+    """
+    var t0 = global_perf_counter_ns()
+    var world = Int(world_i)
+    var rank = Int(rank_i)
+    var tid = Int(global_idx.x)
+    var stride = Int(grid_dim.x) * BLOCK
+    var n = Int(nbytes)
+    var out_stride = Int(stride_b)
+    var stage_off = Int(stage_off_b)
+
+    if not _sync(regions, world, rank, flag_base, t0, timeout_ns):
+        _record_error(regions, rank, ERR_ALLGATHER_SYNC, 0)
+        return
+
+    _copy_bytes[U](
+        regions[rank].unsafe_offset(stage_off), in_ptr, n, tid, stride
+    )
+    _copy_bytes[U](
+        out_ptr.unsafe_offset(rank * out_stride), in_ptr, n, tid, stride
+    )
+
+    if not _sync(regions, world, rank, flag_base + 1, t0, timeout_ns):
+        _record_error(regions, rank, ERR_ALLGATHER_SYNC, 1)
+        return
+
+    for i in range(1, world):
+        var p = rank + i
+        if p >= world:
+            p -= world
+        _copy_bytes[U](
+            out_ptr.unsafe_offset(p * out_stride),
+            regions[p].unsafe_offset(stage_off),
+            n,
+            tid,
+            stride,
+        )
+
+
+# ===-------------------------------------------------------------------=== #
+# region_init
+# ===-------------------------------------------------------------------=== #
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(BLOCK))
+)
+@__name("ccl_zero_signal_area")
+def _zero_kernel(ptr: Pointer[UInt32, MutAnyOrigin], nwords: Int32):
+    var i = Int(global_idx.x)
+    if i < Int(nwords):
+        ptr[unsafe_offset=i] = 0
+
+
+# ===-------------------------------------------------------------------=== #
+# Cached launch (compile_function costs ~180 us per call; do it once)
+# ===-------------------------------------------------------------------=== #
+
+
+@always_inline
+def _enqueue_cached[
+    declared_arg_types: TypeList[Trait=AnyType, ...], //,
+    func: def (*args: *declared_arg_types) thin -> None,
     *Ts: DevicePassable,
 ](
     ctx: DeviceContext,
     stream: DeviceStream,
     key: String,
-    threads: Int,
+    blocks: Int,
     *args: *Ts,
 ) raises:
-    """Enqueue `func` (grid of 1 block) on the caller's `stream`, compiling
-    it at most once per process and context.
-
-    Self-contained copy of eager_kernels/op_utils's `_enqueue_cached`
-    pattern (this library builds and loads standalone, outside that
-    package): compile once via `ctx`, cache the `DeviceFunction` in the
-    process-global registry, enqueue onto `stream` on every call after.
-    """
-    var name = String(t"MOJOCCL_KERNEL_{key}_{ctx.id()}")
+    """Enqueue `func` on `stream`, compiling it at most once per process and
+    context. `ctx` is only the compilation/caching handle -- the launch always
+    goes to the stream the caller handed us, which in production is a foreign
+    `cudaStream_t` wrapped by `DeviceContext.create_external_stream`. Same
+    caching pattern as the repo's eager kernels."""
+    var name = String(t"CCL_KERNEL_{key}_{ctx.id()}")
     comptime FuncT = type_of(ctx.compile_function[func]())
+
     var global_ptr = _get_global_or_null(name)
     if global_ptr:
         var fptr = global_ptr.value().unsafe_bitcast[FuncT]()
         stream.enqueue_function(
-            fptr[], *args, grid_dim=(1, 1, 1), block_dim=(threads,)
+            fptr[], *args, grid_dim=(blocks,), block_dim=(BLOCK,)
         )
         return
+
     var compiled = ctx.compile_function[func]()
     var fptr = unsafe_alloc[FuncT](1)
     fptr.unsafe_write(compiled^)
@@ -147,71 +905,155 @@ def _enqueue_cached_stream[
         StringSlice(name), fptr.unsafe_bitcast[NoneType]()
     )
     stream.enqueue_function(
-        fptr[], *args, grid_dim=(1, 1, 1), block_dim=(threads,)
+        fptr[], *args, grid_dim=(blocks,), block_dim=(BLOCK,)
     )
 
 
-# ---------------------------------------------------------------------------
-# allreduce: copy-in, barrier, every rank independently sums every peer's
-# stage_in (no reduce-scatter partitioning -- simplest correct thing, per
-# "plain copy-in / RS+AG / copy-out is fine"), barrier, copy-out. Generic
-# Float64 accumulation covers all five dtypes with one code path; SUM is
-# exact for the small integer values these tests use, AVG divides via
-# `scale`.
-# ---------------------------------------------------------------------------
+@always_inline
+def _region_ptrs(
+    regions: StaticTuple[Int, MAX_WORLD], rank: Int, world: Int
+) -> InlineArray[Pointer[UInt8, MutAnyOrigin], MAX_WORLD]:
+    """Peer region bases as mapped in this process. Unused slots are filled
+    with my own region so no kernel can ever hold a null pointer."""
+    var out = InlineArray[Pointer[UInt8, MutAnyOrigin], MAX_WORLD](
+        uninitialized=True
+    )
+    for r in range(MAX_WORLD):
+        var addr = regions[r] if r < world else regions[rank]
+        out[r] = Pointer[UInt8, MutAnyOrigin](unsafe_from_address=addr)
+    return out^
 
 
-@__llvm_metadata(
-    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(BLOCK))
-)
-def _allreduce_kernel[
-    dtype: DType
+def _check_common(
+    rank: Int, world: Int, cap_bytes: Int, generation: Int
+) raises:
+    if world < 1 or world > MAX_WORLD:
+        raise Error("collectives: world must be in 1.." + String(MAX_WORLD))
+    if rank < 0 or rank >= world:
+        raise Error("collectives: rank out of range")
+    if generation < 1:
+        raise Error("collectives: generation must start at 1")
+    if cap_bytes <= 0 or cap_bytes % 4096 != 0:
+        raise Error("collectives: cap_bytes must be a positive 4 KiB multiple")
+
+
+# ===-------------------------------------------------------------------=== #
+# Public API
+# ===-------------------------------------------------------------------=== #
+
+
+def region_init(ctx: DeviceContext, region: Int) raises:
+    """Zero the signal area of this rank's region and block until it is done.
+
+    Called once per rank at communicator creation, on `ctx`'s own queue -- no
+    `stream` parameter, unlike the collectives: this must be complete before
+    any peer writes a flag into the area, and the caller only has to make the
+    ranks meet (its own rendezvous) after calling it.
+    """
+    var words = _SIGNAL_BYTES // 4
+    _enqueue_cached[_zero_kernel](
+        ctx,
+        ctx.stream(),
+        "zero",
+        (words + BLOCK - 1) // BLOCK,
+        Pointer[UInt32, MutAnyOrigin](unsafe_from_address=region),
+        Int32(words),
+    )
+    ctx.synchronize()
+
+
+@always_inline
+def _launch_allreduce[
+    dtype: DType, W: Int, NW: Int
 ](
-    regions: StaticTuple[Int64, MAX_WORLD],
-    rank: Int32,
-    world: Int32,
-    in_ptr: Int64,
-    out_ptr: Int64,
-    numel: Int32,
-    cap_bytes: Int32,
+    ctx: DeviceContext,
+    stream: DeviceStream,
+    regions: InlineArray[Pointer[UInt8, MutAnyOrigin], MAX_WORLD],
+    in_ptr: Int,
+    out_ptr: Int,
+    numel: Int,
+    world: Int,
+    rank: Int,
+    cap_bytes: Int,
     scale: Float32,
-    generation: UInt64,
-):
-    var my_region = Int(regions[Int(rank)])
-    var stage_in = Pointer[Scalar[dtype], MutAnyOrigin](
-        unsafe_from_address=my_region + SIG_BYTES
+    generation: Int,
+    one_shot: Bool,
+) raises:
+    var arena = _SIGNAL_BYTES
+    var arena_end = _SIGNAL_BYTES + 2 * cap_bytes
+    var esize = size_of[dtype]()
+    var nvec = numel // W
+    var tail = numel - nvec * W
+    var ip = Pointer[Scalar[dtype], MutAnyOrigin](
+        unsafe_from_address=in_ptr
     )
-    var src = Pointer[Scalar[dtype], MutAnyOrigin](
-        unsafe_from_address=Int(in_ptr)
+    var op = Pointer[Scalar[dtype], MutAnyOrigin](
+        unsafe_from_address=out_ptr
     )
-    var n = Int(numel)
-    var tid = Int(thread_idx.x)
-    for i in range(tid, n, BLOCK):
-        stage_in[unsafe_offset=i] = src[unsafe_offset=i]
 
-    _gen_barrier(regions, rank, world, 2 * generation)
+    if one_shot:
+        # `world` slots, each a whole message, at the base of the arena. They
+        # overlap the two-shot staging on purpose: the start barrier orders
+        # every generation's writes after the previous generation's reads, so
+        # collectives of different shapes and sizes may interleave freely.
+        var slot = _align_up(numel * esize, 16)
+        if world * slot > 2 * cap_bytes:
+            raise Error("collectives: one-shot slots exceed the region")
+        var push_off = arena
+        var blocks = min(
+            _AR_MAX_BLOCKS, max(1, (nvec + BLOCK - 1) // BLOCK)
+        )
+        _enqueue_cached[_ar_oneshot_kernel[dtype, W, _UNROLL, NW]](
+            ctx,
+            stream,
+            String(t"ar1_{dtype}_{NW}"),
+            blocks,
+            regions,
+            ip,
+            op,
+            Int64(numel),
+            Int64(slot),
+            Int64(push_off),
+            Int32(world),
+            Int32(rank),
+            _flag_target(generation, 0),
+            scale,
+            UInt64(DEFAULT_TIMEOUT_NS),
+        )
+        return
 
-    var stage_out = Pointer[Scalar[dtype], MutAnyOrigin](
-        unsafe_from_address=my_region + SIG_BYTES + Int(cap_bytes)
+    var q = nvec // world
+    var rem = nvec % world
+    var max_shard_elems = max(
+        (q + (1 if rem > 0 else 0)) * W, q * W + tail
     )
-    var w = Int(world)
-    var fscale = Float64(scale)
-    for i in range(tid, n, BLOCK):
-        var acc: Float64 = 0
-        for p in range(w):
-            var peer_in = Pointer[Scalar[dtype], MutAnyOrigin](
-                unsafe_from_address=Int(regions[p]) + SIG_BYTES
-            )
-            acc += Float64(peer_in[unsafe_offset=i])
-        stage_out[unsafe_offset=i] = Scalar[dtype](acc * fscale)
-
-    _gen_barrier(regions, rank, world, 2 * generation + 1)
-
-    var dst = Pointer[Scalar[dtype], MutAnyOrigin](
-        unsafe_from_address=Int(out_ptr)
+    var slot = _align_up(max_shard_elems * esize, 16)
+    var push_off = arena
+    var shard_off = arena + world * slot
+    if shard_off + slot > arena_end:
+        raise Error("collectives: allreduce staging exceeds the region")
+    var cap_blocks = (
+        _AR_BIG_BLOCKS if numel * esize >= _AR_BIG_BYTES else _AR_MAX_BLOCKS
     )
-    for i in range(tid, n, BLOCK):
-        dst[unsafe_offset=i] = stage_out[unsafe_offset=i]
+    var blocks = min(cap_blocks, max(1, (q + 1 + BLOCK - 1) // BLOCK))
+    _enqueue_cached[_ar_twoshot_kernel[dtype, W, _UNROLL, NW]](
+        ctx,
+        stream,
+        String(t"ar2_{dtype}_{NW}"),
+        blocks,
+        regions,
+        ip,
+        op,
+        Int64(numel),
+        Int64(slot),
+        Int64(push_off),
+        Int64(shard_off),
+        Int32(world),
+        Int32(rank),
+        _flag_target(generation, 0),
+        scale,
+        UInt64(DEFAULT_TIMEOUT_NS),
+    )
 
 
 def allreduce[
@@ -229,71 +1071,58 @@ def allreduce[
     scale: Float32,
     generation: Int,
 ) raises:
-    var regions64 = StaticTuple[Int64, MAX_WORLD](fill=0)
-    for i in range(MAX_WORLD):
-        regions64[i] = Int64(regions[i])
-    comptime kern = _allreduce_kernel[dtype]
-    _enqueue_cached_stream[kern](
-        ctx,
-        stream,
-        String("allreduce_") + String(dtype),
-        BLOCK,
-        regions64,
-        Int32(rank),
-        Int32(world),
-        Int64(in_ptr),
-        Int64(out_ptr),
-        Int32(numel),
-        Int32(cap_bytes),
-        scale,
-        UInt64(generation),
-    )
+    """out[i] = scale * sum over ranks of in_r[i], enqueued on `stream`.
 
-
-# ---------------------------------------------------------------------------
-# broadcast: root copies its send buffer into its own stage_in, barrier,
-# every rank (root included) copies root's stage_in into its own recv
-# buffer, barrier. Byte-granular: NCCL's broadcast moves opaque bytes, no
-# reduction, so there is no dtype to specialize on.
-# ---------------------------------------------------------------------------
-
-
-@__llvm_metadata(
-    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(BLOCK))
-)
-def _broadcast_kernel(
-    regions: StaticTuple[Int64, MAX_WORLD],
-    rank: Int32,
-    root: Int32,
-    world: Int32,
-    send_ptr: Int64,
-    recv_ptr: Int64,
-    nbytes: Int32,
-    generation: UInt64,
-):
-    var my_region = Int(regions[Int(rank)])
-    var stage = Pointer[UInt8, MutAnyOrigin](
-        unsafe_from_address=my_region + SIG_BYTES
-    )
-    var n = Int(nbytes)
-    var tid = Int(thread_idx.x)
-    if rank == root:
-        var src = Pointer[UInt8, MutAnyOrigin](
-            unsafe_from_address=Int(send_ptr)
+    `in_ptr` may equal `out_ptr`. `numel * size_of[dtype]()` must be <=
+    `cap_bytes`. `scale` is applied on the final write and ignored for integer
+    dtypes (the caller passes 1.0 there).
+    """
+    _check_common(rank, world, cap_bytes, generation)
+    if numel == 0:
+        return
+    if numel < 0:
+        raise Error("collectives: numel must be >= 0")
+    comptime W = 16 // size_of[dtype]()
+    if numel * size_of[dtype]() > cap_bytes:
+        raise Error("collectives: allreduce message exceeds cap_bytes")
+    if (in_ptr | out_ptr) % 16 != 0:
+        # The payload loops use 16-byte vector loads/stores, which fault (or
+        # silently misbehave) on a misaligned address. Every allocator-returned
+        # pointer satisfies this; a mid-tensor view may not, and the caller
+        # must stage such a tensor into an aligned buffer rather than have this
+        # kernel guess. Byte collectives have a scalar fallback and need no
+        # such rule.
+        raise Error(
+            "collectives: allreduce needs 16-byte aligned in_ptr and out_ptr"
         )
-        for i in range(tid, n, BLOCK):
-            stage[unsafe_offset=i] = src[unsafe_offset=i]
-
-    _gen_barrier(regions, rank, world, 2 * generation)
-
-    var root_stage = Pointer[UInt8, MutAnyOrigin](
-        unsafe_from_address=Int(regions[Int(root)]) + SIG_BYTES
+    var rp = _region_ptrs(regions, rank, world)
+    # world == 1 needs no special case: the push and pull loops are empty, the
+    # sync is a self-rendezvous, and the reduce degenerates to out = scale*in.
+    var bytes = numel * size_of[dtype]()
+    var one_shot = bytes <= _ONESHOT_MAX_BYTES and (
+        world * _align_up(bytes, 16) <= 2 * cap_bytes
     )
-    var dst = Pointer[UInt8, MutAnyOrigin](unsafe_from_address=Int(recv_ptr))
-    for i in range(tid, n, BLOCK):
-        dst[unsafe_offset=i] = root_stage[unsafe_offset=i]
 
-    _gen_barrier(regions, rank, world, 2 * generation + 1)
+    if world == 8:
+        _launch_allreduce[dtype, W, 8](
+            ctx, stream, rp, in_ptr, out_ptr, numel, world, rank, cap_bytes, scale,
+            generation, one_shot,
+        )
+    elif world == 4:
+        _launch_allreduce[dtype, W, 4](
+            ctx, stream, rp, in_ptr, out_ptr, numel, world, rank, cap_bytes, scale,
+            generation, one_shot,
+        )
+    elif world == 2:
+        _launch_allreduce[dtype, W, 2](
+            ctx, stream, rp, in_ptr, out_ptr, numel, world, rank, cap_bytes, scale,
+            generation, one_shot,
+        )
+    else:
+        _launch_allreduce[dtype, W, 0](
+            ctx, stream, rp, in_ptr, out_ptr, numel, world, rank, cap_bytes, scale,
+            generation, one_shot,
+        )
 
 
 def broadcast(
@@ -309,72 +1138,42 @@ def broadcast(
     cap_bytes: Int,
     generation: Int,
 ) raises:
+    """recv on every rank <- send on `root`, dtype-agnostic, on `stream`.
+
+    Out-of-place capable: `send_ptr` and `recv_ptr` may differ (only the root
+    reads `send_ptr`). `nbytes` must be <= `cap_bytes`; the caller chunks
+    anything larger.
+    """
+    _check_common(rank, world, cap_bytes, generation)
+    if root < 0 or root >= world:
+        raise Error("collectives: root out of range")
+    if nbytes == 0:
+        return
+    if nbytes < 0:
+        raise Error("collectives: nbytes must be >= 0")
     if nbytes > cap_bytes:
-        raise Error("mojoccl: broadcast nbytes exceeds the region capacity")
-    var regions64 = StaticTuple[Int64, MAX_WORLD](fill=0)
-    for i in range(MAX_WORLD):
-        regions64[i] = Int64(regions[i])
-    comptime kern = _broadcast_kernel
-    _enqueue_cached_stream[kern](
+        raise Error("collectives: broadcast message exceeds cap_bytes")
+    var rp = _region_ptrs(regions, rank, world)
+    var blocks = min(
+        _COPY_MAX_BLOCKS,
+        max(1, (nbytes // 16 // world + BLOCK - 1) // BLOCK),
+    )
+    _enqueue_cached[_bcast_kernel[_UNROLL]](
         ctx,
         stream,
-        String("broadcast"),
-        BLOCK,
-        regions64,
+        "bcast",
+        blocks,
+        rp,
+        Pointer[UInt8, MutAnyOrigin](unsafe_from_address=send_ptr),
+        Pointer[UInt8, MutAnyOrigin](unsafe_from_address=recv_ptr),
+        Int64(nbytes),
+        Int64(_SIGNAL_BYTES),
+        Int32(world),
         Int32(rank),
         Int32(root),
-        Int32(world),
-        Int64(send_ptr),
-        Int64(recv_ptr),
-        Int32(nbytes),
-        UInt64(generation),
+        _flag_target(generation, 0),
+        UInt64(DEFAULT_TIMEOUT_NS),
     )
-
-
-# ---------------------------------------------------------------------------
-# allgather: every rank copies its chunk into its own stage_in, barrier,
-# every rank copies every peer's stage_in into the right slice of its own
-# output, barrier.
-# ---------------------------------------------------------------------------
-
-
-@__llvm_metadata(
-    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(BLOCK))
-)
-def _allgather_kernel(
-    regions: StaticTuple[Int64, MAX_WORLD],
-    rank: Int32,
-    world: Int32,
-    in_ptr: Int64,
-    out_ptr: Int64,
-    nbytes: Int32,
-    stride_bytes: Int32,
-    generation: UInt64,
-):
-    var my_region = Int(regions[Int(rank)])
-    var stage = Pointer[UInt8, MutAnyOrigin](
-        unsafe_from_address=my_region + SIG_BYTES
-    )
-    var src = Pointer[UInt8, MutAnyOrigin](unsafe_from_address=Int(in_ptr))
-    var n = Int(nbytes)
-    var tid = Int(thread_idx.x)
-    for i in range(tid, n, BLOCK):
-        stage[unsafe_offset=i] = src[unsafe_offset=i]
-
-    _gen_barrier(regions, rank, world, 2 * generation)
-
-    var dst = Pointer[UInt8, MutAnyOrigin](unsafe_from_address=Int(out_ptr))
-    var w = Int(world)
-    var stride = Int(stride_bytes)
-    for p in range(w):
-        var peer_stage = Pointer[UInt8, MutAnyOrigin](
-            unsafe_from_address=Int(regions[p]) + SIG_BYTES
-        )
-        var base = p * stride
-        for i in range(tid, n, BLOCK):
-            dst[unsafe_offset=base + i] = peer_stage[unsafe_offset=i]
-
-    _gen_barrier(regions, rank, world, 2 * generation + 1)
 
 
 def allgather(
@@ -390,34 +1189,41 @@ def allgather(
     generation: Int,
     stride_bytes: Int = -1,
 ) raises:
-    """`stride_bytes` (default `nbytes_per_rank`) is the OUTPUT layout's true
-    per-rank size, in bytes, separate from `nbytes_per_rank` (how much THIS
-    call moves). They differ only when the caller chunks one rank's
-    contribution across several calls: each chunk still lands at
-    `peer * stride_bytes + chunk_offset` in the flat `[rank0 | rank1 | ...]`
-    output, never at `peer * nbytes_per_rank`. A one-call (unchunked)
-    allgather needs no stride argument at all.
+    """out[r*stride_bytes ...] <- rank r's `nbytes_per_rank` input, on `stream`.
+
+    `stride_bytes` defaults to `nbytes_per_rank` and is the output layout's
+    true per-rank size, which differs when the caller splits one rank's
+    contribution across several calls. `nbytes_per_rank` must be <=
+    `cap_bytes`.
     """
+    _check_common(rank, world, cap_bytes, generation)
+    if nbytes_per_rank == 0:
+        return
+    if nbytes_per_rank < 0:
+        raise Error("collectives: nbytes_per_rank must be >= 0")
     if nbytes_per_rank > cap_bytes:
-        raise Error(
-            "mojoccl: allgather nbytes_per_rank exceeds the region capacity"
-        )
-    var stride = nbytes_per_rank if stride_bytes < 0 else stride_bytes
-    var regions64 = StaticTuple[Int64, MAX_WORLD](fill=0)
-    for i in range(MAX_WORLD):
-        regions64[i] = Int64(regions[i])
-    comptime kern = _allgather_kernel
-    _enqueue_cached_stream[kern](
+        raise Error("collectives: allgather message exceeds cap_bytes")
+    var stride = stride_bytes if stride_bytes >= 0 else nbytes_per_rank
+    if stride < nbytes_per_rank:
+        raise Error("collectives: stride_bytes < nbytes_per_rank")
+    var rp = _region_ptrs(regions, rank, world)
+    var blocks = min(
+        _COPY_MAX_BLOCKS,
+        max(1, (nbytes_per_rank // 16 + BLOCK - 1) // BLOCK),
+    )
+    _enqueue_cached[_allgather_kernel[_UNROLL]](
         ctx,
         stream,
-        String("allgather"),
-        BLOCK,
-        regions64,
-        Int32(rank),
+        "allgather",
+        blocks,
+        rp,
+        Pointer[UInt8, MutAnyOrigin](unsafe_from_address=in_ptr),
+        Pointer[UInt8, MutAnyOrigin](unsafe_from_address=out_ptr),
+        Int64(nbytes_per_rank),
+        Int64(stride),
+        Int64(_SIGNAL_BYTES),
         Int32(world),
-        Int64(in_ptr),
-        Int64(out_ptr),
-        Int32(nbytes_per_rank),
-        Int32(stride),
-        UInt64(generation),
+        Int32(rank),
+        _flag_target(generation, 0),
+        UInt64(DEFAULT_TIMEOUT_NS),
     )

--- a/torch_mojo_backend/distributed/mojoccl/collectives_kernels.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/collectives_kernels.mojo
@@ -20,6 +20,11 @@
 #                       slots (used only when they fit);
 #   broadcast/allgather: the base of the arena, one message-sized stage per
 #                        rank (the caller chunks anything larger than cap).
+#   split allreduce:    `world-1` compacted push slots at the base of
+#                       stage_in, and the reduced shard at its own element
+#                       offset inside stage_out (see `shard_range`), so the
+#                       inter-node library can rewrite it in place between the
+#                       two halves.
 #
 # Why the data path looks like it does
 # ------------------------------------
@@ -58,6 +63,12 @@
 # finished reading the previous generation.  That is what lets collectives of
 # different kinds and sizes share the staging area -- see the invariant above
 # `_ar_twoshot_kernel`.
+#
+# The hierarchical (multi-node) allreduce splits that into
+# `reduce_scatter_stage` (phases 1-2) and `allgather_finish` (phase 3), with
+# the vendor library's inter-node allreduce of one shard in between; the split
+# spends two generations and one extra launch. See the block comment above
+# `_rs_stage_kernel`.
 #
 # Broadcast is scatter + all-gather, not "root stages, everyone reads": the
 # latter puts (world-1) x nbytes on the root's one outbound link and measured
@@ -177,6 +188,8 @@ comptime _COPY_MAX_BLOCKS = get_defined_int["ccl_copy_blocks", 432]()
 comptime ERR_ALLREDUCE_SYNC = 1
 comptime ERR_BROADCAST_SYNC = 2
 comptime ERR_ALLGATHER_SYNC = 3
+comptime ERR_RS_STAGE_SYNC = 4
+comptime ERR_AG_FINISH_SYNC = 5
 
 
 # ===-------------------------------------------------------------------=== #
@@ -398,6 +411,78 @@ def _copy_bytes[
     _copy_scalar_tail(dst, src, nvec * 16, nbytes - nvec * 16, tid, stride)
 
 
+@always_inline
+def _copy_span[
+    dtype: DType, W: Int, U: Int
+](
+    dst: Pointer[Scalar[dtype], MutAnyOrigin],
+    src: Pointer[Scalar[dtype], MutAnyOrigin],
+    count: Int,
+    tid: Int,
+    stride: Int,
+):
+    """`count` elements: the 16-byte vectors, then the `count % W` tail."""
+    var vc = count // W
+    _copy_vec[dtype, W, U](dst, src, vc, tid, stride)
+    _copy_scalar_tail(dst, src, vc * W, count - vc * W, tid, stride)
+
+
+@always_inline
+def _copy_span_scaled[
+    dtype: DType, W: Int, U: Int
+](
+    dst: Pointer[Scalar[dtype], MutAnyOrigin],
+    src: Pointer[Scalar[dtype], MutAnyOrigin],
+    count: Int,
+    tid: Int,
+    stride: Int,
+    scale: Float32,
+):
+    """`_copy_span` times `scale`; integer dtypes ignore `scale` (as NCCL's
+    ncclAvg does, and as the fused allreduce does). `scale == 1` takes the
+    plain copy, so the all-gather half of a SUM allreduce costs no more than a
+    peer copy."""
+    comptime accum = DType.float32 if (
+        dtype == DType.bfloat16 or dtype == DType.float16
+    ) else dtype
+    comptime if accum.is_floating_point():
+        if scale != Float32(1.0):
+            var sv = SIMD[accum, W](scale.cast[accum]())
+            var vc = count // W
+            var v = tid
+            var lim = vc - (U - 1) * stride
+            while v < lim:
+                var tmp = InlineArray[SIMD[dtype, W], U](uninitialized=True)
+                comptime for u in range(U):
+                    tmp[u] = src.unsafe_load[width=W, alignment=16](
+                        (v + u * stride) * W
+                    )
+                comptime for u in range(U):
+                    dst.unsafe_store[width=W, alignment=16](
+                        (v + u * stride) * W,
+                        (tmp[u].cast[accum]() * sv).cast[dtype](),
+                    )
+                v += U * stride
+            while v < vc:
+                dst.unsafe_store[width=W, alignment=16](
+                    v * W,
+                    (
+                        src.unsafe_load[width=W, alignment=16](v * W).cast[
+                            accum
+                        ]()
+                        * sv
+                    ).cast[dtype](),
+                )
+                v += stride
+            for i in range(tid, count - vc * W, stride):
+                var k = vc * W + i
+                dst[unsafe_offset=k] = (
+                    src[unsafe_offset=k].cast[accum]() * scale.cast[accum]()
+                ).cast[dtype]()
+            return
+    _copy_span[dtype, W, U](dst, src, count, tid, stride)
+
+
 # ===-------------------------------------------------------------------=== #
 # Shard partition. Every rank derives the same table from (numel, world).
 # ===-------------------------------------------------------------------=== #
@@ -414,6 +499,74 @@ def _vcount(s: Int, q: Int, rem: Int) -> Int:
     """16-byte vectors in rank `s`'s shard (the `numel % W` scalar tail, if
     any, belongs to the last rank and is counted separately)."""
     return q + (1 if s < rem else 0)
+
+
+# ===-------------------------------------------------------------------=== #
+# Split shard partition -- the one the hierarchical (multi-node) path uses
+# ===-------------------------------------------------------------------=== #
+#
+# `shard_range` is a *different* partition from `_vstart`/`_vcount` above and
+# deliberately so. The fused allreduce spreads the `nvec % world` leftover
+# vectors one each over the first ranks, which balances best but makes every
+# shard's offset depend on the whole remainder table. The split path hands its
+# shard offset to a foreign library (NCCL/RCCL, which allreduces shard `r`
+# across nodes among the ranks whose local index is `r`), so the rule has to be
+# something a caller can state in one line and every rank must derive the same
+# answer from (numel, world, elem_bytes) alone:
+#
+#     equal shards of `per` elements, `per` rounded up to the 16-byte vector
+#     width, the last non-empty shard short, the ranks past the end empty.
+#
+# Imbalance is at most one vector per rank against the balanced split -- below
+# the noise at every size that reaches the split path -- and in exchange every
+# shard starts 16-byte aligned, which the vector loops and the vendor library
+# both want.
+
+
+@always_inline
+def _shard_per(numel: Int, world: Int, W: Int) -> Int:
+    """Elements per shard, rounded up to the 16-byte vector width `W`."""
+    if numel <= 0 or world <= 0:
+        return 0
+    var c = (numel + world - 1) // world
+    return (c + W - 1) // W * W
+
+
+@always_inline
+def _shard_off(numel: Int, per: Int, s: Int) -> Int:
+    """First element of rank `s`'s shard (== numel once the shards run out)."""
+    var o = s * per
+    return o if o < numel else numel
+
+
+@always_inline
+def _shard_cnt(numel: Int, per: Int, s: Int) -> Int:
+    """Elements in rank `s`'s shard; 0 for the ranks past the end."""
+    var rest = numel - _shard_off(numel, per, s)
+    return per if per < rest else rest
+
+
+def shard_range(
+    numel: Int, world: Int, rank: Int, elem_bytes: Int
+) -> Tuple[Int, Int]:
+    """`(offset_elems, count_elems)` of rank `rank`'s shard of a `numel` buffer.
+
+    Pure host arithmetic, no device state, identical on every rank -- the ABI
+    layer calls it to address the shard `reduce_scatter_stage` leaves in
+    stage_out and to size the inter-node collective it runs on it.
+
+    Shards are contiguous and cover `[0, numel)` in rank order; every offset is
+    16-byte aligned for this dtype (so the shard pointer is as well, given a
+    16-byte aligned buffer); the last non-empty shard may be shorter and the
+    ranks past the end get `(numel, 0)`. `elem_bytes` must divide 16 (all
+    supported dtypes are 1, 2, 4 or 8 bytes wide).
+    """
+    if elem_bytes <= 0 or elem_bytes > 16 or 16 % elem_bytes != 0:
+        return Tuple(0, 0)
+    var per = _shard_per(numel, world, 16 // elem_bytes)
+    if per == 0 or rank < 0 or rank >= world:
+        return Tuple(0, 0)
+    return Tuple(_shard_off(numel, per, rank), _shard_cnt(numel, per, rank))
 
 
 # ===-------------------------------------------------------------------=== #
@@ -692,6 +845,241 @@ def _ar_oneshot_kernel[
         comptime if accum.is_floating_point():
             a *= scale.cast[accum]()
         out_ptr[unsafe_offset=k] = a.cast[dtype]()
+
+
+# ===-------------------------------------------------------------------=== #
+# Split allreduce -- reduce-scatter stage, then all-gather finish
+# ===-------------------------------------------------------------------=== #
+#
+# The hierarchical (multi-node) allreduce is
+#
+#   reduce_scatter_stage(g)   my shard, summed over the node, into my stage_out
+#   <inter-node step>         NCCL/RCCL allreduces that shard across nodes,
+#                             in place, on the same stream, among the ranks
+#                             that share my local index
+#   allgather_finish(g+1)     pull every rank's now-global shard into my output
+#
+# Layout. Shards follow `shard_range` (equal, 16-byte aligned, last one short).
+#   push slots  stage_in base, `world-1` slots of `per * elem_bytes` bytes.
+#               Slot indices are *compacted*: writer r stores into destination
+#               rank s's slot `r if r < s else r-1`, because s never writes its
+#               own slot (it reads its own contribution from user memory). The
+#               compaction is not cosmetic: `world` uncompacted slots can be
+#               up to 16*world bytes larger than stage_in when
+#               numel*elem_bytes == cap (the per-shard round-up to the vector
+#               width, times world), which would spill onto rank 0's shard in
+#               stage_out. `world-1` of them never can -- checked exhaustively
+#               for every dtype width, world and cap.
+#   shard       stage_out + offset(rank) * elem_bytes, i.e. stage_out is an
+#               image of the whole buffer of which only my shard is live. That
+#               placement is what makes the ABI layer's job one line -- the
+#               inter-node collective gets `stage_out + offset*elem_bytes` and
+#               `count` -- and it makes the pull address the same on both
+#               sides. It always fits: offset+count <= numel and
+#               numel*elem_bytes <= cap_bytes.
+#
+# Ordering. Three things happen between the two kernels that the fused
+# allreduce never has to think about, and all three are covered without a new
+# protocol:
+#
+#  1. A foreign library writes my stage_out shard in place. Nobody may read it
+#     before that write lands. `allgather_finish`'s start barrier is the fence:
+#     a rank publishes its generation g+1 flags only from inside that kernel,
+#     which its stream starts only after its inter-node op has completed, so
+#     seeing peer p's flag implies p's shard is final.
+#  2. Peer p's shard was written by a *previous kernel* (p's reduce_scatter_
+#     stage), not by the thread that publishes the flag. Stream order makes
+#     that kernel's writes happen-before the flag's release store, and the
+#     release/acquire pair is system-scoped and cumulative, so they are visible
+#     to the acquiring reader. (On gfx942 `_sync`'s AMD-only release fence adds
+#     the `buffer_wbl2 sc0 sc1` writeback that the workgroup barrier omits.)
+#     Note the consequence: block-index matching, which the fused allreduce
+#     relies on *within* a kernel, is not needed across this boundary -- the
+#     two kernels may be launched with different grids, and they are.
+#  3. Arena reuse after the pulls. Nothing extra is needed: the next collective
+#     of any kind opens with a start barrier, and a rank reaches it only after
+#     its own `allgather_finish` retired, so no generation g+2 write can race a
+#     generation g+1 pull. That is the same one rule as everywhere else in this
+#     file -- the split pair just spends two generations instead of one.
+#
+# Each call consumes one generation. `reduce_scatter_stage` uses flag phases
+# 0 and 1, `allgather_finish` phase 0.
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(BLOCK))
+)
+@__name(t"ccl_reduce_scatter_stage_{dtype}_w{NW}")
+def _rs_stage_kernel[
+    dtype: DType, W: Int, U: Int, NW: Int
+](
+    regions: InlineArray[Pointer[UInt8, MutAnyOrigin], MAX_WORLD],
+    in_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    numel: Int64,
+    per_e: Int64,
+    slot_stride_b: Int64,
+    push_off_b: Int64,
+    out_off_b: Int64,
+    world_i: Int32,
+    rank_i: Int32,
+    flag_base: UInt64,
+    timeout_ns: UInt64,
+):
+    comptime accum = DType.float32 if (
+        dtype == DType.bfloat16 or dtype == DType.float16
+    ) else dtype
+    comptime esize = size_of[dtype]()
+    var t0 = global_perf_counter_ns()
+    var world = NW if NW > 0 else Int(world_i)
+    var rank = Int(rank_i)
+    var tid = Int(global_idx.x)
+    var stride = Int(grid_dim.x) * BLOCK
+    var n = Int(numel)
+    var per = Int(per_e)
+    var slot_stride = Int(slot_stride_b)
+    var push_off = Int(push_off_b)
+    var out_off = Int(out_off_b)
+
+    # --- phase 0: start barrier (the arena-reuse invariant) -----------------
+    if not _sync(regions, world, rank, flag_base, t0, timeout_ns):
+        _record_error(regions, rank, ERR_RS_STAGE_SYNC, 0)
+        return
+
+    # --- phase 1: push shard s of my input into peer s's slot for me --------
+    for i in range(1, world):
+        var s = rank + i
+        if s >= world:
+            s -= world
+        var off = _shard_off(n, per, s)
+        var cnt = _shard_cnt(n, per, s)
+        if cnt <= 0:
+            continue
+        var dst = regions[s].unsafe_offset(
+            push_off + slot_stride * (rank if rank < s else rank - 1)
+        ).unsafe_bitcast[Scalar[dtype]]()
+        _copy_span[dtype, W, U](
+            dst, in_ptr.unsafe_offset(off), cnt, tid, stride
+        )
+
+    if not _sync(regions, world, rank, flag_base + 1, t0, timeout_ns):
+        _record_error(regions, rank, ERR_RS_STAGE_SYNC, 1)
+        return
+
+    # --- phase 2: sum the `world` contributions to my shard into stage_out --
+    # SUM only, unscaled: the caller's inter-node step reduces the same shard
+    # again, so any averaging has to happen once, at the end, in
+    # `allgather_finish`.
+    var my_off = _shard_off(n, per, rank)
+    var my_cnt = _shard_cnt(n, per, rank)
+    if my_cnt <= 0:
+        return
+    var uin = in_ptr.unsafe_offset(my_off)
+    var shard = regions[rank].unsafe_offset(
+        out_off + my_off * esize
+    ).unsafe_bitcast[Scalar[dtype]]()
+    # Slot pointers are formed arithmetically, never held in a stack array:
+    # such an array is demoted to local memory (MOCO-1431) and every payload
+    # load becomes a generic-address `ld.v4.b32` plus an `ld.local.b64`.
+    var slots = regions[rank].unsafe_offset(push_off)
+    var my_vc = my_cnt // W
+
+    for v in range(tid, my_vc, stride):
+        var acc = uin.unsafe_load[width=W, alignment=16](v * W).cast[accum]()
+        comptime if NW > 0:
+            comptime for j in range(1, NW):
+                var p = rank + j
+                if p >= NW:
+                    p -= NW
+                acc += (
+                    slots.unsafe_offset(
+                        slot_stride * (p if p < rank else p - 1)
+                    )
+                    .unsafe_bitcast[Scalar[dtype]]()
+                    .unsafe_load[width=W, alignment=16](v * W)
+                    .cast[accum]()
+                )
+        else:
+            for j in range(1, world):
+                var p = rank + j
+                if p >= world:
+                    p -= world
+                acc += (
+                    slots.unsafe_offset(
+                        slot_stride * (p if p < rank else p - 1)
+                    )
+                    .unsafe_bitcast[Scalar[dtype]]()
+                    .unsafe_load[width=W, alignment=16](v * W)
+                    .cast[accum]()
+                )
+        shard.unsafe_store[width=W, alignment=16](v * W, acc.cast[dtype]())
+
+    for i in range(tid, my_cnt - my_vc * W, stride):
+        var k = my_vc * W + i
+        var a = uin[unsafe_offset=k].cast[accum]()
+        for j in range(1, world):
+            var p = rank + j
+            if p >= world:
+                p -= world
+            a += (
+                slots.unsafe_offset(slot_stride * (p if p < rank else p - 1))
+                .unsafe_bitcast[Scalar[dtype]]()[unsafe_offset=k]
+                .cast[accum]()
+            )
+        shard[unsafe_offset=k] = a.cast[dtype]()
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(BLOCK))
+)
+@__name(t"ccl_allgather_finish_{dtype}_w{NW}")
+def _ag_finish_kernel[
+    dtype: DType, W: Int, U: Int, NW: Int
+](
+    regions: InlineArray[Pointer[UInt8, MutAnyOrigin], MAX_WORLD],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    numel: Int64,
+    per_e: Int64,
+    out_off_b: Int64,
+    world_i: Int32,
+    rank_i: Int32,
+    flag_base: UInt64,
+    scale: Float32,
+    timeout_ns: UInt64,
+):
+    comptime esize = size_of[dtype]()
+    var t0 = global_perf_counter_ns()
+    var world = NW if NW > 0 else Int(world_i)
+    var rank = Int(rank_i)
+    var tid = Int(global_idx.x)
+    var stride = Int(grid_dim.x) * BLOCK
+    var n = Int(numel)
+    var per = Int(per_e)
+    var out_off = Int(out_off_b)
+
+    # Start barrier. Doubles as the wait for every peer's inter-node step: a
+    # peer publishes this flag from inside this kernel, which its stream runs
+    # after that step.
+    if not _sync(regions, world, rank, flag_base, t0, timeout_ns):
+        _record_error(regions, rank, ERR_AG_FINISH_SYNC, 0)
+        return
+
+    # My own shard is pulled out of my own stage_out like everyone else's: the
+    # inter-node step rewrote it, so the reduce-scatter's result in the user
+    # buffer would be stale even if it had been written there.
+    for i in range(world):
+        var p = rank + i
+        if p >= world:
+            p -= world
+        var off = _shard_off(n, per, p)
+        var cnt = _shard_cnt(n, per, p)
+        if cnt <= 0:
+            continue
+        var src = regions[p].unsafe_offset(out_off + off * esize).unsafe_bitcast[
+            Scalar[dtype]
+        ]()
+        _copy_span_scaled[dtype, W, U](
+            out_ptr.unsafe_offset(off), src, cnt, tid, stride, scale
+        )
 
 
 # ===-------------------------------------------------------------------=== #
@@ -1071,7 +1459,7 @@ def allreduce[
     scale: Float32,
     generation: Int,
 ) raises:
-    """out[i] = scale * sum over ranks of in_r[i], enqueued on `stream`.
+    """Elementwise `out[i] = scale * sum over ranks of in_r[i]`, on `stream`.
 
     `in_ptr` may equal `out_ptr`. `numel * size_of[dtype]()` must be <=
     `cap_bytes`. `scale` is applied on the final write and ignored for integer
@@ -1125,6 +1513,227 @@ def allreduce[
         )
 
 
+@always_inline
+def _split_blocks[dtype: DType, W: Int](numel: Int, per: Int) -> Int:
+    """Grid for both halves of the split allreduce: sized by the shard, capped
+    by the same one-wave rule the fused kernel uses (RESULTS.md block sweep).
+    The two halves need not agree -- see ordering note 2 above the kernels."""
+    var cap_blocks = (
+        _AR_BIG_BLOCKS if numel * size_of[dtype]() >= _AR_BIG_BYTES else _AR_MAX_BLOCKS
+    )
+    return min(cap_blocks, max(1, (per // W + 1 + BLOCK - 1) // BLOCK))
+
+
+def _check_split[
+    dtype: DType, W: Int
+](
+    rank: Int,
+    world: Int,
+    ptr: Int,
+    numel: Int,
+    cap_bytes: Int,
+    generation: Int,
+    what: String,
+) raises -> Int:
+    """Shared preconditions of the two split entry points; returns `per`."""
+    _check_common(rank, world, cap_bytes, generation)
+    if numel < 0:
+        raise Error("collectives: numel must be >= 0")
+    if numel * size_of[dtype]() > cap_bytes:
+        raise Error("collectives: " + what + " message exceeds cap_bytes")
+    if ptr % 16 != 0:
+        # Same rule as `allreduce`: the payload loops use 16-byte vectors.
+        raise Error("collectives: " + what + " needs a 16-byte aligned buffer")
+    var per = _shard_per(numel, world, W)
+    if (world - 1) * per * size_of[dtype]() > cap_bytes:
+        # Cannot happen -- the compacted slot table is ~(world-1)/world of the
+        # message -- but the arena has no guard page, so check it anyway.
+        raise Error("collectives: split push slots exceed the region")
+    return per
+
+
+@always_inline
+def _launch_rs_stage[
+    dtype: DType, W: Int, NW: Int
+](
+    ctx: DeviceContext,
+    stream: DeviceStream,
+    regions: InlineArray[Pointer[UInt8, MutAnyOrigin], MAX_WORLD],
+    in_ptr: Int,
+    numel: Int,
+    per: Int,
+    world: Int,
+    rank: Int,
+    cap_bytes: Int,
+    generation: Int,
+) raises:
+    _enqueue_cached[_rs_stage_kernel[dtype, W, _UNROLL, NW]](
+        ctx,
+        stream,
+        String(t"rs_{dtype}_{NW}"),
+        _split_blocks[dtype, W](numel, per),
+        regions,
+        Pointer[Scalar[dtype], MutAnyOrigin](unsafe_from_address=in_ptr),
+        Int64(numel),
+        Int64(per),
+        Int64(per * size_of[dtype]()),
+        Int64(_SIGNAL_BYTES),
+        Int64(_SIGNAL_BYTES + cap_bytes),
+        Int32(world),
+        Int32(rank),
+        _flag_target(generation, 0),
+        UInt64(DEFAULT_TIMEOUT_NS),
+    )
+
+
+@always_inline
+def _launch_ag_finish[
+    dtype: DType, W: Int, NW: Int
+](
+    ctx: DeviceContext,
+    stream: DeviceStream,
+    regions: InlineArray[Pointer[UInt8, MutAnyOrigin], MAX_WORLD],
+    out_ptr: Int,
+    numel: Int,
+    per: Int,
+    world: Int,
+    rank: Int,
+    cap_bytes: Int,
+    scale: Float32,
+    generation: Int,
+) raises:
+    _enqueue_cached[_ag_finish_kernel[dtype, W, _UNROLL, NW]](
+        ctx,
+        stream,
+        String(t"agf_{dtype}_{NW}"),
+        _split_blocks[dtype, W](numel, per),
+        regions,
+        Pointer[Scalar[dtype], MutAnyOrigin](unsafe_from_address=out_ptr),
+        Int64(numel),
+        Int64(per),
+        Int64(_SIGNAL_BYTES + cap_bytes),
+        Int32(world),
+        Int32(rank),
+        _flag_target(generation, 0),
+        scale,
+        UInt64(DEFAULT_TIMEOUT_NS),
+    )
+
+
+def reduce_scatter_stage[
+    dtype: DType
+](
+    ctx: DeviceContext,
+    stream: DeviceStream,
+    rank: Int,
+    world: Int,
+    regions: StaticTuple[Int, MAX_WORLD],
+    in_ptr: Int,
+    numel: Int,
+    cap_bytes: Int,
+    generation: Int,
+) raises:
+    """First half of a hierarchical allreduce: push + local reduce, on `stream`.
+
+    When the enqueued work completes, this rank's shard --
+    `shard_range(numel, world, rank, size_of[dtype]())` -- summed (SUM,
+    **unscaled**) over the `world` node-local ranks, sits in this rank's own
+    stage_out, at element offset `offset` from `region + signal_bytes() +
+    cap_bytes`. The caller then runs the inter-node collective in place on
+    exactly that range, on this same stream, and calls `allgather_finish` with
+    `generation + 1`.
+
+    `rank` / `world` / `regions` are the node-local group. Preconditions are
+    `allreduce`'s: 16-byte aligned `in_ptr`, `numel * size_of[dtype]() <=
+    cap_bytes`, strictly increasing `generation`.
+    """
+    comptime W = 16 // size_of[dtype]()
+    var per = _check_split[dtype, W](
+        rank, world, in_ptr, numel, cap_bytes, generation, "reduce_scatter"
+    )
+    if numel == 0:
+        return
+    var rp = _region_ptrs(regions, rank, world)
+    # world == 1 needs no special case: the push loop is empty, the sync is a
+    # self-rendezvous and the reduce copies the input into stage_out.
+    if world == 8:
+        _launch_rs_stage[dtype, W, 8](
+            ctx, stream, rp, in_ptr, numel, per, world, rank, cap_bytes, generation
+        )
+    elif world == 4:
+        _launch_rs_stage[dtype, W, 4](
+            ctx, stream, rp, in_ptr, numel, per, world, rank, cap_bytes, generation
+        )
+    elif world == 2:
+        _launch_rs_stage[dtype, W, 2](
+            ctx, stream, rp, in_ptr, numel, per, world, rank, cap_bytes, generation
+        )
+    else:
+        _launch_rs_stage[dtype, W, 0](
+            ctx, stream, rp, in_ptr, numel, per, world, rank, cap_bytes, generation
+        )
+
+
+def allgather_finish[
+    dtype: DType
+](
+    ctx: DeviceContext,
+    stream: DeviceStream,
+    rank: Int,
+    world: Int,
+    regions: StaticTuple[Int, MAX_WORLD],
+    out_ptr: Int,
+    numel: Int,
+    cap_bytes: Int,
+    scale: Float32,
+    generation: Int,
+) raises:
+    """Second half: start barrier, then pull every rank's shard, on `stream`.
+
+    The start barrier is also the wait for the peers' inter-node steps -- a
+    peer publishes this generation's flags from inside this kernel, which its
+    stream runs only after that step. Then rank p's shard is read from p's
+    stage_out (mine included, since the inter-node step rewrote it) into
+    `out_ptr` at the same element offset, times `scale` (ignored for integer
+    dtypes). Same `numel`, `world` and preconditions as the matching
+    `reduce_scatter_stage`; `generation` is that call's plus one.
+
+    In place is safe: `out_ptr` may be the `in_ptr` the matching
+    `reduce_scatter_stage` read, because the two are separate launches on one
+    stream and no rank ever touches another rank's user memory.
+
+    No exit protocol is needed: the next collective's start barrier already
+    orders any arena reuse after every peer's pulls.
+    """
+    comptime W = 16 // size_of[dtype]()
+    var per = _check_split[dtype, W](
+        rank, world, out_ptr, numel, cap_bytes, generation, "allgather_finish"
+    )
+    if numel == 0:
+        return
+    var rp = _region_ptrs(regions, rank, world)
+    if world == 8:
+        _launch_ag_finish[dtype, W, 8](
+            ctx, stream, rp, out_ptr, numel, per, world, rank, cap_bytes, scale,
+            generation,
+        )
+    elif world == 4:
+        _launch_ag_finish[dtype, W, 4](
+            ctx, stream, rp, out_ptr, numel, per, world, rank, cap_bytes, scale,
+            generation,
+        )
+    elif world == 2:
+        _launch_ag_finish[dtype, W, 2](
+            ctx, stream, rp, out_ptr, numel, per, world, rank, cap_bytes, scale,
+            generation,
+        )
+    else:
+        _launch_ag_finish[dtype, W, 0](
+            ctx, stream, rp, out_ptr, numel, per, world, rank, cap_bytes, scale,
+            generation,
+        )
+
+
 def broadcast(
     ctx: DeviceContext,
     stream: DeviceStream,
@@ -1138,7 +1747,7 @@ def broadcast(
     cap_bytes: Int,
     generation: Int,
 ) raises:
-    """recv on every rank <- send on `root`, dtype-agnostic, on `stream`.
+    """Every rank's `recv` <- `root`'s `send`, dtype-agnostic, on `stream`.
 
     Out-of-place capable: `send_ptr` and `recv_ptr` may differ (only the root
     reads `send_ptr`). `nbytes` must be <= `cap_bytes`; the caller chunks
@@ -1189,7 +1798,7 @@ def allgather(
     generation: Int,
     stride_bytes: Int = -1,
 ) raises:
-    """out[r*stride_bytes ...] <- rank r's `nbytes_per_rank` input, on `stream`.
+    """Gather: `out[r*stride_bytes ...]` <- rank r's input, on `stream`.
 
     `stride_bytes` defaults to `nbytes_per_rank` and is the output layout's
     true per-rank size, which differs when the caller splits one rank's

--- a/torch_mojo_backend/distributed/mojoccl/collectives_kernels.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/collectives_kernels.mojo
@@ -102,6 +102,7 @@ from std.atomic import Atomic, Ordering, fence
 from std.builtin.device_passable import DevicePassable
 from std.collections import InlineArray
 from std.ffi import _get_global_or_null, external_call
+from std.os import getenv
 from std.gpu import (
     MAX_THREADS_PER_BLOCK_METADATA,
     block_idx,
@@ -156,7 +157,11 @@ never resets, so headroom costs nothing, but a tight bound documents the
 contract."""
 
 comptime DEFAULT_TIMEOUT_NS = 60_000_000_000
-"""Spin-loop deadline (60 s), measured with this GPU's own timer."""
+"""Default spin-loop deadline (60 s), measured with this GPU's own timer.
+
+`MOJOCCL_IB_TIMEOUT_S` overrides it (`spin_timeout_ns`): one variable for
+"how long a rank waits for a peer that stopped answering", whether the peer
+is on this node's NVLink or on the other end of the fabric."""
 
 comptime _SPIN_CHECK = 4096
 """Spins between two reads of the (not free) global timer."""
@@ -242,6 +247,37 @@ def abort_ptr_offset() -> Int:
 @always_inline
 def _align_up(x: Int, a: Int) -> Int:
     return (x + a - 1) // a * a
+
+
+def spin_timeout_ns() -> UInt64:
+    """The deadline every device spin in this library is launched with.
+
+    `MOJOCCL_IB_TIMEOUT_S` governs it, the same variable the inter-node
+    transport's own waits use: a rank waiting on a peer that stopped
+    answering should give up after one interval, not two different ones
+    depending on which side of the hierarchy the peer is. Read from the
+    environment once per process and cached in a process global -- a getenv
+    and a float parse per collective would be a measurable slice of a 27 MiB
+    allreduce's 164 us.
+    """
+    var g = _get_global_or_null("CCL_SPIN_TIMEOUT_NS")
+    if g:
+        return g.value().unsafe_bitcast[UInt64]()[unsafe_offset=0]
+    var ns = UInt64(DEFAULT_TIMEOUT_NS)
+    var raw = getenv("MOJOCCL_IB_TIMEOUT_S", String(""))
+    if raw != String(""):
+        try:
+            var seconds = Float64(raw)
+            if seconds > 0.0:
+                ns = UInt64(seconds * 1.0e9)
+        except:
+            pass
+    var slot = unsafe_alloc[UInt64](1)
+    slot[unsafe_offset=0] = ns
+    external_call["KGEN_CompilerRT_InsertGlobal", NoneType](
+        StringSlice("CCL_SPIN_TIMEOUT_NS"), slot.unsafe_bitcast[NoneType]()
+    )
+    return ns
 
 
 @always_inline
@@ -1491,7 +1527,7 @@ def _launch_allreduce[
             Int32(rank),
             _flag_target(generation, 0),
             scale,
-            UInt64(DEFAULT_TIMEOUT_NS),
+            spin_timeout_ns(),
         )
         return
 
@@ -1525,7 +1561,7 @@ def _launch_allreduce[
         Int32(rank),
         _flag_target(generation, 0),
         scale,
-        UInt64(DEFAULT_TIMEOUT_NS),
+        spin_timeout_ns(),
     )
 
 
@@ -1669,7 +1705,7 @@ def _launch_rs_stage[
         Int32(rank),
         _flag_target(generation, 0),
         scale,
-        UInt64(DEFAULT_TIMEOUT_NS),
+        spin_timeout_ns(),
     )
 
 
@@ -1703,7 +1739,7 @@ def _launch_ag_finish[
         Int32(rank),
         _flag_target(generation, 0),
         scale,
-        UInt64(DEFAULT_TIMEOUT_NS),
+        spin_timeout_ns(),
     )
 
 
@@ -1878,7 +1914,7 @@ def broadcast(
         Int32(rank),
         Int32(root),
         _flag_target(generation, 0),
-        UInt64(DEFAULT_TIMEOUT_NS),
+        spin_timeout_ns(),
     )
 
 
@@ -1931,5 +1967,5 @@ def allgather(
         Int32(world),
         Int32(rank),
         _flag_target(generation, 0),
-        UInt64(DEFAULT_TIMEOUT_NS),
+        spin_timeout_ns(),
     )

--- a/torch_mojo_backend/distributed/mojoccl/driver.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/driver.mojo
@@ -9,6 +9,7 @@
 # through the library MAX already dlopened -- no C shim, no NCCL/RCCL.
 
 from std.ffi import OwnedDLHandle
+from std.memory.alloc import unsafe_alloc
 from max.gpu.host import DeviceContext, DeviceBuffer
 from std.sys import has_amd_gpu_accelerator
 
@@ -20,6 +21,12 @@ comptime FN_OPEN_HANDLE = "hipIpcOpenMemHandle" if AMD else "cuIpcOpenMemHandle"
 comptime FN_CLOSE_HANDLE = "hipIpcCloseMemHandle" if AMD else "cuIpcCloseMemHandle"
 comptime FN_FREE = "hipFree" if AMD else "cuMemFree_v2"
 comptime FN_GET_DEVICE = "hipGetDevice" if AMD else "cuCtxGetDevice"
+comptime FN_LAUNCH_HOST_FUNC = (
+    "hipLaunchHostFunc" if AMD else "cuLaunchHostFunc"
+)
+comptime FN_PCI_BUS_ID = (
+    "hipDeviceGetPCIBusId" if AMD else "cuDeviceGetPCIBusId"
+)
 # CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS == hipIpcMemLazyEnablePeerAccess == 1
 comptime IPC_LAZY_PEER: UInt32 = 1
 # hipDeviceMallocUncached: cross-agent flag buffers must be uncached on AMD
@@ -148,3 +155,50 @@ def zero_bytes(ctx: DeviceContext, addr: Int, nbytes: Int) raises:
     )
     ctx.enqueue_memset(buf, 0)
     ctx.synchronize()
+
+
+def launch_host_func(
+    lib: OwnedDLHandle, stream: Int, func_addr: Int, user_data: Int
+) raises:
+    """cuLaunchHostFunc / hipLaunchHostFunc on a RAW stream handle.
+
+    The ordering primitive the inter-node hop stands on: a host function
+    enqueued on the caller's stream runs after everything enqueued before it
+    has completed, and everything enqueued after it waits for it to return.
+    That is what lets `internode.mojo` post its RDMA writes knowing the
+    reduce-scatter's output is final, and lets the add kernel start knowing
+    the peers' shards have landed.
+
+    Contract (identical in both vendors' docs): the callback must not call
+    into the driver. This library's callback only touches libibverbs and its
+    own host memory, never cu*/hip*.
+    """
+    _check(
+        lib.get_function[Int32](FN_LAUNCH_HOST_FUNC)(
+            stream, func_addr, user_data
+        ),
+        FN_LAUNCH_HOST_FUNC,
+    )
+
+
+def device_pci_bus_id(lib: OwnedDLHandle, ordinal: Int) raises -> String:
+    """The GPU's PCI address, e.g. `0000:1b:00.0`, lowercased.
+
+    Used to pair a rank with the IB HCA nearest its GPU (internode.mojo);
+    both vendors expose the same call with the same signature.
+    """
+    var buf = unsafe_alloc[UInt8](32)
+    for i in range(32):
+        buf[unsafe_offset=i] = 0
+    var rc = lib.get_function[Int32](FN_PCI_BUS_ID)(buf, Int32(32), Int32(ordinal))
+    if rc != 0:
+        return String("")
+    var s = String("")
+    var i = 0
+    while i < 31 and buf[unsafe_offset=i] != 0:
+        var c = Int(buf[unsafe_offset=i])
+        if c >= 65 and c <= 90:
+            c += 32
+        s += chr(c)
+        i += 1
+    return s^

--- a/torch_mojo_backend/distributed/mojoccl/driver.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/driver.mojo
@@ -1,0 +1,150 @@
+# Vendor CUDA/HIP driver shims for mojoccl.
+#
+# MAX's own allocator memory cannot be exported with legacy IPC (measured:
+# cuIpcGetMemHandle rc=1 on enqueue_create_buffer memory -- see
+# docs/mojo_collectives_feasibility.md in the main worktree, section 5.6), so
+# this library owns raw driver allocations (cuMemAlloc_v2 / hipExtMallocWith-
+# Flags) for its communication regions and shares them with legacy IPC
+# (cuIpc*/hipIpc*). Mirrors proto/ipc_probe.mojo's driver-call shape, called
+# through the library MAX already dlopened -- no C shim, no NCCL/RCCL.
+
+from std.ffi import OwnedDLHandle
+from max.gpu.host import DeviceContext, DeviceBuffer
+from std.sys import has_amd_gpu_accelerator
+
+comptime AMD = has_amd_gpu_accelerator()
+comptime DRIVER_LIB = "libamdhip64.so" if AMD else "libcuda.so.1"
+comptime FN_ALLOC = "hipExtMallocWithFlags" if AMD else "cuMemAlloc_v2"
+comptime FN_GET_HANDLE = "hipIpcGetMemHandle" if AMD else "cuIpcGetMemHandle"
+comptime FN_OPEN_HANDLE = "hipIpcOpenMemHandle" if AMD else "cuIpcOpenMemHandle"
+comptime FN_CLOSE_HANDLE = "hipIpcCloseMemHandle" if AMD else "cuIpcCloseMemHandle"
+comptime FN_FREE = "hipFree" if AMD else "cuMemFree_v2"
+comptime FN_GET_DEVICE = "hipGetDevice" if AMD else "cuCtxGetDevice"
+# CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS == hipIpcMemLazyEnablePeerAccess == 1
+comptime IPC_LAZY_PEER: UInt32 = 1
+# hipDeviceMallocUncached: cross-agent flag buffers must be uncached on AMD
+# (RCCL's own precondition for polled P2P flags); NVIDIA needs no such flag.
+comptime HIP_DEVICE_MALLOC_UNCACHED: UInt32 = 0x2
+
+comptime HANDLE_BYTES = 64
+
+
+def open_driver() raises -> OwnedDLHandle:
+    return OwnedDLHandle(DRIVER_LIB)
+
+
+def _check(rc: Int32, what: String) raises:
+    if rc != 0:
+        raise Error(what + " failed, rc=" + String(rc))
+
+
+def current_device_ordinal(lib: OwnedDLHandle) raises -> Int:
+    """The GPU this thread already has current.
+
+    NCCL's binding contract is "the device current on the calling thread"
+    (cudaSetDevice / hipSetDevice); nccl.py's set_current_device runs this
+    before ncclCommInitRank, matching real NCCL/RCCL -- so this queries
+    rather than sets, unlike proto/ipc_probe.mojo's standalone `make_current`.
+    """
+    var dev: Int32 = 0
+    _check(
+        lib.get_function[Int32](FN_GET_DEVICE)(Pointer(to=dev)), FN_GET_DEVICE
+    )
+    return Int(dev)
+
+
+def alloc_region(lib: OwnedDLHandle, nbytes: Int) raises -> Int:
+    """cuMemAlloc_v2 / hipExtMallocWithFlags(hipDeviceMallocUncached, size).
+
+    Returns the base device address. Not zeroed -- the caller zeros the
+    signal-area prefix via `zero_bytes` (region_init).
+    """
+    var base: Int = 0
+    comptime if AMD:
+        _check(
+            lib.get_function[Int32](FN_ALLOC)(
+                Pointer(to=base), nbytes, HIP_DEVICE_MALLOC_UNCACHED
+            ),
+            FN_ALLOC,
+        )
+    else:
+        _check(
+            lib.get_function[Int32](FN_ALLOC)(Pointer(to=base), nbytes),
+            FN_ALLOC,
+        )
+    return base
+
+
+def free_region(lib: OwnedDLHandle, addr: Int) raises:
+    _check(lib.get_function[Int32](FN_FREE)(addr), FN_FREE)
+
+
+def get_handle(
+    lib: OwnedDLHandle, addr: Int, out_bytes: Pointer[UInt8, MutAnyOrigin]
+) raises:
+    """cuIpcGetMemHandle / hipIpcGetMemHandle: fills `out_bytes[0:64]`."""
+    _check(
+        lib.get_function[Int32](FN_GET_HANDLE)(out_bytes, addr), FN_GET_HANDLE
+    )
+
+
+def open_handle(
+    lib: OwnedDLHandle, handle: Pointer[UInt8, MutAnyOrigin]
+) raises -> Int:
+    """cuIpcOpenMemHandle / hipIpcOpenMemHandle(..., LazyEnablePeerAccess).
+
+    `CUipcMemHandle`/`hipIpcMemHandle_t` is a 64-byte struct passed BY VALUE
+    (SysV MEMORY class: no integer register, pushed on the stack as 8 qwords)
+    after the two real leading args (pdptr -> rdi, flags -> esi) -- the exact
+    shim proto/ipc_probe.mojo uses and measured working (§5.3): four dummy
+    Int64 args exhaust rdx/rcx/r8/r9, then the 8 handle qwords land on the
+    stack where a real C caller would place them. `std.ffi` has no C-struct
+    ABI yet (MOCO-3692/3709).
+    """
+    var opn = lib.get_function[Int32](FN_OPEN_HANDLE)
+    var h64 = handle.unsafe_bitcast[UInt64]()
+    var ptr: Int = 0
+    _check(
+        opn(
+            Pointer(to=ptr),
+            IPC_LAZY_PEER,
+            Int64(0),
+            Int64(0),
+            Int64(0),
+            Int64(0),
+            h64[unsafe_offset=0],
+            h64[unsafe_offset=1],
+            h64[unsafe_offset=2],
+            h64[unsafe_offset=3],
+            h64[unsafe_offset=4],
+            h64[unsafe_offset=5],
+            h64[unsafe_offset=6],
+            h64[unsafe_offset=7],
+        ),
+        FN_OPEN_HANDLE,
+    )
+    return ptr
+
+
+def close_handle(lib: OwnedDLHandle, addr: Int) raises:
+    _check(lib.get_function[Int32](FN_CLOSE_HANDLE)(addr), FN_CLOSE_HANDLE)
+
+
+def zero_bytes(ctx: DeviceContext, addr: Int, nbytes: Int) raises:
+    """Zero-fill `nbytes` at a raw device address, blocking.
+
+    Blocking (unlike every per-collective op here) is fine: this runs once
+    per rank, at communicator creation, on `ctx`'s own queue -- while later
+    collectives run on the caller-supplied external stream, so without a
+    synchronize here the first collective could race this region_init.
+    """
+    var buf = DeviceBuffer[DType.uint8](
+        ctx,
+        Pointer[Scalar[DType.uint8], MutUntrackedOrigin](
+            unsafe_from_address=addr
+        ),
+        nbytes,
+        owning=False,
+    )
+    ctx.enqueue_memset(buf, 0)
+    ctx.synchronize()

--- a/torch_mojo_backend/distributed/mojoccl/driver.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/driver.mojo
@@ -11,7 +11,7 @@
 from std.ffi import OwnedDLHandle
 from std.memory.alloc import unsafe_alloc
 from max.gpu.host import DeviceContext, DeviceBuffer
-from std.sys import has_amd_gpu_accelerator
+from std.sys import has_amd_gpu_accelerator, stderr
 
 comptime AMD = has_amd_gpu_accelerator()
 comptime DRIVER_LIB = "libamdhip64.so" if AMD else "libcuda.so.1"
@@ -269,3 +269,13 @@ def host_device_ptr(lib: OwnedDLHandle, host_addr: Int) raises -> Int:
 
 def free_host(lib: OwnedDLHandle, addr: Int) raises:
     _check(lib.get_function[Int32](FN_HOST_FREE)(addr), FN_HOST_FREE)
+
+
+def warn_teardown(what: String, e: Error):
+    """Best-effort cleanup that failed: say so on stderr rather than hide it.
+    The error that started the teardown is the one propagating; this one only
+    needs to be visible."""
+    print(
+        "mojoccl: " + what + " failed during teardown: " + String(e),
+        file=stderr,
+    )

--- a/torch_mojo_backend/distributed/mojoccl/driver.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/driver.mojo
@@ -217,7 +217,9 @@ def device_pci_bus_id(lib: OwnedDLHandle, ordinal: Int) raises -> String:
     var buf = unsafe_alloc[UInt8](32)
     for i in range(32):
         buf[unsafe_offset=i] = 0
-    var rc = lib.get_function[Int32](FN_PCI_BUS_ID)(buf, Int32(32), Int32(ordinal))
+    var rc = lib.get_function[Int32](FN_PCI_BUS_ID)(
+        buf, Int32(32), Int32(ordinal)
+    )
     if rc != 0:
         return String("")
     var s = String("")

--- a/torch_mojo_backend/distributed/mojoccl/driver.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/driver.mojo
@@ -27,6 +27,7 @@ comptime FN_LAUNCH_HOST_FUNC = (
 comptime FN_PCI_BUS_ID = (
     "hipDeviceGetPCIBusId" if AMD else "cuDeviceGetPCIBusId"
 )
+comptime FN_STREAM_QUERY = "hipStreamQuery" if AMD else "cuStreamQuery"
 comptime FN_HOST_ALLOC = "hipHostMalloc" if AMD else "cuMemHostAlloc"
 comptime FN_HOST_FREE = "hipHostFree" if AMD else "cuMemFreeHost"
 comptime FN_HOST_DEVPTR = (
@@ -188,6 +189,23 @@ def launch_host_func(
         ),
         FN_LAUNCH_HOST_FUNC,
     )
+
+
+def stream_done(lib: OwnedDLHandle, stream: Int) -> Bool:
+    """`cuStreamQuery`/`hipStreamQuery` on a RAW stream handle: has everything
+    enqueued on it completed?
+
+    `ncclCommAbort` polls this instead of synchronizing. A synchronize is
+    exactly the unbounded wait abort must not do, and the whole point of the
+    abort word is that the spin kernels are already leaving; a poll turns
+    "quiesced" into something abort can put a deadline on. Anything but
+    success (`CUDA_ERROR_NOT_READY`, or a sticky error from a launch that
+    faulted) reads as not-done and the caller's deadline ends the wait.
+    """
+    try:
+        return lib.get_function[Int32](FN_STREAM_QUERY)(stream) == 0
+    except:
+        return False
 
 
 def device_pci_bus_id(lib: OwnedDLHandle, ordinal: Int) raises -> String:

--- a/torch_mojo_backend/distributed/mojoccl/driver.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/driver.mojo
@@ -27,6 +27,15 @@ comptime FN_LAUNCH_HOST_FUNC = (
 comptime FN_PCI_BUS_ID = (
     "hipDeviceGetPCIBusId" if AMD else "cuDeviceGetPCIBusId"
 )
+comptime FN_HOST_ALLOC = "hipHostMalloc" if AMD else "cuMemHostAlloc"
+comptime FN_HOST_FREE = "hipHostFree" if AMD else "cuMemFreeHost"
+comptime FN_HOST_DEVPTR = (
+    "hipHostGetDevicePointer" if AMD else "cuMemHostGetDevicePointer_v2"
+)
+# PORTABLE | DEVICEMAP, spelled the same in both APIs
+# (CU_MEMHOSTALLOC_PORTABLE|CU_MEMHOSTALLOC_DEVICEMAP,
+# hipHostMallocPortable|hipHostMallocMapped).
+comptime HOST_ALLOC_FLAGS: UInt32 = 3
 # CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS == hipIpcMemLazyEnablePeerAccess == 1
 comptime IPC_LAZY_PEER: UInt32 = 1
 # hipDeviceMallocUncached: cross-agent flag buffers must be uncached on AMD
@@ -202,3 +211,41 @@ def device_pci_bus_id(lib: OwnedDLHandle, ordinal: Int) raises -> String:
         s += chr(c)
         i += 1
     return s^
+
+
+def alloc_host(lib: OwnedDLHandle, nbytes: Int) raises -> Int:
+    """Pinned, device-mapped host memory: the proxy thread's mailbox.
+
+    The two words the GPU and the progress thread exchange live here --
+    written by a one-thread kernel with a system-scope release and read by
+    the CPU (and the reverse). Pageable memory would not do: the device
+    mapping is what lets a kernel touch it at all.
+    """
+    var p: Int = 0
+    _check(
+        lib.get_function[Int32](FN_HOST_ALLOC)(
+            Pointer(to=p), nbytes, HOST_ALLOC_FLAGS
+        ),
+        FN_HOST_ALLOC,
+    )
+    return p
+
+
+def host_device_ptr(lib: OwnedDLHandle, host_addr: Int) raises -> Int:
+    """The address a kernel must use for `alloc_host` memory.
+
+    Equal to the host address under unified addressing on both vendors, but
+    asked for rather than assumed.
+    """
+    var d: Int = 0
+    _check(
+        lib.get_function[Int32](FN_HOST_DEVPTR)(
+            Pointer(to=d), host_addr, UInt32(0)
+        ),
+        FN_HOST_DEVPTR,
+    )
+    return d
+
+
+def free_host(lib: OwnedDLHandle, addr: Int) raises:
+    _check(lib.get_function[Int32](FN_HOST_FREE)(addr), FN_HOST_FREE)

--- a/torch_mojo_backend/distributed/mojoccl/driver.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/driver.mojo
@@ -10,7 +10,7 @@
 
 from std.ffi import OwnedDLHandle
 from max.gpu.host import DeviceContext, DeviceBuffer
-from std.sys import has_amd_gpu_accelerator
+from std.sys import has_amd_gpu_accelerator, stderr
 
 comptime AMD = has_amd_gpu_accelerator()
 comptime DRIVER_LIB = "libamdhip64.so" if AMD else "libcuda.so.1"
@@ -148,3 +148,13 @@ def zero_bytes(ctx: DeviceContext, addr: Int, nbytes: Int) raises:
     )
     ctx.enqueue_memset(buf, 0)
     ctx.synchronize()
+
+
+def warn_teardown(what: String, e: Error):
+    """Best-effort cleanup that failed: say so on stderr rather than hide it.
+    The error that started the teardown is the one propagating; this one only
+    needs to be visible."""
+    print(
+        "mojoccl: " + what + " failed during teardown: " + String(e),
+        file=stderr,
+    )

--- a/torch_mojo_backend/distributed/mojoccl/ibverbs.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/ibverbs.mojo
@@ -1,0 +1,645 @@
+# libibverbs bindings for mojoccl's inter-node hop -- a narrow RC/RDMA-WRITE
+# client, no vendor collective library anywhere.
+#
+# Two calling conventions, because libibverbs has two:
+#
+#  * control path (open/query/alloc/reg/create/modify/destroy) -- real
+#    exported symbols, reached with OwnedDLHandle.get_function. Runs a
+#    couple of dozen times per communicator, at init.
+#  * data path (post_send / post_recv / poll_cq) -- NOT exported: they are
+#    `static inline` in <infiniband/verbs.h> and dispatch through
+#    `qp->context->ops.post_send` etc. NCCL does not include the inline
+#    either, it hand-writes the same dereference
+#    (nccl:src/include/ibvwrap.h:61,78,88), and so does this file: load the
+#    8-byte function pointer at a fixed offset from the ibv_context and call
+#    it. Zero dlsym on the hot path.
+#
+# Every struct offset below was dumped with gcc offsetof against
+# /usr/include/infiniband/verbs.h on this machine (rdma-core 1.14.54.0 /
+# MLNX OFED 24.10) and the ops-table offsets were additionally read back
+# from a live mlx5 context; enum values likewise. Nothing here is from
+# memory. x86-64 SysV: the structs are built in raw byte buffers because
+# std.ffi still has no C-struct ABI (MOCO-3692).
+
+from std.ffi import OwnedDLHandle
+from std.memory.alloc import unsafe_alloc
+
+comptime P8 = Pointer[UInt8, MutAnyOrigin]
+
+# ---- enum values ---------------------------------------------------------
+comptime IBV_QPS_INIT: Int32 = 1
+comptime IBV_QPS_RTR: Int32 = 2
+comptime IBV_QPS_RTS: Int32 = 3
+comptime IBV_QPT_RC: Int32 = 2
+
+comptime IBV_ACCESS_LOCAL_WRITE: Int32 = 1
+comptime IBV_ACCESS_REMOTE_WRITE: Int32 = 2
+comptime IBV_ACCESS_REMOTE_READ: Int32 = 4
+
+# The three composite attr masks, spelled out at nccl:src/transport/net_ib/
+# connect.cc:377 (INIT), :435+441 (RTR), :492+500 (RTS).
+comptime QP_MASK_INIT: Int32 = 0x39  # STATE|ACCESS_FLAGS|PKEY_INDEX|PORT
+comptime QP_MASK_RTR: Int32 = 0x129181
+comptime QP_MASK_RTS: Int32 = 0x12E01
+
+comptime IBV_WR_RDMA_WRITE: Int32 = 0
+comptime IBV_WR_RDMA_WRITE_WITH_IMM: Int32 = 1
+comptime IBV_WR_RDMA_READ: Int32 = 4
+comptime IBV_SEND_SIGNALED: Int32 = 2
+
+comptime IBV_WC_SUCCESS: Int32 = 0
+comptime IBV_WC_RDMA_WRITE: Int32 = 1
+comptime IBV_WC_RDMA_READ: Int32 = 2
+comptime IBV_WC_RECV_RDMA_WITH_IMM: Int32 = 129
+
+comptime IBV_PORT_ACTIVE: Int32 = 4
+comptime IBV_LINK_LAYER_INFINIBAND: Int = 1
+
+# ---- struct sizes and field offsets --------------------------------------
+comptime SZ_PORT_ATTR = 56
+comptime SZ_QP_INIT_ATTR = 64
+comptime SZ_QP_ATTR = 144
+comptime SZ_SGE = 16
+comptime SZ_SEND_WR = 128
+comptime SZ_RECV_WR = 32
+comptime SZ_WC = 48
+
+# struct ibv_context: the ops table is at +8; these are absolute offsets of
+# the four live data-path slots (verified against a live mlx5 context).
+comptime CTX_POLL_CQ = 96
+comptime CTX_POST_SEND = 208
+comptime CTX_POST_RECV = 216
+
+comptime DEV_NAME = 24  # struct ibv_device.name[64]
+comptime QP_CONTEXT = 0  # struct ibv_qp.context  (also cq.context, mr.context)
+comptime QP_QP_NUM = 52
+comptime MR_LKEY = 36
+comptime MR_RKEY = 40
+
+comptime PA_STATE = 0  # struct ibv_port_attr
+comptime PA_ACTIVE_MTU = 8
+comptime PA_GID_TBL_LEN = 12
+comptime PA_LID = 34
+comptime PA_LINK_LAYER = 46
+
+comptime QIA_SEND_CQ = 8  # struct ibv_qp_init_attr
+comptime QIA_RECV_CQ = 16
+comptime QIA_MAX_SEND_WR = 32
+comptime QIA_MAX_RECV_WR = 36
+comptime QIA_MAX_SEND_SGE = 40
+comptime QIA_MAX_RECV_SGE = 44
+comptime QIA_QP_TYPE = 52
+
+comptime QA_QP_STATE = 0  # struct ibv_qp_attr
+comptime QA_PATH_MTU = 8
+comptime QA_RQ_PSN = 20
+comptime QA_SQ_PSN = 24
+comptime QA_DEST_QP_NUM = 28
+comptime QA_ACCESS_FLAGS = 32
+comptime QA_AH_DGID = 56  # ah_attr.grh.dgid
+comptime QA_AH_SGID_INDEX = 76
+comptime QA_AH_HOP_LIMIT = 77
+comptime QA_AH_DLID = 80
+comptime QA_AH_SL = 82
+comptime QA_AH_IS_GLOBAL = 85
+comptime QA_AH_PORT_NUM = 86
+comptime QA_PKEY_INDEX = 120
+comptime QA_MAX_RD_ATOMIC = 126
+comptime QA_MAX_DEST_RD_ATOMIC = 127
+comptime QA_MIN_RNR_TIMER = 128
+comptime QA_PORT_NUM = 129
+comptime QA_TIMEOUT = 130
+comptime QA_RETRY_CNT = 131
+comptime QA_RNR_RETRY = 132
+
+comptime SGE_ADDR = 0
+comptime SGE_LENGTH = 8
+comptime SGE_LKEY = 12
+
+comptime WR_ID = 0  # struct ibv_send_wr (and ibv_recv_wr for the first 4)
+comptime WR_NEXT = 8
+comptime WR_SG_LIST = 16
+comptime WR_NUM_SGE = 24
+comptime WR_OPCODE = 28
+comptime WR_SEND_FLAGS = 32
+comptime WR_IMM_DATA = 36
+comptime WR_RDMA_REMOTE_ADDR = 40
+comptime WR_RDMA_RKEY = 48
+
+comptime WC_WR_ID = 0  # struct ibv_wc
+comptime WC_STATUS = 8
+comptime WC_OPCODE = 12
+comptime WC_VENDOR_ERR = 16
+comptime WC_BYTE_LEN = 20
+comptime WC_IMM_DATA = 24
+comptime WC_QP_NUM = 28
+
+# ---- QP attribute values, all from NCCL ----------------------------------
+# nccl:src/transport/net_ib/connect.cc:440,:502 -- both PSNs are hardcoded
+# 0 and no PSN is exchanged, so neither is this library's wire format.
+comptime IB_PSN: Int32 = 0
+comptime IB_MIN_RNR_TIMER: UInt8 = 12  # connect.cc:443
+comptime IB_TIMEOUT: UInt8 = 20  # connect.cc:496, NCCL_IB_TIMEOUT default
+comptime IB_RETRY_CNT: UInt8 = 7  # connect.cc:497, NCCL_IB_RETRY_CNT default
+comptime IB_RNR_RETRY: UInt8 = 7  # connect.cc:498, hardcoded (= infinite)
+comptime IB_HOP_LIMIT: UInt8 = 255  # connect.cc:452,:476
+
+
+@always_inline
+def alloc_bytes(n: Int) -> P8:
+    var p = P8(unsafe_from_address=Int(unsafe_alloc[UInt8](n)))
+    for i in range(n):
+        p[unsafe_offset=i] = 0
+    return p
+
+
+@always_inline
+def _st8(p: P8, off: Int, v: UInt8):
+    p[unsafe_offset=off] = v
+
+
+@always_inline
+def _st16(p: P8, off: Int, v: UInt16):
+    p.unsafe_bitcast[UInt16]()[unsafe_offset=off // 2] = v
+
+
+@always_inline
+def _st32(p: P8, off: Int, v: Int32):
+    p.unsafe_bitcast[Int32]()[unsafe_offset=off // 4] = v
+
+
+@always_inline
+def _stu32(p: P8, off: Int, v: UInt32):
+    p.unsafe_bitcast[UInt32]()[unsafe_offset=off // 4] = v
+
+
+@always_inline
+def _st64(p: P8, off: Int, v: Int):
+    p.unsafe_bitcast[Int64]()[unsafe_offset=off // 8] = Int64(v)
+
+
+@always_inline
+def ld8(p: P8, off: Int) -> Int:
+    return Int(p[unsafe_offset=off])
+
+
+@always_inline
+def ld16(p: P8, off: Int) -> Int:
+    return Int(p.unsafe_bitcast[UInt16]()[unsafe_offset=off // 2])
+
+
+@always_inline
+def ld32(p: P8, off: Int) -> Int:
+    return Int(p.unsafe_bitcast[Int32]()[unsafe_offset=off // 4])
+
+
+@always_inline
+def ldu32(p: P8, off: Int) -> UInt32:
+    return p.unsafe_bitcast[UInt32]()[unsafe_offset=off // 4]
+
+
+@always_inline
+def ld64(p: P8, off: Int) -> Int:
+    return Int(p.unsafe_bitcast[Int64]()[unsafe_offset=off // 8])
+
+
+@always_inline
+def _as_fn[F: TrivialRegisterPassable](addr: Int) -> F:
+    """A callable from a raw function address.
+
+    Same shape as `std.ffi._get_dylib_function`'s cache hit: bitcast a
+    pointer TO the address variable, then load. A `Pointer.unsafe_bitcast`
+    straight to a function type is rejected (function types are not
+    `AnyType`), and the type must be `thin` -- a plain `def(...)` type is a
+    closure trait, not a function pointer.
+    """
+    var a = addr
+    return Pointer(to=a).unsafe_bitcast[F]()[]
+
+
+# ===-------------------------------------------------------------------=== #
+# The library handle (control path)
+# ===-------------------------------------------------------------------=== #
+
+
+struct Ibv(Movable):
+    """The dlopened libibverbs.so.1.
+
+    Control-path calls go through `get_function`; the data path never
+    touches this struct.
+    """
+
+    var lib: OwnedDLHandle
+
+    def __init__(out self) raises:
+        self.lib = OwnedDLHandle("libibverbs.so.1")
+
+    def get_device_list(self, out_n: P8) raises -> Int:
+        return Int(self.lib.get_function[Int64]("ibv_get_device_list")(out_n))
+
+    def free_device_list(self, list_addr: Int) raises:
+        _ = self.lib.get_function[NoneType]("ibv_free_device_list")(list_addr)
+
+    def open_device(self, dev: Int) raises -> Int:
+        return Int(self.lib.get_function[Int64]("ibv_open_device")(dev))
+
+    def close_device(self, ctx: Int) raises:
+        _ = self.lib.get_function[Int32]("ibv_close_device")(ctx)
+
+    def query_port(self, ctx: Int, port: Int, out_attr: P8) raises -> Int32:
+        """The exported `ibv_query_port@IBVERBS_1.1` fills only the first 48
+        of the 56 bytes (the `_compat_ibv_port_attr` layout; the extended
+        entry point is `static inline`). Everything read here -- state@0,
+        active_mtu@8, lid@34, link_layer@46 -- is inside those 48, and
+        `alloc_bytes` zeroed the rest."""
+        return self.lib.get_function[Int32]("ibv_query_port")(
+            ctx, UInt8(port), out_attr
+        )
+
+    def query_gid(self, ctx: Int, port: Int, index: Int, out_gid: P8) raises -> Int32:
+        return self.lib.get_function[Int32]("ibv_query_gid")(
+            ctx, UInt8(port), Int32(index), out_gid
+        )
+
+    def alloc_pd(self, ctx: Int) raises -> Int:
+        return Int(self.lib.get_function[Int64]("ibv_alloc_pd")(ctx))
+
+    def dealloc_pd(self, pd: Int) raises:
+        _ = self.lib.get_function[Int32]("ibv_dealloc_pd")(pd)
+
+    def reg_mr(self, pd: Int, addr: Int, length: Int, access: Int32) raises -> Int:
+        """Plain `ibv_reg_mr`, no IBV_ACCESS_RELAXED_ORDERING: the RO bit
+        (1<<20) is above the range the versioned `ibv_reg_mr@IBVERBS_1.1`
+        accepts, and reaching it needs `ibv_reg_mr_iova2` (what NCCL does,
+        nccl:src/transport/net_ib/reg.cc:41-46). RO is a PCIe throughput
+        tweak, not a correctness requirement; left out until measured."""
+        return Int(
+            self.lib.get_function[Int64]("ibv_reg_mr")(
+                pd, addr, UInt64(length), access
+            )
+        )
+
+    def dereg_mr(self, mr: Int) raises:
+        _ = self.lib.get_function[Int32]("ibv_dereg_mr")(mr)
+
+    def create_cq(self, ctx: Int, cqe: Int) raises -> Int:
+        return Int(
+            self.lib.get_function[Int64]("ibv_create_cq")(
+                ctx, Int32(cqe), Int64(0), Int64(0), Int32(0)
+            )
+        )
+
+    def destroy_cq(self, cq: Int) raises:
+        _ = self.lib.get_function[Int32]("ibv_destroy_cq")(cq)
+
+    def create_qp(self, pd: Int, init_attr: P8) raises -> Int:
+        return Int(self.lib.get_function[Int64]("ibv_create_qp")(pd, init_attr))
+
+    def destroy_qp(self, qp: Int) raises:
+        _ = self.lib.get_function[Int32]("ibv_destroy_qp")(qp)
+
+    def modify_qp(self, qp: Int, attr: P8, mask: Int32) raises -> Int32:
+        return self.lib.get_function[Int32]("ibv_modify_qp")(qp, attr, mask)
+
+
+# ===-------------------------------------------------------------------=== #
+# Data path -- ctx->ops.<fn>, no dlsym
+# ===-------------------------------------------------------------------=== #
+
+
+@always_inline
+def post_send(qp: Int, wr: P8, bad_wr: P8) -> Int32:
+    """`qp->context->ops.post_send(qp, wr, &bad_wr)`; 0 or an errno."""
+    var f = _as_fn[def (Int, P8, P8) thin abi("C") -> Int32](
+        ld64(P8(unsafe_from_address=ld64(P8(unsafe_from_address=qp), QP_CONTEXT)), CTX_POST_SEND)
+    )
+    return f(qp, wr, bad_wr)
+
+
+@always_inline
+def post_recv(qp: Int, wr: P8, bad_wr: P8) -> Int32:
+    var f = _as_fn[def (Int, P8, P8) thin abi("C") -> Int32](
+        ld64(P8(unsafe_from_address=ld64(P8(unsafe_from_address=qp), QP_CONTEXT)), CTX_POST_RECV)
+    )
+    return f(qp, wr, bad_wr)
+
+
+@always_inline
+def poll_cq(cq: Int, num_entries: Int, wc: P8) -> Int32:
+    """Number of completions written into `wc`, or negative on error."""
+    var f = _as_fn[def (Int, Int32, P8) thin abi("C") -> Int32](
+        ld64(P8(unsafe_from_address=ld64(P8(unsafe_from_address=cq), QP_CONTEXT)), CTX_POLL_CQ)
+    )
+    return f(cq, Int32(num_entries), wc)
+
+
+# ===-------------------------------------------------------------------=== #
+# Work-request builders
+# ===-------------------------------------------------------------------=== #
+
+
+def build_write_wr(
+    wr: P8,
+    sge: P8,
+    wr_id: Int,
+    local_addr: Int,
+    lkey: UInt32,
+    nbytes: Int,
+    remote_addr: Int,
+    rkey: UInt32,
+    immediate: UInt32,
+    with_imm: Bool,
+    signaled: Bool,
+):
+    """One unchained RDMA_WRITE[_WITH_IMM]. `wr`/`sge` are caller-owned
+    scratch reused across calls, so every field is written every time
+    rather than relying on what was there before."""
+    _st64(sge, SGE_ADDR, local_addr)
+    _stu32(sge, SGE_LENGTH, UInt32(nbytes))
+    _stu32(sge, SGE_LKEY, lkey)
+    for i in range(SZ_SEND_WR):
+        wr[unsafe_offset=i] = 0
+    _st64(wr, WR_ID, wr_id)
+    _st64(wr, WR_NEXT, 0)
+    _st64(wr, WR_SG_LIST, Int(sge))
+    _st32(wr, WR_NUM_SGE, 1)
+    _st32(
+        wr,
+        WR_OPCODE,
+        IBV_WR_RDMA_WRITE_WITH_IMM if with_imm else IBV_WR_RDMA_WRITE,
+    )
+    _st32(wr, WR_SEND_FLAGS, IBV_SEND_SIGNALED if signaled else 0)
+    # imm_data is __be32 on both sides (nccl:...:p2p.cc:157 htobe32, :653
+    # be32toh). Byte-swapped here so the receiver's plain load reads it back.
+    _stu32(wr, WR_IMM_DATA, _bswap32(immediate))
+    _st64(wr, WR_RDMA_REMOTE_ADDR, remote_addr)
+    _stu32(wr, WR_RDMA_RKEY, rkey)
+
+
+def build_read_wr(
+    wr: P8,
+    sge: P8,
+    wr_id: Int,
+    local_addr: Int,
+    lkey: UInt32,
+    nbytes: Int,
+    remote_addr: Int,
+    rkey: UInt32,
+):
+    """A signaled RDMA_READ -- the GPUDirect flush (see internode.mojo)."""
+    _st64(sge, SGE_ADDR, local_addr)
+    _stu32(sge, SGE_LENGTH, UInt32(nbytes))
+    _stu32(sge, SGE_LKEY, lkey)
+    for i in range(SZ_SEND_WR):
+        wr[unsafe_offset=i] = 0
+    _st64(wr, WR_ID, wr_id)
+    _st64(wr, WR_SG_LIST, Int(sge))
+    _st32(wr, WR_NUM_SGE, 1)
+    _st32(wr, WR_OPCODE, IBV_WR_RDMA_READ)
+    _st32(wr, WR_SEND_FLAGS, IBV_SEND_SIGNALED)
+    _st64(wr, WR_RDMA_REMOTE_ADDR, remote_addr)
+    _stu32(wr, WR_RDMA_RKEY, rkey)
+
+
+def build_recv_wr(wr: P8, wr_id: Int):
+    """An EMPTY receive WR (`sg_list = NULL, num_sge = 0`), which is what
+    NCCL posts too (nccl:src/transport/net_ib/common.cc:88): its only job is
+    to be consumed by an incoming RDMA_WRITE_WITH_IMM so a completion with
+    the immediate appears on the CQ. The payload went straight to the
+    registered region."""
+    for i in range(SZ_RECV_WR):
+        wr[unsafe_offset=i] = 0
+    _st64(wr, WR_ID, wr_id)
+
+
+@always_inline
+def _bswap32(v: UInt32) -> UInt32:
+    return (
+        ((v & 0xFF) << 24)
+        | ((v & 0xFF00) << 8)
+        | ((v >> 8) & 0xFF00)
+        | ((v >> 24) & 0xFF)
+    )
+
+
+@always_inline
+def be32(v: UInt32) -> UInt32:
+    """Host <-> big-endian for the 32-bit immediate (involutive)."""
+    return _bswap32(v)
+
+
+# ===-------------------------------------------------------------------=== #
+# QP bring-up
+# ===-------------------------------------------------------------------=== #
+
+
+def create_rc_qp(
+    ibv: Ibv, pd: Int, cq: Int, max_send_wr: Int, max_recv_wr: Int
+) raises -> Int:
+    var ia = alloc_bytes(SZ_QP_INIT_ATTR)
+    _st64(ia, QIA_SEND_CQ, cq)
+    _st64(ia, QIA_RECV_CQ, cq)
+    _st32(ia, QIA_MAX_SEND_WR, Int32(max_send_wr))
+    _st32(ia, QIA_MAX_RECV_WR, Int32(max_recv_wr))
+    _st32(ia, QIA_MAX_SEND_SGE, 1)
+    _st32(ia, QIA_MAX_RECV_SGE, 1)
+    _st32(ia, QIA_QP_TYPE, IBV_QPT_RC)
+    var qp = ibv.create_qp(pd, ia)
+    if qp == 0:
+        raise Error("mojoccl: ibv_create_qp failed")
+    return qp
+
+
+def qp_number(qp: Int) -> UInt32:
+    return ldu32(P8(unsafe_from_address=qp), QP_QP_NUM)
+
+
+def qp_to_init(ibv: Ibv, qp: Int, port: Int) raises:
+    var a = alloc_bytes(SZ_QP_ATTR)
+    _st32(a, QA_QP_STATE, IBV_QPS_INIT)
+    _st16(a, QA_PKEY_INDEX, 0)
+    _st8(a, QA_PORT_NUM, UInt8(port))
+    # Both directions on one QP pair: this rank writes into the peer's
+    # region and the peer writes into this one, so REMOTE_WRITE is needed
+    # on both ends (NCCL splits it because its QPs are one-directional).
+    _st32(
+        a,
+        QA_ACCESS_FLAGS,
+        IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ,
+    )
+    var rc = ibv.modify_qp(qp, a, QP_MASK_INIT)
+    if rc != 0:
+        raise Error("mojoccl: ibv_modify_qp(INIT) failed, rc=" + String(rc))
+
+
+def qp_to_rtr(
+    ibv: Ibv,
+    qp: Int,
+    dest_qpn: UInt32,
+    dlid: Int,
+    mtu: Int,
+    port: Int,
+    remote_gid: P8,
+    local_gid_index: Int,
+    global_route: Bool,
+) raises:
+    var a = alloc_bytes(SZ_QP_ATTR)
+    _st32(a, QA_QP_STATE, IBV_QPS_RTR)
+    _st32(a, QA_PATH_MTU, Int32(mtu))
+    _stu32(a, QA_DEST_QP_NUM, dest_qpn)
+    _st32(a, QA_RQ_PSN, IB_PSN)
+    _st8(a, QA_MAX_DEST_RD_ATOMIC, 1)
+    _st8(a, QA_MIN_RNR_TIMER, IB_MIN_RNR_TIMER)
+    _st16(a, QA_AH_DLID, UInt16(dlid))
+    _st8(a, QA_AH_SL, 0)
+    _st8(a, QA_AH_PORT_NUM, UInt8(port))
+    if global_route:
+        # Only when the two ports are on different IB subnets -- NCCL's rule
+        # (connect.cc:456-458); a single-subnet fabric never takes this.
+        _st8(a, QA_AH_IS_GLOBAL, 1)
+        for i in range(16):
+            a[unsafe_offset=QA_AH_DGID + i] = remote_gid[unsafe_offset=i]
+        _st8(a, QA_AH_SGID_INDEX, UInt8(local_gid_index))
+        _st8(a, QA_AH_HOP_LIMIT, IB_HOP_LIMIT)
+    var rc = ibv.modify_qp(qp, a, QP_MASK_RTR)
+    if rc != 0:
+        raise Error("mojoccl: ibv_modify_qp(RTR) failed, rc=" + String(rc))
+
+
+def qp_to_rts(ibv: Ibv, qp: Int) raises:
+    var a = alloc_bytes(SZ_QP_ATTR)
+    _st32(a, QA_QP_STATE, IBV_QPS_RTS)
+    _st32(a, QA_SQ_PSN, IB_PSN)
+    _st8(a, QA_TIMEOUT, IB_TIMEOUT)
+    _st8(a, QA_RETRY_CNT, IB_RETRY_CNT)
+    _st8(a, QA_RNR_RETRY, IB_RNR_RETRY)
+    _st8(a, QA_MAX_RD_ATOMIC, 1)
+    var rc = ibv.modify_qp(qp, a, QP_MASK_RTS)
+    if rc != 0:
+        raise Error("mojoccl: ibv_modify_qp(RTS) failed, rc=" + String(rc))
+
+
+# ===-------------------------------------------------------------------=== #
+# Device selection
+# ===-------------------------------------------------------------------=== #
+
+
+struct IbPort(Copyable, Movable):
+    """One usable (device, port): ACTIVE and InfiniBand link layer."""
+
+    var name: String
+    var ctx: Int
+    var port: Int
+    var lid: Int
+    var mtu: Int
+    var gid_index: Int
+    var subnet_prefix: UInt64
+
+    def __init__(
+        out self,
+        var name: String,
+        ctx: Int,
+        port: Int,
+        lid: Int,
+        mtu: Int,
+        gid_index: Int,
+        subnet_prefix: UInt64,
+    ):
+        self.name = name^
+        self.ctx = ctx
+        self.port = port
+        self.lid = lid
+        self.mtu = mtu
+        self.gid_index = gid_index
+        self.subnet_prefix = subnet_prefix
+
+
+def _device_name(dev: Int) -> String:
+    var dp = P8(unsafe_from_address=dev)
+    var s = String("")
+    var k = 0
+    while k < 64 and dp[unsafe_offset=DEV_NAME + k] != 0:
+        s += chr(Int(dp[unsafe_offset=DEV_NAME + k]))
+        k += 1
+    return s^
+
+
+def list_ib_ports(ibv: Ibv, want: String) raises -> List[IbPort]:
+    """Every ACTIVE InfiniBand port, in device order.
+
+    RoCE (link_layer 2) and DOWN ports are skipped -- these nodes carry 10
+    IB HCAs plus 2 RoCE ports and only the former are wanted. `want`, if
+    non-empty, keeps only that device name (MOJOCCL_IB_HCA).
+    Contexts of devices with no accepted port are closed again.
+    """
+    var out = List[IbPort]()
+    var nbuf = alloc_bytes(8)
+    var lst = ibv.get_device_list(nbuf)
+    if lst == 0:
+        return out^
+    var n = ld32(nbuf, 0)
+    var lp = P8(unsafe_from_address=lst)
+    for i in range(n):
+        var dev = ld64(lp, i * 8)
+        var name = _device_name(dev)
+        if want.byte_length() > 0 and name != want:
+            continue
+        var ctx = ibv.open_device(dev)
+        if ctx == 0:
+            continue
+        var kept = False
+        var pa = alloc_bytes(SZ_PORT_ATTR)
+        # phys_port_cnt lives in ibv_device_attr; every HCA here is
+        # single-port and NCCL itself iterates 1..phys_port_cnt, so probe
+        # ports 1 and 2 and let query_port reject what is not there.
+        for port in range(1, 3):
+            for j in range(SZ_PORT_ATTR):
+                pa[unsafe_offset=j] = 0
+            if ibv.query_port(ctx, port, pa) != 0:
+                continue
+            if Int32(ld32(pa, PA_STATE)) != IBV_PORT_ACTIVE:
+                continue
+            if ld8(pa, PA_LINK_LAYER) != IBV_LINK_LAYER_INFINIBAND:
+                continue
+            var gid = alloc_bytes(16)
+            var prefix: UInt64 = 0
+            if ibv.query_gid(ctx, port, 0, gid) == 0:
+                prefix = gid.unsafe_bitcast[UInt64]()[unsafe_offset=0]
+            out.append(
+                IbPort(
+                    String(name),
+                    ctx,
+                    port,
+                    ld16(pa, PA_LID),
+                    ld32(pa, PA_ACTIVE_MTU),
+                    0,
+                    prefix,
+                )
+            )
+            kept = True
+        if not kept:
+            ibv.close_device(ctx)
+    ibv.free_device_list(lst)
+    return out^
+
+
+def gpu_pci_bus(sysfs_hca: String) -> String:
+    """The PCI bus id an HCA hangs off, e.g. `0000:18:00.0` -> `18`.
+
+    /sys/class/infiniband/<hca>/device is a symlink into the PCI tree; its
+    last path component is the BDF. Used to pair an HCA with the GPU on the
+    same PCI switch when the GPU's bus id is known."""
+    var link: String
+    try:
+        with open("/sys/class/infiniband/" + sysfs_hca + "/device/uevent", "r") as f:
+            link = f.read()
+    except:
+        return String("")
+    for line in link.split("\n"):
+        var s = String(line)
+        if s.startswith("PCI_SLOT_NAME="):
+            var bdf = s[byte=14:]
+            var parts = bdf.split(":")
+            if len(parts) >= 2:
+                return String(parts[1])
+    return String("")

--- a/torch_mojo_backend/distributed/mojoccl/ibverbs.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/ibverbs.mojo
@@ -305,8 +305,9 @@ struct Ibv(Movable):
         internode.mojo is what makes the payload visible, and it is posted
         after the completion either way.
         """
+        var mr: Int
         try:
-            var mr = Int(
+            mr = Int(
                 self.lib.get_function[Int64]("ibv_reg_mr_iova2")(
                     pd,
                     addr,
@@ -315,10 +316,11 @@ struct Ibv(Movable):
                     UInt32(access | IBV_ACCESS_RELAXED_ORDERING),
                 )
             )
-            if mr != 0:
-                return mr
         except:
-            pass  # IBVERBS_1.8 absent: an old rdma-core, RO simply unavailable
+            # IBVERBS_1.8 absent: an old rdma-core, RO simply unavailable
+            mr = 0
+        if mr != 0:
+            return mr
         return self.reg_mr(pd, addr, length, access)
 
     def dereg_mr(self, mr: Int) raises:

--- a/torch_mojo_backend/distributed/mojoccl/ibverbs.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/ibverbs.mojo
@@ -35,6 +35,11 @@ comptime IBV_QPT_RC: Int32 = 2
 comptime IBV_ACCESS_LOCAL_WRITE: Int32 = 1
 comptime IBV_ACCESS_REMOTE_WRITE: Int32 = 2
 comptime IBV_ACCESS_REMOTE_READ: Int32 = 4
+# 1<<20, and above the range the versioned `ibv_reg_mr@IBVERBS_1.1` will
+# accept -- reaching it needs `ibv_reg_mr_iova2@IBVERBS_1.8`, which is the
+# only reason NCCL calls that entry point at all
+# (nccl:src/transport/net_ib/reg.cc:41-46).
+comptime IBV_ACCESS_RELAXED_ORDERING: Int32 = 0x100000
 
 # The three composite attr masks, spelled out at nccl:src/transport/net_ib/
 # connect.cc:377 (INIT), :435+441 (RTR), :492+500 (RTS).
@@ -268,16 +273,49 @@ struct Ibv(Movable):
         _ = self.lib.get_function[Int32]("ibv_dealloc_pd")(pd)
 
     def reg_mr(self, pd: Int, addr: Int, length: Int, access: Int32) raises -> Int:
-        """Plain `ibv_reg_mr`, no IBV_ACCESS_RELAXED_ORDERING: the RO bit
-        (1<<20) is above the range the versioned `ibv_reg_mr@IBVERBS_1.1`
-        accepts, and reaching it needs `ibv_reg_mr_iova2` (what NCCL does,
-        nccl:src/transport/net_ib/reg.cc:41-46). RO is a PCIe throughput
-        tweak, not a correctness requirement; left out until measured."""
+        """Plain `ibv_reg_mr@IBVERBS_1.1`."""
         return Int(
             self.lib.get_function[Int64]("ibv_reg_mr")(
                 pd, addr, UInt64(length), access
             )
         )
+
+    def reg_mr_relaxed(
+        self, pd: Int, addr: Int, length: Int, access: Int32
+    ) raises -> Int:
+        """`ibv_reg_mr_iova2` with IBV_ACCESS_RELAXED_ORDERING, falling back
+        to `reg_mr`.
+
+        PCIe relaxed ordering is what lets the NIC's writes into GPU memory
+        retire out of order; without it a GPUDirect RDMA transfer runs at a
+        fraction of link rate on this class of machine. NCCL turns it on by
+        default (`NCCL_IB_PCI_RELAXED_ORDERING=2`,
+        nccl:src/transport/net_ib/init.cc:11,141-150) and reaches it through
+        `ibv_reg_mr_iova2` for the same ABI reason: the older entry point
+        silently drops access bits above 0xFFFFF.
+
+        The iova passed is the address itself -- the identity mapping NCCL
+        also uses -- so remote addresses stay plain virtual addresses.
+        Ordering of the DATA against its COMPLETION is not what RO relaxes
+        and not what this library relies on: the flush read in
+        internode.mojo is what makes the payload visible, and it is posted
+        after the completion either way.
+        """
+        try:
+            var mr = Int(
+                self.lib.get_function[Int64]("ibv_reg_mr_iova2")(
+                    pd,
+                    addr,
+                    UInt64(length),
+                    UInt64(addr),
+                    UInt32(access | IBV_ACCESS_RELAXED_ORDERING),
+                )
+            )
+            if mr != 0:
+                return mr
+        except:
+            pass  # IBVERBS_1.8 absent: an old rdma-core, RO simply unavailable
+        return self.reg_mr(pd, addr, length, access)
 
     def dereg_mr(self, mr: Int) raises:
         _ = self.lib.get_function[Int32]("ibv_dereg_mr")(mr)

--- a/torch_mojo_backend/distributed/mojoccl/ibverbs.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/ibverbs.mojo
@@ -621,25 +621,3 @@ def list_ib_ports(ibv: Ibv, want: String) raises -> List[IbPort]:
             ibv.close_device(ctx)
     ibv.free_device_list(lst)
     return out^
-
-
-def gpu_pci_bus(sysfs_hca: String) -> String:
-    """The PCI bus id an HCA hangs off, e.g. `0000:18:00.0` -> `18`.
-
-    /sys/class/infiniband/<hca>/device is a symlink into the PCI tree; its
-    last path component is the BDF. Used to pair an HCA with the GPU on the
-    same PCI switch when the GPU's bus id is known."""
-    var link: String
-    try:
-        with open("/sys/class/infiniband/" + sysfs_hca + "/device/uevent", "r") as f:
-            link = f.read()
-    except:
-        return String("")
-    for line in link.split("\n"):
-        var s = String(line)
-        if s.startswith("PCI_SLOT_NAME="):
-            var bdf = s[byte=14:]
-            var parts = bdf.split(":")
-            if len(parts) >= 2:
-                return String(parts[1])
-    return String("")

--- a/torch_mojo_backend/distributed/mojoccl/ibverbs.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/ibverbs.mojo
@@ -261,7 +261,9 @@ struct Ibv(Movable):
             ctx, UInt8(port), out_attr
         )
 
-    def query_gid(self, ctx: Int, port: Int, index: Int, out_gid: P8) raises -> Int32:
+    def query_gid(
+        self, ctx: Int, port: Int, index: Int, out_gid: P8
+    ) raises -> Int32:
         return self.lib.get_function[Int32]("ibv_query_gid")(
             ctx, UInt8(port), Int32(index), out_gid
         )
@@ -272,7 +274,9 @@ struct Ibv(Movable):
     def dealloc_pd(self, pd: Int) raises:
         _ = self.lib.get_function[Int32]("ibv_dealloc_pd")(pd)
 
-    def reg_mr(self, pd: Int, addr: Int, length: Int, access: Int32) raises -> Int:
+    def reg_mr(
+        self, pd: Int, addr: Int, length: Int, access: Int32
+    ) raises -> Int:
         """Plain `ibv_reg_mr@IBVERBS_1.1`."""
         return Int(
             self.lib.get_function[Int64]("ibv_reg_mr")(
@@ -348,16 +352,26 @@ struct Ibv(Movable):
 @always_inline
 def post_send(qp: Int, wr: P8, bad_wr: P8) -> Int32:
     """`qp->context->ops.post_send(qp, wr, &bad_wr)`; 0 or an errno."""
-    var f = _as_fn[def (Int, P8, P8) thin abi("C") -> Int32](
-        ld64(P8(unsafe_from_address=ld64(P8(unsafe_from_address=qp), QP_CONTEXT)), CTX_POST_SEND)
+    var f = _as_fn[def(Int, P8, P8) thin abi("C") -> Int32](
+        ld64(
+            P8(
+                unsafe_from_address=ld64(P8(unsafe_from_address=qp), QP_CONTEXT)
+            ),
+            CTX_POST_SEND,
+        )
     )
     return f(qp, wr, bad_wr)
 
 
 @always_inline
 def post_recv(qp: Int, wr: P8, bad_wr: P8) -> Int32:
-    var f = _as_fn[def (Int, P8, P8) thin abi("C") -> Int32](
-        ld64(P8(unsafe_from_address=ld64(P8(unsafe_from_address=qp), QP_CONTEXT)), CTX_POST_RECV)
+    var f = _as_fn[def(Int, P8, P8) thin abi("C") -> Int32](
+        ld64(
+            P8(
+                unsafe_from_address=ld64(P8(unsafe_from_address=qp), QP_CONTEXT)
+            ),
+            CTX_POST_RECV,
+        )
     )
     return f(qp, wr, bad_wr)
 
@@ -365,8 +379,13 @@ def post_recv(qp: Int, wr: P8, bad_wr: P8) -> Int32:
 @always_inline
 def poll_cq(cq: Int, num_entries: Int, wc: P8) -> Int32:
     """Number of completions written into `wc`, or negative on error."""
-    var f = _as_fn[def (Int, Int32, P8) thin abi("C") -> Int32](
-        ld64(P8(unsafe_from_address=ld64(P8(unsafe_from_address=cq), QP_CONTEXT)), CTX_POLL_CQ)
+    var f = _as_fn[def(Int, Int32, P8) thin abi("C") -> Int32](
+        ld64(
+            P8(
+                unsafe_from_address=ld64(P8(unsafe_from_address=cq), QP_CONTEXT)
+            ),
+            CTX_POLL_CQ,
+        )
     )
     return f(cq, Int32(num_entries), wc)
 
@@ -503,7 +522,9 @@ def qp_to_init(ibv: Ibv, qp: Int, port: Int) raises:
     _st32(
         a,
         QA_ACCESS_FLAGS,
-        IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ,
+        IBV_ACCESS_LOCAL_WRITE
+        | IBV_ACCESS_REMOTE_WRITE
+        | IBV_ACCESS_REMOTE_READ,
     )
     var rc = ibv.modify_qp(qp, a, QP_MASK_INIT)
     if rc != 0:

--- a/torch_mojo_backend/distributed/mojoccl/internode.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/internode.mojo
@@ -1,0 +1,786 @@
+# The inter-node hop: GPUDirect RDMA over libibverbs, no vendor collective
+# library. One RC queue pair per remote node, to the rank holding the SAME
+# local_rank there -- so the 8 ranks of a node drive 8 independent NICs and
+# each rank only ever exchanges its own 1/local_world shard.
+#
+# Ordering without a proxy thread. The GPU cannot post verbs and the NIC
+# cannot wait on a kernel, so the two meet in a host function enqueued on
+# the caller's stream (`cuLaunchHostFunc`/`hipLaunchHostFunc`):
+#
+#     [reduce_scatter_stage]  my shard is final in my stage_out
+#     [host callback]         post one RDMA_WRITE_WITH_IMM per peer, then
+#                             poll the CQ until every peer's shard has
+#                             landed in my inbox, then flush (below)
+#     [inbox_add]             shard += the peers' shards
+#     [allgather_finish]      spread the global sum
+#
+# One fused callback rather than the post/poll pair: they would be adjacent
+# on the stream with nothing in between, so splitting only pays a second
+# dispatch latency. A proxy thread with GPU-visible pinned flags (NCCL's
+# design) is the fallback if the dispatch turns out to dominate; the split
+# above is where it would slot in.
+#
+# The GPUDirect flush. Seeing the RDMA_WRITE_WITH_IMM completion does NOT
+# mean the payload is visible in GPU memory: the completion lands in host
+# memory and the payload in the GPU's BAR, two different PCIe destinations
+# with no ordering between them. A read from the GPU BAR flushes the posted
+# writes ahead of it, so the callback finishes with a 4-byte RDMA_READ of
+# the inbox over a self-connected QP -- exactly NCCL's `gpuFlush` QP
+# (nccl:src/transport/net_ib/p2p.cc:589-602). Measured 1.9 us.
+#
+# Inbox aliasing and flow control. The inbox lives in stage_in, above
+# whatever the intra-node collective staged there, and is DOUBLE BUFFERED by
+# the parity of a per-communicator exchange counter. The double buffer is
+# not an optimization, it is the proof of safety: peer B writes half `p` at
+# exchanges e and e+2, and B cannot reach e+2 before receiving my e+1 data,
+# which I send only after my own stream ran the add kernel of exchange e.
+# Single buffering would leave B's e+1 write racing my e add kernel with
+# nothing but timing in between. The immediate carries the exchange counter
+# so an arrival that belongs to e+1 is counted into the other parity's
+# tally instead of satisfying e.
+
+from std.ffi import OwnedDLHandle, external_call
+from std.memory.alloc import unsafe_alloc
+from std.sys import size_of
+from std.os import getenv
+from std.time import perf_counter_ns
+
+from driver import device_pci_bus_id, launch_host_func
+from ibverbs import (
+    IbPort,
+    IBV_ACCESS_LOCAL_WRITE,
+    IBV_ACCESS_REMOTE_READ,
+    IBV_ACCESS_REMOTE_WRITE,
+    IBV_WC_RDMA_READ,
+    IBV_WC_RDMA_WRITE,
+    IBV_WC_RECV_RDMA_WITH_IMM,
+    IBV_WC_SUCCESS,
+    MR_LKEY,
+    MR_RKEY,
+    P8,
+    SZ_RECV_WR,
+    SZ_SEND_WR,
+    SZ_SGE,
+    SZ_WC,
+    WC_IMM_DATA,
+    WC_OPCODE,
+    WC_QP_NUM,
+    WC_STATUS,
+    WC_VENDOR_ERR,
+    Ibv,
+    alloc_bytes,
+    be32,
+    build_read_wr,
+    build_recv_wr,
+    build_write_wr,
+    create_rc_qp,
+    ld32,
+    ldu32,
+    list_ib_ports,
+    poll_cq,
+    post_recv,
+    post_send,
+    qp_number,
+    qp_to_init,
+    qp_to_rtr,
+    qp_to_rts,
+)
+
+# Recv WRs kept posted per peer QP. Each RDMA_WRITE_WITH_IMM consumes one;
+# the callback reposts every one it consumes, so the depth only has to cover
+# the burst a peer can produce while this rank is elsewhere -- two exchanges
+# by the double-buffer argument above, times a wide margin.
+comptime RECV_DEPTH = 64
+comptime CQ_SIZE = 1024
+comptime SEND_WR_DEPTH = 64
+comptime WORK_SLOTS = 512
+comptime MAX_NODES = 16
+comptime DEFAULT_IB_TIMEOUT_S: Float64 = 60.0
+# Bytes of the inbox read back by the flush; any read of the destination
+# device flushes the writes ahead of it, the size is irrelevant.
+comptime FLUSH_BYTES = 4
+
+
+struct IbPeer(Copyable, Movable):
+    var node: Int
+    var qp: Int
+    var qpn: UInt32
+    var remote_base: Int
+    var remote_rkey: UInt32
+
+    def __init__(
+        out self,
+        node: Int,
+        qp: Int,
+        qpn: UInt32,
+        remote_base: Int,
+        remote_rkey: UInt32,
+    ):
+        self.node = node
+        self.qp = qp
+        self.qpn = qpn
+        self.remote_base = remote_base
+        self.remote_rkey = remote_rkey
+
+
+struct IbWork(Copyable, Movable):
+    """One inter-node exchange, handed to the host callback by address.
+
+    Lives in a ring inside `IbState` so the host can enqueue ahead; a slot
+    is reused only once its callback has set `status`.
+    """
+
+    var state: Int
+    var send_addr: Int
+    var send_bytes: Int
+    var inbox_base: Int  # absolute VA offset from a region base, parity folded in
+    var slot_bytes: Int
+    var do_send: Int
+    var nrecv: Int
+    var flush_addr: Int
+    var seq: Int
+    var status: Int  # 0 running, 1 done, 2 failed
+
+    def __init__(out self):
+        self.state = 0
+        self.send_addr = 0
+        self.send_bytes = 0
+        self.inbox_base = 0
+        self.slot_bytes = 0
+        self.do_send = 0
+        self.nrecv = 0
+        self.flush_addr = 0
+        self.seq = 0
+        self.status = 1
+
+
+struct IbState(Movable):
+    """Everything the inter-node hop owns, per communicator."""
+
+    var ibv: Ibv
+    var hca: String
+    var ctx: Int
+    var port: Int
+    var pd: Int
+    var mr: Int
+    var lkey: UInt32
+    var rkey: UInt32
+    var cq: Int
+    var peers: List[IbPeer]
+    var flush_qp: Int
+    var flush_mr: Int
+    var flush_host: Int
+    var flush_lkey: UInt32
+    var region: Int
+    var my_node: Int
+    var nnodes: Int
+    var exchanges: Int
+    var arrivals0: Int
+    var arrivals1: Int
+    var error: Int
+    var timeout_ns: Int
+    # Scratch buffers and the work ring are held as raw addresses: a
+    # `Pointer[..., MutAnyOrigin]` cannot be a struct field, and these
+    # outlive every borrow anyway (allocated once, freed never -- a few
+    # hundred bytes per communicator).
+    var wr: Int
+    var sge: Int
+    var rwr: Int
+    var bad: Int
+    var wc: Int
+    var works: Int
+    var work_next: Int
+    var trace: Bool
+    var t_post_ns: Int
+    var t_wait_ns: Int
+    var t_flush_ns: Int
+    var n_exchanges: Int
+
+    def __init__(out self, var ibv: Ibv, region: Int, my_node: Int, nnodes: Int):
+        self.ibv = ibv^
+        self.hca = String("")
+        self.ctx = 0
+        self.port = 0
+        self.pd = 0
+        self.mr = 0
+        self.lkey = 0
+        self.rkey = 0
+        self.cq = 0
+        self.peers = List[IbPeer]()
+        self.flush_qp = 0
+        self.flush_mr = 0
+        self.flush_host = 0
+        self.flush_lkey = 0
+        self.region = region
+        self.my_node = my_node
+        self.nnodes = nnodes
+        self.exchanges = 0
+        self.arrivals0 = 0
+        self.arrivals1 = 0
+        self.error = 0
+        self.timeout_ns = Int(DEFAULT_IB_TIMEOUT_S * 1.0e9)
+        self.wr = Int(alloc_bytes(SZ_SEND_WR))
+        self.sge = Int(alloc_bytes(SZ_SGE))
+        self.rwr = Int(alloc_bytes(SZ_RECV_WR))
+        self.bad = Int(alloc_bytes(16))
+        self.wc = Int(alloc_bytes(SZ_WC * 16))
+        self.works = Int(unsafe_alloc[IbWork](WORK_SLOTS))
+        var wp = Pointer[IbWork, MutAnyOrigin](unsafe_from_address=self.works)
+        for i in range(WORK_SLOTS):
+            wp[unsafe_offset=i] = IbWork()
+        self.work_next = 0
+        self.trace = getenv("MOJOCCL_IB_TRACE", "0") != "0"
+        self.t_post_ns = 0
+        self.t_wait_ns = 0
+        self.t_flush_ns = 0
+        self.n_exchanges = 0
+
+
+@always_inline
+def _b(addr: Int) -> P8:
+    return P8(unsafe_from_address=addr)
+
+
+@always_inline
+def _st(ib: Int) -> Pointer[IbState, MutAnyOrigin]:
+    return Pointer[IbState, MutAnyOrigin](unsafe_from_address=ib)
+
+
+# ===-------------------------------------------------------------------=== #
+# The host callback
+# ===-------------------------------------------------------------------=== #
+
+
+def _ib_progress(user: OpaquePointer[MutAnyOrigin]) abi("C"):
+    """Post this exchange's RDMA writes, wait for the peers', flush.
+
+    Runs on a driver-owned thread with the stream stalled behind it, so it
+    must be quick and must never call the CUDA/HIP driver. Only libibverbs
+    and this struct's own host memory are touched.
+    """
+    ref w = Pointer[IbWork, MutAnyOrigin](unsafe_from_address=Int(user))[]
+    ref st = _st(w.state)[]
+    if st.error != 0:
+        w.status = 2
+        return
+    var npeers = len(st.peers)
+    var parity = w.seq & 1
+    var t0 = perf_counter_ns()
+    var deadline = t0 + st.timeout_ns
+    var nsend = 0
+
+    if w.do_send != 0 and w.send_bytes > 0:
+        for i in range(npeers):
+            ref p = st.peers[i]
+            # Where MY shard sits in the peer's inbox: senders are indexed by
+            # node, compacted past the receiver's own node.
+            var slot = st.my_node if st.my_node < p.node else st.my_node - 1
+            build_write_wr(
+                _b(st.wr),
+                _b(st.sge),
+                w.seq,
+                w.send_addr,
+                st.lkey,
+                w.send_bytes,
+                p.remote_base + w.inbox_base + slot * w.slot_bytes,
+                p.remote_rkey,
+                UInt32(w.seq & 0x7FFFFFFF),
+                True,
+                True,
+            )
+            if post_send(p.qp, _b(st.wr), _b(st.bad)) != 0:
+                st.error = 1
+                w.status = 2
+                return
+            nsend += 1
+    var t1 = perf_counter_ns()
+
+    var sends_done = 0
+    while sends_done < nsend or _arrivals(st, parity) < w.nrecv:
+        var n = poll_cq(st.cq, 16, _b(st.wc))
+        if n < 0:
+            st.error = 2
+            w.status = 2
+            return
+        for i in range(Int(n)):
+            var c = P8(unsafe_from_address=st.wc + i * SZ_WC)
+            if Int32(ld32(c, WC_STATUS)) != IBV_WC_SUCCESS:
+                st.error = 1000 + ld32(c, WC_STATUS) * 1000 + ld32(
+                    c, WC_VENDOR_ERR
+                )
+                w.status = 2
+                return
+            var op = Int32(ld32(c, WC_OPCODE))
+            if op == IBV_WC_RECV_RDMA_WITH_IMM:
+                var seq = Int(be32(ldu32(c, WC_IMM_DATA)))
+                if seq & 1 == 0:
+                    st.arrivals0 += 1
+                else:
+                    st.arrivals1 += 1
+                var qpn = ldu32(c, WC_QP_NUM)
+                for k in range(npeers):
+                    if st.peers[k].qpn == qpn:
+                        build_recv_wr(_b(st.rwr), 0)
+                        _ = post_recv(st.peers[k].qp, _b(st.rwr), _b(st.bad))
+                        break
+            elif op == IBV_WC_RDMA_WRITE:
+                sends_done += 1
+        if Int(n) == 0 and perf_counter_ns() > deadline:
+            st.error = 3
+            w.status = 2
+            return
+    if parity == 0:
+        st.arrivals0 -= w.nrecv
+    else:
+        st.arrivals1 -= w.nrecv
+    var t2 = perf_counter_ns()
+
+    if w.nrecv > 0 and w.flush_addr != 0:
+        build_read_wr(
+            _b(st.wr),
+            _b(st.sge),
+            0,
+            st.flush_host,
+            st.flush_lkey,
+            FLUSH_BYTES,
+            w.flush_addr,
+            st.rkey,
+        )
+        if post_send(st.flush_qp, _b(st.wr), _b(st.bad)) != 0:
+            st.error = 4
+            w.status = 2
+            return
+        var flushed = False
+        while not flushed:
+            var n = poll_cq(st.cq, 16, _b(st.wc))
+            if n < 0:
+                st.error = 5
+                w.status = 2
+                return
+            for i in range(Int(n)):
+                var c = P8(unsafe_from_address=st.wc + i * SZ_WC)
+                if Int32(ld32(c, WC_STATUS)) != IBV_WC_SUCCESS:
+                    st.error = 6
+                    w.status = 2
+                    return
+                if Int32(ld32(c, WC_OPCODE)) == IBV_WC_RDMA_READ:
+                    flushed = True
+            if Int(n) == 0 and perf_counter_ns() > deadline:
+                st.error = 7
+                w.status = 2
+                return
+    var t3 = perf_counter_ns()
+
+    st.t_post_ns += t1 - t0
+    st.t_wait_ns += t2 - t1
+    st.t_flush_ns += t3 - t2
+    st.n_exchanges += 1
+    w.status = 1
+
+
+@always_inline
+def _arrivals(st: IbState, parity: Int) -> Int:
+    return st.arrivals0 if parity == 0 else st.arrivals1
+
+
+def _callback_address() -> Int:
+    var f: def (OpaquePointer[MutAnyOrigin]) thin abi("C") -> None = _ib_progress
+    return Pointer(to=f).unsafe_bitcast[Int]()[]
+
+
+# ===-------------------------------------------------------------------=== #
+# Setup
+# ===-------------------------------------------------------------------=== #
+
+
+def _readlink(path: String) -> String:
+    var buf = alloc_bytes(1024)
+    var cpath = alloc_bytes(path.byte_length() + 1)
+    var pb = path.as_bytes()
+    for i in range(len(pb)):
+        cpath[unsafe_offset=i] = pb[i]
+    var n = Int(
+        external_call["readlink", Int64](cpath, buf, UInt64(1023))
+    )
+    if n <= 0:
+        return String("")
+    var s = String("")
+    for i in range(n):
+        s += chr(Int(buf[unsafe_offset=i]))
+    return s^
+
+
+def _common_prefix(a: String, b: String) -> Int:
+    var ab = a.as_bytes()
+    var bb = b.as_bytes()
+    var n = min(len(ab), len(bb))
+    var i = 0
+    while i < n and ab[i] == bb[i]:
+        i += 1
+    return i
+
+
+def _choose_port(
+    ports: List[IbPort], gpu_bdf: String, local_rank: Int
+) raises -> Int:
+    """Index of the HCA this rank should use.
+
+    Preference is PCI proximity, measured the cheap way NCCL's topology
+    measures it in spirit: both the GPU and the HCA are PCI devices, so the
+    longer the shared prefix of their /sys/devices paths, the fewer switch
+    hops between them. Ranks that tie fall back to `local_rank % n`, which
+    on these nodes (10 IB HCAs, 8 GPUs) already hands every rank its own
+    NIC. MOJOCCL_IB_HCA short-circuits all of it upstream, in list_ib_ports.
+    """
+    if len(ports) == 1 or gpu_bdf.byte_length() == 0:
+        return local_rank % len(ports)
+    var gpu_path = _readlink("/sys/bus/pci/devices/" + gpu_bdf)
+    if gpu_path.byte_length() == 0:
+        return local_rank % len(ports)
+    var best = -1
+    var best_score = -1
+    var ties = 0
+    for i in range(len(ports)):
+        var hca_path = _readlink(
+            "/sys/class/infiniband/" + ports[i].name + "/device"
+        )
+        var score = _common_prefix(gpu_path, hca_path)
+        if score > best_score:
+            best_score = score
+            best = i
+            ties = 1
+        elif score == best_score:
+            ties += 1
+    if ties > 1 or best < 0:
+        # Several NICs are equally close (the common case: one PCI switch per
+        # pair of GPUs). Spread ranks over them deterministically.
+        var chosen = List[Int]()
+        for i in range(len(ports)):
+            var hca_path = _readlink(
+                "/sys/class/infiniband/" + ports[i].name + "/device"
+            )
+            if _common_prefix(gpu_path, hca_path) == best_score:
+                chosen.append(i)
+        return chosen[local_rank % len(chosen)]
+    return best
+
+
+def ib_setup(
+    driver: OwnedDLHandle,
+    ordinal: Int,
+    local_rank: Int,
+    my_node: Int,
+    nnodes: Int,
+    region: Int,
+    region_bytes: Int,
+) raises -> Int:
+    """Open an HCA, register the region, create the QPs (still in INIT).
+
+    Returns the address of a heap `IbState`. The QPs cannot reach RTR until
+    the peers' `(qpn, lid, gid)` have been gathered, so bring-up is split:
+    this, then `ib_local_info` / `ib_connect`.
+    """
+    var ibv = Ibv()
+    var want = getenv("MOJOCCL_IB_HCA", "")
+    var ports = list_ib_ports(ibv, want)
+    if len(ports) == 0:
+        raise Error(
+            "mojoccl: no ACTIVE InfiniBand port found"
+            + (" matching MOJOCCL_IB_HCA=" + want if want.byte_length() > 0 else "")
+            + "; a multi-node communicator needs one"
+        )
+    var gpu_bdf = device_pci_bus_id(driver, ordinal)
+    var pick = _choose_port(ports, gpu_bdf, local_rank)
+    ref port = ports[pick]
+
+    var st = IbState(ibv^, region, my_node, nnodes)
+    st.hca = String(port.name)
+    st.ctx = port.ctx
+    st.port = port.port
+    st.timeout_ns = Int(_ib_timeout_s() * 1.0e9)
+
+    st.pd = st.ibv.alloc_pd(st.ctx)
+    if st.pd == 0:
+        raise Error("mojoccl: ibv_alloc_pd failed on " + st.hca)
+    st.mr = st.ibv.reg_mr(
+        st.pd,
+        region,
+        region_bytes,
+        IBV_ACCESS_LOCAL_WRITE
+        | IBV_ACCESS_REMOTE_WRITE
+        | IBV_ACCESS_REMOTE_READ,
+    )
+    if st.mr == 0:
+        raise Error(
+            "mojoccl: ibv_reg_mr of the "
+            + String(region_bytes // (1024 * 1024))
+            + " MiB device region failed on "
+            + st.hca
+            + "; is nvidia_peermem (or the ROCm equivalent) loaded?"
+        )
+    var mrp = P8(unsafe_from_address=st.mr)
+    st.lkey = ldu32(mrp, MR_LKEY)
+    st.rkey = ldu32(mrp, MR_RKEY)
+
+    # Host landing pad for the flush read.
+    st.flush_host = Int(alloc_bytes(4096))
+    st.flush_mr = st.ibv.reg_mr(
+        st.pd, st.flush_host, 4096, IBV_ACCESS_LOCAL_WRITE
+    )
+    if st.flush_mr == 0:
+        raise Error("mojoccl: ibv_reg_mr of the flush buffer failed")
+    st.flush_lkey = ldu32(P8(unsafe_from_address=st.flush_mr), MR_LKEY)
+
+    st.cq = st.ibv.create_cq(st.ctx, CQ_SIZE)
+    if st.cq == 0:
+        raise Error("mojoccl: ibv_create_cq failed")
+
+    for j in range(nnodes):
+        if j == my_node:
+            continue
+        var qp = create_rc_qp(
+            st.ibv, st.pd, st.cq, SEND_WR_DEPTH, RECV_DEPTH + 8
+        )
+        qp_to_init(st.ibv, qp, st.port)
+        st.peers.append(IbPeer(j, qp, qp_number(qp), 0, 0))
+    st.flush_qp = create_rc_qp(st.ibv, st.pd, st.cq, SEND_WR_DEPTH, 8)
+    qp_to_init(st.ibv, st.flush_qp, st.port)
+
+    var holder = unsafe_alloc[IbState](1)
+    holder.unsafe_write(st^)
+    return Int(holder)
+
+
+def _ib_timeout_s() -> Float64:
+    var s = getenv("MOJOCCL_IB_TIMEOUT_S", String(DEFAULT_IB_TIMEOUT_S))
+    try:
+        return Float64(s)
+    except:
+        return DEFAULT_IB_TIMEOUT_S
+
+
+def ib_local_info(ib: Int, out_blob: P8, port_lid: Int, port_mtu: Int):
+    """Fill this rank's IB half of the bootstrap blob.
+
+    Layout (little-endian, matches `ib_connect`'s reader):
+      +0   u64 region base VA
+      +8   u32 rkey
+      +12  u32 lid
+      +16  u32 active_mtu (ibv_mtu enum)
+      +20  u32 number of QPs that follow
+      +24  u32 qpn[MAX_NODES]     -- indexed by the PEER's node
+      +24+4*MAX_NODES  u8 gid[16]
+    """
+    ref st = _st(ib)[]
+    out_blob.unsafe_bitcast[UInt64]()[unsafe_offset=0] = UInt64(st.region)
+    out_blob.unsafe_bitcast[UInt32]()[unsafe_offset=2] = st.rkey
+    out_blob.unsafe_bitcast[UInt32]()[unsafe_offset=3] = UInt32(port_lid)
+    out_blob.unsafe_bitcast[UInt32]()[unsafe_offset=4] = UInt32(port_mtu)
+    out_blob.unsafe_bitcast[UInt32]()[unsafe_offset=5] = UInt32(len(st.peers))
+    for i in range(len(st.peers)):
+        out_blob.unsafe_bitcast[UInt32]()[
+            unsafe_offset = 6 + st.peers[i].node
+        ] = st.peers[i].qpn
+
+
+comptime IB_BLOB_BYTES = 24 + 4 * MAX_NODES + 16
+
+
+def ib_port_lid(ib: Int) -> Int:
+    ref st = _st(ib)[]
+    var pa = alloc_bytes(56)
+    try:
+        _ = st.ibv.query_port(st.ctx, st.port, pa)
+    except:
+        return 0
+    return Int(pa.unsafe_bitcast[UInt16]()[unsafe_offset=17])
+
+
+def ib_port_mtu(ib: Int) -> Int:
+    ref st = _st(ib)[]
+    var pa = alloc_bytes(56)
+    try:
+        _ = st.ibv.query_port(st.ctx, st.port, pa)
+    except:
+        return 0
+    return ld32(pa, 8)
+
+
+def ib_connect(
+    ib: Int, blobs: P8, blob_stride: Int, peer_rank_of_node: List[Int], my_mtu: Int
+) raises:
+    """Move every QP to RTS from the gathered table, then pre-post recvs.
+
+    `peer_rank_of_node[j]` is the global rank on node j holding this rank's
+    local_rank -- the one this rank's QP j is paired with. `blobs` is the
+    whole round-2 table; `blob_stride` its per-rank size.
+    """
+    ref st = _st(ib)[]
+    for i in range(len(st.peers)):
+        var j = st.peers[i].node
+        var b = P8(
+            unsafe_from_address=Int(blobs) + peer_rank_of_node[j] * blob_stride
+        )
+        var base = Int(b.unsafe_bitcast[UInt64]()[unsafe_offset=0])
+        var rkey = b.unsafe_bitcast[UInt32]()[unsafe_offset=2]
+        var lid = Int(b.unsafe_bitcast[UInt32]()[unsafe_offset=3])
+        var mtu = Int(b.unsafe_bitcast[UInt32]()[unsafe_offset=4])
+        # The peer's QP for MY node, not for its own.
+        var dest_qpn = b.unsafe_bitcast[UInt32]()[
+            unsafe_offset = 6 + st.my_node
+        ]
+        var gid = P8(unsafe_from_address=Int(b) + 24 + 4 * MAX_NODES)
+        if lid == 0:
+            raise Error(
+                "mojoccl: peer on node "
+                + String(j)
+                + " reported LID 0 -- its HCA port is not on an InfiniBand"
+                " fabric this library can address"
+            )
+        st.peers[i].remote_base = base
+        st.peers[i].remote_rkey = rkey
+        qp_to_rtr(
+            st.ibv,
+            st.peers[i].qp,
+            dest_qpn,
+            lid,
+            min(my_mtu, mtu),
+            st.port,
+            gid,
+            0,
+            False,
+        )
+        qp_to_rts(st.ibv, st.peers[i].qp)
+        for _ in range(RECV_DEPTH):
+            build_recv_wr(_b(st.rwr), 0)
+            if post_recv(st.peers[i].qp, _b(st.rwr), _b(st.bad)) != 0:
+                raise Error("mojoccl: ibv_post_recv failed while pre-posting")
+
+    # The flush QP talks to itself.
+    var self_lid = ib_port_lid(ib)
+    var gid0 = alloc_bytes(16)
+    qp_to_rtr(
+        st.ibv,
+        st.flush_qp,
+        qp_number(st.flush_qp),
+        self_lid,
+        my_mtu,
+        st.port,
+        gid0,
+        0,
+        False,
+    )
+    qp_to_rts(st.ibv, st.flush_qp)
+
+
+# ===-------------------------------------------------------------------=== #
+# Per-collective use
+# ===-------------------------------------------------------------------=== #
+
+
+def ib_npeers(ib: Int) -> Int:
+    return len(_st(ib)[].peers)
+
+
+def ib_error(ib: Int) -> Int:
+    return _st(ib)[].error
+
+
+def ib_next_seq(ib: Int) -> Int:
+    """Consume one exchange counter. Every rank of the communicator calls
+    this the same number of times in the same order, so the parity that
+    selects the inbox half and the immediate that tags an arrival agree
+    across nodes."""
+    ref st = _st(ib)[]
+    st.exchanges += 1
+    return st.exchanges
+
+
+def ib_enqueue(
+    ib: Int,
+    driver: OwnedDLHandle,
+    raw_stream: Int,
+    send_addr: Int,
+    send_bytes: Int,
+    inbox_base: Int,
+    slot_bytes: Int,
+    do_send: Bool,
+    nrecv: Int,
+    flush_addr: Int,
+    seq: Int,
+) raises:
+    """Enqueue one exchange's host callback on `raw_stream`."""
+    ref st = _st(ib)[]
+    var slot = st.work_next % WORK_SLOTS
+    st.work_next += 1
+    ref w = Pointer[IbWork, MutAnyOrigin](unsafe_from_address=st.works)[
+        unsafe_offset=slot
+    ]
+    if w.status == 0:
+        raise Error(
+            "mojoccl: the inter-node work ring wrapped with an exchange still"
+            " in flight; MOJOCCL_IB_TRACE=1 to see how far behind the network"
+            " is"
+        )
+    w.state = ib
+    w.send_addr = send_addr
+    w.send_bytes = send_bytes
+    w.inbox_base = inbox_base
+    w.slot_bytes = slot_bytes
+    w.do_send = 1 if do_send else 0
+    w.nrecv = nrecv
+    w.flush_addr = flush_addr
+    w.seq = seq
+    w.status = 0
+    launch_host_func(
+        driver,
+        raw_stream,
+        _callback_address(),
+        st.works + slot * size_of[IbWork](),
+    )
+
+
+def ib_report(ib: Int):
+    ref st = _st(ib)[]
+    if not st.trace or st.n_exchanges == 0:
+        return
+    print(
+        "mojoccl ib:",
+        st.hca,
+        "port",
+        st.port,
+        "peers",
+        len(st.peers),
+        "exchanges",
+        st.n_exchanges,
+        "| mean us post",
+        Float64(st.t_post_ns) / Float64(st.n_exchanges) / 1000.0,
+        "wait",
+        Float64(st.t_wait_ns) / Float64(st.n_exchanges) / 1000.0,
+        "flush",
+        Float64(st.t_flush_ns) / Float64(st.n_exchanges) / 1000.0,
+    )
+
+
+def ib_teardown(ib: Int):
+    if ib == 0:
+        return
+    ref st = _st(ib)[]
+    ib_report(ib)
+    try:
+        for i in range(len(st.peers)):
+            st.ibv.destroy_qp(st.peers[i].qp)
+        if st.flush_qp != 0:
+            st.ibv.destroy_qp(st.flush_qp)
+        if st.cq != 0:
+            st.ibv.destroy_cq(st.cq)
+        if st.flush_mr != 0:
+            st.ibv.dereg_mr(st.flush_mr)
+        if st.mr != 0:
+            st.ibv.dereg_mr(st.mr)
+        if st.pd != 0:
+            st.ibv.dealloc_pd(st.pd)
+        if st.ctx != 0:
+            st.ibv.close_device(st.ctx)
+    except:
+        pass

--- a/torch_mojo_backend/distributed/mojoccl/internode.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/internode.mojo
@@ -3,41 +3,51 @@
 # local_rank there -- so the 8 ranks of a node drive 8 independent NICs and
 # each rank only ever exchanges its own 1/local_world shard.
 #
-# Ordering without a proxy thread. The GPU cannot post verbs and the NIC
-# cannot wait on a kernel, so the two meet in a host function enqueued on
-# the caller's stream (`cuLaunchHostFunc`/`hipLaunchHostFunc`):
+# Ordering. The GPU cannot post verbs and the NIC cannot wait on a kernel,
+# so a CPU thread stands between them and the stream is what sequences it:
 #
 #     [reduce_scatter_stage]  my shard is final in my stage_out
-#     [host callback]         post one RDMA_WRITE_WITH_IMM per peer, then
-#                             poll the CQ until every peer's shard has
-#                             landed in my inbox, then flush (below)
+#     [proxy_request]         one thread releases the exchange counter into
+#                             a pinned mailbox
+#       ~ progress thread ~   post one RDMA_WRITE_WITH_IMM per peer, poll
+#                             the CQ until every peer's shard has landed in
+#                             my inbox, flush (below), release `done`
+#     [proxy_wait]            one thread spins until `done` catches up
 #     [inbox_add]             shard += the peers' shards
 #     [allgather_finish]      spread the global sum
 #
-# One fused callback rather than the post/poll pair: they would be adjacent
-# on the stream with nothing in between, so splitting only pays a second
-# dispatch latency. A proxy thread with GPU-visible pinned flags (NCCL's
-# design) is the fallback if the dispatch turns out to dominate; the split
-# above is where it would slot in.
+# The obvious alternative -- one `cuLaunchHostFunc` doing all of it inline
+# -- was written first, shipped, and measured: it costs about 480 us per
+# exchange on this cluster, because the driver has to stop the stream, wake
+# a thread and restart it, and that delay does NOT cancel between the two
+# nodes (each side ends up measuring the other's dispatch jitter; both
+# reported ~390 us of "waiting for the peer" on a transfer worth 3 us). It
+# survives behind `MOJOCCL_IB_PROXY=0`: same exchange body, one fewer core
+# burned, several hundred microseconds slower.
 #
 # The GPUDirect flush. Seeing the RDMA_WRITE_WITH_IMM completion does NOT
 # mean the payload is visible in GPU memory: the completion lands in host
 # memory and the payload in the GPU's BAR, two different PCIe destinations
 # with no ordering between them. A read from the GPU BAR flushes the posted
-# writes ahead of it, so the callback finishes with a 4-byte RDMA_READ of
+# writes ahead of it, so an exchange finishes with a 4-byte RDMA_READ of
 # the inbox over a self-connected QP -- exactly NCCL's `gpuFlush` QP
 # (nccl:src/transport/net_ib/p2p.cc:589-602). Measured 1.9 us.
 #
-# Inbox aliasing and flow control. The inbox lives in stage_in, above
-# whatever the intra-node collective staged there, and is DOUBLE BUFFERED by
-# the parity of a per-communicator exchange counter. The double buffer is
-# not an optimization, it is the proof of safety: peer B writes half `p` at
-# exchanges e and e+2, and B cannot reach e+2 before receiving my e+1 data,
-# which I send only after my own stream ran the add kernel of exchange e.
-# Single buffering would leave B's e+1 write racing my e add kernel with
-# nothing but timing in between. The immediate carries the exchange counter
-# so an arrival that belongs to e+1 is counted into the other parity's
-# tally instead of satisfying e.
+# Flow control. The inbox is DOUBLE BUFFERED by the parity of a
+# per-communicator exchange counter, and that is not an optimization, it is
+# the proof of safety: peer B writes half `p` at exchanges e and e+2, and B
+# cannot reach e+2 before receiving my e+1 data, which I send only after my
+# own stream ran the add kernel of exchange e. Single buffering would leave
+# B's e+1 write racing my e add kernel with nothing but timing in between.
+# The argument needs every exchange to be all-to-all, which is why a rank
+# with nothing to contribute still sends CREDIT_BYTES (mojoccl.mojo). The
+# immediate carries the exchange counter, so an arrival belonging to e+1 is
+# counted into the other parity's tally instead of satisfying e.
+#
+# The inbox lives in the region's own network area, never aliased onto the
+# intra-node staging: a peer node writes it as soon as ITS reduce-scatter is
+# done, which is ordered against neither mine nor a local peer still reading
+# the previous generation (see ncclCommInitRank).
 
 from std.ffi import OwnedDLHandle, external_call
 from std.memory.alloc import unsafe_alloc

--- a/torch_mojo_backend/distributed/mojoccl/internode.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/internode.mojo
@@ -44,8 +44,17 @@ from std.memory.alloc import unsafe_alloc
 from std.sys import size_of
 from std.os import getenv
 from std.time import perf_counter_ns
+from max.gpu.host import DeviceContext, DeviceStream
 
-from driver import device_pci_bus_id, launch_host_func
+from std.atomic import Atomic, Ordering
+
+from driver import (
+    alloc_host,
+    device_pci_bus_id,
+    host_device_ptr,
+    launch_host_func,
+)
+from internode_kernels import proxy_request, proxy_wait
 from ibverbs import (
     IbPort,
     IBV_ACCESS_LOCAL_WRITE,
@@ -99,6 +108,15 @@ comptime DEFAULT_IB_TIMEOUT_S: Float64 = 60.0
 # Bytes of the inbox read back by the flush; any read of the destination
 # device flushes the writes ahead of it, the size is irrelevant.
 comptime FLUSH_BYTES = 4
+
+# The proxy mailbox: two 64-bit words the GPU and the progress thread
+# pass the exchange counter through, plus a stop word the host sets at
+# teardown. A cache line apart so the GPU's writes to REQUEST never
+# invalidate the line the CPU is writing DONE into.
+comptime MB_REQUEST = 0
+comptime MB_DONE = 64
+comptime MB_STOP = 128
+comptime MB_BYTES = 192
 
 
 struct IbPeer(Copyable, Movable):
@@ -190,6 +208,11 @@ struct IbState(Movable):
     var wc: Int
     var works: Int
     var work_next: Int
+    var mailbox: Int  # pinned host address
+    var mailbox_dev: Int  # the same memory as a kernel addresses it
+    var error_word: Int  # region + error_offset, for the wait kernel
+    var proxy: Bool
+    var thread_id: Int
     var trace: Bool
     var t_post_ns: Int
     var t_wait_ns: Int
@@ -229,6 +252,11 @@ struct IbState(Movable):
         for i in range(WORK_SLOTS):
             wp[unsafe_offset=i] = IbWork()
         self.work_next = 0
+        self.mailbox = 0
+        self.mailbox_dev = 0
+        self.error_word = region
+        self.proxy = getenv("MOJOCCL_IB_PROXY", "1") != "0"
+        self.thread_id = 0
         self.trace = getenv("MOJOCCL_IB_TRACE", "0") != "0"
         self.t_post_ns = 0
         self.t_wait_ns = 0
@@ -284,14 +312,23 @@ def _consume_wc(mut st: IbState, c: P8, npeers: Int) -> Int:
 
 
 def _ib_progress(user: OpaquePointer[MutAnyOrigin]) abi("C"):
-    """Post this exchange's RDMA writes, wait for the peers', flush.
+    """`cuLaunchHostFunc` entry point -- the MOJOCCL_IB_PROXY=0 path.
 
     Runs on a driver-owned thread with the stream stalled behind it, so it
-    must be quick and must never call the CUDA/HIP driver. Only libibverbs
-    and this struct's own host memory are touched.
+    must never call the CUDA/HIP driver. Kept as a fallback, and as the
+    thing the proxy thread is measured against: on this cluster the
+    driver's stop-the-stream / wake-a-thread / restart round trip costs
+    about 480 us per exchange (job 234035: a 1 MiB two-node allreduce took
+    496 us against 24 us on one node, and the transfer in it is 3 us),
+    which at the 27 MiB DDP bucket is several times the transfer it waits
+    for.
     """
     ref w = Pointer[IbWork, MutAnyOrigin](unsafe_from_address=Int(user))[]
-    ref st = _st(w.state)[]
+    _run_exchange(_st(w.state)[], w)
+
+
+def _run_exchange(mut st: IbState, mut w: IbWork):
+    """Post this exchange's RDMA writes, wait for the peers', flush."""
     if st.error != 0:
         w.status = 2
         return
@@ -400,6 +437,76 @@ def _ib_progress(user: OpaquePointer[MutAnyOrigin]) abi("C"):
 @always_inline
 def _arrivals(st: IbState, parity: Int) -> Int:
     return st.arrivals0 if parity == 0 else st.arrivals1
+
+
+@always_inline
+def _mb(st: IbState, off: Int) -> Pointer[UInt64, MutAnyOrigin]:
+    return Pointer[UInt64, MutAnyOrigin](unsafe_from_address=st.mailbox + off)
+
+
+def _proxy_main(arg: OpaquePointer[MutAnyOrigin]) abi("C"):
+    """The progress thread: one exchange at a time, in stream order.
+
+    Spins on the mailbox word a one-thread kernel releases after the
+    reduce-scatter, runs the exchange, releases the done word the matching
+    spin kernel is waiting on. Exchanges are strictly ordered on the
+    communicator's stream and the counter is dense, so slot `(seq-1) mod
+    WORK_SLOTS` is this exchange's work item and no queue is needed.
+
+    A pure spin, like NCCL's proxy: the whole point is that neither side
+    ever sleeps. One core per rank, and `MOJOCCL_IB_PROXY=0` gives it back
+    at the cost of the host-callback latency.
+    """
+    ref st = _st(Int(arg))[]
+    var next_seq = 1
+    while True:
+        if Atomic[DType.uint64].load[ordering = Ordering.ACQUIRE](
+            _mb(st, MB_STOP)
+        ) != 0:
+            return
+        if Atomic[DType.uint64].load[ordering = Ordering.ACQUIRE](
+            _mb(st, MB_REQUEST)
+        ) < UInt64(next_seq):
+            continue
+        ref w = Pointer[IbWork, MutAnyOrigin](unsafe_from_address=st.works)[
+            unsafe_offset = (next_seq - 1) % WORK_SLOTS
+        ]
+        _run_exchange(st, w)
+        # Published even on failure: the spin kernel must be released or the
+        # stream hangs past the point where the error can be reported.
+        Atomic[DType.uint64].store[ordering = Ordering.RELEASE](
+            _mb(st, MB_DONE), UInt64(next_seq)
+        )
+        next_seq += 1
+
+
+def _proxy_address() -> Int:
+    var f: def (
+        OpaquePointer[MutAnyOrigin]
+    ) thin abi("C") -> None = _proxy_main
+    return Pointer(to=f).unsafe_bitcast[Int]()[]
+
+
+def _start_proxy(ib: Int) raises:
+    ref st = _st(ib)[]
+    var tid = unsafe_alloc[Int64](1)
+    tid[unsafe_offset=0] = 0
+    var rc = external_call["pthread_create", Int32](
+        tid, Int64(0), _proxy_address(), ib
+    )
+    if rc != 0:
+        raise Error("mojoccl: pthread_create failed, rc=" + String(rc))
+    st.thread_id = Int(tid[unsafe_offset=0])
+
+
+def _stop_proxy(mut st: IbState):
+    if st.thread_id == 0:
+        return
+    Atomic[DType.uint64].store[ordering = Ordering.RELEASE](
+        _mb(st, MB_STOP), 1
+    )
+    _ = external_call["pthread_join", Int32](st.thread_id, Int64(0))
+    st.thread_id = 0
 
 
 def _callback_address() -> Int:
@@ -538,13 +645,16 @@ def ib_setup(
     st.pd = st.ibv.alloc_pd(st.ctx)
     if st.pd == 0:
         raise Error("mojoccl: ibv_alloc_pd failed on " + st.hca)
-    st.mr = st.ibv.reg_mr(
-        st.pd,
-        region,
-        region_bytes,
+    var ro = getenv("MOJOCCL_IB_RELAXED_ORDERING", "1") != "0"
+    var acc = (
         IBV_ACCESS_LOCAL_WRITE
         | IBV_ACCESS_REMOTE_WRITE
-        | IBV_ACCESS_REMOTE_READ,
+        | IBV_ACCESS_REMOTE_READ
+    )
+    st.mr = (
+        st.ibv.reg_mr_relaxed(st.pd, region, region_bytes, acc)
+        if ro
+        else st.ibv.reg_mr(st.pd, region, region_bytes, acc)
     )
     if st.mr == 0:
         raise Error(
@@ -582,8 +692,18 @@ def ib_setup(
     st.flush_qp = create_rc_qp(st.ibv, st.pd, st.cq, SEND_WR_DEPTH, 8)
     qp_to_init(st.ibv, st.flush_qp, st.port)
 
+    if st.proxy:
+        st.mailbox = alloc_host(driver, MB_BYTES)
+        st.mailbox_dev = host_device_ptr(driver, st.mailbox)
+        for i in range(MB_BYTES // 8):
+            Pointer[UInt64, MutAnyOrigin](unsafe_from_address=st.mailbox)[
+                unsafe_offset=i
+            ] = 0
+
     var holder = unsafe_alloc[IbState](1)
     holder.unsafe_write(st^)
+    if _st(Int(holder))[].proxy:
+        _start_proxy(Int(holder))
     return Int(holder)
 
 
@@ -735,6 +855,8 @@ def ib_next_seq(ib: Int) -> Int:
 def ib_enqueue(
     ib: Int,
     driver: OwnedDLHandle,
+    ctx: DeviceContext,
+    stream: DeviceStream,
     raw_stream: Int,
     send_addr: Int,
     send_bytes: Int,
@@ -745,10 +867,18 @@ def ib_enqueue(
     flush_addr: Int,
     seq: Int,
 ) raises:
-    """Enqueue one exchange's host callback on `raw_stream`."""
+    """Put one exchange on `stream`, between the kernel that produced its
+    payload and the kernel that consumes what arrives.
+
+    Two shapes, same ordering guarantee. With the proxy thread (default): a
+    one-thread kernel releases `seq` into the pinned mailbox and a second
+    one spins until the thread reports it done. Without it
+    (`MOJOCCL_IB_PROXY=0`): a `cuLaunchHostFunc` that does the exchange
+    inline, which is simpler and several hundred microseconds slower per
+    exchange.
+    """
     ref st = _st(ib)[]
-    var slot = st.work_next % WORK_SLOTS
-    st.work_next += 1
+    var slot = (seq - 1) % WORK_SLOTS
     ref w = Pointer[IbWork, MutAnyOrigin](unsafe_from_address=st.works)[
         unsafe_offset=slot
     ]
@@ -768,53 +898,23 @@ def ib_enqueue(
     w.flush_addr = flush_addr
     w.seq = seq
     w.status = 0
+    if st.proxy:
+        proxy_request(ctx, stream, st.mailbox_dev + MB_REQUEST, seq)
+        proxy_wait(
+            ctx,
+            stream,
+            st.mailbox_dev + MB_DONE,
+            st.error_word,
+            seq,
+            st.timeout_ns,
+        )
+        return
     launch_host_func(
         driver,
         raw_stream,
         _callback_address(),
         st.works + slot * size_of[IbWork](),
     )
-
-
-def ib_exchange_now(
-    ib: Int,
-    send_addr: Int,
-    send_bytes: Int,
-    inbox_base: Int,
-    slot_bytes: Int,
-    do_send: Bool,
-    nrecv: Int,
-    flush_addr: Int,
-    seq: Int,
-) raises:
-    """Run one exchange inline on the calling thread instead of from a
-    stream callback.
-
-    The bring-up self-test uses it: the transport can be exercised on a host
-    with IB but no GPU (registered host memory, no stream to hang a callback
-    on), which is where the bootstrap/QP/immediate wiring is cheapest to
-    debug. Never correct in a collective -- there the callback's position in
-    stream order is the whole ordering argument.
-    """
-    ref st = _st(ib)[]
-    var w = IbWork()
-    w.state = ib
-    w.send_addr = send_addr
-    w.send_bytes = send_bytes
-    w.inbox_base = inbox_base
-    w.slot_bytes = slot_bytes
-    w.do_send = 1 if do_send else 0
-    w.nrecv = nrecv
-    w.flush_addr = flush_addr
-    w.seq = seq
-    w.status = 0
-    var wp = unsafe_alloc[IbWork](1)
-    wp.unsafe_write(w^)
-    _ib_progress(OpaquePointer[MutAnyOrigin](unsafe_from_address=Int(wp)))
-    if wp[unsafe_offset=0].status != 1:
-        raise Error(
-            "mojoccl: inline exchange failed, ib error " + String(st.error)
-        )
 
 
 def ib_report(ib: Int):
@@ -843,6 +943,7 @@ def ib_teardown(ib: Int):
     if ib == 0:
         return
     ref st = _st(ib)[]
+    _stop_proxy(st)
     ib_report(ib)
     try:
         for i in range(len(st.peers)):

--- a/torch_mojo_backend/distributed/mojoccl/internode.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/internode.mojo
@@ -57,7 +57,7 @@ from std.ffi import OwnedDLHandle, external_call
 from std.memory.alloc import unsafe_alloc
 from std.sys import size_of
 from std.os import getenv
-from std.time import perf_counter_ns
+from std.time import perf_counter_ns, sleep
 from max.gpu.host import DeviceContext, DeviceStream
 
 from std.atomic import Atomic, Ordering
@@ -121,6 +121,12 @@ comptime SEND_WR_DEPTH = 64
 comptime WORK_SLOTS = 512
 comptime MAX_NODES = 16
 comptime DEFAULT_IB_TIMEOUT_S: Float64 = 60.0
+# ncclCommAbort's bound on waiting for the progress thread: long enough for
+# it to notice MB_STOP (immediate when idle, at most one poll_cq when inside
+# `_run_exchange` -- see `_stop_requested`), short enough that abort's
+# documented "don't wait" contract still holds even if the thread is wedged
+# somewhere this bound does not anticipate.
+comptime IB_ABORT_JOIN_TIMEOUT_S: Float64 = 2.0
 # Bytes of the inbox read back by the flush; any read of the destination
 # device flushes the writes ahead of it, the size is irrelevant.
 comptime FLUSH_BYTES = 4
@@ -552,6 +558,41 @@ def _stop_proxy(mut st: IbState):
     )
     _ = external_call["pthread_join", Int32](st.thread_id, Int64(0))
     st.thread_id = 0
+
+
+def ib_signal_abort(ib: Int):
+    """`ncclCommAbort`'s hook: raise MB_STOP and reclaim the progress thread
+    without ncclCommDestroy's unbounded wait.
+
+    Left unsignaled, the thread spins on the mailbox forever (nothing else
+    ever sets MB_STOP for it) and burns one CPU core for the rest of the
+    process. Unlike `_stop_proxy`, the join here is bounded
+    (`IB_ABORT_JOIN_TIMEOUT_S`) with `pthread_tryjoin_np`, polled rather than
+    blocking: abort must not hang because a dead peer left this rank's
+    thread waiting inside `_run_exchange` for a completion that will never
+    come -- `_stop_requested` is what actually gets it out of there quickly;
+    this bound is only insurance against the case that doesn't anticipate.
+    A thread this gives up on is simply left running; it exits on its own
+    once it next checks MB_STOP, and the process exiting reclaims it either
+    way.
+    """
+    if ib == 0:
+        return
+    ref st = _st(ib)[]
+    if st.thread_id == 0:
+        return
+    Atomic[DType.uint64].store[ordering = Ordering.RELEASE](
+        _mb(st, MB_STOP), 1
+    )
+    var tid = st.thread_id
+    var deadline = perf_counter_ns() + Int(IB_ABORT_JOIN_TIMEOUT_S * 1.0e9)
+    while perf_counter_ns() < deadline:
+        var retval = unsafe_alloc[Int64](1)
+        var rc = external_call["pthread_tryjoin_np", Int32](tid, retval)
+        if rc == 0:
+            st.thread_id = 0
+            return
+        sleep(0.001)
 
 
 def _callback_address() -> Int:

--- a/torch_mojo_backend/distributed/mojoccl/internode.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/internode.mojo
@@ -33,20 +33,40 @@
 # the inbox over a self-connected QP -- exactly NCCL's `gpuFlush` QP
 # (nccl:src/transport/net_ib/p2p.cc:589-602). Measured 1.9 us.
 #
-# Flow control. The inbox is DOUBLE BUFFERED by the parity of a
-# per-communicator exchange counter, and that is not an optimization, it is
-# the proof of safety: peer B writes half `p` at exchanges e and e+2, and B
-# cannot reach e+2 before receiving my e+1 data, which I send only after my
-# own stream ran the add kernel of exchange e. Single buffering would leave
-# B's e+1 write racing my e add kernel with nothing but timing in between.
-# The argument needs two things. Every exchange must be all-to-all, which is
-# why a rank with nothing to contribute still sends CREDIT_BYTES
-# (mojoccl.mojo); and the two halves must be DISJOINT ADDRESSES for every
-# exchange alike, which is why `_inbox_base` carves them out of the region
-# once instead of sizing them from the message in flight (mojoccl.mojo has
-# the case that broke). The immediate carries the exchange counter, so an
-# arrival belonging to e+1 is counted into the other parity's tally instead
-# of satisfying e.
+# Flow control: EXPLICIT CREDITS. The inbox is carved once into `nslots`
+# fixed slot groups and exchange e lands in group `e % nslots`, so peer B
+# writes the same bytes at e and e+nslots. What makes reuse safe is a credit,
+# not stream order: after my consumer kernel has read group g, my proxy
+# RDMA-writes every peer a cumulative "I have consumed through exchange c"
+# counter, and a peer may post exchange e only once every receiver has
+# released the group e will land in (`c >= e - nslots`). That is NCCL's
+# head/tail pair in miniature (nccl:src/transport/net.cc, the
+# recvNetHead/step counters; nccl:src/device/prims_simple.h for the device
+# side of the same idea).
+#
+# It replaces an earlier double-buffer-by-parity argument that derived
+# reuse safety from stream order -- "B cannot reach e+2 before receiving my
+# e+1 data, which I send only after my own add kernel for e". That chain
+# holds only when exactly one exchange is in flight; the pipelined schedule
+# (mojoccl.mojo `_do_allreduce`) issues the reduce-scatter of later chunks
+# before the add of earlier ones and breaks it. The credit is the
+# replacement proof, and it is a proof rather than a timing margin.
+#
+# Two things survive from the old argument unchanged. Every exchange must
+# still be all-to-all, because an arrival tally of `nrecv` is what completes
+# one -- a rank with nothing to contribute sends EMPTY_SHARD_BYTES
+# (mojoccl.mojo). And every slot group must be a FIXED byte range for every
+# exchange alike, never sized from the message in flight (`_inbox_base` in
+# mojoccl.mojo carries the case that broke). The immediate carries the
+# exchange counter and a credit bit, so an arrival is tallied against its own
+# exchange and a credit is never mistaken for data.
+#
+# `credit_upto` is how the host tells the engine what has been consumed
+# without a further kernel: it is the number of consumer kernels already
+# enqueued on the stream ahead of this exchange's request kernel. When the
+# proxy observes the request, that kernel has run, so every kernel enqueued
+# before it has completed -- the same stream-order argument that makes the
+# shard final at that point.
 #
 # The inbox lives in the region's own network area, never aliased onto the
 # intra-node staging: a peer node writes it as soon as ITS reduce-scatter is
@@ -111,10 +131,11 @@ from ibverbs import (
     qp_to_rts,
 )
 
-# Recv WRs kept posted per peer QP. Each RDMA_WRITE_WITH_IMM consumes one;
-# the callback reposts every one it consumes, so the depth only has to cover
-# the burst a peer can produce while this rank is elsewhere -- two exchanges
-# by the double-buffer argument above, times a wide margin.
+# Recv WRs kept posted per peer QP. Each RDMA_WRITE_WITH_IMM consumes one --
+# data and credits alike; the engine reposts every one it consumes, so the
+# depth only has to cover the burst a peer can produce while this rank is
+# elsewhere: `nslots` data messages plus `nslots` credits, times a wide
+# margin.
 comptime RECV_DEPTH = 64
 comptime CQ_SIZE = 1024
 comptime SEND_WR_DEPTH = 64
@@ -122,10 +143,10 @@ comptime WORK_SLOTS = 512
 comptime MAX_NODES = 16
 comptime DEFAULT_IB_TIMEOUT_S: Float64 = 60.0
 # ncclCommAbort's bound on waiting for the progress thread: long enough for
-# it to notice MB_STOP (at most one idle-backoff quantum plus one poll_cq
-# when inside `_run_exchange` -- see `_stop_requested`), short enough that
-# abort's documented "don't wait" contract still holds even if the thread is
-# wedged somewhere this bound does not anticipate.
+# it to notice MB_STOP (at most one idle-backoff quantum plus one engine
+# step -- `ib_drive` never blocks), short enough that abort's documented
+# "don't wait" contract still holds even if the thread is wedged somewhere
+# this bound does not anticipate.
 comptime IB_ABORT_JOIN_TIMEOUT_S: Float64 = 2.0
 # Default idle-wait quantum for the progress thread between exchanges (see
 # `_proxy_main`). An exchange takes ~280 us at the DDP bucket, so a few tens
@@ -137,6 +158,22 @@ comptime DEFAULT_IB_PROXY_IDLE_US: Int = 20
 # Bytes of the inbox read back by the flush; any read of the destination
 # device flushes the writes ahead of it, the size is irrelevant.
 comptime FLUSH_BYTES = 4
+
+# Largest inbox slot-group count the engine will accept; bounds the arrival
+# tally and, through it, how many exchanges may be outstanding at once.
+comptime PIPE_MAX_SLOTS = 16
+# Immediate layout: bit 31 marks a credit, bits 0..30 carry the exchange
+# counter. 2^31 exchanges is ~10^4 DDP training runs, and the counter never
+# wraps within one communicator.
+comptime IMM_CREDIT_BIT: UInt32 = 0x8000_0000
+comptime IMM_SEQ_MASK: UInt32 = 0x7FFF_FFFF
+# Credit landing pad: one 64-byte line per sender in the region's credit
+# area, so two peers' credits never share a cache line. The bytes are never
+# read -- the immediate is the message -- but a real address is needed
+# because a zero-length RDMA write is not worth relying on across HCAs.
+comptime CREDIT_SLOT_BYTES = 64
+comptime CREDIT_AREA_BYTES = 4096
+comptime CREDIT_PAYLOAD_BYTES = 4
 
 # The proxy mailbox: two 64-bit words the GPU and the progress thread
 # pass the exchange counter through, plus a stop word the host sets at
@@ -171,22 +208,33 @@ struct IbPeer(Copyable, Movable):
 
 
 struct IbWork(Copyable, Movable):
-    """One inter-node exchange, handed to the host callback by address.
+    """One inter-node exchange, described by the host for the engine.
 
-    Lives in a ring inside `IbState` so the host can enqueue ahead; a slot
-    is reused only once its callback has set `status`.
+    Lives in a ring inside `IbState` indexed by `(seq-1) % WORK_SLOTS`: the
+    counter is dense and starts at 1, so a slot is implied by the sequence
+    number and no queue is needed. A slot is refilled only once the engine
+    has set `status` away from 0.
     """
 
     var state: Int
     var send_addr: Int
     var send_bytes: Int
-    var inbox_base: Int  # absolute VA offset from a region base, parity folded in
+    var inbox_base: Int  # region offset of this exchange's inbox slot group
     var slot_bytes: Int
     var do_send: Int
     var nrecv: Int
     var flush_addr: Int
     var seq: Int
     var status: Int  # 0 running, 1 done, 2 failed
+    # Highest exchange whose consumer kernel is already enqueued ahead of
+    # this one's request on the stream -- the credit the engine publishes
+    # when it picks this exchange up. See the header's flow-control note.
+    var credit_upto: Int
+    # Data sends posted, cumulatively, once this exchange is on the wire:
+    # the exchange is not done until that many send completions are in, or
+    # the next reduce-scatter could overwrite a buffer the NIC still reads.
+    var sends_cum: Int
+    var t0: Int  # perf_counter_ns when it was posted, for the trace
 
     def __init__(out self):
         self.state = 0
@@ -199,6 +247,9 @@ struct IbWork(Copyable, Movable):
         self.flush_addr = 0
         self.seq = 0
         self.status = 1
+        self.credit_upto = 0
+        self.sends_cum = 0
+        self.t0 = 0
 
 
 struct IbState(Movable):
@@ -222,10 +273,29 @@ struct IbState(Movable):
     var my_node: Int
     var nnodes: Int
     var exchanges: Int
-    var arrivals0: Int
-    var arrivals1: Int
     var error: Int
     var timeout_ns: Int
+    # --- the progress engine (see `ib_drive`) ---
+    var nslots: Int  # inbox slot groups; exchange e lands in `e % nslots`
+    var credit_off: Int  # region offset of the credit landing pad
+    var request_seq: Int  # highest exchange handed to the engine
+    var posted_seq: Int  # highest exchange whose data writes are posted
+    var done_seq: Int  # highest exchange fully arrived, sent and flushed
+    var flush_seq: Int  # exchange whose flush read is outstanding (0: none)
+    var flush_done: Int  # flush-read completions seen and not yet consumed
+    var flush_t0: Int
+    var sends_posted: Int
+    var sends_completed: Int
+    var credit_sent: Int  # highest credit published to the peers
+    var tally: List[Int]  # arrivals, indexed by `seq % nslots`
+    var credit_recv: List[Int]  # per peer, highest credit it published
+    var last_progress_ns: Int
+    var stall_seq: Int  # exchange the last credit stall was counted against
+    var n_credit_stalls: Int
+    # Host-side: highest exchange whose consumer kernel has been ENQUEUED.
+    # Snapshotted into each work item as `credit_upto` (see
+    # `ib_note_consumed`); never touched by the engine thread.
+    var consumed_enqueued: Int
     # Scratch buffers and the work ring are held as raw addresses: a
     # `Pointer[..., MutAnyOrigin]` cannot be a struct field, and these
     # outlive every borrow anyway (allocated once, freed never -- a few
@@ -248,7 +318,15 @@ struct IbState(Movable):
     var t_flush_ns: Int
     var n_exchanges: Int
 
-    def __init__(out self, var ibv: Ibv, region: Int, my_node: Int, nnodes: Int):
+    def __init__(
+        out self,
+        var ibv: Ibv,
+        region: Int,
+        my_node: Int,
+        nnodes: Int,
+        nslots: Int,
+        credit_off: Int,
+    ):
         self.ibv = ibv^
         self.hca = String("")
         self.ctx = 0
@@ -267,10 +345,27 @@ struct IbState(Movable):
         self.my_node = my_node
         self.nnodes = nnodes
         self.exchanges = 0
-        self.arrivals0 = 0
-        self.arrivals1 = 0
         self.error = 0
         self.timeout_ns = Int(DEFAULT_IB_TIMEOUT_S * 1.0e9)
+        self.nslots = nslots
+        self.credit_off = credit_off
+        self.request_seq = 0
+        self.posted_seq = 0
+        self.done_seq = 0
+        self.flush_seq = 0
+        self.flush_done = 0
+        self.flush_t0 = 0
+        self.sends_posted = 0
+        self.sends_completed = 0
+        self.credit_sent = 0
+        self.tally = List[Int]()
+        for _ in range(nslots):
+            self.tally.append(0)
+        self.credit_recv = List[Int]()
+        self.last_progress_ns = 0
+        self.stall_seq = 0
+        self.n_credit_stalls = 0
+        self.consumed_enqueued = 0
         self.wr = Int(alloc_bytes(SZ_SEND_WR))
         self.sge = Int(alloc_bytes(SZ_SGE))
         self.rwr = Int(alloc_bytes(SZ_RECV_WR))
@@ -304,7 +399,7 @@ def _st(ib: Int) -> Pointer[IbState, MutAnyOrigin]:
 
 
 # `IbState.error` and `IbWork.status` are written by the proxy thread (or the
-# `MOJOCCL_IB_PROXY=0` callback thread) inside `_run_exchange` and read by
+# `MOJOCCL_IB_PROXY=0` callback thread) inside `ib_drive` and read by
 # the calling thread -- `ib_error` from the torch-facing calling thread,
 # `ib_enqueue`'s ring-reuse check from the same -- with no other
 # synchronization between the two. Every access goes through these two
@@ -337,18 +432,135 @@ def _status_ptr(mut w: IbWork) -> Pointer[Int, MutAnyOrigin]:
 
 
 # ===-------------------------------------------------------------------=== #
-# The host callback
+# The progress engine
 # ===-------------------------------------------------------------------=== #
+#
+# One non-blocking step function, `ib_drive`, shared by all three drivers:
+# the progress thread, the `MOJOCCL_IB_PROXY=0` stream callback and the
+# GPU-free self-tests. They differ only in who advances `request_seq` (the
+# mailbox, the callback, the calling thread) and who reads `done_seq`.
+#
+# The engine keeps several exchanges in flight. Per step it publishes any
+# credit the next exchange carries, posts that exchange if flow control
+# allows, drains the completion queue, and retires exchanges in sequence
+# order. Retiring is strictly in order even though arrivals are not: RC
+# ordering is per queue pair, so peer B's message for e+1 can overtake peer
+# C's for e, and `done_seq` is what the GPU waits on.
 
 
-def _consume_wc(mut st: IbState, c: P8, npeers: Int) -> Int:
-    """Classify one completion; returns 1 for a send, 2 for the flush read,
-    0 for anything else, -1 for a failed completion (error recorded).
+@always_inline
+def _work(st: IbState, seq: Int) -> Pointer[IbWork, MutAnyOrigin]:
+    """The ring slot exchange `seq` lives in."""
+    return Pointer[IbWork, MutAnyOrigin](
+        unsafe_from_address=st.works
+        + ((seq - 1) % WORK_SLOTS) * size_of[IbWork]()
+    )
 
-    Shared by both poll loops on purpose. An arrival for the NEXT exchange
-    can land while this one is flushing, and a loop that only looked for its
-    own opcode would drop it -- losing a tally the next callback is waiting
-    on, and a recv WR nobody reposts.
+
+@always_inline
+def _sender_slot(st: IbState, peer_node: Int) -> Int:
+    """Where MY message sits among the receiver's per-sender slots: senders
+    are indexed by node, compacted past the receiver's own node."""
+    return st.my_node if st.my_node < peer_node else st.my_node - 1
+
+
+def _release_on_error(mut st: IbState):
+    """An exchange failed: release everything outstanding rather than leave
+    the GPU's spin kernels (or a host waiter) hanging past the point where
+    `ncclCommGetAsyncError` could report it."""
+    while st.done_seq < st.request_seq:
+        st.done_seq += 1
+        ref w = _work(st, st.done_seq)[]
+        _store_atomic_i(_status_ptr(w), 2)
+    st.flush_seq = 0
+
+
+def _send_credits(mut st: IbState, upto: Int) -> Bool:
+    """Publish "I have consumed through exchange `upto`" to every peer.
+
+    Credits are cumulative, so only the newest is ever on the wire: one
+    unsignaled 4-byte RDMA_WRITE_WITH_IMM per peer, the immediate carrying
+    the credit bit and the number. Unsignaled because a completion here
+    would be indistinguishable from a data send, and the data sends -- which
+    ARE counted, `IbWork.sends_cum` -- are what reclaims the send queue.
+    A failed credit still raises a completion with a bad status.
+    """
+    if upto <= st.credit_sent:
+        return False
+    for i in range(len(st.peers)):
+        ref p = st.peers[i]
+        build_write_wr(
+            _b(st.wr),
+            _b(st.sge),
+            upto,
+            st.flush_host,
+            st.flush_lkey,
+            CREDIT_PAYLOAD_BYTES,
+            p.remote_base
+            + st.credit_off
+            + _sender_slot(st, p.node) * CREDIT_SLOT_BYTES,
+            p.remote_rkey,
+            IMM_CREDIT_BIT | (UInt32(upto) & IMM_SEQ_MASK),
+            True,
+            False,
+        )
+        if post_send(p.qp, _b(st.wr), _b(st.bad)) != 0:
+            _store_atomic_i(_err_ptr(st), 8)
+            return False
+    st.credit_sent = upto
+    return True
+
+
+@always_inline
+def _can_post(st: IbState, seq: Int) -> Bool:
+    """Flow control: exchange `seq` lands in slot group `seq % nslots`, whose
+    previous occupant was `seq - nslots`, so every peer must have released
+    that one first."""
+    var need = seq - st.nslots
+    if need <= 0:
+        return True
+    for i in range(len(st.credit_recv)):
+        if st.credit_recv[i] < need:
+            return False
+    return True
+
+
+def _post_data(mut st: IbState, mut w: IbWork) -> Bool:
+    """Post this exchange's payload to every peer, one
+    RDMA_WRITE_WITH_IMM each."""
+    if w.do_send != 0 and w.send_bytes > 0:
+        for i in range(len(st.peers)):
+            ref p = st.peers[i]
+            build_write_wr(
+                _b(st.wr),
+                _b(st.sge),
+                w.seq,
+                w.send_addr,
+                st.lkey,
+                w.send_bytes,
+                p.remote_base
+                + w.inbox_base
+                + _sender_slot(st, p.node) * w.slot_bytes,
+                p.remote_rkey,
+                UInt32(w.seq) & IMM_SEQ_MASK,
+                True,
+                True,
+            )
+            if post_send(p.qp, _b(st.wr), _b(st.bad)) != 0:
+                _store_atomic_i(_err_ptr(st), 1)
+                return False
+            st.sends_posted += 1
+    w.sends_cum = st.sends_posted
+    return True
+
+
+def _consume_wc(mut st: IbState, c: P8) -> Int:
+    """Account for one completion; -1 for a failed one (error recorded).
+
+    Every completion is classified here, never "the one this exchange is
+    waiting for": an arrival for a later exchange can land at any time, and
+    a loop that dropped it would lose a tally somebody is waiting on and a
+    receive WR nobody reposts.
     """
     if Int32(ld32(c, WC_STATUS)) != IBV_WC_SUCCESS:
         _store_atomic_i(
@@ -358,158 +570,178 @@ def _consume_wc(mut st: IbState, c: P8, npeers: Int) -> Int:
         return -1
     var op = Int32(ld32(c, WC_OPCODE))
     if op == IBV_WC_RECV_RDMA_WITH_IMM:
-        if Int(be32(ldu32(c, WC_IMM_DATA))) & 1 == 0:
-            st.arrivals0 += 1
-        else:
-            st.arrivals1 += 1
+        var imm = be32(ldu32(c, WC_IMM_DATA))
         var qpn = ldu32(c, WC_QP_NUM)
-        for k in range(npeers):
+        var pi = -1
+        for k in range(len(st.peers)):
             if st.peers[k].qpn == qpn:
-                build_recv_wr(_b(st.rwr), 0)
-                _ = post_recv(st.peers[k].qp, _b(st.rwr), _b(st.bad))
+                pi = k
                 break
+        if pi >= 0:
+            build_recv_wr(_b(st.rwr), 0)
+            _ = post_recv(st.peers[pi].qp, _b(st.rwr), _b(st.bad))
+        var seq = Int(imm & IMM_SEQ_MASK)
+        if (imm & IMM_CREDIT_BIT) != 0:
+            if pi >= 0 and st.credit_recv[pi] < seq:
+                st.credit_recv[pi] = seq
+        else:
+            st.tally[seq % st.nslots] += 1
         return 0
     if op == IBV_WC_RDMA_WRITE:
-        return 1
+        st.sends_completed += 1
+        return 0
     if op == IBV_WC_RDMA_READ:
-        return 2
+        st.flush_done += 1
+        return 0
     return 0
+
+
+def _advance(mut st: IbState) -> Bool:
+    """Retire every exchange that is complete, in sequence order.
+
+    An exchange is complete when all `nrecv` peers' messages for it have
+    arrived, its own sends have completed (the NIC is done reading the
+    buffer the next reduce-scatter will overwrite) and its GPUDirect flush
+    read has come back.
+    """
+    var moved = False
+    while True:
+        if st.flush_seq != 0:
+            if st.flush_done <= 0:
+                break
+            st.flush_done -= 1
+            st.t_flush_ns += perf_counter_ns() - st.flush_t0
+            st.done_seq = st.flush_seq
+            st.flush_seq = 0
+            _retire(st, st.done_seq)
+            moved = True
+            continue
+        if st.done_seq >= st.posted_seq:
+            break
+        var e = st.done_seq + 1
+        ref w = _work(st, e)[]
+        var idx = e % st.nslots
+        if st.tally[idx] < w.nrecv or st.sends_completed < w.sends_cum:
+            break
+        st.tally[idx] -= w.nrecv
+        if w.nrecv > 0 and w.flush_addr != 0:
+            # Seeing the arrivals does NOT mean the payload is visible in GPU
+            # memory: the completion lands in host memory and the payload in
+            # the GPU's BAR. A read of the destination flushes the writes
+            # ahead of it -- NCCL's gpuFlush QP,
+            # nccl:src/transport/net_ib/p2p.cc:589-602.
+            build_read_wr(
+                _b(st.wr),
+                _b(st.sge),
+                e,
+                st.flush_host,
+                st.flush_lkey,
+                FLUSH_BYTES,
+                w.flush_addr,
+                st.rkey,
+            )
+            if post_send(st.flush_qp, _b(st.wr), _b(st.bad)) != 0:
+                _store_atomic_i(_err_ptr(st), 4)
+                return moved
+            st.flush_seq = e
+            st.flush_t0 = perf_counter_ns()
+            moved = True
+            continue
+        st.done_seq = e
+        _retire(st, e)
+        moved = True
+    return moved
+
+
+def _retire(mut st: IbState, seq: Int):
+    ref w = _work(st, seq)[]
+    st.t_wait_ns += perf_counter_ns() - w.t0
+    st.n_exchanges += 1
+    _store_atomic_i(_status_ptr(w), 1)
+
+
+def ib_drive(mut st: IbState) -> Bool:
+    """One non-blocking step of the progress engine; True if anything moved.
+
+    Order matters: credits go out BEFORE this step's own flow-control check,
+    or two ranks that arrive at the same exchange together would each wait
+    for a credit the other is holding back.
+    """
+    if _load_atomic_i(_err_ptr(st)) != 0:
+        _release_on_error(st)
+        return False
+    var moved = False
+    if st.posted_seq < st.request_seq:
+        var e = st.posted_seq + 1
+        ref w = _work(st, e)[]
+        if _send_credits(st, w.credit_upto):
+            moved = True
+        if _can_post(st, e):
+            var t0 = perf_counter_ns()
+            if not _post_data(st, w):
+                _release_on_error(st)
+                return False
+            w.t0 = t0
+            st.posted_seq = e
+            st.t_post_ns += perf_counter_ns() - t0
+            moved = True
+        elif st.stall_seq != e:
+            # Counted once per exchange, not once per spin: a nonzero number
+            # in the trace means flow control, not the network, held a chunk
+            # back, which is the knob INBOX_SLOTS turns.
+            st.stall_seq = e
+            st.n_credit_stalls += 1
+    var n = poll_cq(st.cq, 16, _b(st.wc))
+    if n < 0:
+        _store_atomic_i(_err_ptr(st), 2)
+        _release_on_error(st)
+        return False
+    for i in range(Int(n)):
+        if _consume_wc(st, P8(unsafe_from_address=st.wc + i * SZ_WC)) < 0:
+            _release_on_error(st)
+            return False
+        moved = True
+    if _advance(st):
+        moved = True
+    if moved:
+        st.last_progress_ns = perf_counter_ns()
+    elif st.request_seq > st.done_seq:
+        # Nothing outstanding can move and nothing has moved for a whole
+        # timeout: a peer is gone, or a credit was lost.
+        if perf_counter_ns() - st.last_progress_ns > st.timeout_ns:
+            _store_atomic_i(_err_ptr(st), 3)
+            _release_on_error(st)
+    return moved
 
 
 def _ib_progress(user: OpaquePointer[MutAnyOrigin]) abi("C"):
     """`cuLaunchHostFunc` entry point -- the MOJOCCL_IB_PROXY=0 path.
 
     Runs on a driver-owned thread with the stream stalled behind it, so it
-    must never call the CUDA/HIP driver. Kept as a fallback, and as the
-    thing the proxy thread is measured against: on this cluster the
+    must never call the CUDA/HIP driver, and it cannot pipeline: it drives
+    the engine until its own exchange is done. Kept as a fallback, and as
+    the thing the proxy thread is measured against: on this cluster the
     driver's stop-the-stream / wake-a-thread / restart round trip costs
     about 480 us per exchange (job 234035: a 1 MiB two-node allreduce took
-    496 us against 24 us on one node, and the transfer in it is 3 us),
-    which at the 27 MiB DDP bucket is several times the transfer it waits
-    for.
+    496 us against 24 us on one node, and the transfer in it is 3 us).
     """
     ref w = Pointer[IbWork, MutAnyOrigin](unsafe_from_address=Int(user))[]
-    _run_exchange(_st(w.state)[], w)
+    ref st = _st(w.state)[]
+    _drive_until(st, w.seq)
 
 
-def _run_exchange(mut st: IbState, mut w: IbWork):
-    """Post this exchange's RDMA writes, wait for the peers', flush."""
-    if _load_atomic_i(_err_ptr(st)) != 0:
-        _store_atomic_i(_status_ptr(w), 2)
-        return
-    var npeers = len(st.peers)
-    var parity = w.seq & 1
-    var t0 = perf_counter_ns()
-    var deadline = t0 + st.timeout_ns
-    var nsend = 0
-
-    if w.do_send != 0 and w.send_bytes > 0:
-        for i in range(npeers):
-            ref p = st.peers[i]
-            # Where MY shard sits in the peer's inbox: senders are indexed by
-            # node, compacted past the receiver's own node.
-            var slot = st.my_node if st.my_node < p.node else st.my_node - 1
-            build_write_wr(
-                _b(st.wr),
-                _b(st.sge),
-                w.seq,
-                w.send_addr,
-                st.lkey,
-                w.send_bytes,
-                p.remote_base + w.inbox_base + slot * w.slot_bytes,
-                p.remote_rkey,
-                UInt32(w.seq & 0x7FFFFFFF),
-                True,
-                True,
-            )
-            if post_send(p.qp, _b(st.wr), _b(st.bad)) != 0:
-                _store_atomic_i(_err_ptr(st), 1)
-                _store_atomic_i(_status_ptr(w), 2)
-                return
-            nsend += 1
-    var t1 = perf_counter_ns()
-
-    var sends_done = 0
-    while sends_done < nsend or _arrivals(st, parity) < w.nrecv:
-        if _stop_requested(st):
-            _store_atomic_i(_err_ptr(st), 6)
-            _store_atomic_i(_status_ptr(w), 2)
+def _drive_until(mut st: IbState, seq: Int):
+    """Run the engine until exchange `seq` is retired (or the engine fails).
+    The stall deadline inside `ib_drive` is what ends this if a peer never
+    answers."""
+    if seq > st.request_seq:
+        st.request_seq = seq
+        st.last_progress_ns = perf_counter_ns()
+    while st.done_seq < seq:
+        if _load_atomic_i(_err_ptr(st)) != 0:
+            _release_on_error(st)
             return
-        var n = poll_cq(st.cq, 16, _b(st.wc))
-        if n < 0:
-            _store_atomic_i(_err_ptr(st), 2)
-            _store_atomic_i(_status_ptr(w), 2)
-            return
-        for i in range(Int(n)):
-            var kind = _consume_wc(
-                st, P8(unsafe_from_address=st.wc + i * SZ_WC), npeers
-            )
-            if kind < 0:
-                _store_atomic_i(_status_ptr(w), 2)
-                return
-            if kind == 1:
-                sends_done += 1
-        if perf_counter_ns() > deadline:
-            _store_atomic_i(_err_ptr(st), 3)
-            _store_atomic_i(_status_ptr(w), 2)
-            return
-    if parity == 0:
-        st.arrivals0 -= w.nrecv
-    else:
-        st.arrivals1 -= w.nrecv
-    var t2 = perf_counter_ns()
-
-    if w.nrecv > 0 and w.flush_addr != 0:
-        build_read_wr(
-            _b(st.wr),
-            _b(st.sge),
-            0,
-            st.flush_host,
-            st.flush_lkey,
-            FLUSH_BYTES,
-            w.flush_addr,
-            st.rkey,
-        )
-        if post_send(st.flush_qp, _b(st.wr), _b(st.bad)) != 0:
-            _store_atomic_i(_err_ptr(st), 4)
-            _store_atomic_i(_status_ptr(w), 2)
-            return
-        var flushed = False
-        while not flushed:
-            if _stop_requested(st):
-                _store_atomic_i(_err_ptr(st), 6)
-                _store_atomic_i(_status_ptr(w), 2)
-                return
-            var n = poll_cq(st.cq, 16, _b(st.wc))
-            if n < 0:
-                _store_atomic_i(_err_ptr(st), 5)
-                _store_atomic_i(_status_ptr(w), 2)
-                return
-            for i in range(Int(n)):
-                var kind = _consume_wc(
-                    st, P8(unsafe_from_address=st.wc + i * SZ_WC), npeers
-                )
-                if kind < 0:
-                    _store_atomic_i(_status_ptr(w), 2)
-                    return
-                if kind == 2:
-                    flushed = True
-            if perf_counter_ns() > deadline:
-                _store_atomic_i(_err_ptr(st), 7)
-                _store_atomic_i(_status_ptr(w), 2)
-                return
-    var t3 = perf_counter_ns()
-
-    st.t_post_ns += t1 - t0
-    st.t_wait_ns += t2 - t1
-    st.t_flush_ns += t3 - t2
-    st.n_exchanges += 1
-    _store_atomic_i(_status_ptr(w), 1)
-
-
-@always_inline
-def _arrivals(st: IbState, parity: Int) -> Int:
-    return st.arrivals0 if parity == 0 else st.arrivals1
+        _ = ib_drive(st)
 
 
 @always_inline
@@ -517,78 +749,57 @@ def _mb(st: IbState, off: Int) -> Pointer[UInt64, MutAnyOrigin]:
     return Pointer[UInt64, MutAnyOrigin](unsafe_from_address=st.mailbox + off)
 
 
-@always_inline
-def _stop_requested(st: IbState) -> Bool:
-    """True once `ncclCommAbort` (or teardown) has raised MB_STOP.
-
-    Checked inside `_run_exchange`'s two poll loops so a stop request ends a
-    stuck exchange (a dead peer, nothing left to poll) promptly instead of
-    making `_stop_proxy`'s `pthread_join` wait out the rest of
-    `MOJOCCL_IB_TIMEOUT_S`. Only meaningful under the proxy -- the mailbox is
-    allocated only when `st.proxy`, so the `MOJOCCL_IB_PROXY=0` callback path
-    and the self-test's `ib_exchange_now` (no mailbox, no thread) never see
-    it set.
-    """
-    return (
-        st.mailbox != 0
-        and Atomic[DType.uint64].load[ordering = Ordering.ACQUIRE](
-            _mb(st, MB_STOP)
-        )
-        != 0
-    )
-
-
 def _proxy_main(arg: OpaquePointer[MutAnyOrigin]) abi("C"):
-    """The progress thread: one exchange at a time, in stream order.
+    """The progress thread: `ib_drive` in a loop, with the mailbox on both
+    ends.
 
-    Waits on the mailbox word a one-thread kernel releases after the
-    reduce-scatter, runs the exchange, releases the done word the matching
-    spin kernel is waiting on. Exchanges are strictly ordered on the
-    communicator's stream and the counter is dense, so slot `(seq-1) mod
-    WORK_SLOTS` is this exchange's work item and no queue is needed.
+    `MB_REQUEST` is the highest exchange the stream has released (a
+    one-thread kernel's release store); `MB_DONE` is the highest one
+    retired, which the matching spin kernel waits for. Several exchanges may
+    be in flight between the two.
 
-    Hard-spins like NCCL's proxy only WHILE AN EXCHANGE IS IN FLIGHT
-    (`_run_exchange`'s own poll loops) -- between exchanges, this loop backs
-    off (`sched_yield` once, then a short `nanosleep`) instead of burning a
-    full core on a mailbox word that is not going to change for a while. A
-    training step's host-side dispatch (hundreds of aten launches on the
-    Python main thread) shares this core's SMT sibling, and measured end to
-    end (job 234072, 2x8 H100) an unconditional hot spin here cost nanoGPT
-    DDP ~20% of its steady-state tok/s against real NCCL even though the
-    per-bucket allreduce itself was within 5%. `MOJOCCL_IB_PROXY_IDLE_US`
-    tunes the backoff quantum; `MOJOCCL_IB_PROXY=0` gives the core back
-    entirely, at the cost of the host-callback latency.
+    Hard-spins like NCCL's proxy only WHILE SOMETHING IS OUTSTANDING --
+    otherwise it backs off (`sched_yield` once, then a short `nanosleep`)
+    instead of burning a full core on a mailbox word that is not going to
+    change for a while. A training step's host-side dispatch (hundreds of
+    aten launches on the Python main thread) shares this core's SMT sibling,
+    and measured end to end (job 234072, 2x8 H100) an unconditional hot spin
+    here cost nanoGPT DDP ~20% of its steady-state tok/s against real NCCL.
+    `MOJOCCL_IB_PROXY_IDLE_US` tunes the backoff quantum.
     """
     ref st = _st(Int(arg))[]
-    var next_seq = 1
     var idle_ns = _proxy_idle_ns()
+    var published = 0
+    st.last_progress_ns = perf_counter_ns()
     while True:
         if Atomic[DType.uint64].load[ordering = Ordering.ACQUIRE](
             _mb(st, MB_STOP)
         ) != 0:
             return
+        var req = Int(
+            Atomic[DType.uint64].load[ordering = Ordering.ACQUIRE](
+                _mb(st, MB_REQUEST)
+            )
+        )
+        if req > st.request_seq:
+            st.request_seq = req
+            st.last_progress_ns = perf_counter_ns()
+        var moved = ib_drive(st)
+        if st.done_seq > published:
+            # Published even on failure: the spin kernels must be released or
+            # the stream hangs past the point where the error can be
+            # reported.
+            published = st.done_seq
+            Atomic[DType.uint64].store[ordering = Ordering.RELEASE](
+                _mb(st, MB_DONE), UInt64(published)
+            )
+        if moved or st.done_seq < st.request_seq:
+            continue
+        _ = external_call["sched_yield", Int32]()
         if Atomic[DType.uint64].load[ordering = Ordering.ACQUIRE](
             _mb(st, MB_REQUEST)
-        ) < UInt64(next_seq):
-            # Idle: yield once (catches a request that lands right away for
-            # free) and only pay for a sleep if that didn't help.
-            _ = external_call["sched_yield", Int32]()
-            if Atomic[DType.uint64].load[ordering = Ordering.ACQUIRE](
-                _mb(st, MB_REQUEST)
-            ) < UInt64(next_seq):
-                _nanosleep_ns(idle_ns)
-            continue
-        ref w = Pointer[IbWork, MutAnyOrigin](unsafe_from_address=st.works)[
-            unsafe_offset = (next_seq - 1) % WORK_SLOTS
-        ]
-        _run_exchange(st, w)
-        # Published even on failure: the spin kernel must be released or the
-        # stream hangs past the point where the error can be reported.
-        Atomic[DType.uint64].store[ordering = Ordering.RELEASE](
-            _mb(st, MB_DONE), UInt64(next_seq)
-        )
-        next_seq += 1
-
+        ) <= UInt64(st.request_seq):
+            _nanosleep_ns(idle_ns)
 
 def _proxy_address() -> Int:
     var f: def (
@@ -657,9 +868,9 @@ def ib_signal_abort(ib: Int):
     process. Unlike `_stop_proxy`, the join here is bounded
     (`IB_ABORT_JOIN_TIMEOUT_S`) with `pthread_tryjoin_np`, polled rather than
     blocking: abort must not hang because a dead peer left this rank's
-    thread waiting inside `_run_exchange` for a completion that will never
-    come -- `_stop_requested` is what actually gets it out of there quickly;
-    this bound is only insurance against the case that doesn't anticipate.
+    thread waiting for a completion that will never come -- `ib_drive` never
+    blocks, so the loop notices MB_STOP within one step; this bound is only
+    insurance against the case that doesn't anticipate.
     A thread this gives up on is simply left running; it exits on its own
     once it next checks MB_STOP, and the process exiting reclaims it either
     way.
@@ -779,12 +990,19 @@ def ib_setup(
     nnodes: Int,
     region: Int,
     region_bytes: Int,
+    nslots: Int,
+    credit_off: Int,
 ) raises -> Int:
     """Open an HCA, register the region, create the QPs (still in INIT).
 
     Returns the address of a heap `IbState`. The QPs cannot reach RTR until
     the peers' `(qpn, lid, gid)` have been gathered, so bring-up is split:
     this, then `ib_local_info` / `ib_connect`.
+
+    `nslots` is how many fixed inbox slot groups the caller carved out of the
+    region and therefore how many exchanges may be outstanding; `credit_off`
+    is the region offset of the credit landing pad. Both must be identical on
+    every rank -- they are part of the wire layout.
     """
     var ibv = Ibv()
     var want = getenv("MOJOCCL_IB_HCA", "")
@@ -810,7 +1028,14 @@ def ib_setup(
         if ports[i].ctx != port.ctx:
             ibv.close_device(ports[i].ctx)
 
-    var st = IbState(ibv^, region, my_node, nnodes)
+    if nslots < 1 or nslots > PIPE_MAX_SLOTS:
+        raise Error(
+            "mojoccl: nslots must be in 1.."
+            + String(PIPE_MAX_SLOTS)
+            + ", got "
+            + String(nslots)
+        )
+    var st = IbState(ibv^, region, my_node, nnodes, nslots, credit_off)
     st.hca = String(port.name)
     st.ctx = port.ctx
     st.port = port.port
@@ -867,6 +1092,7 @@ def ib_setup(
             )
             qp_to_init(st.ibv, qp, st.port)
             st.peers.append(IbPeer(j, qp, qp_number(qp), 0, 0))
+            st.credit_recv.append(0)
         st.flush_qp = create_rc_qp(st.ibv, st.pd, st.cq, SEND_WR_DEPTH, 8)
         qp_to_init(st.ibv, st.flush_qp, st.port)
 
@@ -1063,20 +1289,33 @@ def ib_error(ib: Int) -> Int:
 
 def ib_next_seq(ib: Int) -> Int:
     """Consume one exchange counter. Every rank of the communicator calls
-    this the same number of times in the same order, so the parity that
-    selects the inbox half and the immediate that tags an arrival agree
-    across nodes."""
+    this the same number of times in the same order, so the slot group an
+    exchange lands in, the credit window and the immediate that tags an
+    arrival all agree across nodes."""
     ref st = _st(ib)[]
     st.exchanges += 1
     return st.exchanges
 
 
-def ib_enqueue(
+def ib_note_consumed(ib: Int, seq: Int):
+    """Record that the consumer kernel for exchange `seq` has just been
+    ENQUEUED on the stream.
+
+    The number is carried into the next exchange's work item as
+    `credit_upto` and published to the peers when the engine picks that
+    exchange up -- at which point the request kernel has run and therefore
+    every kernel enqueued before it, this consumer included, has completed.
+    Callers must enqueue the consumer first and call this second, on the
+    stream the exchanges run on.
+    """
+    ref st = _st(ib)[]
+    if seq > st.consumed_enqueued:
+        st.consumed_enqueued = seq
+
+
+def _fill_work(
+    mut st: IbState,
     ib: Int,
-    driver: OwnedDLHandle,
-    ctx: DeviceContext,
-    stream: DeviceStream,
-    raw_stream: Int,
     send_addr: Int,
     send_bytes: Int,
     inbox_base: Int,
@@ -1085,22 +1324,9 @@ def ib_enqueue(
     nrecv: Int,
     flush_addr: Int,
     seq: Int,
+    credit_upto: Int,
 ) raises:
-    """Put one exchange on `stream`, between the kernel that produced its
-    payload and the kernel that consumes what arrives.
-
-    Two shapes, same ordering guarantee. With the proxy thread (default): a
-    one-thread kernel releases `seq` into the pinned mailbox and a second
-    one spins until the thread reports it done. Without it
-    (`MOJOCCL_IB_PROXY=0`): a `cuLaunchHostFunc` that does the exchange
-    inline, which is simpler and several hundred microseconds slower per
-    exchange.
-    """
-    ref st = _st(ib)[]
-    var slot = (seq - 1) % WORK_SLOTS
-    ref w = Pointer[IbWork, MutAnyOrigin](unsafe_from_address=st.works)[
-        unsafe_offset=slot
-    ]
+    ref w = _work(st, seq)[]
     if _load_atomic_i(_status_ptr(w)) == 0:
         raise Error(
             "mojoccl: the inter-node work ring wrapped with an exchange still"
@@ -1116,24 +1342,131 @@ def ib_enqueue(
     w.nrecv = nrecv
     w.flush_addr = flush_addr
     w.seq = seq
+    w.credit_upto = credit_upto
+    w.sends_cum = 0
+    w.t0 = 0
     _store_atomic_i(_status_ptr(w), 0)
+
+
+def ib_enqueue_request(
+    ib: Int,
+    driver: OwnedDLHandle,
+    ctx: DeviceContext,
+    stream: DeviceStream,
+    raw_stream: Int,
+    send_addr: Int,
+    send_bytes: Int,
+    inbox_base: Int,
+    slot_bytes: Int,
+    do_send: Bool,
+    nrecv: Int,
+    flush_addr: Int,
+    seq: Int,
+) raises:
+    """Release exchange `seq` to the network, at this point in stream order.
+
+    Enqueued right after the kernel that produced its payload. With the
+    proxy thread (default) it is a one-thread kernel storing `seq` into the
+    pinned mailbox, and the stream runs on: several exchanges may be in
+    flight, and `ib_enqueue_wait` is what eventually stops the stream.
+    Without the proxy (`MOJOCCL_IB_PROXY=0`) it is a `cuLaunchHostFunc` that
+    runs the whole exchange inline -- correct with the same schedule, but
+    with no overlap and several hundred microseconds of driver latency per
+    exchange.
+    """
+    ref st = _st(ib)[]
+    _fill_work(
+        st,
+        ib,
+        send_addr,
+        send_bytes,
+        inbox_base,
+        slot_bytes,
+        do_send,
+        nrecv,
+        flush_addr,
+        seq,
+        st.consumed_enqueued,
+    )
     if st.proxy:
         proxy_request(ctx, stream, st.mailbox_dev + MB_REQUEST, seq)
-        proxy_wait(
-            ctx,
-            stream,
-            st.mailbox_dev + MB_DONE,
-            st.error_word,
-            seq,
-            st.timeout_ns,
-        )
         return
     launch_host_func(
         driver,
         raw_stream,
         _callback_address(),
-        st.works + slot * size_of[IbWork](),
+        st.works + ((seq - 1) % WORK_SLOTS) * size_of[IbWork](),
     )
+
+
+def ib_enqueue_wait(
+    ib: Int, ctx: DeviceContext, stream: DeviceStream, seq: Int
+) raises:
+    """Hold the stream until exchange `seq` has been retired, so the kernel
+    enqueued next may read the inbox. A no-op on the `MOJOCCL_IB_PROXY=0`
+    path, where `ib_enqueue_request`'s callback already waited."""
+    ref st = _st(ib)[]
+    if not st.proxy:
+        return
+    proxy_wait(
+        ctx,
+        stream,
+        st.mailbox_dev + MB_DONE,
+        st.error_word,
+        seq,
+        st.timeout_ns,
+    )
+
+
+def ib_submit_now(
+    ib: Int,
+    send_addr: Int,
+    send_bytes: Int,
+    inbox_base: Int,
+    slot_bytes: Int,
+    do_send: Bool,
+    nrecv: Int,
+    flush_addr: Int,
+    seq: Int,
+    credit_upto: Int,
+) raises:
+    """Hand one exchange to the engine from the calling thread, without
+    waiting for it.
+
+    The GPU-free self-tests use this (with `ib_wait_now`) to keep several
+    exchanges in flight and exercise the credit protocol past the slot
+    count, which is the case a leaked credit turns into a hang. Never
+    correct inside a collective: there the exchange's position in stream
+    order is the whole ordering argument.
+    """
+    ref st = _st(ib)[]
+    _fill_work(
+        st,
+        ib,
+        send_addr,
+        send_bytes,
+        inbox_base,
+        slot_bytes,
+        do_send,
+        nrecv,
+        flush_addr,
+        seq,
+        credit_upto,
+    )
+    if seq > st.request_seq:
+        st.request_seq = seq
+        st.last_progress_ns = perf_counter_ns()
+
+
+def ib_wait_now(ib: Int, seq: Int) raises:
+    """Drive the engine on the calling thread until exchange `seq` is done."""
+    ref st = _st(ib)[]
+    _drive_until(st, seq)
+    if _load_atomic_i(_err_ptr(st)) != 0:
+        raise Error(
+            "mojoccl: inline exchange failed, ib error "
+            + String(_load_atomic_i(_err_ptr(st)))
+        )
 
 
 def ib_exchange_now(
@@ -1146,35 +1479,29 @@ def ib_exchange_now(
     nrecv: Int,
     flush_addr: Int,
     seq: Int,
+    credit_upto: Int,
 ) raises:
-    """Run one exchange inline on the calling thread.
+    """One exchange, submitted and waited for on the calling thread.
 
     The bring-up self-test uses it: the transport can then be exercised on
     a host with InfiniBand but no GPU (registered host memory, no stream to
     hang kernels on), which is where the bootstrap/QP/immediate wiring is
     cheapest to debug -- run it with `MOJOCCL_IB_PROXY=0`, since the proxy
-    mailbox needs a driver that can pin host memory. Never correct inside a
-    collective: there the exchange's position in stream order is the whole
-    ordering argument.
+    mailbox needs a driver that can pin host memory.
     """
-    ref st = _st(ib)[]
-    var w = IbWork()
-    w.state = ib
-    w.send_addr = send_addr
-    w.send_bytes = send_bytes
-    w.inbox_base = inbox_base
-    w.slot_bytes = slot_bytes
-    w.do_send = 1 if do_send else 0
-    w.nrecv = nrecv
-    w.flush_addr = flush_addr
-    w.seq = seq
-    _store_atomic_i(_status_ptr(w), 0)
-    _run_exchange(st, w)
-    if _load_atomic_i(_status_ptr(w)) != 1:
-        raise Error(
-            "mojoccl: inline exchange failed, ib error "
-            + String(_load_atomic_i(_err_ptr(st)))
-        )
+    ib_submit_now(
+        ib,
+        send_addr,
+        send_bytes,
+        inbox_base,
+        slot_bytes,
+        do_send,
+        nrecv,
+        flush_addr,
+        seq,
+        credit_upto,
+    )
+    ib_wait_now(ib, seq)
 
 
 def ib_report(ib: Int):
@@ -1188,11 +1515,15 @@ def ib_report(ib: Int):
         st.port,
         "peers",
         len(st.peers),
+        "slots",
+        st.nslots,
         "exchanges",
         st.n_exchanges,
+        "credit stalls",
+        st.n_credit_stalls,
         "| mean us post",
         Float64(st.t_post_ns) / Float64(st.n_exchanges) / 1000.0,
-        "wait",
+        "in flight",
         Float64(st.t_wait_ns) / Float64(st.n_exchanges) / 1000.0,
         "flush",
         Float64(st.t_flush_ns) / Float64(st.n_exchanges) / 1000.0,

--- a/torch_mojo_backend/distributed/mojoccl/internode.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/internode.mojo
@@ -112,6 +112,7 @@ from ibverbs import (
     WC_QP_NUM,
     WC_STATUS,
     WC_VENDOR_ERR,
+    WC_WR_ID,
     Ibv,
     alloc_bytes,
     be32,
@@ -120,6 +121,7 @@ from ibverbs import (
     build_write_wr,
     create_rc_qp,
     ld32,
+    ld64,
     ldu32,
     list_ib_ports,
     poll_cq,
@@ -230,10 +232,11 @@ struct IbWork(Copyable, Movable):
     # this one's request on the stream -- the credit the engine publishes
     # when it picks this exchange up. See the header's flow-control note.
     var credit_upto: Int
-    # Data sends posted, cumulatively, once this exchange is on the wire:
-    # the exchange is not done until that many send completions are in, or
-    # the next reduce-scatter could overwrite a buffer the NIC still reads.
-    var sends_cum: Int
+    # 1 once this exchange's data write is posted to every peer. The exchange
+    # is not done until each of those sends has completed on ITS queue pair
+    # (`IbState.send_done`), or the consumer kernel could overwrite a buffer
+    # the NIC is still reading for a slower peer.
+    var sent: Int
     var t0: Int  # perf_counter_ns when it was posted, for the trace
 
     def __init__(out self):
@@ -248,7 +251,7 @@ struct IbWork(Copyable, Movable):
         self.seq = 0
         self.status = 1
         self.credit_upto = 0
-        self.sends_cum = 0
+        self.sent = 0
         self.t0 = 0
 
 
@@ -284,8 +287,14 @@ struct IbState(Movable):
     var flush_seq: Int  # exchange whose flush read is outstanding (0: none)
     var flush_done: Int  # flush-read completions seen and not yet consumed
     var flush_t0: Int
-    var sends_posted: Int
-    var sends_completed: Int
+    # Per peer, the highest exchange whose data write has completed on that
+    # peer's queue pair (the wr_id of the completion is the exchange number).
+    # Per QP, not one global count: RC completes in order on ONE queue pair
+    # only, so with three or more nodes a completion for e+1 towards a fast
+    # peer can land before the completion for e towards a slow one, and a
+    # global tally would call e's sends finished while the NIC still reads
+    # e's source for the slow peer.
+    var send_done: List[Int]
     var credit_sent: Int  # highest credit published to the peers
     var tally: List[Int]  # arrivals, indexed by `seq % nslots`
     var credit_recv: List[Int]  # per peer, highest credit it published
@@ -355,8 +364,7 @@ struct IbState(Movable):
         self.flush_seq = 0
         self.flush_done = 0
         self.flush_t0 = 0
-        self.sends_posted = 0
-        self.sends_completed = 0
+        self.send_done = List[Int]()
         self.credit_sent = 0
         self.tally = List[Int]()
         for _ in range(nslots):
@@ -549,8 +557,30 @@ def _post_data(mut st: IbState, mut w: IbWork) -> Bool:
             if post_send(p.qp, _b(st.wr), _b(st.bad)) != 0:
                 _store_atomic_i(_err_ptr(st), 1)
                 return False
-            st.sends_posted += 1
-    w.sends_cum = st.sends_posted
+        w.sent = 1
+    return True
+
+
+@always_inline
+def _peer_index(st: IbState, qpn: UInt32) -> Int:
+    """Index into `st.peers` of the queue pair a completion came from, or -1
+    (the flush QP, whose completions are classified by opcode instead)."""
+    for k in range(len(st.peers)):
+        if st.peers[k].qpn == qpn:
+            return k
+    return -1
+
+
+@always_inline
+def _sends_done(st: IbState, mut w: IbWork) -> Bool:
+    """Every peer's queue pair has completed this exchange's data write.
+    Completions on one RC queue pair are in order, so `send_done[i] >= seq`
+    covers every earlier send on that pair too."""
+    if w.sent == 0:
+        return True
+    for i in range(len(st.send_done)):
+        if st.send_done[i] < w.seq:
+            return False
     return True
 
 
@@ -569,17 +599,16 @@ def _consume_wc(mut st: IbState, c: P8) -> Int:
         )
         return -1
     var op = Int32(ld32(c, WC_OPCODE))
+    var pi = _peer_index(st, ldu32(c, WC_QP_NUM))
     if op == IBV_WC_RECV_RDMA_WITH_IMM:
         var imm = be32(ldu32(c, WC_IMM_DATA))
-        var qpn = ldu32(c, WC_QP_NUM)
-        var pi = -1
-        for k in range(len(st.peers)):
-            if st.peers[k].qpn == qpn:
-                pi = k
-                break
         if pi >= 0:
             build_recv_wr(_b(st.rwr), 0)
-            _ = post_recv(st.peers[pi].qp, _b(st.rwr), _b(st.bad))
+            if post_recv(st.peers[pi].qp, _b(st.rwr), _b(st.bad)) != 0:
+                # A receive slot lost here is a later RNR the peer retries
+                # forever (IB_RNR_RETRY = 7), i.e. a silent hang; latch it.
+                _store_atomic_i(_err_ptr(st), 5)
+                return -1
         var seq = Int(imm & IMM_SEQ_MASK)
         if (imm & IMM_CREDIT_BIT) != 0:
             if pi >= 0 and st.credit_recv[pi] < seq:
@@ -588,7 +617,11 @@ def _consume_wc(mut st: IbState, c: P8) -> Int:
             st.tally[seq % st.nslots] += 1
         return 0
     if op == IBV_WC_RDMA_WRITE:
-        st.sends_completed += 1
+        # Only data writes are signaled (credits are not), and their wr_id
+        # is the exchange number, dense and increasing per queue pair.
+        var seq = ld64(c, WC_WR_ID)
+        if pi >= 0 and st.send_done[pi] < seq:
+            st.send_done[pi] = seq
         return 0
     if op == IBV_WC_RDMA_READ:
         st.flush_done += 1
@@ -600,9 +633,9 @@ def _advance(mut st: IbState) -> Bool:
     """Retire every exchange that is complete, in sequence order.
 
     An exchange is complete when all `nrecv` peers' messages for it have
-    arrived, its own sends have completed (the NIC is done reading the
-    buffer the next reduce-scatter will overwrite) and its GPUDirect flush
-    read has come back.
+    arrived, its own send to EVERY peer has completed (the NIC is done
+    reading the buffer the consumer kernel and the next reduce-scatter will
+    overwrite) and its GPUDirect flush read has come back.
     """
     var moved = False
     while True:
@@ -621,7 +654,7 @@ def _advance(mut st: IbState) -> Bool:
         var e = st.done_seq + 1
         ref w = _work(st, e)[]
         var idx = e % st.nslots
-        if st.tally[idx] < w.nrecv or st.sends_completed < w.sends_cum:
+        if st.tally[idx] < w.nrecv or not _sends_done(st, w):
             break
         st.tally[idx] -= w.nrecv
         if w.nrecv > 0 and w.flush_addr != 0:
@@ -1091,9 +1124,12 @@ def ib_setup(
             var qp = create_rc_qp(
                 st.ibv, st.pd, st.cq, SEND_WR_DEPTH, RECV_DEPTH + 8
             )
-            qp_to_init(st.ibv, qp, st.port)
+            # Recorded before `qp_to_init` can raise, so the unwind below
+            # destroys it.
             st.peers.append(IbPeer(j, qp, qp_number(qp), 0, 0))
             st.credit_recv.append(0)
+            st.send_done.append(0)
+            qp_to_init(st.ibv, qp, st.port)
         st.flush_qp = create_rc_qp(st.ibv, st.pd, st.cq, SEND_WR_DEPTH, 8)
         qp_to_init(st.ibv, st.flush_qp, st.port)
 
@@ -1348,7 +1384,7 @@ def _fill_work(
     w.flush_addr = flush_addr
     w.seq = seq
     w.credit_upto = credit_upto
-    w.sends_cum = 0
+    w.sent = 0
     w.t0 = 0
     _store_atomic_i(_status_ptr(w), 0)
 

--- a/torch_mojo_backend/distributed/mojoccl/internode.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/internode.mojo
@@ -1149,7 +1149,11 @@ def ib_setup(
     var holder = unsafe_alloc[IbState](1)
     holder.unsafe_write(st^)
     if _st(Int(holder))[].proxy:
-        _start_proxy(Int(holder))
+        try:
+            _start_proxy(Int(holder))
+        except e:
+            _teardown_ib_resources(_st(Int(holder))[])
+            raise e
     return Int(holder)
 
 

--- a/torch_mojo_backend/distributed/mojoccl/internode.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/internode.mojo
@@ -122,11 +122,18 @@ comptime WORK_SLOTS = 512
 comptime MAX_NODES = 16
 comptime DEFAULT_IB_TIMEOUT_S: Float64 = 60.0
 # ncclCommAbort's bound on waiting for the progress thread: long enough for
-# it to notice MB_STOP (immediate when idle, at most one poll_cq when inside
-# `_run_exchange` -- see `_stop_requested`), short enough that abort's
-# documented "don't wait" contract still holds even if the thread is wedged
-# somewhere this bound does not anticipate.
+# it to notice MB_STOP (at most one idle-backoff quantum plus one poll_cq
+# when inside `_run_exchange` -- see `_stop_requested`), short enough that
+# abort's documented "don't wait" contract still holds even if the thread is
+# wedged somewhere this bound does not anticipate.
 comptime IB_ABORT_JOIN_TIMEOUT_S: Float64 = 2.0
+# Default idle-wait quantum for the progress thread between exchanges (see
+# `_proxy_main`). An exchange takes ~280 us at the DDP bucket, so a few tens
+# of us of wake-up latency between exchanges is cheap; measured end to end
+# (job 234072, 2x8 H100) an unconditional hot spin here cost nanoGPT DDP
+# ~20% of its steady-state tok/s against real NCCL, competing for a core/SMT
+# sibling with the ~760-aten-op-per-step host dispatch of the training loop.
+comptime DEFAULT_IB_PROXY_IDLE_US: Int = 20
 # Bytes of the inbox read back by the flush; any read of the destination
 # device flushes the writes ahead of it, the size is irrelevant.
 comptime FLUSH_BYTES = 4
@@ -534,18 +541,27 @@ def _stop_requested(st: IbState) -> Bool:
 def _proxy_main(arg: OpaquePointer[MutAnyOrigin]) abi("C"):
     """The progress thread: one exchange at a time, in stream order.
 
-    Spins on the mailbox word a one-thread kernel releases after the
+    Waits on the mailbox word a one-thread kernel releases after the
     reduce-scatter, runs the exchange, releases the done word the matching
     spin kernel is waiting on. Exchanges are strictly ordered on the
     communicator's stream and the counter is dense, so slot `(seq-1) mod
     WORK_SLOTS` is this exchange's work item and no queue is needed.
 
-    A pure spin, like NCCL's proxy: the whole point is that neither side
-    ever sleeps. One core per rank, and `MOJOCCL_IB_PROXY=0` gives it back
-    at the cost of the host-callback latency.
+    Hard-spins like NCCL's proxy only WHILE AN EXCHANGE IS IN FLIGHT
+    (`_run_exchange`'s own poll loops) -- between exchanges, this loop backs
+    off (`sched_yield` once, then a short `nanosleep`) instead of burning a
+    full core on a mailbox word that is not going to change for a while. A
+    training step's host-side dispatch (hundreds of aten launches on the
+    Python main thread) shares this core's SMT sibling, and measured end to
+    end (job 234072, 2x8 H100) an unconditional hot spin here cost nanoGPT
+    DDP ~20% of its steady-state tok/s against real NCCL even though the
+    per-bucket allreduce itself was within 5%. `MOJOCCL_IB_PROXY_IDLE_US`
+    tunes the backoff quantum; `MOJOCCL_IB_PROXY=0` gives the core back
+    entirely, at the cost of the host-callback latency.
     """
     ref st = _st(Int(arg))[]
     var next_seq = 1
+    var idle_ns = _proxy_idle_ns()
     while True:
         if Atomic[DType.uint64].load[ordering = Ordering.ACQUIRE](
             _mb(st, MB_STOP)
@@ -554,6 +570,13 @@ def _proxy_main(arg: OpaquePointer[MutAnyOrigin]) abi("C"):
         if Atomic[DType.uint64].load[ordering = Ordering.ACQUIRE](
             _mb(st, MB_REQUEST)
         ) < UInt64(next_seq):
+            # Idle: yield once (catches a request that lands right away for
+            # free) and only pay for a sleep if that didn't help.
+            _ = external_call["sched_yield", Int32]()
+            if Atomic[DType.uint64].load[ordering = Ordering.ACQUIRE](
+                _mb(st, MB_REQUEST)
+            ) < UInt64(next_seq):
+                _nanosleep_ns(idle_ns)
             continue
         ref w = Pointer[IbWork, MutAnyOrigin](unsafe_from_address=st.works)[
             unsafe_offset = (next_seq - 1) % WORK_SLOTS
@@ -574,6 +597,26 @@ def _proxy_address() -> Int:
     return Pointer(to=f).unsafe_bitcast[Int]()[]
 
 
+def _set_thread_affinity(tid: Int, cpu: Int) raises:
+    """`pthread_setaffinity_np` to a single CPU. `cpu_set_t` is a 128-byte
+    (1024-bit) bitmask on this ABI; only the one bit for `cpu` is set."""
+    comptime CPU_SET_BYTES = 128
+    var byte_idx = cpu // 8
+    if cpu < 0 or byte_idx >= CPU_SET_BYTES:
+        raise Error(
+            "mojoccl: MOJOCCL_IB_PROXY_CPU=" + String(cpu) + " out of range"
+        )
+    var mask = alloc_bytes(CPU_SET_BYTES)
+    mask[unsafe_offset=byte_idx] = UInt8(1) << UInt8(cpu % 8)
+    var rc = external_call["pthread_setaffinity_np", Int32](
+        Int64(tid), UInt64(CPU_SET_BYTES), mask
+    )
+    if rc != 0:
+        raise Error(
+            "mojoccl: pthread_setaffinity_np failed, rc=" + String(rc)
+        )
+
+
 def _start_proxy(ib: Int) raises:
     ref st = _st(ib)[]
     var tid = unsafe_alloc[Int64](1)
@@ -584,6 +627,15 @@ def _start_proxy(ib: Int) raises:
     if rc != 0:
         raise Error("mojoccl: pthread_create failed, rc=" + String(rc))
     st.thread_id = Int(tid[unsafe_offset=0])
+    # Opt-in only (default: no pinning) -- a best-effort placement hint, not
+    # load-bearing for correctness, so a bad CPU index or a failed syscall
+    # only prints rather than failing communicator init.
+    var cpu_s = getenv("MOJOCCL_IB_PROXY_CPU", "")
+    if cpu_s.byte_length() > 0:
+        try:
+            _set_thread_affinity(st.thread_id, Int(cpu_s))
+        except e:
+            print("mojoccl: MOJOCCL_IB_PROXY_CPU pinning failed:", e)
 
 
 def _stop_proxy(mut st: IbState):
@@ -842,6 +894,33 @@ def _ib_timeout_s() -> Float64:
         return Float64(s)
     except:
         return DEFAULT_IB_TIMEOUT_S
+
+
+def _proxy_idle_ns() -> Int:
+    """`MOJOCCL_IB_PROXY_IDLE_US`, read once at thread start (not from inside
+    the progress-thread loop -- a `getenv` per idle iteration would defeat
+    the point of backing off)."""
+    var s = getenv(
+        "MOJOCCL_IB_PROXY_IDLE_US", String(DEFAULT_IB_PROXY_IDLE_US)
+    )
+    var us = DEFAULT_IB_PROXY_IDLE_US
+    try:
+        var parsed = Int(s)
+        if parsed > 0:
+            us = parsed
+    except:
+        pass
+    return us * 1000
+
+
+def _nanosleep_ns(ns: Int):
+    """`nanosleep(2)` for `ns` nanoseconds; `struct timespec{tv_sec,tv_nsec}`,
+    16 bytes on this ABI. Best-effort: an interrupted sleep just returns
+    early, which only means the next mailbox check happens a bit sooner."""
+    var ts = unsafe_alloc[Int64](2)
+    ts[unsafe_offset=0] = 0
+    ts[unsafe_offset=1] = Int64(ns)
+    _ = external_call["nanosleep", Int32](ts, Int64(0))
 
 
 def ib_local_info(ib: Int, out_blob: P8, port_lid: Int, port_mtu: Int):

--- a/torch_mojo_backend/distributed/mojoccl/internode.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/internode.mojo
@@ -296,6 +296,39 @@ def _st(ib: Int) -> Pointer[IbState, MutAnyOrigin]:
     return Pointer[IbState, MutAnyOrigin](unsafe_from_address=ib)
 
 
+# `IbState.error` and `IbWork.status` are written by the proxy thread (or the
+# `MOJOCCL_IB_PROXY=0` callback thread) inside `_run_exchange` and read by
+# the calling thread -- `ib_error` from the torch-facing calling thread,
+# `ib_enqueue`'s ring-reuse check from the same -- with no other
+# synchronization between the two. Every access goes through these two
+# helpers rather than a plain field read/write so that relationship is a
+# real release/acquire pair, not two threads racing a plain `Int`.
+@always_inline
+def _load_atomic_i(p: Pointer[Int, MutAnyOrigin]) -> Int:
+    return Int(
+        Atomic[DType.int64].load[ordering = Ordering.ACQUIRE](
+            p.unsafe_bitcast[Int64]()
+        )
+    )
+
+
+@always_inline
+def _store_atomic_i(p: Pointer[Int, MutAnyOrigin], v: Int):
+    Atomic[DType.int64].store[ordering = Ordering.RELEASE](
+        p.unsafe_bitcast[Int64](), Int64(v)
+    )
+
+
+@always_inline
+def _err_ptr(mut st: IbState) -> Pointer[Int, MutAnyOrigin]:
+    return Pointer(to=st.error).unsafe_origin_cast[MutAnyOrigin]()
+
+
+@always_inline
+def _status_ptr(mut w: IbWork) -> Pointer[Int, MutAnyOrigin]:
+    return Pointer(to=w.status).unsafe_origin_cast[MutAnyOrigin]()
+
+
 # ===-------------------------------------------------------------------=== #
 # The host callback
 # ===-------------------------------------------------------------------=== #
@@ -311,7 +344,10 @@ def _consume_wc(mut st: IbState, c: P8, npeers: Int) -> Int:
     on, and a recv WR nobody reposts.
     """
     if Int32(ld32(c, WC_STATUS)) != IBV_WC_SUCCESS:
-        st.error = 1000 + ld32(c, WC_STATUS) * 1000 + ld32(c, WC_VENDOR_ERR)
+        _store_atomic_i(
+            _err_ptr(st),
+            1000 + ld32(c, WC_STATUS) * 1000 + ld32(c, WC_VENDOR_ERR),
+        )
         return -1
     var op = Int32(ld32(c, WC_OPCODE))
     if op == IBV_WC_RECV_RDMA_WITH_IMM:
@@ -351,8 +387,8 @@ def _ib_progress(user: OpaquePointer[MutAnyOrigin]) abi("C"):
 
 def _run_exchange(mut st: IbState, mut w: IbWork):
     """Post this exchange's RDMA writes, wait for the peers', flush."""
-    if st.error != 0:
-        w.status = 2
+    if _load_atomic_i(_err_ptr(st)) != 0:
+        _store_atomic_i(_status_ptr(w), 2)
         return
     var npeers = len(st.peers)
     var parity = w.seq & 1
@@ -380,8 +416,8 @@ def _run_exchange(mut st: IbState, mut w: IbWork):
                 True,
             )
             if post_send(p.qp, _b(st.wr), _b(st.bad)) != 0:
-                st.error = 1
-                w.status = 2
+                _store_atomic_i(_err_ptr(st), 1)
+                _store_atomic_i(_status_ptr(w), 2)
                 return
             nsend += 1
     var t1 = perf_counter_ns()
@@ -389,26 +425,26 @@ def _run_exchange(mut st: IbState, mut w: IbWork):
     var sends_done = 0
     while sends_done < nsend or _arrivals(st, parity) < w.nrecv:
         if _stop_requested(st):
-            st.error = 6
-            w.status = 2
+            _store_atomic_i(_err_ptr(st), 6)
+            _store_atomic_i(_status_ptr(w), 2)
             return
         var n = poll_cq(st.cq, 16, _b(st.wc))
         if n < 0:
-            st.error = 2
-            w.status = 2
+            _store_atomic_i(_err_ptr(st), 2)
+            _store_atomic_i(_status_ptr(w), 2)
             return
         for i in range(Int(n)):
             var kind = _consume_wc(
                 st, P8(unsafe_from_address=st.wc + i * SZ_WC), npeers
             )
             if kind < 0:
-                w.status = 2
+                _store_atomic_i(_status_ptr(w), 2)
                 return
             if kind == 1:
                 sends_done += 1
         if perf_counter_ns() > deadline:
-            st.error = 3
-            w.status = 2
+            _store_atomic_i(_err_ptr(st), 3)
+            _store_atomic_i(_status_ptr(w), 2)
             return
     if parity == 0:
         st.arrivals0 -= w.nrecv
@@ -428,32 +464,32 @@ def _run_exchange(mut st: IbState, mut w: IbWork):
             st.rkey,
         )
         if post_send(st.flush_qp, _b(st.wr), _b(st.bad)) != 0:
-            st.error = 4
-            w.status = 2
+            _store_atomic_i(_err_ptr(st), 4)
+            _store_atomic_i(_status_ptr(w), 2)
             return
         var flushed = False
         while not flushed:
             if _stop_requested(st):
-                st.error = 6
-                w.status = 2
+                _store_atomic_i(_err_ptr(st), 6)
+                _store_atomic_i(_status_ptr(w), 2)
                 return
             var n = poll_cq(st.cq, 16, _b(st.wc))
             if n < 0:
-                st.error = 5
-                w.status = 2
+                _store_atomic_i(_err_ptr(st), 5)
+                _store_atomic_i(_status_ptr(w), 2)
                 return
             for i in range(Int(n)):
                 var kind = _consume_wc(
                     st, P8(unsafe_from_address=st.wc + i * SZ_WC), npeers
                 )
                 if kind < 0:
-                    w.status = 2
+                    _store_atomic_i(_status_ptr(w), 2)
                     return
                 if kind == 2:
                     flushed = True
             if perf_counter_ns() > deadline:
-                st.error = 7
-                w.status = 2
+                _store_atomic_i(_err_ptr(st), 7)
+                _store_atomic_i(_status_ptr(w), 2)
                 return
     var t3 = perf_counter_ns()
 
@@ -461,7 +497,7 @@ def _run_exchange(mut st: IbState, mut w: IbWork):
     st.t_wait_ns += t2 - t1
     st.t_flush_ns += t3 - t2
     st.n_exchanges += 1
-    w.status = 1
+    _store_atomic_i(_status_ptr(w), 1)
 
 
 @always_inline
@@ -925,7 +961,8 @@ def ib_npeers(ib: Int) -> Int:
 
 
 def ib_error(ib: Int) -> Int:
-    return _st(ib)[].error
+    ref st = _st(ib)[]
+    return _load_atomic_i(_err_ptr(st))
 
 
 def ib_next_seq(ib: Int) -> Int:
@@ -968,7 +1005,7 @@ def ib_enqueue(
     ref w = Pointer[IbWork, MutAnyOrigin](unsafe_from_address=st.works)[
         unsafe_offset=slot
     ]
-    if w.status == 0:
+    if _load_atomic_i(_status_ptr(w)) == 0:
         raise Error(
             "mojoccl: the inter-node work ring wrapped with an exchange still"
             " in flight; MOJOCCL_IB_TRACE=1 to see how far behind the network"
@@ -983,7 +1020,7 @@ def ib_enqueue(
     w.nrecv = nrecv
     w.flush_addr = flush_addr
     w.seq = seq
-    w.status = 0
+    _store_atomic_i(_status_ptr(w), 0)
     if st.proxy:
         proxy_request(ctx, stream, st.mailbox_dev + MB_REQUEST, seq)
         proxy_wait(
@@ -1035,11 +1072,12 @@ def ib_exchange_now(
     w.nrecv = nrecv
     w.flush_addr = flush_addr
     w.seq = seq
-    w.status = 0
+    _store_atomic_i(_status_ptr(w), 0)
     _run_exchange(st, w)
-    if w.status != 1:
+    if _load_atomic_i(_status_ptr(w)) != 1:
         raise Error(
-            "mojoccl: inline exchange failed, ib error " + String(st.error)
+            "mojoccl: inline exchange failed, ib error "
+            + String(_load_atomic_i(_err_ptr(st)))
         )
 
 

--- a/torch_mojo_backend/distributed/mojoccl/internode.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/internode.mojo
@@ -927,6 +927,46 @@ def ib_enqueue(
     )
 
 
+def ib_exchange_now(
+    ib: Int,
+    send_addr: Int,
+    send_bytes: Int,
+    inbox_base: Int,
+    slot_bytes: Int,
+    do_send: Bool,
+    nrecv: Int,
+    flush_addr: Int,
+    seq: Int,
+) raises:
+    """Run one exchange inline on the calling thread.
+
+    The bring-up self-test uses it: the transport can then be exercised on
+    a host with InfiniBand but no GPU (registered host memory, no stream to
+    hang kernels on), which is where the bootstrap/QP/immediate wiring is
+    cheapest to debug -- run it with `MOJOCCL_IB_PROXY=0`, since the proxy
+    mailbox needs a driver that can pin host memory. Never correct inside a
+    collective: there the exchange's position in stream order is the whole
+    ordering argument.
+    """
+    ref st = _st(ib)[]
+    var w = IbWork()
+    w.state = ib
+    w.send_addr = send_addr
+    w.send_bytes = send_bytes
+    w.inbox_base = inbox_base
+    w.slot_bytes = slot_bytes
+    w.do_send = 1 if do_send else 0
+    w.nrecv = nrecv
+    w.flush_addr = flush_addr
+    w.seq = seq
+    w.status = 0
+    _run_exchange(st, w)
+    if w.status != 1:
+        raise Error(
+            "mojoccl: inline exchange failed, ib error " + String(st.error)
+        )
+
+
 def ib_report(ib: Int):
     ref st = _st(ib)[]
     if not st.trace or st.n_exchanges == 0:

--- a/torch_mojo_backend/distributed/mojoccl/internode.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/internode.mojo
@@ -801,6 +801,7 @@ def _proxy_main(arg: OpaquePointer[MutAnyOrigin]) abi("C"):
         ) <= UInt64(st.request_seq):
             _nanosleep_ns(idle_ns)
 
+
 def _proxy_address() -> Int:
     var f: def (
         OpaquePointer[MutAnyOrigin]
@@ -1305,8 +1306,12 @@ def ib_note_consumed(ib: Int, seq: Int):
     `credit_upto` and published to the peers when the engine picks that
     exchange up -- at which point the request kernel has run and therefore
     every kernel enqueued before it, this consumer included, has completed.
-    Callers must enqueue the consumer first and call this second, on the
-    stream the exchanges run on.
+    Callers enqueue the consumer first and call this second.
+
+    That argument is stream order, so every exchange of one communicator has
+    to be enqueued on ONE stream in issue order. The engine's dense sequence
+    counter already required that (`_work` derives a ring slot from the
+    number); `credit_upto` is the second thing that does.
     """
     ref st = _st(ib)[]
     if seq > st.consumed_enqueued:

--- a/torch_mojo_backend/distributed/mojoccl/internode.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/internode.mojo
@@ -871,23 +871,33 @@ def ib_local_info(ib: Int, out_blob: P8, port_lid: Int, port_mtu: Int):
 comptime IB_BLOB_BYTES = 24 + 4 * MAX_NODES + 16
 
 
-def ib_port_lid(ib: Int) -> Int:
+def ib_port_lid(ib: Int) raises -> Int:
+    """The port's LID, straight from `ibv_query_port`.
+
+    A nonzero return code (not the same thing as the `try/except` this used
+    to have -- `query_port`'s own C call never raises, it returns an errno)
+    used to be silently discarded, reading LID 0 out of `pa`'s zeroed
+    scratch. For the self-connected flush QP that 0 is not a sentinel
+    anyone downstream checks; it just quietly modifies the flush QP with the
+    wrong address. Raise instead.
+    """
     ref st = _st(ib)[]
     var pa = alloc_bytes(56)
-    try:
-        _ = st.ibv.query_port(st.ctx, st.port, pa)
-    except:
-        return 0
+    var rc = st.ibv.query_port(st.ctx, st.port, pa)
+    if rc != 0:
+        raise Error("mojoccl: ibv_query_port failed, rc=" + String(rc))
     return Int(pa.unsafe_bitcast[UInt16]()[unsafe_offset=17])
 
 
-def ib_port_mtu(ib: Int) -> Int:
+def ib_port_mtu(ib: Int) raises -> Int:
+    """The port's active MTU, straight from `ibv_query_port` (see
+    `ib_port_lid` for why a failed query now raises instead of reading 0 out
+    of zeroed scratch)."""
     ref st = _st(ib)[]
     var pa = alloc_bytes(56)
-    try:
-        _ = st.ibv.query_port(st.ctx, st.port, pa)
-    except:
-        return 0
+    var rc = st.ibv.query_port(st.ctx, st.port, pa)
+    if rc != 0:
+        raise Error("mojoccl: ibv_query_port failed, rc=" + String(rc))
     return ld32(pa, 8)
 
 

--- a/torch_mojo_backend/distributed/mojoccl/internode.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/internode.mojo
@@ -89,6 +89,7 @@ from driver import (
     host_device_ptr,
     launch_host_func,
     open_driver,
+    warn_teardown,
 )
 from internode_kernels import proxy_request, proxy_wait
 from ibverbs import (
@@ -1202,11 +1203,11 @@ def ib_setup(
         )
     # Only a hint for HCA affinity: a driver without the symbol, or a
     # device that will not report one, falls back to round-robin.
-    var gpu_bdf = String("")
+    var gpu_bdf: String
     try:
         gpu_bdf = device_pci_bus_id(driver, ordinal)
     except:
-        pass
+        gpu_bdf = String("")  # no PCI id: round-robin HCA choice
     var pick = _choose_port(ports, gpu_bdf, local_rank)
     ref port = ports[pick]
     # These nodes carry ~10 IB HCAs and every rank opened all of them to
@@ -1325,7 +1326,7 @@ def _proxy_idle_ns() -> Int:
         if parsed > 0:
             us = parsed
     except:
-        pass
+        us = DEFAULT_IB_PROXY_IDLE_US  # unparsable: keep the default
     return us * 1000
 
 
@@ -1748,8 +1749,8 @@ def _teardown_ib_resources(mut st: IbState):
         # costs a refcount.
         try:
             free_host(open_driver(), st.mailbox)
-        except:
-            pass
+        except e:
+            warn_teardown("freeing the pinned mailbox", e)
         st.mailbox = 0
         st.mailbox_dev = 0
     try:
@@ -1767,8 +1768,8 @@ def _teardown_ib_resources(mut st: IbState):
             st.ibv.dealloc_pd(st.pd)
         if st.ctx != 0:
             st.ibv.close_device(st.ctx)
-    except:
-        pass
+    except e:
+        warn_teardown("releasing the IB resources", e)
 
 
 def ib_teardown(ib: Int):

--- a/torch_mojo_backend/distributed/mojoccl/internode.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/internode.mojo
@@ -909,9 +909,13 @@ def ib_set_abort_word(ib: Int, abort_dev: Int):
     _st(ib)[].abort_dev = abort_dev
 
 
-def ib_signal_abort(ib: Int):
+def ib_signal_abort(ib: Int) -> Bool:
     """`ncclCommAbort`'s hook: raise MB_STOP and reclaim the progress thread
-    without ncclCommDestroy's unbounded wait.
+    without ncclCommDestroy's unbounded wait. True once the thread is gone
+    (or there never was one), which is the caller's licence to tear the
+    transport down: `ib_teardown` joins unconditionally, so releasing the
+    queue pairs while this thread is still running would both reintroduce the
+    unbounded wait and pull memory out from under it.
 
     Left unsignaled, the thread spins on the mailbox forever (nothing else
     ever sets MB_STOP for it) and burns one CPU core for the rest of the
@@ -926,10 +930,10 @@ def ib_signal_abort(ib: Int):
     way.
     """
     if ib == 0:
-        return
+        return True
     ref st = _st(ib)[]
     if st.thread_id == 0:
-        return
+        return True
     Atomic[DType.uint64].store[ordering = Ordering.RELEASE](
         _mb(st, MB_STOP), 1
     )
@@ -940,8 +944,9 @@ def ib_signal_abort(ib: Int):
         var rc = external_call["pthread_tryjoin_np", Int32](tid, retval)
         if rc == 0:
             st.thread_id = 0
-            return
+            return True
         sleep(0.001)
+    return False
 
 
 def _callback_address() -> Int:

--- a/torch_mojo_backend/distributed/mojoccl/internode.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/internode.mojo
@@ -764,63 +764,70 @@ def ib_setup(
     st.port = port.port
     st.timeout_ns = Int(_ib_timeout_s() * 1.0e9)
 
-    st.pd = st.ibv.alloc_pd(st.ctx)
-    if st.pd == 0:
-        raise Error("mojoccl: ibv_alloc_pd failed on " + st.hca)
-    var ro = getenv("MOJOCCL_IB_RELAXED_ORDERING", "1") != "0"
-    var acc = (
-        IBV_ACCESS_LOCAL_WRITE
-        | IBV_ACCESS_REMOTE_WRITE
-        | IBV_ACCESS_REMOTE_READ
-    )
-    st.mr = (
-        st.ibv.reg_mr_relaxed(st.pd, region, region_bytes, acc)
-        if ro
-        else st.ibv.reg_mr(st.pd, region, region_bytes, acc)
-    )
-    if st.mr == 0:
-        raise Error(
-            "mojoccl: ibv_reg_mr of the "
-            + String(region_bytes // (1024 * 1024))
-            + " MiB device region failed on "
-            + st.hca
-            + "; is nvidia_peermem (or the ROCm equivalent) loaded?"
+    # Every step below can raise after an earlier one already allocated a
+    # real ibverbs/host resource (pd, mr, cq, QPs, the pinned mailbox) --
+    # unwind whatever got that far instead of leaking it.
+    try:
+        st.pd = st.ibv.alloc_pd(st.ctx)
+        if st.pd == 0:
+            raise Error("mojoccl: ibv_alloc_pd failed on " + st.hca)
+        var ro = getenv("MOJOCCL_IB_RELAXED_ORDERING", "1") != "0"
+        var acc = (
+            IBV_ACCESS_LOCAL_WRITE
+            | IBV_ACCESS_REMOTE_WRITE
+            | IBV_ACCESS_REMOTE_READ
         )
-    var mrp = P8(unsafe_from_address=st.mr)
-    st.lkey = ldu32(mrp, MR_LKEY)
-    st.rkey = ldu32(mrp, MR_RKEY)
-
-    # Host landing pad for the flush read.
-    st.flush_host = Int(alloc_bytes(4096))
-    st.flush_mr = st.ibv.reg_mr(
-        st.pd, st.flush_host, 4096, IBV_ACCESS_LOCAL_WRITE
-    )
-    if st.flush_mr == 0:
-        raise Error("mojoccl: ibv_reg_mr of the flush buffer failed")
-    st.flush_lkey = ldu32(P8(unsafe_from_address=st.flush_mr), MR_LKEY)
-
-    st.cq = st.ibv.create_cq(st.ctx, CQ_SIZE)
-    if st.cq == 0:
-        raise Error("mojoccl: ibv_create_cq failed")
-
-    for j in range(nnodes):
-        if j == my_node:
-            continue
-        var qp = create_rc_qp(
-            st.ibv, st.pd, st.cq, SEND_WR_DEPTH, RECV_DEPTH + 8
+        st.mr = (
+            st.ibv.reg_mr_relaxed(st.pd, region, region_bytes, acc)
+            if ro
+            else st.ibv.reg_mr(st.pd, region, region_bytes, acc)
         )
-        qp_to_init(st.ibv, qp, st.port)
-        st.peers.append(IbPeer(j, qp, qp_number(qp), 0, 0))
-    st.flush_qp = create_rc_qp(st.ibv, st.pd, st.cq, SEND_WR_DEPTH, 8)
-    qp_to_init(st.ibv, st.flush_qp, st.port)
+        if st.mr == 0:
+            raise Error(
+                "mojoccl: ibv_reg_mr of the "
+                + String(region_bytes // (1024 * 1024))
+                + " MiB device region failed on "
+                + st.hca
+                + "; is nvidia_peermem (or the ROCm equivalent) loaded?"
+            )
+        var mrp = P8(unsafe_from_address=st.mr)
+        st.lkey = ldu32(mrp, MR_LKEY)
+        st.rkey = ldu32(mrp, MR_RKEY)
 
-    if st.proxy:
-        st.mailbox = alloc_host(driver, MB_BYTES)
-        st.mailbox_dev = host_device_ptr(driver, st.mailbox)
-        for i in range(MB_BYTES // 8):
-            Pointer[UInt64, MutAnyOrigin](unsafe_from_address=st.mailbox)[
-                unsafe_offset=i
-            ] = 0
+        # Host landing pad for the flush read.
+        st.flush_host = Int(alloc_bytes(4096))
+        st.flush_mr = st.ibv.reg_mr(
+            st.pd, st.flush_host, 4096, IBV_ACCESS_LOCAL_WRITE
+        )
+        if st.flush_mr == 0:
+            raise Error("mojoccl: ibv_reg_mr of the flush buffer failed")
+        st.flush_lkey = ldu32(P8(unsafe_from_address=st.flush_mr), MR_LKEY)
+
+        st.cq = st.ibv.create_cq(st.ctx, CQ_SIZE)
+        if st.cq == 0:
+            raise Error("mojoccl: ibv_create_cq failed")
+
+        for j in range(nnodes):
+            if j == my_node:
+                continue
+            var qp = create_rc_qp(
+                st.ibv, st.pd, st.cq, SEND_WR_DEPTH, RECV_DEPTH + 8
+            )
+            qp_to_init(st.ibv, qp, st.port)
+            st.peers.append(IbPeer(j, qp, qp_number(qp), 0, 0))
+        st.flush_qp = create_rc_qp(st.ibv, st.pd, st.cq, SEND_WR_DEPTH, 8)
+        qp_to_init(st.ibv, st.flush_qp, st.port)
+
+        if st.proxy:
+            st.mailbox = alloc_host(driver, MB_BYTES)
+            st.mailbox_dev = host_device_ptr(driver, st.mailbox)
+            for i in range(MB_BYTES // 8):
+                Pointer[UInt64, MutAnyOrigin](unsafe_from_address=st.mailbox)[
+                    unsafe_offset=i
+                ] = 0
+    except e:
+        _teardown_ib_resources(st)
+        raise e
 
     var holder = unsafe_alloc[IbState](1)
     holder.unsafe_write(st^)
@@ -1103,18 +1110,23 @@ def ib_report(ib: Int):
     )
 
 
-def ib_teardown(ib: Int):
-    if ib == 0:
-        return
-    ref st = _st(ib)[]
-    _stop_proxy(st)
-    ib_report(ib)
+def _teardown_ib_resources(mut st: IbState):
+    """Release every ibverbs/host resource `ib_setup` may have created.
+
+    Shared by `ib_teardown` (a live communicator) and `ib_setup`'s own
+    failure path (a later step raised after an earlier one already
+    succeeded) -- both leave `st` in the same "some fields non-zero, some
+    still their zero default" shape, and every field here is zero-guarded
+    for exactly that reason.
+    """
     if st.mailbox != 0:
         # Pinned, device-mapped host memory: a scarce OS resource, unlike the
         # few hundred bytes of plain heap this struct also holds. Safe here
-        # and only here -- the progress thread is joined and the caller
-        # synchronized the stream the spin kernels were on. `open_driver`
-        # re-opens an already-loaded library, so it costs a refcount.
+        # and only here -- the progress thread is joined (or, from
+        # `ib_setup`'s failure path, never started) and, for a live
+        # communicator, the caller synchronized the stream the spin kernels
+        # were on. `open_driver` re-opens an already-loaded library, so it
+        # costs a refcount.
         try:
             free_host(open_driver(), st.mailbox)
         except:
@@ -1138,3 +1150,12 @@ def ib_teardown(ib: Int):
             st.ibv.close_device(st.ctx)
     except:
         pass
+
+
+def ib_teardown(ib: Int):
+    if ib == 0:
+        return
+    ref st = _st(ib)[]
+    _stop_proxy(st)
+    ib_report(ib)
+    _teardown_ib_resources(st)

--- a/torch_mojo_backend/distributed/mojoccl/internode.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/internode.mojo
@@ -251,6 +251,38 @@ def _st(ib: Int) -> Pointer[IbState, MutAnyOrigin]:
 # ===-------------------------------------------------------------------=== #
 
 
+def _consume_wc(mut st: IbState, c: P8, npeers: Int) -> Int:
+    """Classify one completion; returns 1 for a send, 2 for the flush read,
+    0 for anything else, -1 for a failed completion (error recorded).
+
+    Shared by both poll loops on purpose. An arrival for the NEXT exchange
+    can land while this one is flushing, and a loop that only looked for its
+    own opcode would drop it -- losing a tally the next callback is waiting
+    on, and a recv WR nobody reposts.
+    """
+    if Int32(ld32(c, WC_STATUS)) != IBV_WC_SUCCESS:
+        st.error = 1000 + ld32(c, WC_STATUS) * 1000 + ld32(c, WC_VENDOR_ERR)
+        return -1
+    var op = Int32(ld32(c, WC_OPCODE))
+    if op == IBV_WC_RECV_RDMA_WITH_IMM:
+        if Int(be32(ldu32(c, WC_IMM_DATA))) & 1 == 0:
+            st.arrivals0 += 1
+        else:
+            st.arrivals1 += 1
+        var qpn = ldu32(c, WC_QP_NUM)
+        for k in range(npeers):
+            if st.peers[k].qpn == qpn:
+                build_recv_wr(_b(st.rwr), 0)
+                _ = post_recv(st.peers[k].qp, _b(st.rwr), _b(st.bad))
+                break
+        return 0
+    if op == IBV_WC_RDMA_WRITE:
+        return 1
+    if op == IBV_WC_RDMA_READ:
+        return 2
+    return 0
+
+
 def _ib_progress(user: OpaquePointer[MutAnyOrigin]) abi("C"):
     """Post this exchange's RDMA writes, wait for the peers', flush.
 
@@ -303,27 +335,13 @@ def _ib_progress(user: OpaquePointer[MutAnyOrigin]) abi("C"):
             w.status = 2
             return
         for i in range(Int(n)):
-            var c = P8(unsafe_from_address=st.wc + i * SZ_WC)
-            if Int32(ld32(c, WC_STATUS)) != IBV_WC_SUCCESS:
-                st.error = 1000 + ld32(c, WC_STATUS) * 1000 + ld32(
-                    c, WC_VENDOR_ERR
-                )
+            var kind = _consume_wc(
+                st, P8(unsafe_from_address=st.wc + i * SZ_WC), npeers
+            )
+            if kind < 0:
                 w.status = 2
                 return
-            var op = Int32(ld32(c, WC_OPCODE))
-            if op == IBV_WC_RECV_RDMA_WITH_IMM:
-                var seq = Int(be32(ldu32(c, WC_IMM_DATA)))
-                if seq & 1 == 0:
-                    st.arrivals0 += 1
-                else:
-                    st.arrivals1 += 1
-                var qpn = ldu32(c, WC_QP_NUM)
-                for k in range(npeers):
-                    if st.peers[k].qpn == qpn:
-                        build_recv_wr(_b(st.rwr), 0)
-                        _ = post_recv(st.peers[k].qp, _b(st.rwr), _b(st.bad))
-                        break
-            elif op == IBV_WC_RDMA_WRITE:
+            if kind == 1:
                 sends_done += 1
         if perf_counter_ns() > deadline:
             st.error = 3
@@ -358,12 +376,13 @@ def _ib_progress(user: OpaquePointer[MutAnyOrigin]) abi("C"):
                 w.status = 2
                 return
             for i in range(Int(n)):
-                var c = P8(unsafe_from_address=st.wc + i * SZ_WC)
-                if Int32(ld32(c, WC_STATUS)) != IBV_WC_SUCCESS:
-                    st.error = 6
+                var kind = _consume_wc(
+                    st, P8(unsafe_from_address=st.wc + i * SZ_WC), npeers
+                )
+                if kind < 0:
                     w.status = 2
                     return
-                if Int32(ld32(c, WC_OPCODE)) == IBV_WC_RDMA_READ:
+                if kind == 2:
                     flushed = True
             if perf_counter_ns() > deadline:
                 st.error = 7

--- a/torch_mojo_backend/distributed/mojoccl/internode.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/internode.mojo
@@ -61,8 +61,10 @@ from std.atomic import Atomic, Ordering
 from driver import (
     alloc_host,
     device_pci_bus_id,
+    free_host,
     host_device_ptr,
     launch_host_func,
+    open_driver,
 )
 from internode_kernels import proxy_request, proxy_wait
 from ibverbs import (
@@ -995,6 +997,18 @@ def ib_teardown(ib: Int):
     ref st = _st(ib)[]
     _stop_proxy(st)
     ib_report(ib)
+    if st.mailbox != 0:
+        # Pinned, device-mapped host memory: a scarce OS resource, unlike the
+        # few hundred bytes of plain heap this struct also holds. Safe here
+        # and only here -- the progress thread is joined and the caller
+        # synchronized the stream the spin kernels were on. `open_driver`
+        # re-opens an already-loaded library, so it costs a refcount.
+        try:
+            free_host(open_driver(), st.mailbox)
+        except:
+            pass
+        st.mailbox = 0
+        st.mailbox_dev = 0
     try:
         for i in range(len(st.peers)):
             st.ibv.destroy_qp(st.peers[i].qp)

--- a/torch_mojo_backend/distributed/mojoccl/internode.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/internode.mojo
@@ -382,6 +382,10 @@ def _run_exchange(mut st: IbState, mut w: IbWork):
 
     var sends_done = 0
     while sends_done < nsend or _arrivals(st, parity) < w.nrecv:
+        if _stop_requested(st):
+            st.error = 6
+            w.status = 2
+            return
         var n = poll_cq(st.cq, 16, _b(st.wc))
         if n < 0:
             st.error = 2
@@ -423,6 +427,10 @@ def _run_exchange(mut st: IbState, mut w: IbWork):
             return
         var flushed = False
         while not flushed:
+            if _stop_requested(st):
+                st.error = 6
+                w.status = 2
+                return
             var n = poll_cq(st.cq, 16, _b(st.wc))
             if n < 0:
                 st.error = 5
@@ -458,6 +466,27 @@ def _arrivals(st: IbState, parity: Int) -> Int:
 @always_inline
 def _mb(st: IbState, off: Int) -> Pointer[UInt64, MutAnyOrigin]:
     return Pointer[UInt64, MutAnyOrigin](unsafe_from_address=st.mailbox + off)
+
+
+@always_inline
+def _stop_requested(st: IbState) -> Bool:
+    """True once `ncclCommAbort` (or teardown) has raised MB_STOP.
+
+    Checked inside `_run_exchange`'s two poll loops so a stop request ends a
+    stuck exchange (a dead peer, nothing left to poll) promptly instead of
+    making `_stop_proxy`'s `pthread_join` wait out the rest of
+    `MOJOCCL_IB_TIMEOUT_S`. Only meaningful under the proxy -- the mailbox is
+    allocated only when `st.proxy`, so the `MOJOCCL_IB_PROXY=0` callback path
+    and the self-test's `ib_exchange_now` (no mailbox, no thread) never see
+    it set.
+    """
+    return (
+        st.mailbox != 0
+        and Atomic[DType.uint64].load[ordering = Ordering.ACQUIRE](
+            _mb(st, MB_STOP)
+        )
+        != 0
+    )
 
 
 def _proxy_main(arg: OpaquePointer[MutAnyOrigin]) abi("C"):

--- a/torch_mojo_backend/distributed/mojoccl/internode.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/internode.mojo
@@ -314,6 +314,7 @@ struct IbState(Movable):
     var rwr: Int
     var bad: Int
     var wc: Int
+    var ts: Int  # struct timespec scratch for the idle nanosleep
     var works: Int
     var work_next: Int
     var mailbox: Int  # pinned host address
@@ -379,6 +380,7 @@ struct IbState(Movable):
         self.rwr = Int(alloc_bytes(SZ_RECV_WR))
         self.bad = Int(alloc_bytes(16))
         self.wc = Int(alloc_bytes(SZ_WC * 16))
+        self.ts = Int(alloc_bytes(16))
         self.works = Int(unsafe_alloc[IbWork](WORK_SLOTS))
         var wp = Pointer[IbWork, MutAnyOrigin](unsafe_from_address=self.works)
         for i in range(WORK_SLOTS):
@@ -832,7 +834,7 @@ def _proxy_main(arg: OpaquePointer[MutAnyOrigin]) abi("C"):
         if Atomic[DType.uint64].load[ordering = Ordering.ACQUIRE](
             _mb(st, MB_REQUEST)
         ) <= UInt64(st.request_seq):
-            _nanosleep_ns(idle_ns)
+            _nanosleep_ns(st.ts, idle_ns)
 
 
 def _proxy_address() -> Int:
@@ -919,8 +921,8 @@ def ib_signal_abort(ib: Int):
     )
     var tid = st.thread_id
     var deadline = perf_counter_ns() + Int(IB_ABORT_JOIN_TIMEOUT_S * 1.0e9)
+    var retval = unsafe_alloc[Int64](1)
     while perf_counter_ns() < deadline:
-        var retval = unsafe_alloc[Int64](1)
         var rc = external_call["pthread_tryjoin_np", Int32](tid, retval)
         if rc == 0:
             st.thread_id = 0
@@ -1176,11 +1178,13 @@ def _proxy_idle_ns() -> Int:
     return us * 1000
 
 
-def _nanosleep_ns(ns: Int):
+def _nanosleep_ns(ts_addr: Int, ns: Int):
     """`nanosleep(2)` for `ns` nanoseconds; `struct timespec{tv_sec,tv_nsec}`,
-    16 bytes on this ABI. Best-effort: an interrupted sleep just returns
-    early, which only means the next mailbox check happens a bit sooner."""
-    var ts = unsafe_alloc[Int64](2)
+    16 bytes on this ABI, in the caller-owned scratch at `ts_addr` (an
+    allocation per call here leaked 16 bytes per idle iteration, ~3 GB/h at
+    the 20 us quantum). Best-effort: an interrupted sleep just returns early,
+    which only means the next mailbox check happens a bit sooner."""
+    var ts = Pointer[Int64, MutAnyOrigin](unsafe_from_address=ts_addr)
     ts[unsafe_offset=0] = 0
     ts[unsafe_offset=1] = Int64(ns)
     _ = external_call["nanosleep", Int32](ts, Int64(0))

--- a/torch_mojo_backend/distributed/mojoccl/internode.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/internode.mojo
@@ -423,7 +423,7 @@ def _st(ib: Int) -> Pointer[IbState, MutAnyOrigin]:
 @always_inline
 def _load_atomic_i(p: Pointer[Int, MutAnyOrigin]) -> Int:
     return Int(
-        Atomic[DType.int64].load[ordering = Ordering.ACQUIRE](
+        Atomic[DType.int64].load[ordering=Ordering.ACQUIRE](
             p.unsafe_bitcast[Int64]()
         )
     )
@@ -431,7 +431,7 @@ def _load_atomic_i(p: Pointer[Int, MutAnyOrigin]) -> Int:
 
 @always_inline
 def _store_atomic_i(p: Pointer[Int, MutAnyOrigin], v: Int):
-    Atomic[DType.int64].store[ordering = Ordering.RELEASE](
+    Atomic[DType.int64].store[ordering=Ordering.RELEASE](
         p.unsafe_bitcast[Int64](), Int64(v)
     )
 
@@ -812,12 +812,15 @@ def _proxy_main(arg: OpaquePointer[MutAnyOrigin]) abi("C"):
     var published = 0
     st.last_progress_ns = perf_counter_ns()
     while True:
-        if Atomic[DType.uint64].load[ordering = Ordering.ACQUIRE](
-            _mb(st, MB_STOP)
-        ) != 0:
+        if (
+            Atomic[DType.uint64].load[ordering=Ordering.ACQUIRE](
+                _mb(st, MB_STOP)
+            )
+            != 0
+        ):
             return
         var req = Int(
-            Atomic[DType.uint64].load[ordering = Ordering.ACQUIRE](
+            Atomic[DType.uint64].load[ordering=Ordering.ACQUIRE](
                 _mb(st, MB_REQUEST)
             )
         )
@@ -830,22 +833,20 @@ def _proxy_main(arg: OpaquePointer[MutAnyOrigin]) abi("C"):
             # the stream hangs past the point where the error can be
             # reported.
             published = st.done_seq
-            Atomic[DType.uint64].store[ordering = Ordering.RELEASE](
+            Atomic[DType.uint64].store[ordering=Ordering.RELEASE](
                 _mb(st, MB_DONE), UInt64(published)
             )
         if moved or st.done_seq < st.request_seq:
             continue
         _ = external_call["sched_yield", Int32]()
-        if Atomic[DType.uint64].load[ordering = Ordering.ACQUIRE](
+        if Atomic[DType.uint64].load[ordering=Ordering.ACQUIRE](
             _mb(st, MB_REQUEST)
         ) <= UInt64(st.request_seq):
             _nanosleep_ns(st.ts, idle_ns)
 
 
 def _proxy_address() -> Int:
-    var f: def (
-        OpaquePointer[MutAnyOrigin]
-    ) thin abi("C") -> None = _proxy_main
+    var f: def(OpaquePointer[MutAnyOrigin]) thin abi("C") -> None = _proxy_main
     return Pointer(to=f).unsafe_bitcast[Int]()[]
 
 
@@ -864,9 +865,7 @@ def _set_thread_affinity(tid: Int, cpu: Int) raises:
         Int64(tid), UInt64(CPU_SET_BYTES), mask
     )
     if rc != 0:
-        raise Error(
-            "mojoccl: pthread_setaffinity_np failed, rc=" + String(rc)
-        )
+        raise Error("mojoccl: pthread_setaffinity_np failed, rc=" + String(rc))
 
 
 def _start_proxy(ib: Int) raises:
@@ -893,9 +892,7 @@ def _start_proxy(ib: Int) raises:
 def _stop_proxy(mut st: IbState):
     if st.thread_id == 0:
         return
-    Atomic[DType.uint64].store[ordering = Ordering.RELEASE](
-        _mb(st, MB_STOP), 1
-    )
+    Atomic[DType.uint64].store[ordering=Ordering.RELEASE](_mb(st, MB_STOP), 1)
     _ = external_call["pthread_join", Int32](st.thread_id, Int64(0))
     st.thread_id = 0
 
@@ -934,9 +931,7 @@ def ib_signal_abort(ib: Int) -> Bool:
     ref st = _st(ib)[]
     if st.thread_id == 0:
         return True
-    Atomic[DType.uint64].store[ordering = Ordering.RELEASE](
-        _mb(st, MB_STOP), 1
-    )
+    Atomic[DType.uint64].store[ordering=Ordering.RELEASE](_mb(st, MB_STOP), 1)
     var tid = st.thread_id
     var deadline = perf_counter_ns() + Int(IB_ABORT_JOIN_TIMEOUT_S * 1.0e9)
     var retval = unsafe_alloc[Int64](1)
@@ -950,7 +945,7 @@ def ib_signal_abort(ib: Int) -> Bool:
 
 
 def _callback_address() -> Int:
-    var f: def (OpaquePointer[MutAnyOrigin]) thin abi("C") -> None = _ib_progress
+    var f: def(OpaquePointer[MutAnyOrigin]) thin abi("C") -> None = _ib_progress
     return Pointer(to=f).unsafe_bitcast[Int]()[]
 
 
@@ -1065,7 +1060,10 @@ def ib_setup(
     if len(ports) == 0:
         raise Error(
             "mojoccl: no ACTIVE InfiniBand port found"
-            + (" matching MOJOCCL_IB_HCA=" + want if want.byte_length() > 0 else "")
+            + (
+                " matching MOJOCCL_IB_HCA=" + want if want.byte_length()
+                > 0 else ""
+            )
             + "; a multi-node communicator needs one"
         )
     # Only a hint for HCA affinity: a driver without the symbol, or a
@@ -1109,11 +1107,9 @@ def ib_setup(
             | IBV_ACCESS_REMOTE_WRITE
             | IBV_ACCESS_REMOTE_READ
         )
-        st.mr = (
-            st.ibv.reg_mr_relaxed(st.pd, region, region_bytes, acc)
-            if ro
-            else st.ibv.reg_mr(st.pd, region, region_bytes, acc)
-        )
+        st.mr = st.ibv.reg_mr_relaxed(
+            st.pd, region, region_bytes, acc
+        ) if ro else st.ibv.reg_mr(st.pd, region, region_bytes, acc)
         if st.mr == 0:
             raise Error(
                 "mojoccl: ibv_reg_mr of the "
@@ -1188,9 +1184,7 @@ def _proxy_idle_ns() -> Int:
     """`MOJOCCL_IB_PROXY_IDLE_US`, read once at thread start (not from inside
     the progress-thread loop -- a `getenv` per idle iteration would defeat
     the point of backing off)."""
-    var s = getenv(
-        "MOJOCCL_IB_PROXY_IDLE_US", String(DEFAULT_IB_PROXY_IDLE_US)
-    )
+    var s = getenv("MOJOCCL_IB_PROXY_IDLE_US", String(DEFAULT_IB_PROXY_IDLE_US))
     var us = DEFAULT_IB_PROXY_IDLE_US
     try:
         var parsed = Int(s)
@@ -1233,7 +1227,7 @@ def ib_local_info(ib: Int, out_blob: P8, port_lid: Int, port_mtu: Int):
     out_blob.unsafe_bitcast[UInt32]()[unsafe_offset=5] = UInt32(len(st.peers))
     for i in range(len(st.peers)):
         out_blob.unsafe_bitcast[UInt32]()[
-            unsafe_offset = 6 + st.peers[i].node
+            unsafe_offset=6 + st.peers[i].node
         ] = st.peers[i].qpn
 
 
@@ -1271,7 +1265,11 @@ def ib_port_mtu(ib: Int) raises -> Int:
 
 
 def ib_connect(
-    ib: Int, blobs: P8, blob_stride: Int, peer_rank_of_node: List[Int], my_mtu: Int
+    ib: Int,
+    blobs: P8,
+    blob_stride: Int,
+    peer_rank_of_node: List[Int],
+    my_mtu: Int,
 ) raises:
     """Move every QP to RTS from the gathered table, then pre-post recvs.
 
@@ -1290,9 +1288,7 @@ def ib_connect(
         var lid = Int(b.unsafe_bitcast[UInt32]()[unsafe_offset=3])
         var mtu = Int(b.unsafe_bitcast[UInt32]()[unsafe_offset=4])
         # The peer's QP for MY node, not for its own.
-        var dest_qpn = b.unsafe_bitcast[UInt32]()[
-            unsafe_offset = 6 + st.my_node
-        ]
+        var dest_qpn = b.unsafe_bitcast[UInt32]()[unsafe_offset=6 + st.my_node]
         var gid = P8(unsafe_from_address=Int(b) + 24 + 4 * MAX_NODES)
         if lid == 0:
             raise Error(

--- a/torch_mojo_backend/distributed/mojoccl/internode.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/internode.mojo
@@ -39,10 +39,14 @@
 # cannot reach e+2 before receiving my e+1 data, which I send only after my
 # own stream ran the add kernel of exchange e. Single buffering would leave
 # B's e+1 write racing my e add kernel with nothing but timing in between.
-# The argument needs every exchange to be all-to-all, which is why a rank
-# with nothing to contribute still sends CREDIT_BYTES (mojoccl.mojo). The
-# immediate carries the exchange counter, so an arrival belonging to e+1 is
-# counted into the other parity's tally instead of satisfying e.
+# The argument needs two things. Every exchange must be all-to-all, which is
+# why a rank with nothing to contribute still sends CREDIT_BYTES
+# (mojoccl.mojo); and the two halves must be DISJOINT ADDRESSES for every
+# exchange alike, which is why `_inbox_base` carves them out of the region
+# once instead of sizing them from the message in flight (mojoccl.mojo has
+# the case that broke). The immediate carries the exchange counter, so an
+# arrival belonging to e+1 is counted into the other parity's tally instead
+# of satisfying e.
 #
 # The inbox lives in the region's own network area, never aliased onto the
 # intra-node staging: a peer node writes it as soon as ITS reduce-scatter is

--- a/torch_mojo_backend/distributed/mojoccl/internode.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/internode.mojo
@@ -320,6 +320,10 @@ struct IbState(Movable):
     var mailbox: Int  # pinned host address
     var mailbox_dev: Int  # the same memory as a kernel addresses it
     var error_word: Int  # region + error_offset, for the wait kernel
+    # Device mapping of the communicator's pinned abort word, so the wait
+    # kernel leaves as soon as `ncclCommAbort` raises it instead of holding
+    # the stream to its own deadline. 0 until `ib_set_abort_word` runs.
+    var abort_dev: Int
     var proxy: Bool
     var thread_id: Int
     var trace: Bool
@@ -389,6 +393,7 @@ struct IbState(Movable):
         self.mailbox = 0
         self.mailbox_dev = 0
         self.error_word = region
+        self.abort_dev = 0
         self.proxy = getenv("MOJOCCL_IB_PROXY", "1") != "0"
         self.thread_id = 0
         self.trace = getenv("MOJOCCL_IB_TRACE", "0") != "0"
@@ -893,6 +898,15 @@ def _stop_proxy(mut st: IbState):
     )
     _ = external_call["pthread_join", Int32](st.thread_id, Int64(0))
     st.thread_id = 0
+
+
+def ib_set_abort_word(ib: Int, abort_dev: Int):
+    """Hand the transport the device address of the communicator's pinned
+    abort word (mojoccl.mojo owns it -- a single-node communicator has one
+    too, and there is no IB state there to hold it)."""
+    if ib == 0:
+        return
+    _st(ib)[].abort_dev = abort_dev
 
 
 def ib_signal_abort(ib: Int):
@@ -1462,6 +1476,7 @@ def ib_enqueue_wait(
         stream,
         st.mailbox_dev + MB_DONE,
         st.error_word,
+        st.abort_dev,
         seq,
         st.timeout_ns,
     )

--- a/torch_mojo_backend/distributed/mojoccl/internode.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/internode.mojo
@@ -325,7 +325,7 @@ def _ib_progress(user: OpaquePointer[MutAnyOrigin]) abi("C"):
                         break
             elif op == IBV_WC_RDMA_WRITE:
                 sends_done += 1
-        if Int(n) == 0 and perf_counter_ns() > deadline:
+        if perf_counter_ns() > deadline:
             st.error = 3
             w.status = 2
             return
@@ -365,7 +365,7 @@ def _ib_progress(user: OpaquePointer[MutAnyOrigin]) abi("C"):
                     return
                 if Int32(ld32(c, WC_OPCODE)) == IBV_WC_RDMA_READ:
                     flushed = True
-            if Int(n) == 0 and perf_counter_ns() > deadline:
+            if perf_counter_ns() > deadline:
                 st.error = 7
                 w.status = 2
                 return
@@ -393,20 +393,26 @@ def _callback_address() -> Int:
 # ===-------------------------------------------------------------------=== #
 
 
-def _readlink(path: String) -> String:
-    var buf = alloc_bytes(1024)
+def _realpath(path: String) -> String:
+    """realpath(3): the ABSOLUTE /sys/devices path behind a sysfs symlink.
+
+    `readlink` would return the stored relative target (`../../..0000:18:00.0`),
+    and two of those share no comparable prefix -- the whole point here is to
+    compare where a GPU and an HCA sit in one PCI tree.
+    """
+    var buf = alloc_bytes(4096)
     var cpath = alloc_bytes(path.byte_length() + 1)
     var pb = path.as_bytes()
     for i in range(len(pb)):
         cpath[unsafe_offset=i] = pb[i]
-    var n = Int(
-        external_call["readlink", Int64](cpath, buf, UInt64(1023))
-    )
-    if n <= 0:
+    var rc = Int(external_call["realpath", Int64](cpath, buf))
+    if rc == 0:
         return String("")
     var s = String("")
-    for i in range(n):
+    var i = 0
+    while i < 4095 and buf[unsafe_offset=i] != 0:
         s += chr(Int(buf[unsafe_offset=i]))
+        i += 1
     return s^
 
 
@@ -434,14 +440,14 @@ def _choose_port(
     """
     if len(ports) == 1 or gpu_bdf.byte_length() == 0:
         return local_rank % len(ports)
-    var gpu_path = _readlink("/sys/bus/pci/devices/" + gpu_bdf)
+    var gpu_path = _realpath("/sys/bus/pci/devices/" + gpu_bdf)
     if gpu_path.byte_length() == 0:
         return local_rank % len(ports)
     var best = -1
     var best_score = -1
     var ties = 0
     for i in range(len(ports)):
-        var hca_path = _readlink(
+        var hca_path = _realpath(
             "/sys/class/infiniband/" + ports[i].name + "/device"
         )
         var score = _common_prefix(gpu_path, hca_path)
@@ -456,7 +462,7 @@ def _choose_port(
         # pair of GPUs). Spread ranks over them deterministically.
         var chosen = List[Int]()
         for i in range(len(ports)):
-            var hca_path = _readlink(
+            var hca_path = _realpath(
                 "/sys/class/infiniband/" + ports[i].name + "/device"
             )
             if _common_prefix(gpu_path, hca_path) == best_score:
@@ -489,9 +495,20 @@ def ib_setup(
             + (" matching MOJOCCL_IB_HCA=" + want if want.byte_length() > 0 else "")
             + "; a multi-node communicator needs one"
         )
-    var gpu_bdf = device_pci_bus_id(driver, ordinal)
+    # Only a hint for HCA affinity: a driver without the symbol, or a
+    # device that will not report one, falls back to round-robin.
+    var gpu_bdf = String("")
+    try:
+        gpu_bdf = device_pci_bus_id(driver, ordinal)
+    except:
+        pass
     var pick = _choose_port(ports, gpu_bdf, local_rank)
     ref port = ports[pick]
+    # These nodes carry ~10 IB HCAs and every rank opened all of them to
+    # read their ports; hold only the one this rank will use.
+    for i in range(len(ports)):
+        if ports[i].ctx != port.ctx:
+            ibv.close_device(ports[i].ctx)
 
     var st = IbState(ibv^, region, my_node, nnodes)
     st.hca = String(port.name)
@@ -738,6 +755,47 @@ def ib_enqueue(
         _callback_address(),
         st.works + slot * size_of[IbWork](),
     )
+
+
+def ib_exchange_now(
+    ib: Int,
+    send_addr: Int,
+    send_bytes: Int,
+    inbox_base: Int,
+    slot_bytes: Int,
+    do_send: Bool,
+    nrecv: Int,
+    flush_addr: Int,
+    seq: Int,
+) raises:
+    """Run one exchange inline on the calling thread instead of from a
+    stream callback.
+
+    The bring-up self-test uses it: the transport can be exercised on a host
+    with IB but no GPU (registered host memory, no stream to hang a callback
+    on), which is where the bootstrap/QP/immediate wiring is cheapest to
+    debug. Never correct in a collective -- there the callback's position in
+    stream order is the whole ordering argument.
+    """
+    ref st = _st(ib)[]
+    var w = IbWork()
+    w.state = ib
+    w.send_addr = send_addr
+    w.send_bytes = send_bytes
+    w.inbox_base = inbox_base
+    w.slot_bytes = slot_bytes
+    w.do_send = 1 if do_send else 0
+    w.nrecv = nrecv
+    w.flush_addr = flush_addr
+    w.seq = seq
+    w.status = 0
+    var wp = unsafe_alloc[IbWork](1)
+    wp.unsafe_write(w^)
+    _ib_progress(OpaquePointer[MutAnyOrigin](unsafe_from_address=Int(wp)))
+    if wp[unsafe_offset=0].status != 1:
+        raise Error(
+            "mojoccl: inline exchange failed, ib error " + String(st.error)
+        )
 
 
 def ib_report(ib: Int):

--- a/torch_mojo_backend/distributed/mojoccl/internode.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/internode.mojo
@@ -157,6 +157,10 @@ comptime IB_ABORT_JOIN_TIMEOUT_S: Float64 = 2.0
 # ~20% of its steady-state tok/s against real NCCL, competing for a core/SMT
 # sibling with the ~760-aten-op-per-step host dispatch of the training loop.
 comptime DEFAULT_IB_PROXY_IDLE_US: Int = 20
+# `cpu_set_t` size for `sched_getaffinity`/`pthread_setaffinity_np` on this
+# ABI: 128 bytes (1024 bits), shared by the default-pin CPU scan and the
+# explicit-CPU pin below.
+comptime CPU_SET_BYTES = 128
 # Bytes of the inbox read back by the flush; any read of the destination
 # device flushes the writes ahead of it, the size is irrelevant.
 comptime FLUSH_BYTES = 4
@@ -853,7 +857,6 @@ def _proxy_address() -> Int:
 def _set_thread_affinity(tid: Int, cpu: Int) raises:
     """`pthread_setaffinity_np` to a single CPU. `cpu_set_t` is a 128-byte
     (1024-bit) bitmask on this ABI; only the one bit for `cpu` is set."""
-    comptime CPU_SET_BYTES = 128
     var byte_idx = cpu // 8
     if cpu < 0 or byte_idx >= CPU_SET_BYTES:
         raise Error(
@@ -868,7 +871,111 @@ def _set_thread_affinity(tid: Int, cpu: Int) raises:
         raise Error("mojoccl: pthread_setaffinity_np failed, rc=" + String(rc))
 
 
-def _start_proxy(ib: Int) raises:
+def _cpu_in_mask(mask: P8, cpu: Int) -> Bool:
+    if cpu < 0 or cpu // 8 >= CPU_SET_BYTES:
+        return False
+    return (mask[unsafe_offset=cpu // 8] >> UInt8(cpu % 8)) & 1 != 0
+
+
+def _mask_cpus_desc(mask: P8) -> List[Int]:
+    """CPU ids set in the affinity `mask`, highest first."""
+    var out = List[Int]()
+    for cpu in range(CPU_SET_BYTES * 8 - 1, -1, -1):
+        if _cpu_in_mask(mask, cpu):
+            out.append(cpu)
+    return out^
+
+
+def _smt_sibling_free(cpu: Int, reserved: List[Int]) -> Bool:
+    """Best-effort: True unless `cpu`'s hyperthread sibling is itself one of
+    `reserved` -- i.e. would put two ranks' progress threads on one physical
+    core's shared execution units. "Free" only means "not another rank's
+    proxy pin": Python thread placement isn't ours to observe, so that's the
+    only sibling contention this can detect. Reads
+    `topology/thread_siblings_list` (comma-separated CPU ids/ranges) once; a
+    missing file (no HT, non-Linux sysfs layout, permission) reads as free
+    rather than blocking the pick.
+    """
+    var path = (
+        "/sys/devices/system/cpu/cpu"
+        + String(cpu)
+        + "/topology/thread_siblings_list"
+    )
+    var text: String
+    try:
+        with open(path, "r") as f:
+            text = String(f.read().strip())
+    except:
+        return True
+    for part in text.split(","):
+        var s = String(part)
+        if s.byte_length() == 0:
+            continue
+        var pieces = s.split("-")
+        var lo_s = String(pieces[0])
+        var hi_s = lo_s if len(pieces) < 2 else String(pieces[1])
+        try:
+            var lo = Int(lo_s)
+            var hi = Int(hi_s)
+            for sib in range(lo, hi + 1):
+                if sib != cpu:
+                    for r in reserved:
+                        if r == sib:
+                            return False
+        except:
+            continue
+    return True
+
+
+def _default_proxy_cpu(local_rank: Int, local_world: Int) -> Int:
+    """Default pin when `MOJOCCL_IB_PROXY_CPU` is unset, or -1 for "don't
+    pin".
+
+    torchrun gives every rank of a node the same affinity mask, so taking
+    that mask's CPUs in descending order and indexing by `local_rank` spreads
+    the `local_world` progress threads over the top `local_world` CPUs, out
+    of the way of Python's dispatch threads (unpinned, so scheduled wherever
+    the OS puts them across the whole mask). Needs the mask to hold at least
+    `2 * local_world` CPUs, so pinning never claims a CPU Python is likely to
+    need; a small mask (few cores, or an explicit `--cpus-per-task` slice)
+    leaves the thread unpinned rather than fighting over a scarce core.
+
+    Among those candidates, prefer ones whose SMT sibling is not itself
+    another rank's pin (`_smt_sibling_free`): reorder sibling-free CPUs to
+    the front, then reuse the same descending/by-rank rule. Every rank
+    derives this reordering from the same mask and `local_world` alone, so
+    it needs no coordination and never assigns two ranks the same CPU.
+    """
+    if local_world < 1 or local_rank < 0 or local_rank >= local_world:
+        return -1
+    var mask = alloc_bytes(CPU_SET_BYTES)
+    var rc = external_call["sched_getaffinity", Int32](
+        Int32(0), UInt64(CPU_SET_BYTES), mask
+    )
+    if rc != 0:
+        return -1
+    var desc = _mask_cpus_desc(mask)
+    if len(desc) < 2 * local_world:
+        return -1
+    var naive = desc[local_rank]
+    var reserved = List[Int]()
+    for r in range(local_world):
+        reserved.append(desc[r])
+    if _smt_sibling_free(naive, reserved):
+        return naive
+    var ordered = List[Int]()
+    var dirty = List[Int]()
+    for cpu in desc:
+        if _smt_sibling_free(cpu, reserved):
+            ordered.append(cpu)
+        else:
+            dirty.append(cpu)
+    for cpu in dirty:
+        ordered.append(cpu)
+    return ordered[local_rank]
+
+
+def _start_proxy(ib: Int, local_rank: Int, local_world: Int) raises:
     ref st = _st(ib)[]
     var tid = unsafe_alloc[Int64](1)
     tid[unsafe_offset=0] = 0
@@ -878,15 +985,40 @@ def _start_proxy(ib: Int) raises:
     if rc != 0:
         raise Error("mojoccl: pthread_create failed, rc=" + String(rc))
     st.thread_id = Int(tid[unsafe_offset=0])
-    # Opt-in only (default: no pinning) -- a best-effort placement hint, not
-    # load-bearing for correctness, so a bad CPU index or a failed syscall
-    # only prints rather than failing communicator init.
+    # A best-effort placement hint, not load-bearing for correctness, so a
+    # bad CPU index or a failed syscall only prints rather than failing
+    # communicator init. MOJOCCL_IB_PROXY_CPU=none opts out of the default
+    # policy below (unpinned, like every release before this one); any other
+    # value overrides it with an exact CPU.
     var cpu_s = getenv("MOJOCCL_IB_PROXY_CPU", "")
+    if cpu_s == "none":
+        return
+    var cpu: Int
     if cpu_s.byte_length() > 0:
         try:
-            _set_thread_affinity(st.thread_id, Int(cpu_s))
+            cpu = Int(cpu_s)
         except e:
             print("mojoccl: MOJOCCL_IB_PROXY_CPU pinning failed:", e)
+            return
+    else:
+        cpu = _default_proxy_cpu(local_rank, local_world)
+        if cpu < 0:
+            if st.trace:
+                print(
+                    (
+                        "mojoccl: progress thread left unpinned (affinity mask"
+                        " too small for"
+                    ),
+                    local_world,
+                    "local ranks)",
+                )
+            return
+    try:
+        _set_thread_affinity(st.thread_id, cpu)
+        if st.trace:
+            print("mojoccl: progress thread pinned to cpu", cpu)
+    except e:
+        print("mojoccl: MOJOCCL_IB_PROXY_CPU pinning failed:", e)
 
 
 def _stop_proxy(mut st: IbState):
@@ -1036,6 +1168,7 @@ def ib_setup(
     driver: OwnedDLHandle,
     ordinal: Int,
     local_rank: Int,
+    local_world: Int,
     my_node: Int,
     nnodes: Int,
     region: Int,
@@ -1052,7 +1185,8 @@ def ib_setup(
     `nslots` is how many fixed inbox slot groups the caller carved out of the
     region and therefore how many exchanges may be outstanding; `credit_off`
     is the region offset of the credit landing pad. Both must be identical on
-    every rank -- they are part of the wire layout.
+    every rank -- they are part of the wire layout. `local_world` only feeds
+    the progress thread's default CPU pin (`_default_proxy_cpu`).
     """
     var ibv = Ibv()
     var want = getenv("MOJOCCL_IB_HCA", "")
@@ -1165,7 +1299,7 @@ def ib_setup(
     holder.unsafe_write(st^)
     if _st(Int(holder))[].proxy:
         try:
-            _start_proxy(Int(holder))
+            _start_proxy(Int(holder), local_rank, local_world)
         except e:
             _teardown_ib_resources(_st(Int(holder))[])
             raise e

--- a/torch_mojo_backend/distributed/mojoccl/internode_kernels.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/internode_kernels.mojo
@@ -58,14 +58,18 @@ def _inbox_add_kernel[
     for v in range(tid, nv, stride):
         var acc = shard.unsafe_load[width=W, alignment=16](v * W)
         for j in range(npeers):
-            var src = inbox.unsafe_offset(j * sb).unsafe_bitcast[Scalar[dtype]]()
+            var src = inbox.unsafe_offset(j * sb).unsafe_bitcast[
+                Scalar[dtype]
+            ]()
             acc += src.unsafe_load[width=W, alignment=16](v * W)
         shard.unsafe_store[width=W, alignment=16](v * W, acc)
 
     for i in range(nv * W + tid, n, stride):
         var acc = shard[unsafe_offset=i]
         for j in range(npeers):
-            var src = inbox.unsafe_offset(j * sb).unsafe_bitcast[Scalar[dtype]]()
+            var src = inbox.unsafe_offset(j * sb).unsafe_bitcast[
+                Scalar[dtype]
+            ]()
             acc += src[unsafe_offset=i]
         shard[unsafe_offset=i] = acc
 
@@ -74,9 +78,7 @@ def _inbox_add_kernel[
     MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(BLOCK))
 )
 @__name("ccl_internode_proxy_request")
-def _proxy_request_kernel(
-    mailbox: Pointer[UInt64, MutAnyOrigin], seq: UInt64
-):
+def _proxy_request_kernel(mailbox: Pointer[UInt64, MutAnyOrigin], seq: UInt64):
     """Hand exchange `seq` to the progress thread.
 
     A release store into pinned host memory, so everything the stream did
@@ -84,7 +86,7 @@ def _proxy_request_kernel(
     thread is about to send -- is visible to the CPU that acquires it.
     """
     if global_idx.x == 0:
-        Atomic[DType.uint64].store[ordering = Ordering.RELEASE](mailbox, seq)
+        Atomic[DType.uint64].store[ordering=Ordering.RELEASE](mailbox, seq)
 
 
 @__llvm_metadata(
@@ -117,25 +119,24 @@ def _proxy_wait_kernel(
         var t0 = global_perf_counter_ns()
         var spins = 0
         while (
-            Atomic[DType.uint64].load[ordering = Ordering.ACQUIRE](mailbox)
-            < seq
+            Atomic[DType.uint64].load[ordering=Ordering.ACQUIRE](mailbox) < seq
         ):
             spins += 1
             if spins >= _ABORT_CHECK:
                 spins = 0
                 if (
                     Int(abort_word) != 0
-                    and Atomic[DType.uint64].load[
-                        ordering = Ordering.ACQUIRE
-                    ](abort_word)
+                    and Atomic[DType.uint64].load[ordering=Ordering.ACQUIRE](
+                        abort_word
+                    )
                     != 0
                 ):
-                    Atomic[DType.uint64].store[ordering = Ordering.RELEASE](
+                    Atomic[DType.uint64].store[ordering=Ordering.RELEASE](
                         error_word, UInt64(9) * 1_000_000
                     )
                     return
             if global_perf_counter_ns() - t0 > timeout_ns:
-                Atomic[DType.uint64].store[ordering = Ordering.RELEASE](
+                Atomic[DType.uint64].store[ordering=Ordering.RELEASE](
                     error_word, UInt64(9) * 1_000_000
                 )
                 return

--- a/torch_mojo_backend/distributed/mojoccl/internode_kernels.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/internode_kernels.mojo
@@ -18,9 +18,6 @@ from collectives_kernels import BLOCK, MAX_WORLD, _copy_bytes, _enqueue_cached
 
 comptime _UNROLL = 4
 comptime _MAX_BLOCKS = 432
-# (nnodes - 1) inbox slots; 16 nodes x 8 GPUs is far past what this library
-# is built for, and the array below is what makes it a compile-time bound.
-comptime MAX_NODES = 16
 
 
 @__llvm_metadata(

--- a/torch_mojo_backend/distributed/mojoccl/internode_kernels.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/internode_kernels.mojo
@@ -7,7 +7,9 @@
 # no flag protocol here and no peer pointer -- every address is inside this
 # rank's own region or its own user buffers.
 
+from std.atomic import Atomic, Ordering
 from std.gpu import MAX_THREADS_PER_BLOCK_METADATA, global_idx, grid_dim
+from std.time import global_perf_counter_ns
 from std.sys import size_of
 from std.utils import StaticTuple
 from max.gpu.host import DeviceContext, DeviceStream
@@ -65,6 +67,59 @@ def _inbox_add_kernel[
             var src = inbox.unsafe_offset(j * sb).unsafe_bitcast[Scalar[dtype]]()
             acc += src[unsafe_offset=i]
         shard[unsafe_offset=i] = acc
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(BLOCK))
+)
+@__name("ccl_internode_proxy_request")
+def _proxy_request_kernel(
+    mailbox: Pointer[UInt64, MutAnyOrigin], seq: UInt64
+):
+    """Hand exchange `seq` to the progress thread.
+
+    A release store into pinned host memory, so everything the stream did
+    before this kernel -- the reduce-scatter that produced the shard the
+    thread is about to send -- is visible to the CPU that acquires it.
+    """
+    if global_idx.x == 0:
+        Atomic[DType.uint64].store[ordering = Ordering.RELEASE](mailbox, seq)
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(BLOCK))
+)
+@__name("ccl_internode_proxy_wait")
+def _proxy_wait_kernel(
+    mailbox: Pointer[UInt64, MutAnyOrigin],
+    error_word: Pointer[UInt64, MutAnyOrigin],
+    seq: UInt64,
+    timeout_ns: UInt64,
+):
+    """Hold the stream until the progress thread reports exchange `seq` done.
+
+    One thread spinning on pinned host memory. This is the whole reason the
+    proxy exists: the same rendezvous through `cuLaunchHostFunc` cost about
+    480 us per exchange on this cluster (measured, job 234035 -- 1 MiB
+    allreduce 496 us against 24 us on one node), because the driver has to
+    stop the stream, wake a thread and restart it. A spin kernel and a
+    spinning CPU thread cost a launch each.
+
+    On the deadline it writes the region's error word and gives up rather
+    than hanging the stream forever; the add kernel then runs on stale
+    inbox bytes, which `ncclCommGetAsyncError` reports.
+    """
+    if global_idx.x == 0:
+        var t0 = global_perf_counter_ns()
+        while (
+            Atomic[DType.uint64].load[ordering = Ordering.ACQUIRE](mailbox)
+            < seq
+        ):
+            if global_perf_counter_ns() - t0 > timeout_ns:
+                Atomic[DType.uint64].store[ordering = Ordering.RELEASE](
+                    error_word, UInt64(9) * 1_000_000
+                )
+                return
 
 
 @__llvm_metadata(
@@ -193,4 +248,37 @@ def place_blocks(
         dst_offsets,
         Int64(block_bytes),
         Int32(nblocks),
+    )
+
+
+def proxy_request(
+    ctx: DeviceContext, stream: DeviceStream, mailbox: Int, seq: Int
+) raises:
+    _enqueue_cached[_proxy_request_kernel](
+        ctx,
+        stream,
+        "ib_req",
+        1,
+        Pointer[UInt64, MutAnyOrigin](unsafe_from_address=mailbox),
+        UInt64(seq),
+    )
+
+
+def proxy_wait(
+    ctx: DeviceContext,
+    stream: DeviceStream,
+    mailbox: Int,
+    error_word: Int,
+    seq: Int,
+    timeout_ns: Int,
+) raises:
+    _enqueue_cached[_proxy_wait_kernel](
+        ctx,
+        stream,
+        "ib_wait",
+        1,
+        Pointer[UInt64, MutAnyOrigin](unsafe_from_address=mailbox),
+        Pointer[UInt64, MutAnyOrigin](unsafe_from_address=error_word),
+        UInt64(seq),
+        UInt64(timeout_ns),
     )

--- a/torch_mojo_backend/distributed/mojoccl/internode_kernels.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/internode_kernels.mojo
@@ -1,0 +1,196 @@
+# The three device kernels the inter-node hop needs on top of
+# collectives_kernels.mojo, which is untouched.
+#
+# None of them synchronizes with anything: stream order does it. Each runs
+# after the host callback that put the network data in place (internode.mojo)
+# and before the intra-node collective that consumes the result, so there is
+# no flag protocol here and no peer pointer -- every address is inside this
+# rank's own region or its own user buffers.
+
+from std.gpu import MAX_THREADS_PER_BLOCK_METADATA, global_idx, grid_dim
+from std.sys import size_of
+from std.utils import StaticTuple
+from max.gpu.host import DeviceContext, DeviceStream
+
+from collectives_kernels import BLOCK, MAX_WORLD, _copy_bytes, _enqueue_cached
+
+comptime _UNROLL = 4
+comptime _MAX_BLOCKS = 432
+# (nnodes - 1) inbox slots; 16 nodes x 8 GPUs is far past what this library
+# is built for, and the array below is what makes it a compile-time bound.
+comptime MAX_NODES = 16
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(BLOCK))
+)
+@__name(t"ccl_internode_inbox_add_{dtype}")
+def _inbox_add_kernel[
+    dtype: DType, W: Int
+](
+    shard: Pointer[Scalar[dtype], MutAnyOrigin],
+    inbox: Pointer[UInt8, MutAnyOrigin],
+    count: Int64,
+    slot_bytes: Int64,
+    npeers_i: Int32,
+):
+    """`shard += sum of the npeers inbox slots`, elementwise.
+
+    The node-local sum of this rank's shard is already in `shard` (that is
+    what `reduce_scatter_stage` left there); each remote node's node-local
+    sum of the SAME shard has landed in one inbox slot. Adding them makes
+    `shard` the global sum, which `allgather_finish` then spreads.
+
+    Accumulated in the wire dtype, like the rest of the hierarchical path:
+    the remote sums arrived rounded already, so a wider accumulator here
+    would buy nothing.
+    """
+    var tid = Int(global_idx.x)
+    var stride = Int(grid_dim.x) * BLOCK
+    var n = Int(count)
+    var npeers = Int(npeers_i)
+    var sb = Int(slot_bytes)
+    var nv = n // W
+
+    for v in range(tid, nv, stride):
+        var acc = shard.unsafe_load[width=W, alignment=16](v * W)
+        for j in range(npeers):
+            var src = inbox.unsafe_offset(j * sb).unsafe_bitcast[Scalar[dtype]]()
+            acc += src.unsafe_load[width=W, alignment=16](v * W)
+        shard.unsafe_store[width=W, alignment=16](v * W, acc)
+
+    for i in range(nv * W + tid, n, stride):
+        var acc = shard[unsafe_offset=i]
+        for j in range(npeers):
+            var src = inbox.unsafe_offset(j * sb).unsafe_bitcast[Scalar[dtype]]()
+            acc += src[unsafe_offset=i]
+        shard[unsafe_offset=i] = acc
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(BLOCK))
+)
+@__name("ccl_internode_copy_bytes")
+def _copy_kernel(
+    dst: Pointer[UInt8, MutAnyOrigin],
+    src: Pointer[UInt8, MutAnyOrigin],
+    nbytes: Int64,
+):
+    """Staging copy: a user buffer is not in the registered region, so
+    broadcast and allgather have to move their payload in and out of it."""
+    _copy_bytes[_UNROLL](
+        dst,
+        src,
+        Int(nbytes),
+        Int(global_idx.x),
+        Int(grid_dim.x) * BLOCK,
+    )
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(BLOCK))
+)
+@__name("ccl_internode_place_blocks")
+def _place_blocks_kernel(
+    dst: Pointer[UInt8, MutAnyOrigin],
+    src: Pointer[UInt8, MutAnyOrigin],
+    dst_offsets: StaticTuple[Int64, MAX_WORLD],
+    block_bytes: Int64,
+    nblocks_i: Int32,
+):
+    """Scatter one node's allgather block into the output by global rank.
+
+    A node's block holds its `local_world` contributions in local-rank order;
+    the output wants them at their global ranks, which torchrun's numbering
+    makes contiguous but which this library reads out of the bootstrap table
+    instead of assuming. One launch per node beats `local_world` launches of
+    a few bytes each.
+    """
+    var nb = Int(block_bytes)
+    var tid = Int(global_idx.x)
+    var stride = Int(grid_dim.x) * BLOCK
+    for l in range(Int(nblocks_i)):
+        _copy_bytes[_UNROLL](
+            dst.unsafe_offset(Int(dst_offsets[l])),
+            src.unsafe_offset(l * nb),
+            nb,
+            tid,
+            stride,
+        )
+
+
+# ===-------------------------------------------------------------------=== #
+# Launchers
+# ===-------------------------------------------------------------------=== #
+
+
+def _blocks_for(nbytes: Int) -> Int:
+    return min(_MAX_BLOCKS, max(1, (nbytes // 16 + BLOCK - 1) // BLOCK))
+
+
+def inbox_add[
+    dtype: DType
+](
+    ctx: DeviceContext,
+    stream: DeviceStream,
+    shard_ptr: Int,
+    inbox_ptr: Int,
+    count: Int,
+    slot_bytes: Int,
+    npeers: Int,
+) raises:
+    """Enqueue `shard += sum(inbox slots)` on `stream`."""
+    if count <= 0 or npeers <= 0:
+        return
+    comptime W = 16 // size_of[dtype]()
+    _enqueue_cached[_inbox_add_kernel[dtype, W]](
+        ctx,
+        stream,
+        String(t"ib_add_{dtype}"),
+        _blocks_for(count * size_of[dtype]()),
+        Pointer[Scalar[dtype], MutAnyOrigin](unsafe_from_address=shard_ptr),
+        Pointer[UInt8, MutAnyOrigin](unsafe_from_address=inbox_ptr),
+        Int64(count),
+        Int64(slot_bytes),
+        Int32(npeers),
+    )
+
+
+def copy_bytes(
+    ctx: DeviceContext, stream: DeviceStream, dst: Int, src: Int, nbytes: Int
+) raises:
+    if nbytes <= 0:
+        return
+    _enqueue_cached[_copy_kernel](
+        ctx,
+        stream,
+        "ib_copy",
+        _blocks_for(nbytes),
+        Pointer[UInt8, MutAnyOrigin](unsafe_from_address=dst),
+        Pointer[UInt8, MutAnyOrigin](unsafe_from_address=src),
+        Int64(nbytes),
+    )
+
+
+def place_blocks(
+    ctx: DeviceContext,
+    stream: DeviceStream,
+    dst: Int,
+    src: Int,
+    dst_offsets: StaticTuple[Int64, MAX_WORLD],
+    block_bytes: Int,
+    nblocks: Int,
+) raises:
+    if block_bytes <= 0 or nblocks <= 0:
+        return
+    _enqueue_cached[_place_blocks_kernel](
+        ctx,
+        stream,
+        "ib_place",
+        _blocks_for(block_bytes),
+        Pointer[UInt8, MutAnyOrigin](unsafe_from_address=dst),
+        Pointer[UInt8, MutAnyOrigin](unsafe_from_address=src),
+        dst_offsets,
+        Int64(block_bytes),
+        Int32(nblocks),
+    )

--- a/torch_mojo_backend/distributed/mojoccl/internode_kernels.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/internode_kernels.mojo
@@ -18,6 +18,10 @@ from collectives_kernels import BLOCK, MAX_WORLD, _copy_bytes, _enqueue_cached
 
 comptime _UNROLL = 4
 comptime _MAX_BLOCKS = 432
+comptime _ABORT_CHECK = 256
+"""Mailbox reads between two probes of the abort word. Both are host memory
+across PCIe, so probing every iteration would double the wait kernel's traffic
+for no gain: 256 iterations is well under a millisecond."""
 
 
 @__llvm_metadata(
@@ -90,6 +94,7 @@ def _proxy_request_kernel(
 def _proxy_wait_kernel(
     mailbox: Pointer[UInt64, MutAnyOrigin],
     error_word: Pointer[UInt64, MutAnyOrigin],
+    abort_word: Pointer[UInt64, MutAnyOrigin],
     seq: UInt64,
     timeout_ns: UInt64,
 ):
@@ -102,16 +107,33 @@ def _proxy_wait_kernel(
     stop the stream, wake a thread and restart it. A spin kernel and a
     spinning CPU thread cost a launch each.
 
-    On the deadline it writes the region's error word and gives up rather
-    than hanging the stream forever; the add kernel then runs on stale
-    inbox bytes, which `ncclCommGetAsyncError` reports.
+    On the deadline -- or as soon as `ncclCommAbort` raises `abort_word`,
+    which is why abort does not cost a full deadline -- it writes the region's
+    error word and gives up rather than hanging the stream forever; the add
+    kernel then runs on stale inbox bytes, which `ncclCommGetAsyncError`
+    reports.
     """
     if global_idx.x == 0:
         var t0 = global_perf_counter_ns()
+        var spins = 0
         while (
             Atomic[DType.uint64].load[ordering = Ordering.ACQUIRE](mailbox)
             < seq
         ):
+            spins += 1
+            if spins >= _ABORT_CHECK:
+                spins = 0
+                if (
+                    Int(abort_word) != 0
+                    and Atomic[DType.uint64].load[
+                        ordering = Ordering.ACQUIRE
+                    ](abort_word)
+                    != 0
+                ):
+                    Atomic[DType.uint64].store[ordering = Ordering.RELEASE](
+                        error_word, UInt64(9) * 1_000_000
+                    )
+                    return
             if global_perf_counter_ns() - t0 > timeout_ns:
                 Atomic[DType.uint64].store[ordering = Ordering.RELEASE](
                     error_word, UInt64(9) * 1_000_000
@@ -266,6 +288,7 @@ def proxy_wait(
     stream: DeviceStream,
     mailbox: Int,
     error_word: Int,
+    abort_word: Int,
     seq: Int,
     timeout_ns: Int,
 ) raises:
@@ -276,6 +299,7 @@ def proxy_wait(
         1,
         Pointer[UInt64, MutAnyOrigin](unsafe_from_address=mailbox),
         Pointer[UInt64, MutAnyOrigin](unsafe_from_address=error_word),
+        Pointer[UInt64, MutAnyOrigin](unsafe_from_address=abort_word),
         UInt64(seq),
         UInt64(timeout_ns),
     )

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -1147,6 +1147,7 @@ def _bootstrap(
                 lib,
                 ordinal,
                 topo.my_local_rank,
+                topo.local_world,
                 topo.my_node,
                 topo.nnodes,
                 base,

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -42,9 +42,8 @@
 # with at most `PIPE_ARENAS` chunks alive, so the proxy exchanges chunk k
 # while the GPU reduce-scatters later chunks and all-gathers earlier ones.
 # Two things make that safe and neither is stream order across ranks: the
-# staging arena is replicated `PIPE_ARENAS` times so concurrent chunks never
-# share stage_in/stage_out (`_arena_regions`), and the inbox is reused only
-# against an explicit credit from the peer's add kernel (internode.mojo).
+# staging arena is replicated (`_arena_regions`), and the inbox is reused
+# only against an explicit credit (internode.mojo's header).
 #
 # Single-node communicators never touch libibverbs at all -- same fused
 # kernels, same numbers as before this file learned about nodes.
@@ -140,56 +139,47 @@ comptime NCCL_BFLOAT16: Int32 = 9
 comptime NCCL_SUM: Int32 = 0
 comptime NCCL_AVG: Int32 = 4
 
-# Payload a rank sends when it has nothing to contribute to an exchange.
-#
-# Every exchange is all-to-all among the ranks sharing a local_rank, even
-# when only one of them has data (a broadcast, or an allreduce whose shard
-# table leaves this rank empty), and that is a correctness requirement, not
-# tidiness: an exchange completes when its arrival tally reaches `npeers`,
-# so a rank that stayed silent would hang its peers. (Inbox REUSE is a
-# separate question, answered by the credit protocol in internode.mojo, not
-# by this.)
+# Payload a rank sends when it has nothing to contribute to an exchange:
+# a broadcast, or an allreduce whose shard table leaves this rank empty
+# (7 of 8 local ranks on DDP's 4-byte AVG allreduce). Every exchange has to
+# be all-to-all because an arrival tally of `npeers` is what completes one,
+# so a rank that stayed silent would hang its peers.
 comptime EMPTY_SHARD_BYTES = 16
 
-# Pipeline depth of the multi-node allreduce: how many staging arenas the
-# region is carved into, and therefore how many chunks may be alive at once.
-# Chunk k uses arena `k % PIPE_ARENAS`, and the schedule enqueues chunk k's
-# all-gather before chunk k+PIPE_ARENAS's reduce-scatter, so the arena's own
-# start barrier is what orders the reuse -- the invariant one arena already
-# had, applied per arena.
+# Staging arenas the multi-node region is carved into, and therefore chunks
+# the pipeline may keep alive (`_arena_regions`, `_do_allreduce`).
 #
-# 4 is the measured default: the pipeline is GPU-bound at every size that
-# gets chunked (the reduce-scatter plus all-gather of one chunk outlasts its
-# RDMA), so depth 2 would already overlap in principle, but the overlap
-# window at depth 2 is one reduce-scatter and the progress thread's idle
-# backoff alone (MOJOCCL_IB_PROXY_IDLE_US, 20 us) can eat that. Depth 4
-# gives a window of two whole chunks. It costs region layout, not memory:
-# each arena is 1/4 of the staging, so the total is what it always was.
+# 4, not 2: the pipeline is GPU-bound at every size that gets chunked, so
+# depth 2 overlaps in principle, but its window is one reduce-scatter and
+# the progress thread's idle backoff alone (MOJOCCL_IB_PROXY_IDLE_US, 20 us)
+# can eat that. Depth 4 gives a window of two whole chunks, and costs region
+# layout rather than memory -- each arena is 1/4 of the staging.
 comptime PIPE_ARENAS = 4
 
-# Fixed inbox slot groups. One more than the arenas on purpose: a peer needs
-# my credit for exchange e-INBOX_SLOTS before it may post e, and my credits
-# ride on my own requests (`credit_upto`), so an extra group means the credit
-# it needs went out one chunk before it was needed instead of exactly when.
+# Fixed inbox slot groups (internode.mojo owns what they are for). One more
+# than the arenas: at PIPE_ARENAS the credit a rank needs arrives exactly
+# when it asks for it, putting a round trip on the critical path; the extra
+# group means it went out a chunk earlier.
 comptime INBOX_SLOTS = PIPE_ARENAS + 1
 
 # Largest number of pipeline chunks one collective is cut into.
 comptime PIPE_MAX_CHUNKS = 16
 
-# Chunking constant, in bytes: the optimum split of a `B`-byte multi-node
-# allreduce is `K = sqrt(B / (local_world * PIPE_SPLIT_UNIT))`.
+# Chunking constant, in bytes: a `B`-byte multi-node allreduce is cut into
+# `K = sqrt(B / (local_world * PIPE_SPLIT_UNIT))` chunks.
 #
-# Derivation. An extra chunk costs one more reduce-scatter and one more
-# all-gather launch, each a kernel launch plus an 8-way start barrier, about
-# 8 us each on this cluster (docs/mojo_collectives_kernel_results.md 10.3
-# reads the pair at 15.9 us for a 4-byte message, which is all fixed cost).
-# Pipelining hides all but ~1/K of the network, and the network of a B-byte
-# allreduce is B/(local_world * 40 GB/s) with the RDMA measured at 40-45 GB/s
-# per rank (one HCA each, job 234072). Minimising 16K + B/(L*40000) us over K
-# gives K = sqrt(B / (L * 640000)). The rule also keeps a chunk's shard
-# comfortably above 1 MiB, where the RDMA is still at line rate, without a
-# second clause: at K > 1 the shard is sqrt(B * 640000 / L) bytes, 1.5 MB at
-# the 27 MiB bucket and 3.8 MB at 168 MiB.
+# An extra chunk costs one more reduce-scatter and one more all-gather
+# launch, each a launch plus an 8-way start barrier, ~8 us apiece on this
+# cluster (docs/mojo_collectives_kernel_results.md 10.3 reads the pair at
+# 15.9 us for a 4-byte message, which is all fixed cost). Pipelining hides
+# all but ~1/K of the network, and the network of a B-byte allreduce is
+# B/(local_world * 40 GB/s), the RDMA measured at 40-45 GB/s per rank (one
+# HCA each, job 234072). Minimising 16K + B/(L*40000) us gives
+# K = sqrt(B / (L * 640000)).
+#
+# It also keeps a chunk's shard above 1 MiB, where the RDMA is still at line
+# rate, without a second clause: at K > 1 the shard is sqrt(B * 640000 / L)
+# bytes, 1.5 MB at the 27 MiB bucket and 3.8 MB at 168 MiB.
 comptime PIPE_SPLIT_UNIT = 640_000
 
 comptime DEFAULT_REGION_MB = 256

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -384,9 +384,25 @@ def ncclCommInitRank(
         for r in range(Int(nranks)):
             if r == Int(rank):
                 continue
-            wait_for_rank(dir, r, timeout_s)
-            _ = read_rank_handle(dir, r, _any(peer_handle))
-            regions[r] = open_handle(lib, _any(peer_handle))
+            try:
+                wait_for_rank(dir, r, timeout_s)
+                _ = read_rank_handle(dir, r, _any(peer_handle))
+                regions[r] = open_handle(lib, _any(peer_handle))
+            except:
+                # A peer past this one never got opened: close whatever
+                # peers < r WERE opened and free our own region before
+                # propagating, so a failed init leaks no IPC mappings.
+                for r2 in range(Int(nranks)):
+                    if r2 != Int(rank) and regions[r2] != 0:
+                        try:
+                            close_handle(lib, regions[r2])
+                        except:
+                            pass
+                try:
+                    free_region(lib, base)
+                except:
+                    pass
+                raise
 
         var state = CommState(
             rank=Int(rank),
@@ -402,7 +418,7 @@ def ncclCommInitRank(
         handle_ptr.unsafe_write(state^)
         comm_out[] = Int64(Int(handle_ptr))
         return NCCL_SUCCESS
-    except e:
+    except:
         return NCCL_INTERNAL_ERROR
 
 

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -43,7 +43,10 @@ from bootstrap import (
     decode_dir,
     encode_dir,
     read_rank_handle,
+    remove_rendezvous_dir,
+    wait_for_done,
     wait_for_rank,
+    write_rank_done,
     write_rank_handle,
 )
 from collectives_kernels import (
@@ -355,69 +358,105 @@ def ncclCommInitRank(
         idbuf64[unsafe_offset=15] = id15
         var dir = decode_dir(_any(idbuf))
 
-        var lib = open_driver()
-        var ordinal = current_device_ordinal(lib)
-        var ctx = DeviceContext(device_id=ordinal)
+        # Everything below either succeeds together or is unwound together:
+        # a failure past this point (region alloc, handle exchange, the
+        # peer-open loop, the done-marker wait) is caught here so rank 0 can
+        # remove the rendezvous directory it created in ncclGetUniqueId --
+        # otherwise it and every rank's handle/done file leak in /dev/shm
+        # forever, since no other rank will ever revisit this path.
+        try:
+            var lib = open_driver()
+            var ordinal = current_device_ordinal(lib)
+            var ctx = DeviceContext(device_id=ordinal)
 
-        var cap_bytes = _region_cap_bytes()
-        # A positive multiple of 4096 (the production kernel's own
-        # precondition, RESULTS.md §9) is what keeps every per-chunk offset
-        # `ncclAllReduce` forms (multiples of cap_bytes, one full chunk at a
-        # time) 16-byte aligned for every supported dtype -- 4096 divides
-        # evenly by 2, 4 and 8. A misconfigured MOJOCCL_REGION_MB (e.g. 0)
-        # would otherwise degrade chunk offsets to non-16-byte-aligned
-        # single-element steps.
-        if cap_bytes <= 0 or cap_bytes % 4096 != 0:
-            return NCCL_INVALID_ARGUMENT
-        var region_bytes = signal_bytes() + 2 * cap_bytes
-        var base = alloc_region(lib, region_bytes)
-        region_init(ctx, base)
+            var cap_bytes = _region_cap_bytes()
+            # A positive multiple of 4096 (the production kernel's own
+            # precondition, RESULTS.md §9) is what keeps every per-chunk
+            # offset `ncclAllReduce` forms (multiples of cap_bytes, one full
+            # chunk at a time) 16-byte aligned for every supported dtype --
+            # 4096 divides evenly by 2, 4 and 8. A misconfigured
+            # MOJOCCL_REGION_MB (e.g. 0) would otherwise degrade chunk
+            # offsets to non-16-byte-aligned single-element steps.
+            if cap_bytes <= 0 or cap_bytes % 4096 != 0:
+                if Int(rank) == 0:
+                    try:
+                        remove_rendezvous_dir(dir, Int(nranks))
+                    except:
+                        pass
+                return NCCL_INVALID_ARGUMENT
+            var region_bytes = signal_bytes() + 2 * cap_bytes
+            var base = alloc_region(lib, region_bytes)
+            region_init(ctx, base)
 
-        var my_handle = unsafe_alloc[UInt8](HANDLE_BYTES)
-        get_handle(lib, base, _any(my_handle))
-        write_rank_handle(dir, Int(rank), ordinal, _any(my_handle))
+            var my_handle = unsafe_alloc[UInt8](HANDLE_BYTES)
+            get_handle(lib, base, _any(my_handle))
+            write_rank_handle(dir, Int(rank), ordinal, _any(my_handle))
 
-        var timeout_s = _bootstrap_timeout_s()
-        var regions = StaticTuple[Int, MAX_WORLD](fill=0)
-        regions[Int(rank)] = base
-        var peer_handle = unsafe_alloc[UInt8](HANDLE_BYTES)
-        for r in range(Int(nranks)):
-            if r == Int(rank):
-                continue
-            try:
-                wait_for_rank(dir, r, timeout_s)
-                _ = read_rank_handle(dir, r, _any(peer_handle))
-                regions[r] = open_handle(lib, _any(peer_handle))
-            except:
-                # A peer past this one never got opened: close whatever
-                # peers < r WERE opened and free our own region before
-                # propagating, so a failed init leaks no IPC mappings.
-                for r2 in range(Int(nranks)):
-                    if r2 != Int(rank) and regions[r2] != 0:
-                        try:
-                            close_handle(lib, regions[r2])
-                        except:
-                            pass
+            var timeout_s = _bootstrap_timeout_s()
+            var regions = StaticTuple[Int, MAX_WORLD](fill=0)
+            regions[Int(rank)] = base
+            var peer_handle = unsafe_alloc[UInt8](HANDLE_BYTES)
+            for r in range(Int(nranks)):
+                if r == Int(rank):
+                    continue
                 try:
-                    free_region(lib, base)
+                    wait_for_rank(dir, r, timeout_s)
+                    _ = read_rank_handle(dir, r, _any(peer_handle))
+                    regions[r] = open_handle(lib, _any(peer_handle))
+                except:
+                    # A peer past this one never got opened: close whatever
+                    # peers < r WERE opened and free our own region before
+                    # propagating, so a failed init leaks no IPC mappings.
+                    for r2 in range(Int(nranks)):
+                        if r2 != Int(rank) and regions[r2] != 0:
+                            try:
+                                close_handle(lib, regions[r2])
+                            except:
+                                pass
+                    try:
+                        free_region(lib, base)
+                    except:
+                        pass
+                    raise
+
+            # Done protocol: every rank marks itself done once it has opened
+            # every peer's handle; rank 0 (and only rank 0) waits for all
+            # `nranks` markers and then removes `dir` -- otherwise
+            # /dev/shm/mojoccl-* directories and their per-rank handle files
+            # accumulate forever on a shared node (mkdtemp never cleans up
+            # after itself). Other ranks return as soon as their own marker
+            # is written; they do not wait for the directory to disappear.
+            write_rank_done(dir, Int(rank))
+            if Int(rank) == 0:
+                for r in range(Int(nranks)):
+                    if r != 0:
+                        wait_for_done(dir, r, timeout_s)
+                try:
+                    remove_rendezvous_dir(dir, Int(nranks))
+                except:
+                    pass  # a leftover /dev/shm dir is a nuisance, not a correctness bug
+
+            var state = CommState(
+                rank=Int(rank),
+                world=Int(nranks),
+                ordinal=ordinal,
+                ctx=ctx,
+                driver=lib^,
+                cap_bytes=cap_bytes,
+                regions=regions,
+                owned_base=base,
+            )
+            var handle_ptr = unsafe_alloc[CommState](1)
+            handle_ptr.unsafe_write(state^)
+            comm_out[] = Int64(Int(handle_ptr))
+            return NCCL_SUCCESS
+        except:
+            if Int(rank) == 0:
+                try:
+                    remove_rendezvous_dir(dir, Int(nranks))
                 except:
                     pass
-                raise
-
-        var state = CommState(
-            rank=Int(rank),
-            world=Int(nranks),
-            ordinal=ordinal,
-            ctx=ctx,
-            driver=lib^,
-            cap_bytes=cap_bytes,
-            regions=regions,
-            owned_base=base,
-        )
-        var handle_ptr = unsafe_alloc[CommState](1)
-        handle_ptr.unsafe_write(state^)
-        comm_out[] = Int64(Int(handle_ptr))
-        return NCCL_SUCCESS
+            raise
     except:
         return NCCL_INTERNAL_ERROR
 

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -393,7 +393,7 @@ def ncclGetUniqueId(uid_out: Pointer[UInt8, MutAnyOrigin]) abi("C") -> Int32:
     try:
         make_unique_id(uid_out)
         return NCCL_SUCCESS
-    except e:
+    except:
         return NCCL_SYSTEM_ERROR
 
 
@@ -647,6 +647,12 @@ def ncclCommDestroy(comm: Int64) abi("C") -> Int32:
         var ptr = _comm_ptr(comm)
         ref state = ptr[]
         if not state.aborted:
+            # The inter-node callbacks were enqueued on the CALLER's stream,
+            # not on the context's own, and they dereference the IbState this
+            # tears down -- so drain that stream too before touching it.
+            if state.last_stream != 0:
+                _ensure_stream_cached(state, state.last_stream)
+                state.stream_cache[state.last_stream].synchronize()
             state.ctx.synchronize()
             ib_teardown(state.ib)
             for r in range(state.local_world):
@@ -654,7 +660,7 @@ def ncclCommDestroy(comm: Int64) abi("C") -> Int32:
                     close_handle(state.driver, state.regions[r])
             free_region(state.driver, state.owned_base)
         return NCCL_SUCCESS
-    except e:
+    except:
         return NCCL_INTERNAL_ERROR
 
 
@@ -707,7 +713,7 @@ def ncclCommGetAsyncError(
         )
         err_out[] = NCCL_REMOTE_ERROR if Int(word) != 0 else NCCL_SUCCESS
         return NCCL_SUCCESS
-    except e:
+    except:
         return NCCL_INTERNAL_ERROR
 
 

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -1310,6 +1310,12 @@ def ncclCommGetAsyncError(
             )
         ) if state.last_stream != 0 else DeviceStream(state.ctx)
         s.synchronize()
+        if state.ib != 0 and ib_error(state.ib) != 0:
+            # A proxy failure during that sync releases the spin kernels
+            # through MB_DONE without touching the device error word; the
+            # host word is the only record of it.
+            err_out[] = NCCL_REMOTE_ERROR
+            return NCCL_SUCCESS
         # One error word per pipeline arena: a multi-node allreduce spreads
         # its chunks over all of them, and a barrier that gave up did so in
         # exactly one.

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -548,7 +548,8 @@ def _bootstrap(
     if topo.nnodes > MAX_NODES:
         raise Error(
             "mojoccl: " + String(topo.nnodes) + " nodes exceeds the "
-            + String(MAX_NODES) + "-node limit of the inbox layout"
+            + String(MAX_NODES)
+            + "-node limit of the per-node QPN table in the bootstrap blob"
         )
 
     var lib = open_driver()

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -490,6 +490,32 @@ def _init_rank(
     nranks: Int,
     comm_out: Pointer[Int64, MutAnyOrigin],
 ) raises -> Int32:
+    """Bring the rendezvous up, run init under it, and always hand it back.
+
+    `BootstrapConn` has no destructor, so every path out of `_bootstrap`
+    has to close its sockets explicitly: a leaked root listener keeps the
+    unique id's port bound for the life of the process, and a leaked
+    per-rank socket leaves the peers blocked in `_recv_all` until their own
+    deadline instead of failing fast on a closed connection.
+    """
+    var timeout_s = _bootstrap_timeout_s()
+    var conn = bootstrap_connect(uid, rank, nranks, timeout_s)
+    try:
+        var rc = _bootstrap(conn, rank, nranks, comm_out, timeout_s)
+        conn.close()
+        return rc
+    except e:
+        conn.close()
+        raise e
+
+
+def _bootstrap(
+    mut conn: BootstrapConn,
+    rank: Int,
+    nranks: Int,
+    comm_out: Pointer[Int64, MutAnyOrigin],
+    timeout_s: Float64,
+) raises -> Int32:
     """Three bootstrap rounds and everything they gate.
 
     Round 1 gathers host identity, from which every rank derives the same
@@ -499,9 +525,6 @@ def _init_rank(
     and its queue pairs are in RTS, so the first collective may write into
     it.
     """
-    var timeout_s = _bootstrap_timeout_s()
-    var conn = bootstrap_connect(uid, rank, nranks, timeout_s)
-
     # Round 1: host identity.
     var b1 = unsafe_alloc[UInt8](16)
     var b1w = b1.unsafe_bitcast[UInt64]()
@@ -515,7 +538,6 @@ def _init_rank(
         hashes.append(t1w[unsafe_offset = 2 * r])
     var topo = derive_topology(hashes, rank)
     if topo.local_world > MAX_WORLD:
-        conn.close()
         raise Error(
             "mojoccl: "
             + String(topo.local_world)
@@ -524,7 +546,6 @@ def _init_rank(
             + String(MAX_WORLD)
         )
     if topo.nnodes > MAX_NODES:
-        conn.close()
         raise Error(
             "mojoccl: " + String(topo.nnodes) + " nodes exceeds the "
             + String(MAX_NODES) + "-node limit of the inbox layout"
@@ -538,7 +559,6 @@ def _init_rank(
     # RESULTS.md section 9) is what keeps every per-chunk offset the
     # collectives form 16-byte aligned for every supported dtype.
     if cap_bytes <= 0 or cap_bytes % 4096 != 0:
-        conn.close()
         raise Error("mojoccl: MOJOCCL_REGION_MB must be a positive 4 KiB multiple")
     # A multi-node communicator gets a third cap-sized area on top of
     # [signal | stage_in | stage_out]: everything the network touches --
@@ -622,7 +642,6 @@ def _init_rank(
         )
 
     bootstrap_barrier(conn, timeout_s)
-    conn.close()
 
     var rank_at = List[Int]()
     for i in range(len(topo.rank_at)):

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -183,8 +183,11 @@ def _wrap_stream(ctx: DeviceContext, handle: Int64) raises -> DeviceStream:
 
 @export
 def ncclGetVersion(version: Pointer[Int32, MutAnyOrigin]) abi("C") -> Int32:
-    # 2.31.2-shaped: matches the pinned header this ABI was written against.
-    version[] = 22031
+    # 2.31.2, encoded per nccl.h.in's NCCL_VERSION macro: X*10000+Y*100+Z for
+    # Y>8 (true from 2.9 on) -- 2*10000 + 31*100 + 2 = 23102, matching the
+    # pinned header this ABI was written against. (A prior value here, 22031,
+    # did not decode to 2.31.2 under that formula.)
+    version[] = 23102
     return NCCL_SUCCESS
 
 

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -73,6 +73,7 @@ from bootstrap import (
     bootstrap_allgather,
     bootstrap_barrier,
     bootstrap_connect,
+    decode_id,
     derive_topology,
     host_hash,
     make_unique_id,
@@ -109,6 +110,28 @@ from internode import (
     ib_teardown,
 )
 from internode_kernels import copy_bytes, inbox_add, place_blocks
+from nvls_kernels import (
+    nvls_allreduce,
+    nvls_available,
+    nvls_barriers_per_call,
+    nvls_blocks,
+    nvls_chunk_bytes,
+    nvls_chunk_vecs,
+    nvls_min_bytes,
+)
+from vmm import (
+    NvlsRegion,
+    multicast_capable,
+    multicast_granularity,
+    nvls_bind_and_map,
+    nvls_create_and_share,
+    nvls_fit_cap,
+    nvls_teardown,
+    scm_bind,
+    scm_unbind,
+    sm_count,
+    socket_path,
+)
 
 
 # ncclResult_t (nccl.h.in:44-53)
@@ -192,6 +215,18 @@ comptime PIPE_SPLIT_UNIT = 640_000
 comptime DEFAULT_REGION_MB = 256
 comptime DEFAULT_BOOTSTRAP_TIMEOUT_S: Float64 = 120.0
 
+comptime DEFAULT_SOCKET_DIR = "/tmp"
+"""Where the node-local AF_UNIX sockets that carry the VMM/multicast file
+descriptors are bound (`MOJOCCL_SOCKET_DIR`). Node-local by definition -- a
+shared filesystem would work too but buys nothing, since the ranks that talk
+over it are on one host. NCCL puts its own at /tmp as well
+(nccl:src/os/linux_ipcsocket.cc)."""
+
+comptime NVLS_FD_TIMEOUT_S: Float64 = 30.0
+"""Bound on one fd hand-off. The whole bring-up is 150-230 ms when it works,
+so 30 s only ever fires when a local peer died mid-init -- and it has to fire,
+or the surviving ranks block in `recvmsg` forever."""
+
 
 def _region_cap_bytes() -> Int:
     var s = getenv("MOJOCCL_REGION_MB", String(DEFAULT_REGION_MB))
@@ -209,6 +244,34 @@ def _bootstrap_timeout_s() -> Float64:
         return Float64(s)
     except:
         return DEFAULT_BOOTSTRAP_TIMEOUT_S
+
+
+def _nvls_enabled() -> Bool:
+    """`MOJOCCL_NVLS=0` turns the multicast path off, region and all.
+
+    Folded into the round-1 capability word, so one rank setting it takes the
+    whole communicator back to the unicast kernels -- a communicator where
+    some ranks bound a multicast region and others did not is not a
+    configuration, it is a crash.
+    """
+    return getenv("MOJOCCL_NVLS", String("1")) != String("0")
+
+
+def _nvls_min_bytes() -> Int:
+    """Message size at or above which a single-node allreduce goes through the
+    switch (`MOJOCCL_NVLS_MIN_MB`, default 48 MiB -- the measured crossover,
+    see `NVLS_MIN_BYTES` in nvls_kernels.mojo)."""
+    var s = getenv("MOJOCCL_NVLS_MIN_MB", String(""))
+    if s == String(""):
+        return nvls_min_bytes()
+    try:
+        return Int(s) * 1024 * 1024
+    except:
+        return nvls_min_bytes()
+
+
+def _socket_dir() -> String:
+    return getenv("MOJOCCL_SOCKET_DIR", String(DEFAULT_SOCKET_DIR))
 
 
 def _dtype_item_bytes(nccl_dtype: Int32) -> Int:
@@ -283,6 +346,11 @@ struct CommState(Movable):
     var arena_cap: Int
     var arena_stride: Int
     var nslots: Int
+    var nvls: NvlsRegion
+    var nvls_on: Bool
+    var nvls_grid: Int
+    var nvls_min: Int
+    var nvls_bars: Int
 
     def __init__(
         out self,
@@ -305,6 +373,10 @@ struct CommState(Movable):
         arena_cap: Int,
         arena_stride: Int,
         nslots: Int,
+        var nvls: NvlsRegion,
+        nvls_on: Bool,
+        nvls_grid: Int,
+        nvls_min: Int,
     ):
         self.rank = rank
         self.world = world
@@ -329,6 +401,16 @@ struct CommState(Movable):
         self.arena_cap = arena_cap
         self.arena_stride = arena_stride
         self.nslots = nslots
+        self.nvls = nvls^
+        self.nvls_on = nvls_on
+        self.nvls_grid = nvls_grid
+        self.nvls_min = nvls_min
+        # Barriers the NVLS kernel has completed on this region. Its flag is a
+        # single UInt64 counter that every GPU adds 1 to per barrier, so the
+        # value to wait for is `(nvls_bars + 1) * local_world`; it is never
+        # reset, and it is independent of `generation` (different address,
+        # different protocol) so the two paths can alternate freely.
+        self.nvls_bars = 0
 
 
 @always_inline
@@ -633,9 +715,12 @@ def _init_rank(
     deadline instead of failing fast on a closed connection.
     """
     var timeout_s = _bootstrap_timeout_s()
+    # The id's magic names this communicator's node-local fd sockets, so the
+    # rendezvous carries no extra round for them (vmm.mojo's `socket_path`).
+    var magic = decode_id(uid)[2]
     var conn = bootstrap_connect(uid, rank, nranks, timeout_s)
     try:
-        var rc = _bootstrap(conn, rank, nranks, comm_out, timeout_s)
+        var rc = _bootstrap(conn, rank, nranks, magic, comm_out, timeout_s)
         conn.close()
         return rc
     except e:
@@ -647,6 +732,7 @@ def _bootstrap(
     mut conn: BootstrapConn,
     rank: Int,
     nranks: Int,
+    magic: UInt64,
     comm_out: Pointer[Int64, MutAnyOrigin],
     timeout_s: Float64,
 ) raises -> Int32:
@@ -659,17 +745,44 @@ def _bootstrap(
     and its queue pairs are in RTS, so the first collective may write into
     it.
     """
-    # Round 1: host identity.
-    var b1 = unsafe_alloc[UInt8](16)
+    var lib = open_driver()
+    var ordinal = current_device_ordinal(lib)
+    var ctx = DeviceContext(device_id=ordinal)
+
+    # Round 1: host identity, and whether this rank can take the NVLS path.
+    #
+    # The capability travels here, before anything is allocated, because the
+    # answer decides what KIND of memory the region is: VMM bound to a
+    # multicast object, or a plain cuMemAlloc. Every rank ANDs the whole
+    # column, so one rank without multicast (or with MOJOCCL_NVLS=0) takes the
+    # communicator back to the unicast kernels with no half-built state to
+    # unwind. Rank 0 additionally does a real `cuMulticastCreate` of a
+    # granularity-sized object and releases it: that is where a broken
+    # fabric-manager setup shows up, it costs ~88 us, and finding out now is
+    # what makes "fall back" a decision rather than a recovery.
+    comptime BLOB1 = 24
+    var b1 = unsafe_alloc[UInt8](BLOB1)
     var b1w = b1.unsafe_bitcast[UInt64]()
     b1w[unsafe_offset=0] = host_hash()
     b1w[unsafe_offset=1] = UInt64(rank)
-    var t1 = unsafe_alloc[UInt8](16 * nranks)
-    bootstrap_allgather(conn, _any(b1), 16, _any(t1), timeout_s)
+    var my_caps: UInt64 = 0
+    if (
+        _nvls_enabled()
+        and nvls_available()
+        and nranks >= 2
+        and multicast_capable(lib, ordinal, nranks, rank == 0)
+    ):
+        my_caps = 1
+    b1w[unsafe_offset=2] = my_caps
+    var t1 = unsafe_alloc[UInt8](BLOB1 * nranks)
+    bootstrap_allgather(conn, _any(b1), BLOB1, _any(t1), timeout_s)
     var t1w = t1.unsafe_bitcast[UInt64]()
     var hashes = List[UInt64]()
+    var all_caps = True
     for r in range(nranks):
-        hashes.append(t1w[unsafe_offset = 2 * r])
+        hashes.append(t1w[unsafe_offset=3 * r])
+        if t1w[unsafe_offset=3 * r + 2] & 1 == 0:
+            all_caps = False
     var topo = derive_topology(hashes, rank)
     if topo.local_world > MAX_WORLD:
         raise Error(
@@ -681,20 +794,21 @@ def _bootstrap(
         )
     if topo.nnodes > MAX_NODES:
         raise Error(
-            "mojoccl: " + String(topo.nnodes) + " nodes exceeds the "
+            "mojoccl: "
+            + String(topo.nnodes)
+            + " nodes exceeds the "
             + String(MAX_NODES)
             + "-node limit of the per-node QPN table in the bootstrap blob"
         )
 
-    var lib = open_driver()
-    var ordinal = current_device_ordinal(lib)
-    var ctx = DeviceContext(device_id=ordinal)
     var cap_bytes = _region_cap_bytes()
     # A positive multiple of 4096 (the kernels' own precondition,
     # RESULTS.md section 9) is what keeps every per-chunk offset the
     # collectives form 16-byte aligned for every supported dtype.
     if cap_bytes <= 0 or cap_bytes % 4096 != 0:
-        raise Error("mojoccl: MOJOCCL_REGION_MB must be a positive 4 KiB multiple")
+        raise Error(
+            "mojoccl: MOJOCCL_REGION_MB must be a positive 4 KiB multiple"
+        )
     # Region layout.
     #
     # Single node, unchanged: one arena, [signal | stage_in cap | stage_out
@@ -720,6 +834,35 @@ def _bootstrap(
     # reduce-scatter is done, which is not ordered against MY reduce-scatter
     # still using stage_in, nor against a local peer still reading the
     # previous generation's staging.
+    # NVLS: on a single-node communicator whose devices all support NVSwitch
+    # multicast, the region is VMM memory bound to a per-node multicast object
+    # instead of a `cuMemAlloc` block, and peers are imported with
+    # `cuMemImportFromShareableHandle` instead of `cuIpcOpenMemHandle` (legacy
+    # IPC cannot open VMM memory). The unicast kernels do not notice: they get
+    # the plain mapping of exactly the same layout, and `nvls.mc` is a second
+    # mapping only nvls_kernels.mojo ever touches.
+    #
+    # Single node only, deliberately. The inter-node path RDMA-writes straight
+    # out of an arena's stage_out, so the arenas have to be inside the
+    # registered MR -- and `ibv_reg_mr` on a cuMemMap'd VA did not work on this
+    # cluster first try, with no dmabuf fallback (CU_DEVICE_ATTRIBUTE_DMA_BUF_
+    # SUPPORTED is 0 there), see the prototype's RESULTS.md section 4. Since
+    # the multi-node collective stays on the unicast split kernels anyway
+    # (their pipeline chunks are below the NVLS crossover; see
+    # docs/distributed.md), a multicast region there would cost 150-230 ms of
+    # bring-up and a granularity rounding for nothing.
+    var use_nvls = all_caps and topo.nnodes == 1 and topo.local_world >= 2
+    var granularity = 0
+    if use_nvls:
+        granularity = multicast_granularity(
+            lib, topo.local_world, ordinal, signal_bytes() + 2 * cap_bytes
+        )
+        # The multicast object can only be a multiple of the granularity, so
+        # the rounding is paid either way; spend it on the staging halves
+        # rather than waste it. Every rank derives the same number from the
+        # same device property, and round 2 checks that.
+        cap_bytes = nvls_fit_cap(signal_bytes(), cap_bytes, granularity)
+
     var layout = region_layout(cap_bytes, topo.nnodes)
     var narenas = layout[0]
     var arena_cap = layout[1]
@@ -732,7 +875,66 @@ def _bootstrap(
             + " pipeline arenas out of"
         )
     var net_off = narenas * arena_stride
-    var base = alloc_region(lib, region_bytes)
+
+    var nvls = NvlsRegion()
+    var base: Int
+    if use_nvls:
+        var libc = OwnedDLHandle("libc.so.6")
+        var spath = socket_path(_socket_dir(), magic, topo.my_local_rank)
+        var sock = scm_bind(libc, spath, NVLS_FD_TIMEOUT_S)
+        try:
+            # Three rendezvous, and the two inner ones are the ordering rules
+            # of the multicast API: every device must be in the team before
+            # any memory is bound, and every rank must have mapped before any
+            # rank issues a multimem instruction. On a single-node
+            # communicator the bootstrap barrier IS the node barrier.
+            bootstrap_barrier(conn, timeout_s)
+            nvls_create_and_share(
+                lib,
+                libc,
+                _socket_dir(),
+                magic,
+                topo.my_local_rank,
+                topo.local_world,
+                ordinal,
+                _align_up(region_bytes, granularity),
+                granularity,
+                sock,
+                NVLS_FD_TIMEOUT_S,
+                nvls,
+            )
+            bootstrap_barrier(conn, timeout_s)
+            nvls_bind_and_map(
+                lib,
+                libc,
+                _socket_dir(),
+                magic,
+                topo.my_local_rank,
+                topo.local_world,
+                ordinal,
+                sock,
+                NVLS_FD_TIMEOUT_S,
+                nvls,
+            )
+            bootstrap_barrier(conn, timeout_s)
+        except e:
+            try:
+                nvls_teardown(nvls, lib, ordinal)
+                scm_unbind(libc, sock, spath)
+            except:
+                pass
+            raise Error(
+                "mojoccl: the NVSwitch-multicast region failed to come up ("
+                + String(e)
+                + "); every device reported CU_DEVICE_ATTRIBUTE_MULTICAST_"
+                "SUPPORTED and rank 0's create probe passed, so this is a"
+                " real fault rather than an unsupported machine. Set"
+                " MOJOCCL_NVLS=0 to run on the unicast kernels."
+            )
+        scm_unbind(libc, sock, spath)
+        base = nvls.uc
+    else:
+        base = alloc_region(lib, region_bytes)
     for a in range(narenas):
         region_init(ctx, base + a * arena_stride)
 
@@ -760,7 +962,11 @@ def _bootstrap(
     var b2 = unsafe_alloc[UInt8](BLOB2)
     for i in range(BLOB2):
         b2[unsafe_offset=i] = 0
-    get_handle(lib, base, _any(b2))
+    if not use_nvls:
+        # `cuIpcGetMemHandle` cannot export VMM memory; under NVLS the peers
+        # already have this region through the fd exchange above, and these
+        # 64 bytes stay zero.
+        get_handle(lib, base, _any(b2))
     var my_lid = 0
     var my_mtu = 0
     if ib != 0:
@@ -778,12 +984,17 @@ def _bootstrap(
         unsafe_from_address=Int(b2) + HANDLE_BYTES + IB_BLOB_BYTES
     )
     cfg[unsafe_offset=0] = Int64(cap_bytes)
-    cfg[unsafe_offset=1] = Int64(narenas * 1000 + INBOX_SLOTS)
+    cfg[unsafe_offset=1] = Int64(
+        narenas * 1000 + INBOX_SLOTS + (1_000_000 if use_nvls else 0)
+    )
     var t2 = unsafe_alloc[UInt8](BLOB2 * nranks)
     bootstrap_allgather(conn, _any(b2), BLOB2, _any(t2), timeout_s)
     for r in range(nranks):
         var rcfg = Pointer[Int64, MutAnyOrigin](
-            unsafe_from_address=Int(t2) + r * BLOB2 + HANDLE_BYTES + IB_BLOB_BYTES
+            unsafe_from_address=Int(t2)
+            + r * BLOB2
+            + HANDLE_BYTES
+            + IB_BLOB_BYTES
         )
         if (
             rcfg[unsafe_offset=0] != cfg[unsafe_offset=0]
@@ -806,16 +1017,20 @@ def _bootstrap(
     # Same-node peers only: an IPC handle from another host is meaningless.
     var regions = StaticTuple[Int, MAX_WORLD](fill=0)
     regions[topo.my_local_rank] = base
-    for r in range(nranks):
-        if topo.node_of[r] != topo.my_node or r == rank:
-            continue
-        var lr = topo.local_rank_of[r]
-        regions[lr] = open_handle(
-            lib,
-            Pointer[UInt8, MutAnyOrigin](
-                unsafe_from_address=Int(t2) + r * BLOB2
-            ),
-        )
+    if use_nvls:
+        for r in range(topo.local_world):
+            regions[r] = nvls.peer_va[r]
+    else:
+        for r in range(nranks):
+            if topo.node_of[r] != topo.my_node or r == rank:
+                continue
+            var lr = topo.local_rank_of[r]
+            regions[lr] = open_handle(
+                lib,
+                Pointer[UInt8, MutAnyOrigin](
+                    unsafe_from_address=Int(t2) + r * BLOB2
+                ),
+            )
 
     if ib != 0:
         var peer_rank_of_node = List[Int]()
@@ -838,6 +1053,10 @@ def _bootstrap(
     var rank_at = List[Int]()
     for i in range(len(topo.rank_at)):
         rank_at.append(topo.rank_at[i])
+    # Read before `lib` is moved into the state. The NVLS grid must be
+    # entirely resident (see `nvls_blocks`), so it is a function of this
+    # device's SM count, not a constant.
+    var nvls_grid = nvls_blocks(sm_count(lib, ordinal))
     var state = CommState(
         rank=rank,
         world=nranks,
@@ -858,6 +1077,10 @@ def _bootstrap(
         arena_cap=arena_cap,
         arena_stride=arena_stride,
         nslots=INBOX_SLOTS,
+        nvls=nvls^,
+        nvls_on=use_nvls,
+        nvls_grid=nvls_grid,
+        nvls_min=_nvls_min_bytes(),
     )
     var handle_ptr = unsafe_alloc[CommState](1)
     handle_ptr.unsafe_write(state^)
@@ -911,10 +1134,16 @@ def ncclCommDestroy(comm: Int64) abi("C") -> Int32:
             _drain_all_streams(state)
             state.ctx.synchronize()
             ib_teardown(state.ib)
-            for r in range(state.local_world):
-                if r != state.local_rank:
-                    close_handle(state.driver, state.regions[r])
-            free_region(state.driver, state.owned_base)
+            if state.nvls_on:
+                # One call releases the peer mappings, both of my own, the
+                # multicast binding and every handle; there is no cuIpc
+                # mapping and no cuMemAlloc block to free.
+                nvls_teardown(state.nvls, state.driver, state.ordinal)
+            else:
+                for r in range(state.local_world):
+                    if r != state.local_rank:
+                        close_handle(state.driver, state.regions[r])
+                free_region(state.driver, state.owned_base)
         return NCCL_SUCCESS
     except:
         return NCCL_INTERNAL_ERROR
@@ -960,13 +1189,11 @@ def ncclCommGetAsyncError(
         # and this is the one call site that needs a *fresh* wrap or the
         # comm's own default stream depending on whether a collective has
         # run yet, which does not fit the single-handle cache lookup below.
-        var s = (
-            state.ctx.create_external_stream(
-                OpaquePointer[MutAnyOrigin](unsafe_from_address=Int(state.last_stream))
+        var s = state.ctx.create_external_stream(
+            OpaquePointer[MutAnyOrigin](
+                unsafe_from_address=Int(state.last_stream)
             )
-            if state.last_stream != 0
-            else DeviceStream(state.ctx)
-        )
+        ) if state.last_stream != 0 else DeviceStream(state.ctx)
         s.synchronize()
         # One error word per pipeline arena: a multi-node allreduce spreads
         # its chunks over all of them, and a barrier that gave up did so in
@@ -1209,6 +1436,57 @@ def _exchange_consume[
     ib_note_consumed(state.ib, seq)
 
 
+def _do_allreduce_nvls[
+    dtype: DType
+](
+    mut state: CommState,
+    stream: DeviceStream,
+    sendbuff: Int,
+    recvbuff: Int,
+    count: Int,
+    scale: Float32,
+) raises:
+    """The single-node allreduce through the NVSwitch.
+
+    Chunked by the region, then pipelined inside the kernel: `chunk` here is
+    "what fits the staging half", `nvls_chunk_bytes` is the much smaller unit
+    the kernel overlaps copy-in / reduce / copy-out over.
+
+    The flag counter is advanced by exactly what the kernel will consume, on
+    the host, before the launch -- the kernel gets the value its FIRST barrier
+    waits for and walks up from there, so back-to-back calls on one stream
+    never reuse a target.
+    """
+    comptime item = size_of[dtype]()
+    var world = state.local_world
+    # A chunk is padded up to whole per-rank 16-byte slices, so the largest
+    # message a staging half holds is a whole number of them.
+    var max_elems = (state.cap_bytes // 16) // world * world * (16 // item)
+    var done = 0
+    while done < count:
+        var chunk = min(max_elems, count - done)
+        var cv = nvls_chunk_vecs(nvls_chunk_bytes(chunk * item), world)
+        var target = (state.nvls_bars + 1) * world
+        state.nvls_bars += nvls_barriers_per_call(chunk, world, item, cv)
+        nvls_allreduce[dtype](
+            state.ctx,
+            stream,
+            state.local_rank,
+            world,
+            state.nvls.mc,
+            state.owned_base,
+            sendbuff + done * item,
+            recvbuff + done * item,
+            chunk,
+            state.cap_bytes,
+            scale,
+            target,
+            state.nvls_grid,
+            cv,
+        )
+        done += chunk
+
+
 def _do_allreduce[
     dtype: DType
 ](
@@ -1222,6 +1500,19 @@ def _do_allreduce[
 ) raises:
     comptime item = size_of[dtype]()
     if state.nnodes == 1:
+        comptime if not dtype.is_integral():
+            # NVLS: above the measured crossover the switch's own reduction
+            # engine moves 1.75x fewer NVLink bytes than the unicast
+            # push/reduce/pull, and wins by 4% at 48 MiB growing to 23% at
+            # 512 MiB. Below it the extra HBM staging dominates and the
+            # unicast kernel keeps the traffic. int32/int64 stay unicast --
+            # `multimem.ld_reduce` has no integer add this schedule can use
+            # and integer allreduces are never the bucket that matters.
+            if state.nvls_on and count * item >= state.nvls_min:
+                _do_allreduce_nvls[dtype](
+                    state, stream, sendbuff, recvbuff, count, scale
+                )
+                return
         var max_elems = max(1, state.cap_bytes // item)
         var done = 0
         while done < count:
@@ -1249,9 +1540,7 @@ def _do_allreduce[
     # while the proxy exchanges this one. `depth <= narenas` is what keeps
     # chunk k+narenas's reduce-scatter enqueued AFTER chunk k's all-gather,
     # which is what the arena's start barrier needs to order the reuse.
-    var chunk_elems = max(
-        1, _pipeline_chunk_bytes(state, count * item) // item
-    )
+    var chunk_elems = max(1, _pipeline_chunk_bytes(state, count * item) // item)
     var nchunks = (count + chunk_elems - 1) // chunk_elems
     var depth = min(state.narenas, nchunks)
     # Two generations per chunk, reserved up front, so each chunk's
@@ -1341,23 +1630,53 @@ def ncclAllReduce(
             scale = Float32(1.0) / Float32(state.world)
         if datatype == NCCL_INT32:
             _do_allreduce[DType.int32](
-                state, s, stream, Int(sendbuff), Int(recvbuff), Int(count), scale
+                state,
+                s,
+                stream,
+                Int(sendbuff),
+                Int(recvbuff),
+                Int(count),
+                scale,
             )
         elif datatype == NCCL_INT64:
             _do_allreduce[DType.int64](
-                state, s, stream, Int(sendbuff), Int(recvbuff), Int(count), scale
+                state,
+                s,
+                stream,
+                Int(sendbuff),
+                Int(recvbuff),
+                Int(count),
+                scale,
             )
         elif datatype == NCCL_FLOAT16:
             _do_allreduce[DType.float16](
-                state, s, stream, Int(sendbuff), Int(recvbuff), Int(count), scale
+                state,
+                s,
+                stream,
+                Int(sendbuff),
+                Int(recvbuff),
+                Int(count),
+                scale,
             )
         elif datatype == NCCL_FLOAT32:
             _do_allreduce[DType.float32](
-                state, s, stream, Int(sendbuff), Int(recvbuff), Int(count), scale
+                state,
+                s,
+                stream,
+                Int(sendbuff),
+                Int(recvbuff),
+                Int(count),
+                scale,
             )
         else:  # NCCL_BFLOAT16, ruled in by _dtype_item_bytes above
             _do_allreduce[DType.bfloat16](
-                state, s, stream, Int(sendbuff), Int(recvbuff), Int(count), scale
+                state,
+                s,
+                stream,
+                Int(sendbuff),
+                Int(recvbuff),
+                Int(count),
+                scale,
             )
         return NCCL_SUCCESS
     except e:
@@ -1412,7 +1731,13 @@ def ncclBroadcast(
                 done += chunk
             return NCCL_SUCCESS
         _broadcast_multinode(
-            state, s, stream, Int(sendbuff), Int(recvbuff), total_bytes, Int(root)
+            state,
+            s,
+            stream,
+            Int(sendbuff),
+            Int(recvbuff),
+            total_bytes,
+            Int(root),
         )
         return NCCL_SUCCESS
     except e:
@@ -1475,7 +1800,9 @@ def _broadcast_multinode(
         var inbox_base = _inbox_base(state, seq)
         var recv_slot = 0
         if receives:
-            recv_slot = root_node if root_node < state.my_node else root_node - 1
+            recv_slot = (
+                root_node if root_node < state.my_node else root_node - 1
+            )
         var send_ptr = recvbuff + done
         # Everyone in this local_rank group exchanges; only the root's
         # payload is real (see EMPTY_SHARD_BYTES).
@@ -1496,9 +1823,7 @@ def _broadcast_multinode(
             send_bytes = chunk
             send_ptr = sendbuff + done
         elif receives:
-            flush_addr = (
-                state.owned_base + inbox_base + recv_slot * slot_bytes
-            )
+            flush_addr = state.owned_base + inbox_base + recv_slot * slot_bytes
             send_ptr = flush_addr
         ib_enqueue_request(
             state.ib,
@@ -1660,7 +1985,13 @@ def _allgather_multinode(
         # Unpipelined, like broadcast: one exchange, waited for in place.
         ib_enqueue_wait(state.ib, state.ctx, stream, seq)
         _place_node_block(
-            state, stream, recvbuff, block_stage, state.my_node, chunk, done,
+            state,
+            stream,
+            recvbuff,
+            block_stage,
+            state.my_node,
+            chunk,
+            done,
             per_rank_bytes,
         )
         var slot = 0

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -180,6 +180,13 @@ comptime PIPE_MAX_CHUNKS = 16
 # It also keeps a chunk's shard above 1 MiB, where the RDMA is still at line
 # rate, without a second clause: at K > 1 the shard is sqrt(B * 640000 / L)
 # bytes, 1.5 MB at the 27 MiB bucket and 3.8 MB at 168 MiB.
+#
+# Measured, not assumed: halving this to 320_000 (K of 3/8/14 instead of
+# 2/5/10 at 27/168/512 MiB) is WORSE -- 27 MiB unchanged, 168 MiB 1291 vs
+# 1192 us and 512 MiB 3648 vs 3541, 16 ranks on 2x8 H100, ABBA against the
+# same base commit in one job (234242 against 234237). The per-exchange
+# latency an extra chunk adds is not fully hidden, so splitting past the
+# point where the network is covered only buys launches.
 comptime PIPE_SPLIT_UNIT = 640_000
 
 comptime DEFAULT_REGION_MB = 256

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -129,13 +129,13 @@ comptime NCCL_AVG: Int32 = 4
 # Every exchange is all-to-all among the ranks sharing a local_rank, even
 # when only one of them has data (a broadcast, or an allreduce whose shard
 # table leaves this rank empty), and that is a correctness requirement, not
-# tidiness. The inbox is double buffered by the exchange counter's parity,
-# so what has to be true is: peer B's write for exchange e+2 lands after MY
-# add kernel for exchange e has read that half. All-to-all makes it a proof
-# -- B cannot post e+2 before its callback for e+1 returned, which needed MY
-# e+1 message, which my stream sent only after running my add kernel for e.
-# Let one exchange be one-directional and that chain breaks, leaving nothing
-# but a timing margin between B's write and my read.
+# tidiness. The inbox is double buffered by the exchange counter's parity
+# (`_inbox_base`), so what has to be true is: peer B's write for exchange
+# e+2 lands after MY add kernel for exchange e has read that half. All-to-all
+# makes it a proof -- B cannot post e+2 before its callback for e+1 returned,
+# which needed MY e+1 message, which my stream sent only after running my add
+# kernel for e. Let one exchange be one-directional and that chain breaks,
+# leaving nothing but a timing margin between B's write and my read.
 comptime CREDIT_BYTES = 16
 
 comptime DEFAULT_REGION_MB = 256
@@ -564,11 +564,13 @@ def _bootstrap(
     # [signal | stage_in | stage_out]: everything the network touches --
     # the inbox the peers RDMA into, and the staging broadcast and
     # allgather need because user buffers are not registered -- lives
-    # there and nowhere else. Aliasing it onto stage_in would have been
-    # free in memory and wrong in fact: a peer node writes my inbox as
-    # soon as ITS reduce-scatter is done, which is not ordered against
-    # MY reduce-scatter still using stage_in, nor against a local peer
-    # still reading the previous generation's staging. A single-node
+    # there and nowhere else, carved as
+    # [staging: cap/2 | inbox half0: cap/4 | inbox half1: cap/4]
+    # (`_inbox_base`). Aliasing it onto stage_in would have been free in
+    # memory and wrong in fact: a peer node writes my inbox as soon as ITS
+    # reduce-scatter is done, which is not ordered against MY
+    # reduce-scatter still using stage_in, nor against a local peer still
+    # reading the previous generation's staging. A single-node
     # communicator allocates none of it and keeps exactly the old
     # region.
     var net_bytes = cap_bytes if topo.nnodes > 1 else 0
@@ -807,11 +809,10 @@ def _inter_node_exchange[
     kernel that adds what arrived. On exit the shard holds the sum over the
     WHOLE communicator, ready for `allgather_finish`.
 
-    Inbox geometry is derived from `(numel, local_world, item)` alone so that
-    a sender computes the same addresses as its receiver: `net_off` holds two
-    halves of `(nnodes-1)` slots of one shard each, and the exchange
-    counter's parity picks the half. `_max_chunk_bytes` keeps both halves
-    inside the area.
+    Slot geometry is derived from `(numel, local_world, item)` alone so that
+    a sender computes the same addresses as its receiver: a half holds
+    `(nnodes-1)` slots of one shard each, at the fixed base `_inbox_base`
+    picks by parity. `_max_chunk_bytes` keeps a half inside its quarter.
     """
     comptime item = size_of[dtype]()
     var sr = shard_range(numel, state.local_world, state.local_rank, item)
@@ -821,13 +822,12 @@ def _inter_node_exchange[
     var npeers = ib_npeers(state.ib)
     var nbytes = cnt_e * item
     var slot_bytes = _align_up(max(nbytes, CREDIT_BYTES), 16)
-    var half = npeers * slot_bytes
-    if 2 * half > state.cap_bytes:
+    if npeers * slot_bytes > _inbox_half_bytes(state):
         raise Error(
             "mojoccl: the inter-node inbox overflows the network area; this"
             " is a chunking bug"
         )
-    var inbox_base = state.net_off + (seq & 1) * half
+    var inbox_base = _inbox_base(state, seq)
     var shard = (
         state.owned_base + signal_bytes() + state.cap_bytes + off_e * item
     )
@@ -862,19 +862,52 @@ def _inter_node_exchange[
         )
 
 
-def _max_chunk_bytes(state: CommState) -> Int:
-    """Largest chunk whose staging and inbox both fit in stage_in.
+def _inbox_half_bytes(state: CommState) -> Int:
+    """Bytes each parity half of the inbox may hold. See `_inbox_base`."""
+    return state.cap_bytes // 4
 
-    A chunk of `B` bytes puts `B/L` bytes in each of the `2(N-1)` inbox
-    slots, so `B <= cap * L / (2(N-1))`, less a page of alignment slop --
+
+def _inbox_base(state: CommState, seq: Int) -> Int:
+    """Region offset of exchange `seq`'s inbox half.
+
+    FIXED, not derived from the message: the network area is carved once as
+    `[staging: cap/2 | half0: cap/4 | half1: cap/4]` and the exchange
+    counter's parity picks a half.
+
+    That the halves do not move is what makes the double buffer a proof
+    rather than a timing margin. Sizing a half from the current message --
+    which is what this used to do -- kept e and e+2 apart but let e and e+1
+    OVERLAP whenever consecutive exchanges had different geometry, and DDP
+    produces exactly that: a 4-byte AVG allreduce (slot 16 B, half 16 B)
+    next to a 27 MiB bucket (half 3.4 MiB) put the small exchange's half 1
+    at `net_off+16` and the big one's half 0 at `net_off+0`. Nothing orders
+    a peer's e+1 write against MY e add kernel -- the peer's e+1 send is
+    gated on its own e completing, not on my consumption -- so the overlap
+    is a silent data race on the inbox, and mixing collectives (an
+    allreduce's half 0 at `net_off` against a broadcast's staged chunk,
+    also at `net_off`) is the same bug once more.
+    """
+    return (
+        state.net_off
+        + state.cap_bytes // 2
+        + (seq & 1) * _inbox_half_bytes(state)
+    )
+
+
+def _max_chunk_bytes(state: CommState) -> Int:
+    """Largest allreduce chunk whose inbox half fits.
+
+    A chunk of `B` bytes puts `B/L` bytes in each of the `N-1` slots of one
+    half, so `B <= (cap/4) * L / (N-1)`, less a page of alignment slop --
     and never more than `cap`, which the intra-node kernels require anyway.
     At the shapes DDP produces (27 MiB buckets against a 256 MiB region)
-    the cap never binds: 256 MiB at 2 nodes, 146 MiB at 8.
+    the cap never binds: 256 MiB at 2 nodes, 73 MiB at 8.
     """
     if state.nnodes <= 1:
         return state.cap_bytes
-    var denom = 2 * (state.nnodes - 1)
-    var b = (state.cap_bytes * state.local_world // denom) - 2 * 4096
+    var b = (
+        _inbox_half_bytes(state) * state.local_world // (state.nnodes - 1)
+    ) - 2 * 4096
     b = min(b, state.cap_bytes)
     if b < 4096:
         return 4096
@@ -1088,23 +1121,27 @@ def _broadcast_multinode(
     var i_am_root = state.rank == root
     var i_am_local_root = state.local_rank == root_lr
     var receives = i_am_local_root and state.my_node != root_node
-    # The network area holds the root's staged chunk plus both inbox halves,
-    # and a half is one slot PER PEER now that the exchange is all-to-all.
+    # The root's staged chunk goes in the network area's staging half; a
+    # peer slot has to fit an inbox quarter, one slot PER PEER now that the
+    # exchange is all-to-all.
     var npeers = ib_npeers(state.ib)
     var max_bytes = max(
         4096,
-        (state.cap_bytes // (1 + 2 * npeers) - 2 * 4096) // 4096 * 4096,
+        (
+            min(state.cap_bytes // 2, _inbox_half_bytes(state) // npeers)
+            - 2 * 4096
+        )
+        // 4096
+        * 4096,
     )
     var done = 0
     while done < total_bytes:
         var chunk = min(max_bytes, total_bytes - done)
         var seq = ib_next_seq(state.ib)
         var slot_bytes = _align_up(chunk, 16)
-        var inbox_off = state.net_off + _align_up(chunk, 4096)
-        var half = npeers * slot_bytes
-        if inbox_off + 2 * half > state.net_off + state.cap_bytes:
+        if npeers * slot_bytes > _inbox_half_bytes(state):
             raise Error("mojoccl: broadcast inbox does not fit; chunking bug")
-        var inbox_base = inbox_off + (seq & 1) * half
+        var inbox_base = _inbox_base(state, seq)
         var recv_slot = 0
         if receives:
             recv_slot = root_node if root_node < state.my_node else root_node - 1
@@ -1236,10 +1273,12 @@ def _allgather_multinode(
     var lw = state.local_world
     var npeers = ib_npeers(state.ib)
     var block_stage = state.owned_base + state.net_off
-    # The network area holds one node block (lw * chunk) plus both inbox
-    # halves (npeers node blocks each).
-    var denom = lw * (1 + 2 * npeers)
-    var max_bytes = max(16, (state.cap_bytes // denom - 8192) // 16 * 16)
+    # One node block (lw * chunk) in the staging half; an inbox quarter has
+    # to hold npeers of them.
+    var max_block = min(
+        state.cap_bytes // 2, _inbox_half_bytes(state) // npeers
+    )
+    var max_bytes = max(16, ((max_block - 8192) // lw) // 16 * 16)
     var done = 0
     while done < per_rank_bytes:
         var chunk = min(max_bytes, per_rank_bytes - done)
@@ -1260,11 +1299,9 @@ def _allgather_multinode(
         var seq = ib_next_seq(state.ib)
         var block = lw * chunk
         var slot_bytes = _align_up(block, 16)
-        var inbox_off = state.net_off + _align_up(block, 4096)
-        var half = npeers * slot_bytes
-        if inbox_off + 2 * half > state.net_off + state.cap_bytes:
+        if npeers * slot_bytes > _inbox_half_bytes(state):
             raise Error("mojoccl: allgather inbox does not fit; chunking bug")
-        var inbox_base = inbox_off + (seq & 1) * half
+        var inbox_base = _inbox_base(state, seq)
         ib_enqueue(
             state.ib,
             state.driver,

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -11,20 +11,39 @@
 # tests/ddp_worker.py skips the checks that need them when
 # TORCH_MOJO_BACKEND_CCL=mojo is set).
 #
-# One process per GPU, one region per rank, raw driver-owned memory shared
-# with legacy IPC (driver.mojo) -- MAX's own allocator memory cannot be
-# exported that way (see docs/mojo_collectives_feasibility.md in the main
-# worktree, §5.6). Bootstrap (the handle exchange ncclCommInitRank itself
-# must do) rides a /dev/shm directory encoded in the 128-byte unique id
-# (bootstrap.mojo); the collectives are the STAND-IN kernel
-# (collectives_kernels.mojo), swapped out wholesale once the production
-# kernel lands.
+# One process per GPU. Within a node, one region per rank of raw
+# driver-owned memory shared with legacy IPC (driver.mojo) -- MAX's own
+# allocator memory cannot be exported that way (see
+# docs/mojo_collectives_feasibility.md, section 5.6) -- and the collectives
+# of collectives_kernels.mojo run over the peer mappings. Across nodes,
+# GPUDirect RDMA written here over libibverbs (ibverbs.mojo,
+# internode.mojo): no vendor collective library takes part at any level.
+#
+# A multi-node communicator runs each collective hierarchically:
+#
+#   allreduce  reduce_scatter_stage (node-local)  ->  one RDMA exchange of
+#              this rank's 1/local_world shard with the SAME local_rank on
+#              every other node, summed by inbox_add  ->  allgather_finish
+#   broadcast  root stages and RDMA-writes to its same-local_rank peers,
+#              then every node runs the node-local broadcast from its own
+#              local root
+#   allgather  node-local allgather into a node block, one RDMA exchange of
+#              node blocks, then place each block by GLOBAL rank (read out
+#              of the bootstrap table, not assumed to be
+#              node * local_world + local_rank)
+#
+# Broadcast and allgather run once at init and are written for clarity
+# rather than speed; allreduce is the one the DDP step waits on.
+#
+# Single-node communicators never touch libibverbs at all -- same fused
+# kernels, same numbers as before this file learned about nodes.
 
 from std.collections import Dict
 from std.ffi import OwnedDLHandle
 from std.gpu import global_idx
 from std.memory.alloc import unsafe_alloc
 from std.os import getenv
+from std.sys import size_of
 from std.utils import StaticTuple
 from max.gpu.host import DeviceContext, DeviceBuffer, DeviceStream
 
@@ -40,25 +59,42 @@ from driver import (
 )
 from bootstrap import (
     UID_BYTES,
-    create_rendezvous_dir,
-    decode_dir,
-    encode_dir,
-    read_rank_handle,
-    remove_rendezvous_dir,
-    wait_for_done,
-    wait_for_rank,
-    write_rank_done,
-    write_rank_handle,
+    BootstrapConn,
+    bootstrap_allgather,
+    bootstrap_barrier,
+    bootstrap_connect,
+    derive_topology,
+    host_hash,
+    make_unique_id,
 )
 from collectives_kernels import (
     MAX_WORLD,
     allgather,
+    allgather_finish,
     allreduce,
     broadcast,
     error_offset,
     region_init,
+    reduce_scatter_stage,
+    shard_range,
     signal_bytes,
 )
+from internode import (
+    IB_BLOB_BYTES,
+    MAX_NODES,
+    ib_connect,
+    ib_enqueue,
+    ib_error,
+    ib_local_info,
+    ib_next_seq,
+    ib_npeers,
+    ib_port_lid,
+    ib_port_mtu,
+    ib_setup,
+    ib_teardown,
+)
+from internode_kernels import copy_bytes, inbox_add, place_blocks
+
 
 # ncclResult_t (nccl.h.in:44-53)
 comptime NCCL_SUCCESS: Int32 = 0
@@ -149,9 +185,12 @@ def _any_dtype_item_bytes(nccl_dtype: Int32) -> Int:
 # Communicator state, behind the opaque `ncclComm_t` (void*) every exported
 # function after ncclCommInitRank receives. Heap-allocated once per
 # communicator and never freed on destroy (the struct itself is a few
-# hundred bytes; only the GPU region and peer IPC mappings -- the resources
-# that matter -- are released there). `regions` is padded to MAX_WORLD with
-# zeros; only indices < world are ever read.
+# hundred bytes; only the GPU region, the peer IPC mappings and the IB
+# resources -- the ones that matter -- are released there).
+#
+# `regions` is indexed by LOCAL rank and padded to MAX_WORLD with zeros:
+# only same-node peers are IPC-mapped, and a node contributes at most
+# MAX_WORLD ranks however large the communicator is.
 # ---------------------------------------------------------------------------
 
 
@@ -168,6 +207,13 @@ struct CommState(Movable):
     var last_stream: Int64
     var aborted: Bool
     var stream_cache: Dict[Int64, DeviceStream]
+    var local_rank: Int
+    var local_world: Int
+    var my_node: Int
+    var nnodes: Int
+    var rank_at: List[Int]
+    var ib: Int
+    var net_off: Int
 
     def __init__(
         out self,
@@ -179,6 +225,13 @@ struct CommState(Movable):
         cap_bytes: Int,
         regions: StaticTuple[Int, MAX_WORLD],
         owned_base: Int,
+        local_rank: Int,
+        local_world: Int,
+        my_node: Int,
+        nnodes: Int,
+        var rank_at: List[Int],
+        ib: Int,
+        net_off: Int,
     ):
         self.rank = rank
         self.world = world
@@ -192,6 +245,18 @@ struct CommState(Movable):
         self.last_stream = 0
         self.aborted = False
         self.stream_cache = Dict[Int64, DeviceStream]()
+        self.local_rank = local_rank
+        self.local_world = local_world
+        self.my_node = my_node
+        self.nnodes = nnodes
+        self.rank_at = rank_at^
+        self.ib = ib
+        self.net_off = net_off
+
+
+@always_inline
+def _align_up(x: Int, a: Int) -> Int:
+    return (x + a - 1) // a * a
 
 
 @always_inline
@@ -326,8 +391,7 @@ def ncclGetErrorString(
 @export
 def ncclGetUniqueId(uid_out: Pointer[UInt8, MutAnyOrigin]) abi("C") -> Int32:
     try:
-        var dir = create_rendezvous_dir()
-        encode_dir(dir, uid_out)
+        make_unique_id(uid_out)
         return NCCL_SUCCESS
     except e:
         return NCCL_SYSTEM_ERROR
@@ -379,9 +443,7 @@ def ncclCommInitRank(
     # end. Guard explicitly rather than rely on StaticTuple's own bounds
     # check, whose behavior under a release (non-debug) build is not this
     # library's contract to depend on.
-    if Int(nranks) > MAX_WORLD or Int(nranks) < 1:
-        return NCCL_INVALID_ARGUMENT
-    if Int(rank) < 0 or Int(rank) >= Int(nranks):
+    if Int(nranks) < 1 or Int(rank) < 0 or Int(rank) >= Int(nranks):
         return NCCL_INVALID_ARGUMENT
     try:
         var idbuf = unsafe_alloc[UInt8](UID_BYTES)
@@ -402,109 +464,176 @@ def ncclCommInitRank(
         idbuf64[unsafe_offset=13] = id13
         idbuf64[unsafe_offset=14] = id14
         idbuf64[unsafe_offset=15] = id15
-        var dir = decode_dir(_any(idbuf))
-
-        # Everything below either succeeds together or is unwound together:
-        # a failure past this point (region alloc, handle exchange, the
-        # peer-open loop, the done-marker wait) is caught here so rank 0 can
-        # remove the rendezvous directory it created in ncclGetUniqueId --
-        # otherwise it and every rank's handle/done file leak in /dev/shm
-        # forever, since no other rank will ever revisit this path.
-        try:
-            var lib = open_driver()
-            var ordinal = current_device_ordinal(lib)
-            var ctx = DeviceContext(device_id=ordinal)
-
-            var cap_bytes = _region_cap_bytes()
-            # A positive multiple of 4096 (the production kernel's own
-            # precondition, RESULTS.md §9) is what keeps every per-chunk
-            # offset `ncclAllReduce` forms (multiples of cap_bytes, one full
-            # chunk at a time) 16-byte aligned for every supported dtype --
-            # 4096 divides evenly by 2, 4 and 8. A misconfigured
-            # MOJOCCL_REGION_MB (e.g. 0) would otherwise degrade chunk
-            # offsets to non-16-byte-aligned single-element steps.
-            if cap_bytes <= 0 or cap_bytes % 4096 != 0:
-                if Int(rank) == 0:
-                    try:
-                        remove_rendezvous_dir(dir, Int(nranks))
-                    except:
-                        pass
-                return NCCL_INVALID_ARGUMENT
-            var region_bytes = signal_bytes() + 2 * cap_bytes
-            var base = alloc_region(lib, region_bytes)
-            region_init(ctx, base)
-
-            var my_handle = unsafe_alloc[UInt8](HANDLE_BYTES)
-            get_handle(lib, base, _any(my_handle))
-            write_rank_handle(dir, Int(rank), ordinal, _any(my_handle))
-
-            var timeout_s = _bootstrap_timeout_s()
-            var regions = StaticTuple[Int, MAX_WORLD](fill=0)
-            regions[Int(rank)] = base
-            var peer_handle = unsafe_alloc[UInt8](HANDLE_BYTES)
-            for r in range(Int(nranks)):
-                if r == Int(rank):
-                    continue
-                try:
-                    wait_for_rank(dir, r, timeout_s)
-                    _ = read_rank_handle(dir, r, _any(peer_handle))
-                    regions[r] = open_handle(lib, _any(peer_handle))
-                except:
-                    # A peer past this one never got opened: close whatever
-                    # peers < r WERE opened and free our own region before
-                    # propagating, so a failed init leaks no IPC mappings.
-                    for r2 in range(Int(nranks)):
-                        if r2 != Int(rank) and regions[r2] != 0:
-                            try:
-                                close_handle(lib, regions[r2])
-                            except:
-                                pass
-                    try:
-                        free_region(lib, base)
-                    except:
-                        pass
-                    raise
-
-            # Done protocol: every rank marks itself done once it has opened
-            # every peer's handle; rank 0 (and only rank 0) waits for all
-            # `nranks` markers and then removes `dir` -- otherwise
-            # /dev/shm/mojoccl-* directories and their per-rank handle files
-            # accumulate forever on a shared node (mkdtemp never cleans up
-            # after itself). Other ranks return as soon as their own marker
-            # is written; they do not wait for the directory to disappear.
-            write_rank_done(dir, Int(rank))
-            if Int(rank) == 0:
-                for r in range(Int(nranks)):
-                    if r != 0:
-                        wait_for_done(dir, r, timeout_s)
-                try:
-                    remove_rendezvous_dir(dir, Int(nranks))
-                except:
-                    pass  # a leftover /dev/shm dir is a nuisance, not a correctness bug
-
-            var state = CommState(
-                rank=Int(rank),
-                world=Int(nranks),
-                ordinal=ordinal,
-                ctx=ctx,
-                driver=lib^,
-                cap_bytes=cap_bytes,
-                regions=regions,
-                owned_base=base,
-            )
-            var handle_ptr = unsafe_alloc[CommState](1)
-            handle_ptr.unsafe_write(state^)
-            comm_out[] = Int64(Int(handle_ptr))
-            return NCCL_SUCCESS
-        except:
-            if Int(rank) == 0:
-                try:
-                    remove_rendezvous_dir(dir, Int(nranks))
-                except:
-                    pass
-            raise
-    except:
+        return _init_rank(_any(idbuf), Int(rank), Int(nranks), comm_out)
+    except e:
+        print("mojoccl: ncclCommInitRank failed:", e)
         return NCCL_INTERNAL_ERROR
+
+
+def _init_rank(
+    uid: Pointer[UInt8, MutAnyOrigin],
+    rank: Int,
+    nranks: Int,
+    comm_out: Pointer[Int64, MutAnyOrigin],
+) raises -> Int32:
+    """Three bootstrap rounds and everything they gate.
+
+    Round 1 gathers host identity, from which every rank derives the same
+    node/local_rank table. Round 2 gathers the 64-byte IPC handle plus, on a
+    multi-node communicator, this rank's IB connection data. Round 3 is a
+    barrier: past it every peer's region is zeroed, its IPC handles are open
+    and its queue pairs are in RTS, so the first collective may write into
+    it.
+    """
+    var timeout_s = _bootstrap_timeout_s()
+    var conn = bootstrap_connect(uid, rank, nranks, timeout_s)
+
+    # Round 1: host identity.
+    var b1 = unsafe_alloc[UInt8](16)
+    var b1w = b1.unsafe_bitcast[UInt64]()
+    b1w[unsafe_offset=0] = host_hash()
+    b1w[unsafe_offset=1] = UInt64(rank)
+    var t1 = unsafe_alloc[UInt8](16 * nranks)
+    bootstrap_allgather(conn, _any(b1), 16, _any(t1), timeout_s)
+    var t1w = t1.unsafe_bitcast[UInt64]()
+    var hashes = List[UInt64]()
+    for r in range(nranks):
+        hashes.append(t1w[unsafe_offset = 2 * r])
+    var topo = derive_topology(hashes, rank)
+    if topo.local_world > MAX_WORLD:
+        conn.close()
+        raise Error(
+            "mojoccl: "
+            + String(topo.local_world)
+            + " ranks on one node, but the intra-node kernels are built for at"
+            " most "
+            + String(MAX_WORLD)
+        )
+    if topo.nnodes > MAX_NODES:
+        conn.close()
+        raise Error(
+            "mojoccl: " + String(topo.nnodes) + " nodes exceeds the "
+            + String(MAX_NODES) + "-node limit of the inbox layout"
+        )
+
+    var lib = open_driver()
+    var ordinal = current_device_ordinal(lib)
+    var ctx = DeviceContext(device_id=ordinal)
+    var cap_bytes = _region_cap_bytes()
+    # A positive multiple of 4096 (the kernels' own precondition,
+    # RESULTS.md section 9) is what keeps every per-chunk offset the
+    # collectives form 16-byte aligned for every supported dtype.
+    if cap_bytes <= 0 or cap_bytes % 4096 != 0:
+        conn.close()
+        raise Error("mojoccl: MOJOCCL_REGION_MB must be a positive 4 KiB multiple")
+    # A multi-node communicator gets a third cap-sized area on top of
+    # [signal | stage_in | stage_out]: everything the network touches --
+    # the inbox the peers RDMA into, and the staging broadcast and
+    # allgather need because user buffers are not registered -- lives
+    # there and nowhere else. Aliasing it onto stage_in would have been
+    # free in memory and wrong in fact: a peer node writes my inbox as
+    # soon as ITS reduce-scatter is done, which is not ordered against
+    # MY reduce-scatter still using stage_in, nor against a local peer
+    # still reading the previous generation's staging. A single-node
+    # communicator allocates none of it and keeps exactly the old
+    # region.
+    var net_bytes = cap_bytes if topo.nnodes > 1 else 0
+    var net_off = signal_bytes() + 2 * cap_bytes
+    var region_bytes = net_off + net_bytes
+    var base = alloc_region(lib, region_bytes)
+    region_init(ctx, base)
+
+    var ib = 0
+    if topo.nnodes > 1:
+        ib = ib_setup(
+            lib,
+            ordinal,
+            topo.my_local_rank,
+            topo.my_node,
+            topo.nnodes,
+            base,
+            region_bytes,
+        )
+
+    # Round 2: IPC handle + IB connection data.
+    comptime BLOB2 = HANDLE_BYTES + IB_BLOB_BYTES
+    var b2 = unsafe_alloc[UInt8](BLOB2)
+    for i in range(BLOB2):
+        b2[unsafe_offset=i] = 0
+    get_handle(lib, base, _any(b2))
+    var my_lid = 0
+    var my_mtu = 0
+    if ib != 0:
+        my_lid = ib_port_lid(ib)
+        my_mtu = ib_port_mtu(ib)
+        ib_local_info(
+            ib,
+            Pointer[UInt8, MutAnyOrigin](
+                unsafe_from_address=Int(b2) + HANDLE_BYTES
+            ),
+            my_lid,
+            my_mtu,
+        )
+    var t2 = unsafe_alloc[UInt8](BLOB2 * nranks)
+    bootstrap_allgather(conn, _any(b2), BLOB2, _any(t2), timeout_s)
+
+    # Same-node peers only: an IPC handle from another host is meaningless.
+    var regions = StaticTuple[Int, MAX_WORLD](fill=0)
+    regions[topo.my_local_rank] = base
+    for r in range(nranks):
+        if topo.node_of[r] != topo.my_node or r == rank:
+            continue
+        var lr = topo.local_rank_of[r]
+        regions[lr] = open_handle(
+            lib,
+            Pointer[UInt8, MutAnyOrigin](
+                unsafe_from_address=Int(t2) + r * BLOB2
+            ),
+        )
+
+    if ib != 0:
+        var peer_rank_of_node = List[Int]()
+        for j in range(topo.nnodes):
+            peer_rank_of_node.append(
+                topo.rank_at[j * topo.local_world + topo.my_local_rank]
+            )
+        ib_connect(
+            ib,
+            Pointer[UInt8, MutAnyOrigin](
+                unsafe_from_address=Int(t2) + HANDLE_BYTES
+            ),
+            BLOB2,
+            peer_rank_of_node,
+            my_mtu,
+        )
+
+    bootstrap_barrier(conn, timeout_s)
+    conn.close()
+
+    var rank_at = List[Int]()
+    for i in range(len(topo.rank_at)):
+        rank_at.append(topo.rank_at[i])
+    var state = CommState(
+        rank=rank,
+        world=nranks,
+        ordinal=ordinal,
+        ctx=ctx,
+        driver=lib^,
+        cap_bytes=cap_bytes,
+        regions=regions,
+        owned_base=base,
+        local_rank=topo.my_local_rank,
+        local_world=topo.local_world,
+        my_node=topo.my_node,
+        nnodes=topo.nnodes,
+        rank_at=rank_at^,
+        ib=ib,
+        net_off=net_off,
+    )
+    var handle_ptr = unsafe_alloc[CommState](1)
+    handle_ptr.unsafe_write(state^)
+    comm_out[] = Int64(Int(handle_ptr))
+    return NCCL_SUCCESS
 
 
 # ---------------------------------------------------------------------------
@@ -519,8 +648,9 @@ def ncclCommDestroy(comm: Int64) abi("C") -> Int32:
         ref state = ptr[]
         if not state.aborted:
             state.ctx.synchronize()
-            for r in range(state.world):
-                if r != state.rank:
+            ib_teardown(state.ib)
+            for r in range(state.local_world):
+                if r != state.local_rank:
                     close_handle(state.driver, state.regions[r])
             free_region(state.driver, state.owned_base)
         return NCCL_SUCCESS
@@ -531,10 +661,11 @@ def ncclCommDestroy(comm: Int64) abi("C") -> Int32:
 @export
 def ncclCommAbort(comm: Int64) abi("C") -> Int32:
     ref state = _comm_ptr(comm)[]
-    # No wait, no cleanup of GPU resources here (a dead peer may hang
-    # forever inside its own barrier spin) -- matches ncclCommAbort's
-    # documented "don't wait" contract. ncclCommDestroy is never called
-    # after abort() by nccl.py's NcclComm.
+    # No wait, no cleanup of GPU or IB resources here (a dead peer may hang
+    # forever inside its own barrier spin, and a queue pair torn down under
+    # an in-flight RDMA write is worse than one left alone) -- matches
+    # ncclCommAbort's documented "don't wait" contract. ncclCommDestroy is
+    # never called after abort() by nccl.py's NcclComm.
     state.aborted = True
     return NCCL_SUCCESS
 
@@ -547,6 +678,12 @@ def ncclCommGetAsyncError(
         ref state = _comm_ptr(comm)[]
         if state.aborted:
             err_out[] = NCCL_SYSTEM_ERROR
+            return NCCL_SUCCESS
+        if state.ib != 0 and ib_error(state.ib) != 0:
+            # A host callback gave up (post failed, a completion came back
+            # with a bad status, or nothing arrived inside the deadline).
+            # Host-side state, so it needs no device read.
+            err_out[] = NCCL_REMOTE_ERROR
             return NCCL_SUCCESS
         # Synchronize first: the freshest read this cheaply-checkable word
         # can give is "everything enqueued so far landed", same as before --
@@ -565,7 +702,9 @@ def ncclCommGetAsyncError(
             else DeviceStream(state.ctx)
         )
         s.synchronize()
-        var word = _read_error_word(state.ctx, s, state.regions[state.rank])
+        var word = _read_error_word(
+            state.ctx, s, state.regions[state.local_rank]
+        )
         err_out[] = NCCL_REMOTE_ERROR if Int(word) != 0 else NCCL_SUCCESS
         return NCCL_SUCCESS
     except e:
@@ -612,6 +751,153 @@ def ncclGroupEnd() abi("C") -> Int32:
 # ---------------------------------------------------------------------------
 
 
+def _inter_node_exchange[
+    dtype: DType
+](
+    mut state: CommState,
+    stream: DeviceStream,
+    raw_stream: Int64,
+    numel: Int,
+) raises:
+    """The middle third of a multi-node allreduce, for one chunk.
+
+    On entry this rank's node-local sum of its own shard sits in its
+    stage_out (that is `reduce_scatter_stage`'s contract). This enqueues, on
+    the caller's stream: a host callback that RDMA-writes that shard to the
+    same-local_rank rank of every other node and waits for theirs, then the
+    kernel that adds what arrived. On exit the shard holds the sum over the
+    WHOLE communicator, ready for `allgather_finish`.
+
+    Inbox geometry, derived from `(numel, local_world, item)` alone so that
+    a sender computes the same addresses as its receiver: `net_off` holds
+    two halves of `(nnodes-1)` slots of one shard each, and the exchange
+    counter's parity picks the half. `_max_chunk_bytes` keeps both halves
+    inside the area.
+    """
+    comptime item = size_of[dtype]()
+    var lw = state.local_world
+    var sr = shard_range(numel, lw, state.local_rank, item)
+    var off_e = sr[0]
+    var cnt_e = sr[1]
+    var seq = ib_next_seq(state.ib)
+    if cnt_e <= 0:
+        return
+    var npeers = ib_npeers(state.ib)
+    var slot_bytes = _align_up(cnt_e * item, 16)
+    var inbox_off = state.net_off
+    var half = npeers * slot_bytes
+    if 2 * half > state.cap_bytes:
+        raise Error(
+            "mojoccl: the inter-node inbox overflows the network area; this"
+            " is a chunking bug"
+        )
+    var inbox_base = inbox_off + (seq & 1) * half
+    var shard = state.owned_base + signal_bytes() + state.cap_bytes + off_e * item
+    ib_enqueue(
+        state.ib,
+        state.driver,
+        Int(raw_stream),
+        shard,
+        cnt_e * item,
+        inbox_base,
+        slot_bytes,
+        True,
+        npeers,
+        state.owned_base + inbox_base,
+        seq,
+    )
+    inbox_add[dtype](
+        state.ctx,
+        stream,
+        shard,
+        state.owned_base + inbox_base,
+        cnt_e,
+        slot_bytes,
+        npeers,
+    )
+
+
+def _max_chunk_bytes(state: CommState) -> Int:
+    """Largest chunk whose staging and inbox both fit in stage_in.
+
+    A chunk of `B` bytes puts `B/L` bytes in each of the `2(N-1)` inbox
+    slots, so `B <= cap * L / (2(N-1))`, less a page of alignment slop --
+    and never more than `cap`, which the intra-node kernels require anyway.
+    At the shapes DDP produces (27 MiB buckets against a 256 MiB region)
+    the cap never binds: 256 MiB at 2 nodes, 146 MiB at 8.
+    """
+    if state.nnodes <= 1:
+        return state.cap_bytes
+    var denom = 2 * (state.nnodes - 1)
+    var b = (state.cap_bytes * state.local_world // denom) - 2 * 4096
+    b = min(b, state.cap_bytes)
+    if b < 4096:
+        return 4096
+    return b // 4096 * 4096
+
+
+def _do_allreduce[
+    dtype: DType
+](
+    mut state: CommState,
+    stream: DeviceStream,
+    raw_stream: Int64,
+    sendbuff: Int,
+    recvbuff: Int,
+    count: Int,
+    scale: Float32,
+) raises:
+    comptime item = size_of[dtype]()
+    var max_elems = max(1, _max_chunk_bytes(state) // item)
+    var done = 0
+    while done < count:
+        var chunk = min(max_elems, count - done)
+        var off = done * item
+        if state.nnodes == 1:
+            state.generation += 1
+            allreduce[dtype](
+                state.ctx,
+                stream,
+                state.local_rank,
+                state.local_world,
+                state.regions,
+                sendbuff + off,
+                recvbuff + off,
+                chunk,
+                state.cap_bytes,
+                scale,
+                state.generation,
+            )
+        else:
+            state.generation += 1
+            reduce_scatter_stage[dtype](
+                state.ctx,
+                stream,
+                state.local_rank,
+                state.local_world,
+                state.regions,
+                sendbuff + off,
+                chunk,
+                state.cap_bytes,
+                state.generation,
+            )
+            _inter_node_exchange[dtype](state, stream, raw_stream, chunk)
+            state.generation += 1
+            allgather_finish[dtype](
+                state.ctx,
+                stream,
+                state.local_rank,
+                state.local_world,
+                state.regions,
+                recvbuff + off,
+                chunk,
+                state.cap_bytes,
+                scale,
+                state.generation,
+            )
+        done += chunk
+
+
 @export
 def ncclAllReduce(
     sendbuff: Int64,
@@ -628,105 +914,49 @@ def ncclAllReduce(
             return NCCL_INVALID_ARGUMENT
         if op != NCCL_SUM and op != NCCL_AVG:
             return NCCL_INVALID_USAGE
-        # The production kernel's payload loops use 16-byte vector
-        # loads/stores on in_ptr/out_ptr and fault on a misaligned address
-        # (RESULTS.md §9). Every allocator-returned pointer and every chunk
-        # offset this function forms satisfy that (cap_bytes is validated a
-        # multiple of 4096 at init) -- only a mid-tensor view the caller
+        # The payload loops use 16-byte vector loads/stores on
+        # in_ptr/out_ptr and fault on a misaligned address (RESULTS.md
+        # section 9). Every allocator-returned pointer and every chunk
+        # offset this function forms satisfy that (the chunk size is a
+        # multiple of 4096 bytes) -- only a mid-tensor view the caller
         # passes directly can violate it, so reject that case here with a
         # clear error instead of letting the kernel raise.
         if Int(sendbuff) % 16 != 0 or Int(recvbuff) % 16 != 0:
             return NCCL_INVALID_ARGUMENT
-        var ptr = _comm_ptr(comm)
-        ref state = ptr[]
+        ref state = _comm_ptr(comm)[]
         if state.aborted:
             return NCCL_INVALID_USAGE
+        if state.ib != 0 and ib_error(state.ib) != 0:
+            return NCCL_REMOTE_ERROR
         state.last_stream = stream
         _ensure_stream_cached(state, stream)
         ref s = state.stream_cache[stream]
         var scale = Float32(1.0)
         if op == NCCL_AVG:
             scale = Float32(1.0) / Float32(state.world)
-        var max_elems = max(1, state.cap_bytes // item)
-        var total = Int(count)
-        var done = 0
-        while done < total:
-            var chunk = min(max_elems, total - done)
-            state.generation += 1
-            var off = done * item
-            if datatype == NCCL_INT32:
-                allreduce[DType.int32](
-                    state.ctx,
-                    s,
-                    state.rank,
-                    state.world,
-                    state.regions,
-                    Int(sendbuff) + off,
-                    Int(recvbuff) + off,
-                    chunk,
-                    state.cap_bytes,
-                    scale,
-                    state.generation,
-                )
-            elif datatype == NCCL_INT64:
-                allreduce[DType.int64](
-                    state.ctx,
-                    s,
-                    state.rank,
-                    state.world,
-                    state.regions,
-                    Int(sendbuff) + off,
-                    Int(recvbuff) + off,
-                    chunk,
-                    state.cap_bytes,
-                    scale,
-                    state.generation,
-                )
-            elif datatype == NCCL_FLOAT16:
-                allreduce[DType.float16](
-                    state.ctx,
-                    s,
-                    state.rank,
-                    state.world,
-                    state.regions,
-                    Int(sendbuff) + off,
-                    Int(recvbuff) + off,
-                    chunk,
-                    state.cap_bytes,
-                    scale,
-                    state.generation,
-                )
-            elif datatype == NCCL_FLOAT32:
-                allreduce[DType.float32](
-                    state.ctx,
-                    s,
-                    state.rank,
-                    state.world,
-                    state.regions,
-                    Int(sendbuff) + off,
-                    Int(recvbuff) + off,
-                    chunk,
-                    state.cap_bytes,
-                    scale,
-                    state.generation,
-                )
-            else:  # NCCL_BFLOAT16, ruled in by _dtype_item_bytes above
-                allreduce[DType.bfloat16](
-                    state.ctx,
-                    s,
-                    state.rank,
-                    state.world,
-                    state.regions,
-                    Int(sendbuff) + off,
-                    Int(recvbuff) + off,
-                    chunk,
-                    state.cap_bytes,
-                    scale,
-                    state.generation,
-                )
-            done += chunk
+        if datatype == NCCL_INT32:
+            _do_allreduce[DType.int32](
+                state, s, stream, Int(sendbuff), Int(recvbuff), Int(count), scale
+            )
+        elif datatype == NCCL_INT64:
+            _do_allreduce[DType.int64](
+                state, s, stream, Int(sendbuff), Int(recvbuff), Int(count), scale
+            )
+        elif datatype == NCCL_FLOAT16:
+            _do_allreduce[DType.float16](
+                state, s, stream, Int(sendbuff), Int(recvbuff), Int(count), scale
+            )
+        elif datatype == NCCL_FLOAT32:
+            _do_allreduce[DType.float32](
+                state, s, stream, Int(sendbuff), Int(recvbuff), Int(count), scale
+            )
+        else:  # NCCL_BFLOAT16, ruled in by _dtype_item_bytes above
+            _do_allreduce[DType.bfloat16](
+                state, s, stream, Int(sendbuff), Int(recvbuff), Int(count), scale
+            )
         return NCCL_SUCCESS
-    except:
+    except e:
+        print("mojoccl: ncclAllReduce failed:", e)
         return NCCL_INTERNAL_ERROR
 
 
@@ -744,38 +974,142 @@ def ncclBroadcast(
         var item = _any_dtype_item_bytes(datatype)
         if item == 0:
             return NCCL_INVALID_ARGUMENT
-        var ptr = _comm_ptr(comm)
-        ref state = ptr[]
+        ref state = _comm_ptr(comm)[]
         if state.aborted:
             return NCCL_INVALID_USAGE
         if Int(root) < 0 or Int(root) >= state.world:
             return NCCL_INVALID_ARGUMENT
+        if state.ib != 0 and ib_error(state.ib) != 0:
+            return NCCL_REMOTE_ERROR
         state.last_stream = stream
         _ensure_stream_cached(state, stream)
         ref s = state.stream_cache[stream]
         var total_bytes = Int(count) * item
-        var max_bytes = max(item, state.cap_bytes)
-        var done = 0
-        while done < total_bytes:
-            var chunk = min(max_bytes, total_bytes - done)
-            state.generation += 1
-            broadcast(
-                state.ctx,
-                s,
-                state.rank,
-                Int(root),
-                state.world,
-                state.regions,
-                Int(sendbuff) + done,
-                Int(recvbuff) + done,
-                chunk,
-                state.cap_bytes,
-                state.generation,
-            )
-            done += chunk
+        if state.nnodes == 1:
+            var max_bytes = max(item, state.cap_bytes)
+            var done = 0
+            while done < total_bytes:
+                var chunk = min(max_bytes, total_bytes - done)
+                state.generation += 1
+                broadcast(
+                    state.ctx,
+                    s,
+                    state.local_rank,
+                    Int(root),
+                    state.local_world,
+                    state.regions,
+                    Int(sendbuff) + done,
+                    Int(recvbuff) + done,
+                    chunk,
+                    state.cap_bytes,
+                    state.generation,
+                )
+                done += chunk
+            return NCCL_SUCCESS
+        _broadcast_multinode(
+            state, s, stream, Int(sendbuff), Int(recvbuff), total_bytes, Int(root)
+        )
         return NCCL_SUCCESS
-    except:
+    except e:
+        print("mojoccl: ncclBroadcast failed:", e)
         return NCCL_INTERNAL_ERROR
+
+
+def _broadcast_multinode(
+    mut state: CommState,
+    stream: DeviceStream,
+    raw_stream: Int64,
+    sendbuff: Int,
+    recvbuff: Int,
+    total_bytes: Int,
+    root: Int,
+) raises:
+    """Root -> one rank per node over IB, then a node-local broadcast.
+
+    The rank that receives on node j is the one sharing the root's
+    local_rank, because that is the only rank the root has a queue pair to.
+    Correct and simple beats fast here: broadcast runs at DDP init, on
+    parameters, not in the step.
+    """
+    var lw = state.local_world
+    var root_node = 0
+    var root_lr = 0
+    for j in range(state.nnodes):
+        for l in range(lw):
+            if state.rank_at[j * lw + l] == root:
+                root_node = j
+                root_lr = l
+    var i_am_root = state.rank == root
+    var i_am_local_root = state.local_rank == root_lr
+    var receives = i_am_local_root and state.my_node != root_node
+    # The network area holds the root's staged chunk plus both inbox
+    # halves (one slot of `chunk` each): three chunks.
+    var max_bytes = max(4096, (state.cap_bytes // 3 - 2 * 4096) // 4096 * 4096)
+    var done = 0
+    while done < total_bytes:
+        var chunk = min(max_bytes, total_bytes - done)
+        var seq = ib_next_seq(state.ib)
+        var slot_bytes = _align_up(chunk, 16)
+        var inbox_off = state.net_off + _align_up(chunk, 4096)
+        var inbox_base = inbox_off + (seq & 1) * slot_bytes
+        var recv_slot = 0
+        if receives:
+            recv_slot = root_node if root_node < state.my_node else root_node - 1
+        var send_ptr = recvbuff + done
+        if i_am_root:
+            # The user buffer is not registered, so the root's payload has to
+            # be copied into the region before the NIC can read it.
+            copy_bytes(
+                state.ctx,
+                stream,
+                state.owned_base + state.net_off,
+                sendbuff + done,
+                chunk,
+            )
+            ib_enqueue(
+                state.ib,
+                state.driver,
+                Int(raw_stream),
+                state.owned_base + state.net_off,
+                chunk,
+                inbox_base,
+                slot_bytes,
+                True,
+                0,
+                0,
+                seq,
+            )
+            send_ptr = sendbuff + done
+        elif receives:
+            ib_enqueue(
+                state.ib,
+                state.driver,
+                Int(raw_stream),
+                0,
+                0,
+                inbox_base,
+                slot_bytes,
+                False,
+                1,
+                state.owned_base + inbox_base + recv_slot * slot_bytes,
+                seq,
+            )
+            send_ptr = state.owned_base + inbox_base + recv_slot * slot_bytes
+        state.generation += 1
+        broadcast(
+            state.ctx,
+            stream,
+            state.local_rank,
+            root_lr,
+            lw,
+            state.regions,
+            send_ptr,
+            recvbuff + done,
+            chunk,
+            state.cap_bytes,
+            state.generation,
+        )
+        done += chunk
 
 
 @export
@@ -791,36 +1125,147 @@ def ncclAllGather(
         var item = _any_dtype_item_bytes(datatype)
         if item == 0:
             return NCCL_INVALID_ARGUMENT
-        var ptr = _comm_ptr(comm)
-        ref state = ptr[]
+        ref state = _comm_ptr(comm)[]
         if state.aborted:
             return NCCL_INVALID_USAGE
+        if state.ib != 0 and ib_error(state.ib) != 0:
+            return NCCL_REMOTE_ERROR
         state.last_stream = stream
         _ensure_stream_cached(state, stream)
         ref s = state.stream_cache[stream]
         var per_rank_bytes = Int(sendcount) * item
-        var max_bytes = max(item, state.cap_bytes)
-        var done = 0
-        while done < per_rank_bytes:
-            var chunk = min(max_bytes, per_rank_bytes - done)
-            state.generation += 1
-            allgather(
-                state.ctx,
-                s,
-                state.rank,
-                state.world,
-                state.regions,
-                Int(sendbuff) + done,
-                Int(recvbuff) + done,
-                chunk,
-                state.cap_bytes,
-                state.generation,
-                stride_bytes=per_rank_bytes,
-            )
-            done += chunk
+        if state.nnodes == 1:
+            var max_bytes = max(item, state.cap_bytes)
+            var done = 0
+            while done < per_rank_bytes:
+                var chunk = min(max_bytes, per_rank_bytes - done)
+                state.generation += 1
+                allgather(
+                    state.ctx,
+                    s,
+                    state.local_rank,
+                    state.local_world,
+                    state.regions,
+                    Int(sendbuff) + done,
+                    Int(recvbuff) + done,
+                    chunk,
+                    state.cap_bytes,
+                    state.generation,
+                    stride_bytes=per_rank_bytes,
+                )
+                done += chunk
+            return NCCL_SUCCESS
+        _allgather_multinode(
+            state, s, stream, Int(sendbuff), Int(recvbuff), per_rank_bytes
+        )
         return NCCL_SUCCESS
-    except:
+    except e:
+        print("mojoccl: ncclAllGather failed:", e)
         return NCCL_INTERNAL_ERROR
+
+
+def _allgather_multinode(
+    mut state: CommState,
+    stream: DeviceStream,
+    raw_stream: Int64,
+    sendbuff: Int,
+    recvbuff: Int,
+    per_rank_bytes: Int,
+) raises:
+    """Node-local allgather, one RDMA exchange of node blocks, then place.
+
+    Every rank ships its whole node block (`local_world * chunk` bytes)
+    rather than a share of it: at DDP's 8-byte allgather that is 64 bytes on
+    the wire and the simpler code is worth more than the bandwidth. Placement
+    reads the global rank of (node, local_rank) out of the bootstrap table --
+    torchrun makes it `node * local_world + local_rank`, but nothing here
+    assumes so.
+    """
+    var lw = state.local_world
+    var npeers = ib_npeers(state.ib)
+    var block_stage = state.owned_base + state.net_off
+    # The network area holds one node block (lw * chunk) plus both inbox
+    # halves (npeers node blocks each).
+    var denom = lw * (1 + 2 * npeers)
+    var max_bytes = max(16, (state.cap_bytes // denom - 8192) // 16 * 16)
+    var done = 0
+    while done < per_rank_bytes:
+        var chunk = min(max_bytes, per_rank_bytes - done)
+        state.generation += 1
+        allgather(
+            state.ctx,
+            stream,
+            state.local_rank,
+            lw,
+            state.regions,
+            sendbuff + done,
+            block_stage,
+            chunk,
+            state.cap_bytes,
+            state.generation,
+            stride_bytes=chunk,
+        )
+        var seq = ib_next_seq(state.ib)
+        var block = lw * chunk
+        var slot_bytes = _align_up(block, 16)
+        var inbox_off = state.net_off + _align_up(block, 4096)
+        var half = npeers * slot_bytes
+        if inbox_off + 2 * half > state.net_off + state.cap_bytes:
+            raise Error("mojoccl: allgather inbox does not fit; chunking bug")
+        var inbox_base = inbox_off + (seq & 1) * half
+        ib_enqueue(
+            state.ib,
+            state.driver,
+            Int(raw_stream),
+            block_stage,
+            block,
+            inbox_base,
+            slot_bytes,
+            True,
+            npeers,
+            state.owned_base + inbox_base,
+            seq,
+        )
+        _place_node_block(
+            state, stream, recvbuff, block_stage, state.my_node, chunk, done,
+            per_rank_bytes,
+        )
+        var slot = 0
+        for j in range(state.nnodes):
+            if j == state.my_node:
+                continue
+            _place_node_block(
+                state,
+                stream,
+                recvbuff,
+                state.owned_base + inbox_base + slot * slot_bytes,
+                j,
+                chunk,
+                done,
+                per_rank_bytes,
+            )
+            slot += 1
+        done += chunk
+
+
+def _place_node_block(
+    mut state: CommState,
+    stream: DeviceStream,
+    recvbuff: Int,
+    src: Int,
+    node: Int,
+    chunk: Int,
+    done: Int,
+    per_rank_bytes: Int,
+) raises:
+    var offs = StaticTuple[Int64, MAX_WORLD](fill=0)
+    for l in range(state.local_world):
+        offs[l] = Int64(
+            state.rank_at[node * state.local_world + l] * per_rank_bytes + done
+        )
+    place_blocks(
+        state.ctx, stream, recvbuff, src, offs, chunk, state.local_world
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -91,6 +91,7 @@ from internode import (
     ib_port_lid,
     ib_port_mtu,
     ib_setup,
+    ib_signal_abort,
     ib_teardown,
 )
 from internode_kernels import copy_bytes, inbox_add, place_blocks
@@ -734,8 +735,12 @@ def ncclCommAbort(comm: Int64) abi("C") -> Int32:
     # forever inside its own barrier spin, and a queue pair torn down under
     # an in-flight RDMA write is worse than one left alone) -- matches
     # ncclCommAbort's documented "don't wait" contract. ncclCommDestroy is
-    # never called after abort() by nccl.py's NcclComm.
+    # never called after abort() by nccl.py's NcclComm. The progress thread
+    # is the one thing still stopped here: left running it spins a CPU core
+    # for the rest of the process, and `ib_signal_abort`'s join is bounded so
+    # this still does not wait in the way the contract forbids.
     state.aborted = True
+    ib_signal_abort(state.ib)
     return NCCL_SUCCESS
 
 

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -1678,6 +1678,10 @@ def _do_allreduce[
     var chunk_elems = max(1, _pipeline_chunk_bytes(state, count * item) // item)
     var nchunks = (count + chunk_elems - 1) // chunk_elems
     var depth = min(state.narenas, nchunks)
+    # AVG's 1/world is applied by the reduce-scatter to each input (NCCL's
+    # PreMulSum): the node partials that cross the network and the inbox add
+    # are then already scaled, so no fp16 sum ever exceeds the average, and
+    # the all-gather copies with scale 1.
     # Two generations per chunk, reserved up front, so each chunk's
     # all-gather is its own reduce-scatter's plus one (the split kernels'
     # documented pairing) even though the enqueue order interleaves chunks.
@@ -1702,6 +1706,7 @@ def _do_allreduce[
                 cnt,
                 state.arena_cap,
                 g0 + 2 * k,
+                scale,
             )
             seqs[k] = _exchange_release[dtype](
                 state, stream, raw_stream, k % state.narenas, cnt
@@ -1722,7 +1727,7 @@ def _do_allreduce[
                 recvbuff + off * item,
                 cnt,
                 state.arena_cap,
-                scale,
+                Float32(1.0),
                 g0 + 2 * j + 1,
             )
 

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -86,6 +86,7 @@ from driver import (
     open_driver,
     open_handle,
     stream_done,
+    warn_teardown,
 )
 from bootstrap import (
     UID_BYTES,
@@ -890,8 +891,8 @@ def _unwind_init(
     try:
         if abort_host != 0:
             free_host(lib, abort_host)
-    except:
-        pass
+    except e:
+        warn_teardown("freeing the abort word", e)
     try:
         if use_nvls:
             nvls_teardown(nvls, lib, ordinal)
@@ -900,8 +901,8 @@ def _unwind_init(
                 if r != local_rank and regions[r] != 0:
                     close_handle(lib, regions[r])
             free_region(lib, base)
-    except:
-        pass
+    except e:
+        warn_teardown("releasing the region", e)
 
 
 def _bootstrap(
@@ -1101,8 +1102,8 @@ def _bootstrap(
             try:
                 nvls_teardown(nvls, lib, ordinal)
                 scm_unbind(libc, sock, spath)
-            except:
-                pass
+            except e2:
+                warn_teardown("tearing down the multicast region", e2)
             raise Error(
                 "mojoccl: the NVSwitch-multicast region failed to come up ("
                 + String(e)
@@ -1350,7 +1351,7 @@ def _async_error_stream(state: CommState) -> DeviceStream:
         if state.last_stream != 0 and state.last_stream in state.stream_cache:
             return state.stream_cache[state.last_stream]
     except:
-        pass
+        return state.own_stream  # the lookup raced a concurrent insert
     return state.own_stream
 
 

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -69,11 +69,18 @@ comptime NCCL_INVALID_USAGE: Int32 = 5
 comptime NCCL_REMOTE_ERROR: Int32 = 6
 comptime NCCL_IN_PROGRESS: Int32 = 7
 
-# ncclDataType_t (nccl.h.in:466-479) -- values this library implements.
+# ncclDataType_t (nccl.h.in:466-479). AllReduce runs a real kernel and only
+# instantiates the five below; Broadcast/AllGather move raw bytes (item size
+# x count -> nbytes) and accept every type in the enum.
+comptime NCCL_INT8: Int32 = 0
+comptime NCCL_UINT8: Int32 = 1
 comptime NCCL_INT32: Int32 = 2
+comptime NCCL_UINT32: Int32 = 3
 comptime NCCL_INT64: Int32 = 4
+comptime NCCL_UINT64: Int32 = 5
 comptime NCCL_FLOAT16: Int32 = 6
 comptime NCCL_FLOAT32: Int32 = 7
+comptime NCCL_FLOAT64: Int32 = 8
 comptime NCCL_BFLOAT16: Int32 = 9
 
 # ncclRedOp_t (nccl.h.in:448-463) -- values this library implements.
@@ -103,9 +110,33 @@ def _bootstrap_timeout_s() -> Float64:
 
 
 def _dtype_item_bytes(nccl_dtype: Int32) -> Int:
+    """Item size for the five dtypes AllReduce's kernel is instantiated for."""
     if nccl_dtype == NCCL_INT32 or nccl_dtype == NCCL_FLOAT32:
         return 4
     elif nccl_dtype == NCCL_INT64:
+        return 8
+    elif nccl_dtype == NCCL_FLOAT16 or nccl_dtype == NCCL_BFLOAT16:
+        return 2
+    else:
+        return 0
+
+
+def _any_dtype_item_bytes(nccl_dtype: Int32) -> Int:
+    """Item size for every ncclDataType_t -- Broadcast/AllGather move raw
+    bytes and never look at the dtype beyond this."""
+    if nccl_dtype == NCCL_INT8 or nccl_dtype == NCCL_UINT8:
+        return 1
+    elif (
+        nccl_dtype == NCCL_INT32
+        or nccl_dtype == NCCL_UINT32
+        or nccl_dtype == NCCL_FLOAT32
+    ):
+        return 4
+    elif (
+        nccl_dtype == NCCL_INT64
+        or nccl_dtype == NCCL_UINT64
+        or nccl_dtype == NCCL_FLOAT64
+    ):
         return 8
     elif nccl_dtype == NCCL_FLOAT16 or nccl_dtype == NCCL_BFLOAT16:
         return 2
@@ -687,7 +718,7 @@ def ncclBroadcast(
     stream: Int64,
 ) abi("C") -> Int32:
     try:
-        var item = _dtype_item_bytes(datatype)
+        var item = _any_dtype_item_bytes(datatype)
         if item == 0:
             return NCCL_INVALID_ARGUMENT
         var ptr = _comm_ptr(comm)
@@ -733,7 +764,7 @@ def ncclAllGather(
     stream: Int64,
 ) abi("C") -> Int32:
     try:
-        var item = _dtype_item_bytes(datatype)
+        var item = _any_dtype_item_bytes(datatype)
         if item == 0:
             return NCCL_INVALID_ARGUMENT
         var ptr = _comm_ptr(comm)

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -785,6 +785,34 @@ def _init_rank(
         raise e
 
 
+def _unwind_init(
+    lib: OwnedDLHandle,
+    ordinal: Int,
+    ib: Int,
+    use_nvls: Bool,
+    mut nvls: NvlsRegion,
+    base: Int,
+    regions: StaticTuple[Int, MAX_WORLD],
+    local_world: Int,
+    local_rank: Int,
+):
+    """Release what `_bootstrap` acquired before it failed: the IB state
+    (progress thread, QPs, MRs, pinned mailbox), the peer mappings opened so
+    far, and the region itself. Best effort -- the error that got us here is
+    the one worth reporting."""
+    ib_teardown(ib)
+    try:
+        if use_nvls:
+            nvls_teardown(nvls, lib, ordinal)
+        else:
+            for r in range(local_world):
+                if r != local_rank and regions[r] != 0:
+                    close_handle(lib, regions[r])
+            free_region(lib, base)
+    except:
+        pass
+
+
 def _bootstrap(
     mut conn: BootstrapConn,
     rank: Int,
@@ -996,120 +1024,139 @@ def _bootstrap(
         base = nvls.uc
     else:
         base = alloc_region(lib, region_bytes)
-    for a in range(narenas):
-        region_init(ctx, base + a * arena_stride)
-
+    # From here on real resources exist (the region, and on several nodes
+    # the IB state with its progress thread); any later failure -- a geometry
+    # mismatch, an IPC import, ib_connect, the closing barrier -- has to
+    # release them, because no communicator handle is returned through
+    # which the caller could.
     var ib = 0
-    if topo.nnodes > 1:
-        ib = ib_setup(
+    var regions = StaticTuple[Int, MAX_WORLD](fill=0)
+    try:
+        for a in range(narenas):
+            region_init(ctx, base + a * arena_stride)
+
+        if topo.nnodes > 1:
+            ib = ib_setup(
+                lib,
+                ordinal,
+                topo.my_local_rank,
+                topo.my_node,
+                topo.nnodes,
+                base,
+                region_bytes,
+                INBOX_SLOTS,
+                net_off,
+            )
+
+        # Round 2: IPC handle + IB connection data + the geometry every rank has
+        # to agree on. `MOJOCCL_REGION_MB` reaching one rank and not another
+        # (a per-node environment, a stale export) silently gives the peers
+        # different arena and inbox offsets, which is a data race, not an error;
+        # checking two integers here turns it into a message.
+        comptime CFG_BYTES = 16
+        comptime BLOB2 = HANDLE_BYTES + IB_BLOB_BYTES + CFG_BYTES
+        var b2 = unsafe_alloc[UInt8](BLOB2)
+        for i in range(BLOB2):
+            b2[unsafe_offset=i] = 0
+        if not use_nvls:
+            # `cuIpcGetMemHandle` cannot export VMM memory; under NVLS the peers
+            # already have this region through the fd exchange above, and these
+            # 64 bytes stay zero.
+            get_handle(lib, base, _any(b2))
+        var my_lid = 0
+        var my_mtu = 0
+        if ib != 0:
+            my_lid = ib_port_lid(ib)
+            my_mtu = ib_port_mtu(ib)
+            ib_local_info(
+                ib,
+                Pointer[UInt8, MutAnyOrigin](
+                    unsafe_from_address=Int(b2) + HANDLE_BYTES
+                ),
+                my_lid,
+                my_mtu,
+            )
+        var cfg = Pointer[Int64, MutAnyOrigin](
+            unsafe_from_address=Int(b2) + HANDLE_BYTES + IB_BLOB_BYTES
+        )
+        cfg[unsafe_offset=0] = Int64(cap_bytes)
+        cfg[unsafe_offset=1] = Int64(
+            narenas * 1000 + INBOX_SLOTS + (1_000_000 if use_nvls else 0)
+        )
+        var t2 = unsafe_alloc[UInt8](BLOB2 * nranks)
+        bootstrap_allgather(conn, _any(b2), BLOB2, _any(t2), timeout_s)
+        for r in range(nranks):
+            var rcfg = Pointer[Int64, MutAnyOrigin](
+                unsafe_from_address=Int(t2)
+                + r * BLOB2
+                + HANDLE_BYTES
+                + IB_BLOB_BYTES
+            )
+            if (
+                rcfg[unsafe_offset=0] != cfg[unsafe_offset=0]
+                or rcfg[unsafe_offset=1] != cfg[unsafe_offset=1]
+            ):
+                raise Error(
+                    "mojoccl: rank "
+                    + String(r)
+                    + " built a region of "
+                    + String(Int(rcfg[unsafe_offset=0]) // (1024 * 1024))
+                    + " MiB with layout code "
+                    + String(Int(rcfg[unsafe_offset=1]))
+                    + ", this rank "
+                    + String(cap_bytes // (1024 * 1024))
+                    + " MiB / "
+                    + String(Int(cfg[unsafe_offset=1]))
+                    + "; MOJOCCL_REGION_MB must match on every rank"
+                )
+
+        # Same-node peers only: an IPC handle from another host is meaningless.
+        regions[topo.my_local_rank] = base
+        if use_nvls:
+            for r in range(topo.local_world):
+                regions[r] = nvls.peer_va[r]
+        else:
+            for r in range(nranks):
+                if topo.node_of[r] != topo.my_node or r == rank:
+                    continue
+                var lr = topo.local_rank_of[r]
+                regions[lr] = open_handle(
+                    lib,
+                    Pointer[UInt8, MutAnyOrigin](
+                        unsafe_from_address=Int(t2) + r * BLOB2
+                    ),
+                )
+
+        if ib != 0:
+            var peer_rank_of_node = List[Int]()
+            for j in range(topo.nnodes):
+                peer_rank_of_node.append(
+                    topo.rank_at[j * topo.local_world + topo.my_local_rank]
+                )
+            ib_connect(
+                ib,
+                Pointer[UInt8, MutAnyOrigin](
+                    unsafe_from_address=Int(t2) + HANDLE_BYTES
+                ),
+                BLOB2,
+                peer_rank_of_node,
+                my_mtu,
+            )
+
+        bootstrap_barrier(conn, timeout_s)
+    except e:
+        _unwind_init(
             lib,
             ordinal,
-            topo.my_local_rank,
-            topo.my_node,
-            topo.nnodes,
+            ib,
+            use_nvls,
+            nvls,
             base,
-            region_bytes,
-            INBOX_SLOTS,
-            net_off,
+            regions,
+            topo.local_world,
+            topo.my_local_rank,
         )
-
-    # Round 2: IPC handle + IB connection data + the geometry every rank has
-    # to agree on. `MOJOCCL_REGION_MB` reaching one rank and not another
-    # (a per-node environment, a stale export) silently gives the peers
-    # different arena and inbox offsets, which is a data race, not an error;
-    # checking two integers here turns it into a message.
-    comptime CFG_BYTES = 16
-    comptime BLOB2 = HANDLE_BYTES + IB_BLOB_BYTES + CFG_BYTES
-    var b2 = unsafe_alloc[UInt8](BLOB2)
-    for i in range(BLOB2):
-        b2[unsafe_offset=i] = 0
-    if not use_nvls:
-        # `cuIpcGetMemHandle` cannot export VMM memory; under NVLS the peers
-        # already have this region through the fd exchange above, and these
-        # 64 bytes stay zero.
-        get_handle(lib, base, _any(b2))
-    var my_lid = 0
-    var my_mtu = 0
-    if ib != 0:
-        my_lid = ib_port_lid(ib)
-        my_mtu = ib_port_mtu(ib)
-        ib_local_info(
-            ib,
-            Pointer[UInt8, MutAnyOrigin](
-                unsafe_from_address=Int(b2) + HANDLE_BYTES
-            ),
-            my_lid,
-            my_mtu,
-        )
-    var cfg = Pointer[Int64, MutAnyOrigin](
-        unsafe_from_address=Int(b2) + HANDLE_BYTES + IB_BLOB_BYTES
-    )
-    cfg[unsafe_offset=0] = Int64(cap_bytes)
-    cfg[unsafe_offset=1] = Int64(
-        narenas * 1000 + INBOX_SLOTS + (1_000_000 if use_nvls else 0)
-    )
-    var t2 = unsafe_alloc[UInt8](BLOB2 * nranks)
-    bootstrap_allgather(conn, _any(b2), BLOB2, _any(t2), timeout_s)
-    for r in range(nranks):
-        var rcfg = Pointer[Int64, MutAnyOrigin](
-            unsafe_from_address=Int(t2)
-            + r * BLOB2
-            + HANDLE_BYTES
-            + IB_BLOB_BYTES
-        )
-        if (
-            rcfg[unsafe_offset=0] != cfg[unsafe_offset=0]
-            or rcfg[unsafe_offset=1] != cfg[unsafe_offset=1]
-        ):
-            raise Error(
-                "mojoccl: rank "
-                + String(r)
-                + " built a region of "
-                + String(Int(rcfg[unsafe_offset=0]) // (1024 * 1024))
-                + " MiB with layout code "
-                + String(Int(rcfg[unsafe_offset=1]))
-                + ", this rank "
-                + String(cap_bytes // (1024 * 1024))
-                + " MiB / "
-                + String(Int(cfg[unsafe_offset=1]))
-                + "; MOJOCCL_REGION_MB must match on every rank"
-            )
-
-    # Same-node peers only: an IPC handle from another host is meaningless.
-    var regions = StaticTuple[Int, MAX_WORLD](fill=0)
-    regions[topo.my_local_rank] = base
-    if use_nvls:
-        for r in range(topo.local_world):
-            regions[r] = nvls.peer_va[r]
-    else:
-        for r in range(nranks):
-            if topo.node_of[r] != topo.my_node or r == rank:
-                continue
-            var lr = topo.local_rank_of[r]
-            regions[lr] = open_handle(
-                lib,
-                Pointer[UInt8, MutAnyOrigin](
-                    unsafe_from_address=Int(t2) + r * BLOB2
-                ),
-            )
-
-    if ib != 0:
-        var peer_rank_of_node = List[Int]()
-        for j in range(topo.nnodes):
-            peer_rank_of_node.append(
-                topo.rank_at[j * topo.local_world + topo.my_local_rank]
-            )
-        ib_connect(
-            ib,
-            Pointer[UInt8, MutAnyOrigin](
-                unsafe_from_address=Int(t2) + HANDLE_BYTES
-            ),
-            BLOB2,
-            peer_rank_of_node,
-            my_mtu,
-        )
-
-    bootstrap_barrier(conn, timeout_s)
+        raise e
 
     var rank_at = List[Int]()
     for i in range(len(topo.rank_at)):

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -672,6 +672,34 @@ def _bootstrap(
     return NCCL_SUCCESS
 
 
+def _cached_stream_handles(state: CommState) -> List[Int64]:
+    """Every raw stream handle wrapped in `state.stream_cache`, copied into a
+    plain List.
+
+    Kept to exactly this -- iterating `Dict.keys()` inside a `raises`
+    function narrows the function's inferred error type to `DictKeyError`,
+    which then rejects every unrelated `raise Error(...)` still in scope. A
+    helper doing nothing else keeps that narrowing from leaking into
+    `_drain_all_streams` or its callers.
+    """
+    var handles = List[Int64]()
+    for h in state.stream_cache.keys():
+        handles.append(h)
+    return handles^
+
+
+def _drain_all_streams(mut state: CommState) raises:
+    """Synchronize every stream a collective has ever run on.
+
+    `state.last_stream` is only the MOST RECENT one: `stream_cache` can hold
+    several (the side-stream test in the suite uses two), and an exchange
+    still in flight on a stream that isn't the last one used would otherwise
+    find its QPs destroyed out from under it by `ncclCommDestroy`.
+    """
+    for h in _cached_stream_handles(state):
+        state.stream_cache[h].synchronize()
+
+
 # ---------------------------------------------------------------------------
 # Communicator lifecycle
 # ---------------------------------------------------------------------------
@@ -683,12 +711,11 @@ def ncclCommDestroy(comm: Int64) abi("C") -> Int32:
         var ptr = _comm_ptr(comm)
         ref state = ptr[]
         if not state.aborted:
-            # The inter-node callbacks were enqueued on the CALLER's stream,
+            # The inter-node callbacks were enqueued on the CALLER's stream(s),
             # not on the context's own, and they dereference the IbState this
-            # tears down -- so drain that stream too before touching it.
-            if state.last_stream != 0:
-                _ensure_stream_cached(state, state.last_stream)
-                state.stream_cache[state.last_stream].synchronize()
+            # tears down -- so drain every cached stream too before touching
+            # it, not just the last one used (see `_drain_all_streams`).
+            _drain_all_streams(state)
             state.ctx.synchronize()
             ib_teardown(state.ib)
             for r in range(state.local_world):

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -20,6 +20,7 @@
 # (collectives_kernels.mojo), swapped out wholesale once the production
 # kernel lands.
 
+from std.collections import Dict
 from std.ffi import OwnedDLHandle
 from std.gpu import global_idx
 from std.memory.alloc import unsafe_alloc
@@ -166,6 +167,7 @@ struct CommState(Movable):
     var generation: Int
     var last_stream: Int64
     var aborted: Bool
+    var stream_cache: Dict[Int64, DeviceStream]
 
     def __init__(
         out self,
@@ -189,6 +191,7 @@ struct CommState(Movable):
         self.generation = 0
         self.last_stream = 0
         self.aborted = False
+        self.stream_cache = Dict[Int64, DeviceStream]()
 
 
 @always_inline
@@ -204,11 +207,23 @@ def _any(p: Pointer[UInt8, MutUntrackedOrigin]) -> Pointer[UInt8, MutAnyOrigin]:
     return Pointer[UInt8, MutAnyOrigin](unsafe_from_address=Int(p))
 
 
-@always_inline
-def _wrap_stream(ctx: DeviceContext, handle: Int64) raises -> DeviceStream:
-    return ctx.create_external_stream(
-        OpaquePointer[MutAnyOrigin](unsafe_from_address=Int(handle))
-    )
+def _ensure_stream_cached(mut state: CommState, handle: Int64) raises:
+    """`create_external_stream` wraps a raw `cudaStream_t`/`hipStream_t` in a
+    `DeviceStream`; every collective call was re-wrapping the SAME handle
+    (torch hands this library one stable stream per torch.Stream for the
+    whole communicator's life -- it is not reused across streams), so cache
+    the wrapper in `state.stream_cache` keyed by the raw handle instead of
+    re-wrapping on every call. A handle not seen before is wrapped and
+    inserted; callers then read `state.stream_cache[handle]` directly (a
+    `ref`, no copy). If a handle were ever reused for a different stream this
+    would keep returning the stale wrapper -- not something a torch process
+    does, but worth knowing if that assumption ever breaks.
+    """
+    if handle not in state.stream_cache:
+        var wrapped = state.ctx.create_external_stream(
+            OpaquePointer[MutAnyOrigin](unsafe_from_address=Int(handle))
+        )
+        _ = state.stream_cache.insert(handle, wrapped^)
 
 
 def _copy_error_word(
@@ -537,8 +552,15 @@ def ncclCommGetAsyncError(
         # can give is "everything enqueued so far landed", same as before --
         # only the read itself changes, from a host dereference of device
         # memory (wrong) to a real D2H copy (_read_error_word).
+        # Not cached: an error poll, not a collective -- rare enough that the
+        # wrap cost this library's cache exists to avoid does not matter here,
+        # and this is the one call site that needs a *fresh* wrap or the
+        # comm's own default stream depending on whether a collective has
+        # run yet, which does not fit the single-handle cache lookup below.
         var s = (
-            _wrap_stream(state.ctx, state.last_stream)
+            state.ctx.create_external_stream(
+                OpaquePointer[MutAnyOrigin](unsafe_from_address=Int(state.last_stream))
+            )
             if state.last_stream != 0
             else DeviceStream(state.ctx)
         )
@@ -620,7 +642,8 @@ def ncclAllReduce(
         if state.aborted:
             return NCCL_INVALID_USAGE
         state.last_stream = stream
-        var s = _wrap_stream(state.ctx, stream)
+        _ensure_stream_cached(state, stream)
+        ref s = state.stream_cache[stream]
         var scale = Float32(1.0)
         if op == NCCL_AVG:
             scale = Float32(1.0) / Float32(state.world)
@@ -703,7 +726,7 @@ def ncclAllReduce(
                 )
             done += chunk
         return NCCL_SUCCESS
-    except e:
+    except:
         return NCCL_INTERNAL_ERROR
 
 
@@ -728,7 +751,8 @@ def ncclBroadcast(
         if Int(root) < 0 or Int(root) >= state.world:
             return NCCL_INVALID_ARGUMENT
         state.last_stream = stream
-        var s = _wrap_stream(state.ctx, stream)
+        _ensure_stream_cached(state, stream)
+        ref s = state.stream_cache[stream]
         var total_bytes = Int(count) * item
         var max_bytes = max(item, state.cap_bytes)
         var done = 0
@@ -750,7 +774,7 @@ def ncclBroadcast(
             )
             done += chunk
         return NCCL_SUCCESS
-    except e:
+    except:
         return NCCL_INTERNAL_ERROR
 
 
@@ -772,7 +796,8 @@ def ncclAllGather(
         if state.aborted:
             return NCCL_INVALID_USAGE
         state.last_stream = stream
-        var s = _wrap_stream(state.ctx, stream)
+        _ensure_stream_cached(state, stream)
+        ref s = state.stream_cache[stream]
         var per_rank_bytes = Int(sendcount) * item
         var max_bytes = max(item, state.cap_bytes)
         var done = 0
@@ -794,7 +819,7 @@ def ncclAllGather(
             )
             done += chunk
         return NCCL_SUCCESS
-    except e:
+    except:
         return NCCL_INTERNAL_ERROR
 
 

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -21,10 +21,11 @@
 # kernel lands.
 
 from std.ffi import OwnedDLHandle
+from std.gpu import global_idx
 from std.memory.alloc import unsafe_alloc
 from std.os import getenv
 from std.utils import StaticTuple
-from max.gpu.host import DeviceContext, DeviceStream
+from max.gpu.host import DeviceContext, DeviceBuffer, DeviceStream
 
 from driver import (
     HANDLE_BYTES,
@@ -174,6 +175,51 @@ def _wrap_stream(ctx: DeviceContext, handle: Int64) raises -> DeviceStream:
     return ctx.create_external_stream(
         OpaquePointer[MutAnyOrigin](unsafe_from_address=Int(handle))
     )
+
+
+def _copy_error_word(
+    dst: Pointer[UInt64, MutAnyOrigin], src: Pointer[UInt64, MutAnyOrigin]
+):
+    """One-thread device kernel: copies the error word out of a region's
+    signal area -- raw driver memory (`cuMemAlloc`/`hipExtMallocWithFlags`),
+    not host-accessible -- into a proper `DeviceBuffer` `enqueue_copy` can
+    D2H-copy from. Mirrors the production kernel harness's `_copy_u64`
+    (kernel/harness.mojo, `check_error`): the error word cannot be read by
+    dereferencing a host pointer at the region address, that faults or reads
+    garbage.
+    """
+    if global_idx.x == 0:
+        dst[unsafe_offset=0] = src[unsafe_offset=0]
+
+
+def _read_error_word(
+    ctx: DeviceContext, stream: DeviceStream, region: Int
+) raises -> UInt64:
+    """The UInt64 error word at `region + error_offset()`, fetched to the
+    host via a real device-to-host copy (see `_copy_error_word`).
+
+    Enqueues the copy kernel on `stream` -- ordered after whatever
+    collective on it last wrote the word -- then a D2H `enqueue_copy`, then
+    blocks for both. Callers that need the fully up-to-date word (a peer's
+    in-flight barrier timeout, not just what already landed) must
+    synchronize `stream` themselves first, as `ncclCommGetAsyncError` does.
+    """
+    var src = Pointer[UInt64, MutAnyOrigin](
+        unsafe_from_address=region + error_offset()
+    )
+    var dev_word = ctx.enqueue_create_buffer[DType.uint64](1)
+    var compiled = ctx.compile_function[_copy_error_word]()
+    stream.enqueue_function(
+        compiled,
+        dev_word.unsafe_ptr(),
+        src,
+        grid_dim=(1, 1, 1),
+        block_dim=(32, 1, 1),
+    )
+    var host_word = unsafe_alloc[UInt64](1)
+    ctx.enqueue_copy(host_word, dev_word)
+    ctx.synchronize()
+    return host_word[unsafe_offset=0]
 
 
 # ---------------------------------------------------------------------------
@@ -392,13 +438,18 @@ def ncclCommGetAsyncError(
         if state.aborted:
             err_out[] = NCCL_SYSTEM_ERROR
             return NCCL_SUCCESS
-        if state.last_stream != 0:
-            var s = _wrap_stream(state.ctx, state.last_stream)
-            s.synchronize()
-        var err_word = Pointer[UInt64, MutAnyOrigin](
-            unsafe_from_address=state.regions[state.rank] + error_offset()
+        # Synchronize first: the freshest read this cheaply-checkable word
+        # can give is "everything enqueued so far landed", same as before --
+        # only the read itself changes, from a host dereference of device
+        # memory (wrong) to a real D2H copy (_read_error_word).
+        var s = (
+            _wrap_stream(state.ctx, state.last_stream)
+            if state.last_stream != 0
+            else DeviceStream(state.ctx)
         )
-        err_out[] = NCCL_REMOTE_ERROR if Int(err_word[]) != 0 else NCCL_SUCCESS
+        s.synchronize()
+        var word = _read_error_word(state.ctx, s, state.regions[state.rank])
+        err_out[] = NCCL_REMOTE_ERROR if Int(word) != 0 else NCCL_SUCCESS
         return NCCL_SUCCESS
     except e:
         return NCCL_INTERNAL_ERROR

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -37,6 +37,7 @@ from driver import (
     get_handle,
     open_driver,
     open_handle,
+    warn_teardown,
 )
 from bootstrap import (
     UID_BYTES,
@@ -427,8 +428,8 @@ def ncclCommInitRank(
                 if Int(rank) == 0:
                     try:
                         remove_rendezvous_dir(dir, Int(nranks))
-                    except:
-                        pass
+                    except e:
+                        warn_teardown("removing the rendezvous dir", e)
                 return NCCL_INVALID_ARGUMENT
             var region_bytes = signal_bytes() + 2 * cap_bytes
             var base = alloc_region(lib, region_bytes)
@@ -457,12 +458,12 @@ def ncclCommInitRank(
                         if r2 != Int(rank) and regions[r2] != 0:
                             try:
                                 close_handle(lib, regions[r2])
-                            except:
-                                pass
+                            except e:
+                                warn_teardown("closing a peer's IPC handle", e)
                     try:
                         free_region(lib, base)
-                    except:
-                        pass
+                    except e:
+                        warn_teardown("freeing the region", e)
                     raise
 
             # Done protocol: every rank marks itself done once it has opened
@@ -479,8 +480,8 @@ def ncclCommInitRank(
                         wait_for_done(dir, r, timeout_s)
                 try:
                     remove_rendezvous_dir(dir, Int(nranks))
-                except:
-                    pass  # a leftover /dev/shm dir is a nuisance, not a correctness bug
+                except e:
+                    warn_teardown("removing the rendezvous dir", e)
 
             var state = CommState(
                 rank=Int(rank),
@@ -500,8 +501,8 @@ def ncclCommInitRank(
             if Int(rank) == 0:
                 try:
                     remove_rendezvous_dir(dir, Int(nranks))
-                except:
-                    pass
+                except e:
+                    warn_teardown("removing the rendezvous dir", e)
             raise
     except:
         return NCCL_INTERNAL_ERROR
@@ -557,13 +558,11 @@ def ncclCommGetAsyncError(
         # and this is the one call site that needs a *fresh* wrap or the
         # comm's own default stream depending on whether a collective has
         # run yet, which does not fit the single-handle cache lookup below.
-        var s = (
-            state.ctx.create_external_stream(
-                OpaquePointer[MutAnyOrigin](unsafe_from_address=Int(state.last_stream))
+        var s = state.ctx.create_external_stream(
+            OpaquePointer[MutAnyOrigin](
+                unsafe_from_address=Int(state.last_stream)
             )
-            if state.last_stream != 0
-            else DeviceStream(state.ctx)
-        )
+        ) if state.last_stream != 0 else DeviceStream(state.ctx)
         s.synchronize()
         var word = _read_error_word(state.ctx, s, state.regions[state.rank])
         err_out[] = NCCL_REMOTE_ERROR if Int(word) != 0 else NCCL_SUCCESS

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -104,6 +104,7 @@ from collectives_kernels import (
     allgather_finish,
     allreduce,
     broadcast,
+    _enqueue_cached,
     error_offset,
     install_abort_word,
     region_init,
@@ -404,6 +405,14 @@ struct CommState(Movable):
     var nvls_grid: Int
     var nvls_min: Int
     var nvls_bars: Int
+    # `ncclCommGetAsyncError`'s scratch, built once instead of per poll: the
+    # device word the copy kernel writes, the host word it lands in, and the
+    # stream to use before any collective has named one. A watchdog polls
+    # this on a timer, and a fresh DeviceStream, DeviceBuffer and host
+    # allocation per poll was three allocations and a leak of the last one.
+    var err_buf: DeviceBuffer[DType.uint64]
+    var err_host: Int
+    var own_stream: DeviceStream
     # Submission lock (`_lock`/`_unlock`): 0 free, 1 held.
     var lock: Int64
 
@@ -434,7 +443,7 @@ struct CommState(Movable):
         nvls_min: Int,
         abort_host: Int,
         abort_dev: Int,
-    ):
+    ) raises:
         self.rank = rank
         self.world = world
         self.ordinal = ordinal
@@ -471,6 +480,9 @@ struct CommState(Movable):
         # reset, and it is independent of `generation` (different address,
         # different protocol) so the two paths can alternate freely.
         self.nvls_bars = 0
+        self.err_buf = self.ctx.enqueue_create_buffer[DType.uint64](1)
+        self.err_host = Int(unsafe_alloc[UInt64](1))
+        self.own_stream = DeviceStream(self.ctx)
         self.lock = 0
 
 
@@ -665,7 +677,7 @@ def _copy_error_word(
 
 
 def _read_error_word(
-    ctx: DeviceContext, stream: DeviceStream, region: Int
+    mut state: CommState, stream: DeviceStream, region: Int
 ) raises -> UInt64:
     """The UInt64 error word at `region + error_offset()`, fetched to the
     host via a real device-to-host copy (see `_copy_error_word`).
@@ -675,22 +687,19 @@ def _read_error_word(
     blocks for both. Callers that need the fully up-to-date word (a peer's
     in-flight barrier timeout, not just what already landed) must
     synchronize `stream` themselves first, as `ncclCommGetAsyncError` does.
+    Kernel, device word and host word are all cached on the communicator.
     """
     var src = Pointer[UInt64, MutAnyOrigin](
         unsafe_from_address=region + error_offset()
     )
-    var dev_word = ctx.enqueue_create_buffer[DType.uint64](1)
-    var compiled = ctx.compile_function[_copy_error_word]()
-    stream.enqueue_function(
-        compiled,
-        dev_word.unsafe_ptr(),
-        src,
-        grid_dim=(1, 1, 1),
-        block_dim=(32, 1, 1),
+    _enqueue_cached[_copy_error_word](
+        state.ctx, stream, "errword", 1, state.err_buf.unsafe_ptr(), src
     )
-    var host_word = unsafe_alloc[UInt64](1)
-    ctx.enqueue_copy(host_word, dev_word)
-    ctx.synchronize()
+    var host_word = Pointer[UInt64, MutUntrackedOrigin](
+        unsafe_from_address=state.err_host
+    )
+    state.ctx.enqueue_copy(host_word, state.err_buf)
+    state.ctx.synchronize()
     return host_word[unsafe_offset=0]
 
 
@@ -1318,6 +1327,26 @@ def _cached_stream_handles(state: CommState) -> List[Int64]:
     return handles^
 
 
+def _async_error_stream(state: CommState) -> DeviceStream:
+    """The stream `ncclCommGetAsyncError` synchronizes: the cached wrapper for
+    the stream a collective last ran on, or the communicator's own if none
+    has.
+
+    A helper of its own for the same reason `_cached_stream_handles` is one:
+    indexing a `Dict` narrows the enclosing function's inferred error type to
+    `DictKeyError`, which then rejects every unrelated `raise Error(...)`
+    still in scope. It also takes no lock, so `last_stream` may be set by a
+    concurrent submission a moment before that stream is cached -- hence the
+    membership test rather than an insert.
+    """
+    try:
+        if state.last_stream != 0 and state.last_stream in state.stream_cache:
+            return state.stream_cache[state.last_stream]
+    except:
+        pass
+    return state.own_stream
+
+
 def _drain_all_streams(mut state: CommState) raises:
     """Synchronize every stream a collective has ever run on.
 
@@ -1478,16 +1507,12 @@ def ncclCommGetAsyncError(
         # can give is "everything enqueued so far landed", same as before --
         # only the read itself changes, from a host dereference of device
         # memory (wrong) to a real D2H copy (_read_error_word).
-        # Not cached: an error poll, not a collective -- rare enough that the
-        # wrap cost this library's cache exists to avoid does not matter here,
-        # and this is the one call site that needs a *fresh* wrap or the
-        # comm's own default stream depending on whether a collective has
-        # run yet, which does not fit the single-handle cache lookup below.
-        var s = state.ctx.create_external_stream(
-            OpaquePointer[MutAnyOrigin](
-                unsafe_from_address=Int(state.last_stream)
-            )
-        ) if state.last_stream != 0 else DeviceStream(state.ctx)
+        # The wrapper comes out of the same cache the collectives use, and
+        # `own_stream` covers the case where no collective has named a stream
+        # yet. This poll takes no lock, so `last_stream` can be set by a
+        # concurrent submission a moment before it is cached -- hence the
+        # membership test rather than an insert.
+        var s = _async_error_stream(state)
         s.synchronize()
         if state.ib != 0 and ib_error(state.ib) != 0:
             # A proxy failure during that sync releases the spin kernels
@@ -1500,7 +1525,7 @@ def ncclCommGetAsyncError(
         # exactly one.
         for a in range(state.narenas):
             var word = _read_error_word(
-                state.ctx,
+                state,
                 s,
                 state.regions[state.local_rank] + a * state.arena_stride,
             )

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -279,6 +279,15 @@ def ncclCommInitRank(
     id14: UInt64,
     id15: UInt64,
 ) abi("C") -> Int32:
+    # `regions` (CommState and every collective kernel's argument list) is a
+    # fixed StaticTuple[.., MAX_WORLD]: a larger world would index past its
+    # end. Guard explicitly rather than rely on StaticTuple's own bounds
+    # check, whose behavior under a release (non-debug) build is not this
+    # library's contract to depend on.
+    if Int(nranks) > MAX_WORLD or Int(nranks) < 1:
+        return NCCL_INVALID_ARGUMENT
+    if Int(rank) < 0 or Int(rank) >= Int(nranks):
+        return NCCL_INVALID_ARGUMENT
     try:
         var idbuf = unsafe_alloc[UInt8](UID_BYTES)
         var idbuf64 = idbuf.unsafe_bitcast[UInt64]()

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -505,8 +505,8 @@ def _lock(mut state: CommState):
     while True:
         var expected: Int64 = 0
         if Atomic[DType.int64].compare_exchange[
-            success_ordering = Ordering.ACQUIRE,
-            failure_ordering = Ordering.RELAXED,
+            success_ordering=Ordering.ACQUIRE,
+            failure_ordering=Ordering.RELAXED,
         ](p, expected, 1):
             return
         _ = external_call["sched_yield", Int32]()
@@ -526,8 +526,8 @@ def _try_lock(mut state: CommState, deadline_ns: Int) -> Bool:
     while True:
         var expected: Int64 = 0
         if Atomic[DType.int64].compare_exchange[
-            success_ordering = Ordering.ACQUIRE,
-            failure_ordering = Ordering.RELAXED,
+            success_ordering=Ordering.ACQUIRE,
+            failure_ordering=Ordering.RELAXED,
         ](p, expected, 1):
             return True
         if perf_counter_ns() > deadline_ns:
@@ -536,7 +536,7 @@ def _try_lock(mut state: CommState, deadline_ns: Int) -> Bool:
 
 
 def _unlock(mut state: CommState):
-    Atomic[DType.int64].store[ordering = Ordering.RELEASE](
+    Atomic[DType.int64].store[ordering=Ordering.RELEASE](
         Pointer(to=state.lock).unsafe_origin_cast[MutAnyOrigin](), 0
     )
 
@@ -547,7 +547,7 @@ def _raise_abort_word(state: CommState):
     next check, and no driver call is needed to do it."""
     if state.abort_host == 0:
         return
-    Atomic[DType.uint64].store[ordering = Ordering.RELEASE](
+    Atomic[DType.uint64].store[ordering=Ordering.RELEASE](
         Pointer[UInt64, MutAnyOrigin](unsafe_from_address=state.abort_host),
         UInt64(1),
     )
@@ -1223,7 +1223,8 @@ def _bootstrap(
                     + String(Int(cfg[unsafe_offset=1]))
                     + " / "
                     + String(Int(cfg[unsafe_offset=2]) // (1024 * 1024))
-                    + " MiB; MOJOCCL_REGION_MB and MOJOCCL_NVLS_MIN_MB must match"
+                    + " MiB; MOJOCCL_REGION_MB and MOJOCCL_NVLS_MIN_MB must"
+                    " match"
                     " on every rank"
                 )
 
@@ -1492,8 +1493,10 @@ def ncclCommAbort(comm: Int64) abi("C") -> Int32:
         )
     else:
         print(
-            "mojoccl: ncclCommAbort left the region allocated -- the device"
-            " was still busy after",
+            (
+                "mojoccl: ncclCommAbort left the region allocated -- the device"
+                " was still busy after"
+            ),
             ABORT_QUIESCE_TIMEOUT_S,
             "s",
         )

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -62,8 +62,9 @@
 # Single-node communicators never touch libibverbs at all -- same fused
 # kernels, same numbers as before this file learned about nodes.
 
+from std.atomic import Atomic, Ordering
 from std.collections import Dict
-from std.ffi import OwnedDLHandle
+from std.ffi import OwnedDLHandle, external_call
 from std.gpu import global_idx
 from std.memory.alloc import unsafe_alloc
 from std.os import getenv
@@ -372,6 +373,8 @@ struct CommState(Movable):
     var nvls_grid: Int
     var nvls_min: Int
     var nvls_bars: Int
+    # Submission lock (`_lock`/`_unlock`): 0 free, 1 held.
+    var lock: Int64
 
     def __init__(
         out self,
@@ -432,6 +435,39 @@ struct CommState(Movable):
         # reset, and it is independent of `generation` (different address,
         # different protocol) so the two paths can alternate freely.
         self.nvls_bars = 0
+        self.lock = 0
+
+
+def _lock(mut state: CommState):
+    """Serialize whole-collective submission on one communicator.
+
+    A collective is several launches plus host bookkeeping (generations,
+    exchange numbers, work descriptors, arena choice). One stream orders the
+    launches, not the sequence: torch can issue collectives from more than
+    one host thread (DDP's reducer runs on the autograd thread while the main
+    thread may broadcast) and ctypes releases the GIL around the call, so two
+    submissions could interleave -- thread A's reduce-scatter, then thread
+    B's on the same arena before A released its exchange. NCCL declares
+    concurrent calls on one communicator unsupported; a spin word costs ~20 ns
+    uncontended and turns that into a serialization. Never taken by
+    `ncclCommAbort` or `ncclCommGetAsyncError`: a watchdog must be able to
+    abort a communicator whose submitter is stuck behind a full launch queue.
+    """
+    var p = Pointer(to=state.lock).unsafe_origin_cast[MutAnyOrigin]()
+    while True:
+        var expected: Int64 = 0
+        if Atomic[DType.int64].compare_exchange[
+            success_ordering = Ordering.ACQUIRE,
+            failure_ordering = Ordering.RELAXED,
+        ](p, expected, 1):
+            return
+        _ = external_call["sched_yield", Int32]()
+
+
+def _unlock(mut state: CommState):
+    Atomic[DType.int64].store[ordering = Ordering.RELEASE](
+        Pointer(to=state.lock).unsafe_origin_cast[MutAnyOrigin](), 0
+    )
 
 
 @always_inline
@@ -1148,9 +1184,16 @@ def _drain_all_streams(mut state: CommState) raises:
 
 @export
 def ncclCommDestroy(comm: Int64) abi("C") -> Int32:
+    ref state = _comm_ptr(comm)[]
+    _lock(state)
+    var rc = _destroy_locked(comm)
+    _unlock(state)
+    return rc
+
+
+def _destroy_locked(comm: Int64) -> Int32:
     try:
-        var ptr = _comm_ptr(comm)
-        ref state = ptr[]
+        ref state = _comm_ptr(comm)[]
         if not state.aborted:
             # The inter-node callbacks were enqueued on the CALLER's stream(s),
             # not on the context's own, and they dereference the IbState this
@@ -1647,70 +1690,93 @@ def ncclAllReduce(
         if Int(sendbuff) % 16 != 0 or Int(recvbuff) % 16 != 0:
             return NCCL_INVALID_ARGUMENT
         ref state = _comm_ptr(comm)[]
-        if state.aborted:
-            return NCCL_INVALID_USAGE
-        if state.ib != 0 and ib_error(state.ib) != 0:
-            return NCCL_REMOTE_ERROR
-        state.last_stream = stream
-        _ensure_stream_cached(state, stream)
-        ref s = state.stream_cache[stream]
-        var scale = Float32(1.0)
-        if op == NCCL_AVG:
-            scale = Float32(1.0) / Float32(state.world)
-        if datatype == NCCL_INT32:
-            _do_allreduce[DType.int32](
-                state,
-                s,
-                stream,
-                Int(sendbuff),
-                Int(recvbuff),
-                Int(count),
-                scale,
+        _lock(state)
+        var rc = NCCL_INTERNAL_ERROR
+        try:
+            rc = _allreduce_locked(
+                comm, sendbuff, recvbuff, count, datatype, op, stream
             )
-        elif datatype == NCCL_INT64:
-            _do_allreduce[DType.int64](
-                state,
-                s,
-                stream,
-                Int(sendbuff),
-                Int(recvbuff),
-                Int(count),
-                scale,
-            )
-        elif datatype == NCCL_FLOAT16:
-            _do_allreduce[DType.float16](
-                state,
-                s,
-                stream,
-                Int(sendbuff),
-                Int(recvbuff),
-                Int(count),
-                scale,
-            )
-        elif datatype == NCCL_FLOAT32:
-            _do_allreduce[DType.float32](
-                state,
-                s,
-                stream,
-                Int(sendbuff),
-                Int(recvbuff),
-                Int(count),
-                scale,
-            )
-        else:  # NCCL_BFLOAT16, ruled in by _dtype_item_bytes above
-            _do_allreduce[DType.bfloat16](
-                state,
-                s,
-                stream,
-                Int(sendbuff),
-                Int(recvbuff),
-                Int(count),
-                scale,
-            )
-        return NCCL_SUCCESS
+        except e:
+            _unlock(state)
+            raise e
+        _unlock(state)
+        return rc
     except e:
         print("mojoccl: ncclAllReduce failed:", e)
         return NCCL_INTERNAL_ERROR
+
+
+def _allreduce_locked(
+    comm: Int64,
+    sendbuff: Int64,
+    recvbuff: Int64,
+    count: Int64,
+    datatype: Int32,
+    op: Int32,
+    stream: Int64,
+) raises -> Int32:
+    ref state = _comm_ptr(comm)[]
+    if state.aborted:
+        return NCCL_INVALID_USAGE
+    if state.ib != 0 and ib_error(state.ib) != 0:
+        return NCCL_REMOTE_ERROR
+    state.last_stream = stream
+    _ensure_stream_cached(state, stream)
+    ref s = state.stream_cache[stream]
+    var scale = Float32(1.0)
+    if op == NCCL_AVG:
+        scale = Float32(1.0) / Float32(state.world)
+    if datatype == NCCL_INT32:
+        _do_allreduce[DType.int32](
+            state,
+            s,
+            stream,
+            Int(sendbuff),
+            Int(recvbuff),
+            Int(count),
+            scale,
+        )
+    elif datatype == NCCL_INT64:
+        _do_allreduce[DType.int64](
+            state,
+            s,
+            stream,
+            Int(sendbuff),
+            Int(recvbuff),
+            Int(count),
+            scale,
+        )
+    elif datatype == NCCL_FLOAT16:
+        _do_allreduce[DType.float16](
+            state,
+            s,
+            stream,
+            Int(sendbuff),
+            Int(recvbuff),
+            Int(count),
+            scale,
+        )
+    elif datatype == NCCL_FLOAT32:
+        _do_allreduce[DType.float32](
+            state,
+            s,
+            stream,
+            Int(sendbuff),
+            Int(recvbuff),
+            Int(count),
+            scale,
+        )
+    else:  # NCCL_BFLOAT16, ruled in by _dtype_item_bytes above
+        _do_allreduce[DType.bfloat16](
+            state,
+            s,
+            stream,
+            Int(sendbuff),
+            Int(recvbuff),
+            Int(count),
+            scale,
+        )
+    return NCCL_SUCCESS
 
 
 @export
@@ -1728,50 +1794,71 @@ def ncclBroadcast(
         if item == 0:
             return NCCL_INVALID_ARGUMENT
         ref state = _comm_ptr(comm)[]
-        if state.aborted:
-            return NCCL_INVALID_USAGE
-        if Int(root) < 0 or Int(root) >= state.world:
-            return NCCL_INVALID_ARGUMENT
-        if state.ib != 0 and ib_error(state.ib) != 0:
-            return NCCL_REMOTE_ERROR
-        state.last_stream = stream
-        _ensure_stream_cached(state, stream)
-        ref s = state.stream_cache[stream]
-        var total_bytes = Int(count) * item
-        if state.nnodes == 1:
-            var max_bytes = max(item, state.cap_bytes)
-            var done = 0
-            while done < total_bytes:
-                var chunk = min(max_bytes, total_bytes - done)
-                state.generation += 1
-                broadcast(
-                    state.ctx,
-                    s,
-                    state.local_rank,
-                    Int(root),
-                    state.local_world,
-                    state.regions,
-                    Int(sendbuff) + done,
-                    Int(recvbuff) + done,
-                    chunk,
-                    state.cap_bytes,
-                    state.generation,
-                )
-                done += chunk
-            return NCCL_SUCCESS
-        _broadcast_multinode(
-            state,
-            s,
-            stream,
-            Int(sendbuff),
-            Int(recvbuff),
-            total_bytes,
-            Int(root),
-        )
-        return NCCL_SUCCESS
+        _lock(state)
+        var rc = NCCL_INTERNAL_ERROR
+        try:
+            rc = _broadcast_locked(
+                comm, sendbuff, recvbuff, Int(count) * item, root, stream
+            )
+        except e:
+            _unlock(state)
+            raise e
+        _unlock(state)
+        return rc
     except e:
         print("mojoccl: ncclBroadcast failed:", e)
         return NCCL_INTERNAL_ERROR
+
+
+def _broadcast_locked(
+    comm: Int64,
+    sendbuff: Int64,
+    recvbuff: Int64,
+    total_bytes: Int,
+    root: Int32,
+    stream: Int64,
+) raises -> Int32:
+    ref state = _comm_ptr(comm)[]
+    if state.aborted:
+        return NCCL_INVALID_USAGE
+    if Int(root) < 0 or Int(root) >= state.world:
+        return NCCL_INVALID_ARGUMENT
+    if state.ib != 0 and ib_error(state.ib) != 0:
+        return NCCL_REMOTE_ERROR
+    state.last_stream = stream
+    _ensure_stream_cached(state, stream)
+    ref s = state.stream_cache[stream]
+    if state.nnodes == 1:
+        var max_bytes = max(1, state.cap_bytes)
+        var done = 0
+        while done < total_bytes:
+            var chunk = min(max_bytes, total_bytes - done)
+            state.generation += 1
+            broadcast(
+                state.ctx,
+                s,
+                state.local_rank,
+                Int(root),
+                state.local_world,
+                state.regions,
+                Int(sendbuff) + done,
+                Int(recvbuff) + done,
+                chunk,
+                state.cap_bytes,
+                state.generation,
+            )
+            done += chunk
+        return NCCL_SUCCESS
+    _broadcast_multinode(
+        state,
+        s,
+        stream,
+        Int(sendbuff),
+        Int(recvbuff),
+        total_bytes,
+        Int(root),
+    )
+    return NCCL_SUCCESS
 
 
 def _broadcast_multinode(
@@ -1908,42 +1995,62 @@ def ncclAllGather(
         if item == 0:
             return NCCL_INVALID_ARGUMENT
         ref state = _comm_ptr(comm)[]
-        if state.aborted:
-            return NCCL_INVALID_USAGE
-        if state.ib != 0 and ib_error(state.ib) != 0:
-            return NCCL_REMOTE_ERROR
-        state.last_stream = stream
-        _ensure_stream_cached(state, stream)
-        ref s = state.stream_cache[stream]
-        var per_rank_bytes = Int(sendcount) * item
-        if state.nnodes == 1:
-            var max_bytes = max(item, state.cap_bytes)
-            var done = 0
-            while done < per_rank_bytes:
-                var chunk = min(max_bytes, per_rank_bytes - done)
-                state.generation += 1
-                allgather(
-                    state.ctx,
-                    s,
-                    state.local_rank,
-                    state.local_world,
-                    state.regions,
-                    Int(sendbuff) + done,
-                    Int(recvbuff) + done,
-                    chunk,
-                    state.cap_bytes,
-                    state.generation,
-                    stride_bytes=per_rank_bytes,
-                )
-                done += chunk
-            return NCCL_SUCCESS
-        _allgather_multinode(
-            state, s, stream, Int(sendbuff), Int(recvbuff), per_rank_bytes
-        )
-        return NCCL_SUCCESS
+        _lock(state)
+        var rc = NCCL_INTERNAL_ERROR
+        try:
+            rc = _allgather_locked(
+                comm, sendbuff, recvbuff, Int(sendcount) * item, stream
+            )
+        except e:
+            _unlock(state)
+            raise e
+        _unlock(state)
+        return rc
     except e:
         print("mojoccl: ncclAllGather failed:", e)
         return NCCL_INTERNAL_ERROR
+
+
+def _allgather_locked(
+    comm: Int64,
+    sendbuff: Int64,
+    recvbuff: Int64,
+    per_rank_bytes: Int,
+    stream: Int64,
+) raises -> Int32:
+    ref state = _comm_ptr(comm)[]
+    if state.aborted:
+        return NCCL_INVALID_USAGE
+    if state.ib != 0 and ib_error(state.ib) != 0:
+        return NCCL_REMOTE_ERROR
+    state.last_stream = stream
+    _ensure_stream_cached(state, stream)
+    ref s = state.stream_cache[stream]
+    if state.nnodes == 1:
+        var max_bytes = max(1, state.cap_bytes)
+        var done = 0
+        while done < per_rank_bytes:
+            var chunk = min(max_bytes, per_rank_bytes - done)
+            state.generation += 1
+            allgather(
+                state.ctx,
+                s,
+                state.local_rank,
+                state.local_world,
+                state.regions,
+                Int(sendbuff) + done,
+                Int(recvbuff) + done,
+                chunk,
+                state.cap_bytes,
+                state.generation,
+                stride_bytes=per_rank_bytes,
+            )
+            done += chunk
+        return NCCL_SUCCESS
+    _allgather_multinode(
+        state, s, stream, Int(sendbuff), Int(recvbuff), per_rank_bytes
+    )
+    return NCCL_SUCCESS
 
 
 def _allgather_multinode(

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -124,6 +124,20 @@ comptime NCCL_BFLOAT16: Int32 = 9
 comptime NCCL_SUM: Int32 = 0
 comptime NCCL_AVG: Int32 = 4
 
+# Payload a rank sends when it has nothing to contribute to an exchange.
+#
+# Every exchange is all-to-all among the ranks sharing a local_rank, even
+# when only one of them has data (a broadcast, or an allreduce whose shard
+# table leaves this rank empty), and that is a correctness requirement, not
+# tidiness. The inbox is double buffered by the exchange counter's parity,
+# so what has to be true is: peer B's write for exchange e+2 lands after MY
+# add kernel for exchange e has read that half. All-to-all makes it a proof
+# -- B cannot post e+2 before its callback for e+1 returned, which needed MY
+# e+1 message, which my stream sent only after running my add kernel for e.
+# Let one exchange be one-directional and that chain breaks, leaving nothing
+# but a timing margin between B's write and my read.
+comptime CREDIT_BYTES = 16
+
 comptime DEFAULT_REGION_MB = 256
 comptime DEFAULT_BOOTSTRAP_TIMEOUT_S: Float64 = 120.0
 
@@ -774,53 +788,57 @@ def _inter_node_exchange[
     kernel that adds what arrived. On exit the shard holds the sum over the
     WHOLE communicator, ready for `allgather_finish`.
 
-    Inbox geometry, derived from `(numel, local_world, item)` alone so that
-    a sender computes the same addresses as its receiver: `net_off` holds
-    two halves of `(nnodes-1)` slots of one shard each, and the exchange
+    Inbox geometry is derived from `(numel, local_world, item)` alone so that
+    a sender computes the same addresses as its receiver: `net_off` holds two
+    halves of `(nnodes-1)` slots of one shard each, and the exchange
     counter's parity picks the half. `_max_chunk_bytes` keeps both halves
     inside the area.
     """
     comptime item = size_of[dtype]()
-    var lw = state.local_world
-    var sr = shard_range(numel, lw, state.local_rank, item)
+    var sr = shard_range(numel, state.local_world, state.local_rank, item)
     var off_e = sr[0]
     var cnt_e = sr[1]
     var seq = ib_next_seq(state.ib)
-    if cnt_e <= 0:
-        return
     var npeers = ib_npeers(state.ib)
-    var slot_bytes = _align_up(cnt_e * item, 16)
-    var inbox_off = state.net_off
+    var nbytes = cnt_e * item
+    var slot_bytes = _align_up(max(nbytes, CREDIT_BYTES), 16)
     var half = npeers * slot_bytes
     if 2 * half > state.cap_bytes:
         raise Error(
             "mojoccl: the inter-node inbox overflows the network area; this"
             " is a chunking bug"
         )
-    var inbox_base = inbox_off + (seq & 1) * half
-    var shard = state.owned_base + signal_bytes() + state.cap_bytes + off_e * item
+    var inbox_base = state.net_off + (seq & 1) * half
+    var shard = (
+        state.owned_base + signal_bytes() + state.cap_bytes + off_e * item
+    )
+    # A rank with an empty shard (numel below local_world's rounded-up shard
+    # size -- DDP's 4-byte AVG allreduce does exactly this on 7 of 8 local
+    # ranks) still exchanges, with CREDIT_BYTES of ignored payload. See
+    # `CREDIT_BYTES` for why every exchange has to be all-to-all.
     ib_enqueue(
         state.ib,
         state.driver,
         Int(raw_stream),
-        shard,
-        cnt_e * item,
+        shard if cnt_e > 0 else state.owned_base,
+        nbytes if cnt_e > 0 else CREDIT_BYTES,
         inbox_base,
         slot_bytes,
         True,
         npeers,
-        state.owned_base + inbox_base,
+        state.owned_base + inbox_base if cnt_e > 0 else 0,
         seq,
     )
-    inbox_add[dtype](
-        state.ctx,
-        stream,
-        shard,
-        state.owned_base + inbox_base,
-        cnt_e,
-        slot_bytes,
-        npeers,
-    )
+    if cnt_e > 0:
+        inbox_add[dtype](
+            state.ctx,
+            stream,
+            shard,
+            state.owned_base + inbox_base,
+            cnt_e,
+            slot_bytes,
+            npeers,
+        )
 
 
 def _max_chunk_bytes(state: CommState) -> Int:
@@ -1034,8 +1052,9 @@ def _broadcast_multinode(
 
     The rank that receives on node j is the one sharing the root's
     local_rank, because that is the only rank the root has a queue pair to.
-    Correct and simple beats fast here: broadcast runs at DDP init, on
-    parameters, not in the step.
+    Every OTHER rank still runs a credit-only exchange with its own
+    same-local_rank peers (CREDIT_BYTES). Correct and simple beats fast
+    here: broadcast runs at DDP init, on parameters, not in the step.
     """
     var lw = state.local_world
     var root_node = 0
@@ -1048,20 +1067,32 @@ def _broadcast_multinode(
     var i_am_root = state.rank == root
     var i_am_local_root = state.local_rank == root_lr
     var receives = i_am_local_root and state.my_node != root_node
-    # The network area holds the root's staged chunk plus both inbox
-    # halves (one slot of `chunk` each): three chunks.
-    var max_bytes = max(4096, (state.cap_bytes // 3 - 2 * 4096) // 4096 * 4096)
+    # The network area holds the root's staged chunk plus both inbox halves,
+    # and a half is one slot PER PEER now that the exchange is all-to-all.
+    var npeers = ib_npeers(state.ib)
+    var max_bytes = max(
+        4096,
+        (state.cap_bytes // (1 + 2 * npeers) - 2 * 4096) // 4096 * 4096,
+    )
     var done = 0
     while done < total_bytes:
         var chunk = min(max_bytes, total_bytes - done)
         var seq = ib_next_seq(state.ib)
         var slot_bytes = _align_up(chunk, 16)
         var inbox_off = state.net_off + _align_up(chunk, 4096)
-        var inbox_base = inbox_off + (seq & 1) * slot_bytes
+        var half = npeers * slot_bytes
+        if inbox_off + 2 * half > state.net_off + state.cap_bytes:
+            raise Error("mojoccl: broadcast inbox does not fit; chunking bug")
+        var inbox_base = inbox_off + (seq & 1) * half
         var recv_slot = 0
         if receives:
             recv_slot = root_node if root_node < state.my_node else root_node - 1
         var send_ptr = recvbuff + done
+        # Everyone in this local_rank group exchanges; only the root's
+        # payload is real (see CREDIT_BYTES).
+        var send_addr = state.owned_base
+        var send_bytes = CREDIT_BYTES
+        var flush_addr = 0
         if i_am_root:
             # The user buffer is not registered, so the root's payload has to
             # be copied into the region before the NIC can read it.
@@ -1072,35 +1103,27 @@ def _broadcast_multinode(
                 sendbuff + done,
                 chunk,
             )
-            ib_enqueue(
-                state.ib,
-                state.driver,
-                Int(raw_stream),
-                state.owned_base + state.net_off,
-                chunk,
-                inbox_base,
-                slot_bytes,
-                True,
-                0,
-                0,
-                seq,
-            )
+            send_addr = state.owned_base + state.net_off
+            send_bytes = chunk
             send_ptr = sendbuff + done
         elif receives:
-            ib_enqueue(
-                state.ib,
-                state.driver,
-                Int(raw_stream),
-                0,
-                0,
-                inbox_base,
-                slot_bytes,
-                False,
-                1,
-                state.owned_base + inbox_base + recv_slot * slot_bytes,
-                seq,
+            flush_addr = (
+                state.owned_base + inbox_base + recv_slot * slot_bytes
             )
-            send_ptr = state.owned_base + inbox_base + recv_slot * slot_bytes
+            send_ptr = flush_addr
+        ib_enqueue(
+            state.ib,
+            state.driver,
+            Int(raw_stream),
+            send_addr,
+            send_bytes,
+            inbox_base,
+            slot_bytes,
+            True,
+            npeers,
+            flush_addr,
+            seq,
+        )
         state.generation += 1
         broadcast(
             state.ctx,

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -819,6 +819,8 @@ def _inter_node_exchange[
     ib_enqueue(
         state.ib,
         state.driver,
+        state.ctx,
+        stream,
         Int(raw_stream),
         shard if cnt_e > 0 else state.owned_base,
         nbytes if cnt_e > 0 else CREDIT_BYTES,
@@ -1114,6 +1116,8 @@ def _broadcast_multinode(
         ib_enqueue(
             state.ib,
             state.driver,
+            state.ctx,
+            stream,
             Int(raw_stream),
             send_addr,
             send_bytes,
@@ -1245,6 +1249,8 @@ def _allgather_multinode(
         ib_enqueue(
             state.ib,
             state.driver,
+            state.ctx,
+            stream,
             Int(raw_stream),
             block_stage,
             block,

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -1,0 +1,689 @@
+# mojoccl: a Mojo shared library exporting NCCL's C ABI (nccl.h), so
+# torch_mojo_backend/distributed/nccl.py can dlopen it exactly like
+# libnccl.so.2/librccl.so.1 (TORCH_MOJO_BACKEND_CCL=mojo), and so external
+# tools (nccl-tests) can link it as a libnccl.so drop-in.
+#
+# Signatures, enum values and ncclResult_t codes are pinned to
+# /home/gabriel/projects/nccl/src/nccl.h.in (2.31.2) -- the source of truth
+# is nccl.py's `_declare()`, which this library's exports were written
+# against. AllReduce/Broadcast/AllGather are real; Reduce/ReduceScatter/
+# Send/Recv return ncclInvalidUsage (GPT-2 DDP needs only the first three;
+# tests/ddp_worker.py skips the checks that need them when
+# TORCH_MOJO_BACKEND_CCL=mojo is set).
+#
+# One process per GPU, one region per rank, raw driver-owned memory shared
+# with legacy IPC (driver.mojo) -- MAX's own allocator memory cannot be
+# exported that way (see docs/mojo_collectives_feasibility.md in the main
+# worktree, §5.6). Bootstrap (the handle exchange ncclCommInitRank itself
+# must do) rides a /dev/shm directory encoded in the 128-byte unique id
+# (bootstrap.mojo); the collectives are the STAND-IN kernel
+# (collectives_kernels.mojo), swapped out wholesale once the production
+# kernel lands.
+
+from std.ffi import OwnedDLHandle
+from std.memory.alloc import unsafe_alloc
+from std.os import getenv
+from std.utils import StaticTuple
+from max.gpu.host import DeviceContext, DeviceStream
+
+from driver import (
+    HANDLE_BYTES,
+    alloc_region,
+    close_handle,
+    current_device_ordinal,
+    free_region,
+    get_handle,
+    open_driver,
+    open_handle,
+)
+from bootstrap import (
+    UID_BYTES,
+    create_rendezvous_dir,
+    decode_dir,
+    encode_dir,
+    read_rank_handle,
+    wait_for_rank,
+    write_rank_handle,
+)
+from collectives_kernels import (
+    MAX_WORLD,
+    allgather,
+    allreduce,
+    broadcast,
+    error_offset,
+    region_init,
+    signal_bytes,
+)
+
+# ncclResult_t (nccl.h.in:44-53)
+comptime NCCL_SUCCESS: Int32 = 0
+comptime NCCL_UNHANDLED_CUDA_ERROR: Int32 = 1
+comptime NCCL_SYSTEM_ERROR: Int32 = 2
+comptime NCCL_INTERNAL_ERROR: Int32 = 3
+comptime NCCL_INVALID_ARGUMENT: Int32 = 4
+comptime NCCL_INVALID_USAGE: Int32 = 5
+comptime NCCL_REMOTE_ERROR: Int32 = 6
+comptime NCCL_IN_PROGRESS: Int32 = 7
+
+# ncclDataType_t (nccl.h.in:466-479) -- values this library implements.
+comptime NCCL_INT32: Int32 = 2
+comptime NCCL_INT64: Int32 = 4
+comptime NCCL_FLOAT16: Int32 = 6
+comptime NCCL_FLOAT32: Int32 = 7
+comptime NCCL_BFLOAT16: Int32 = 9
+
+# ncclRedOp_t (nccl.h.in:448-463) -- values this library implements.
+comptime NCCL_SUM: Int32 = 0
+comptime NCCL_AVG: Int32 = 4
+
+comptime DEFAULT_REGION_MB = 256
+comptime DEFAULT_BOOTSTRAP_TIMEOUT_S: Float64 = 120.0
+
+
+def _region_cap_bytes() -> Int:
+    var s = getenv("MOJOCCL_REGION_MB", String(DEFAULT_REGION_MB))
+    try:
+        return Int(s) * 1024 * 1024
+    except:
+        return DEFAULT_REGION_MB * 1024 * 1024
+
+
+def _bootstrap_timeout_s() -> Float64:
+    var s = getenv(
+        "MOJOCCL_BOOTSTRAP_TIMEOUT_S", String(DEFAULT_BOOTSTRAP_TIMEOUT_S)
+    )
+    try:
+        return Float64(s)
+    except:
+        return DEFAULT_BOOTSTRAP_TIMEOUT_S
+
+
+def _dtype_item_bytes(nccl_dtype: Int32) -> Int:
+    if nccl_dtype == NCCL_INT32 or nccl_dtype == NCCL_FLOAT32:
+        return 4
+    elif nccl_dtype == NCCL_INT64:
+        return 8
+    elif nccl_dtype == NCCL_FLOAT16 or nccl_dtype == NCCL_BFLOAT16:
+        return 2
+    else:
+        return 0
+
+
+# ---------------------------------------------------------------------------
+# Communicator state, behind the opaque `ncclComm_t` (void*) every exported
+# function after ncclCommInitRank receives. Heap-allocated once per
+# communicator and never freed on destroy (the struct itself is a few
+# hundred bytes; only the GPU region and peer IPC mappings -- the resources
+# that matter -- are released there). `regions` is padded to MAX_WORLD with
+# zeros; only indices < world are ever read.
+# ---------------------------------------------------------------------------
+
+
+struct CommState(Movable):
+    var rank: Int
+    var world: Int
+    var ordinal: Int
+    var ctx: DeviceContext
+    var driver: OwnedDLHandle
+    var cap_bytes: Int
+    var regions: StaticTuple[Int, MAX_WORLD]
+    var owned_base: Int
+    var generation: Int
+    var last_stream: Int64
+    var aborted: Bool
+
+    def __init__(
+        out self,
+        rank: Int,
+        world: Int,
+        ordinal: Int,
+        ctx: DeviceContext,
+        var driver: OwnedDLHandle,
+        cap_bytes: Int,
+        regions: StaticTuple[Int, MAX_WORLD],
+        owned_base: Int,
+    ):
+        self.rank = rank
+        self.world = world
+        self.ordinal = ordinal
+        self.ctx = ctx
+        self.driver = driver^
+        self.cap_bytes = cap_bytes
+        self.regions = regions
+        self.owned_base = owned_base
+        self.generation = 0
+        self.last_stream = 0
+        self.aborted = False
+
+
+@always_inline
+def _comm_ptr(comm: Int64) -> Pointer[CommState, MutAnyOrigin]:
+    return Pointer[CommState, MutAnyOrigin](unsafe_from_address=Int(comm))
+
+
+@always_inline
+def _any(p: Pointer[UInt8, MutUntrackedOrigin]) -> Pointer[UInt8, MutAnyOrigin]:
+    """Rebinds an `unsafe_alloc`-returned pointer's origin to `MutAnyOrigin`,
+    matching what driver.mojo/bootstrap.mojo (and the exported ABI functions
+    they share signatures with) declare."""
+    return Pointer[UInt8, MutAnyOrigin](unsafe_from_address=Int(p))
+
+
+@always_inline
+def _wrap_stream(ctx: DeviceContext, handle: Int64) raises -> DeviceStream:
+    return ctx.create_external_stream(
+        OpaquePointer[MutAnyOrigin](unsafe_from_address=Int(handle))
+    )
+
+
+# ---------------------------------------------------------------------------
+# Version / error string / unique id
+# ---------------------------------------------------------------------------
+
+
+@export
+def ncclGetVersion(version: Pointer[Int32, MutAnyOrigin]) abi("C") -> Int32:
+    # 2.31.2-shaped: matches the pinned header this ABI was written against.
+    version[] = 22031
+    return NCCL_SUCCESS
+
+
+comptime _ERR_SUCCESS: StaticString = "no error"
+comptime _ERR_UNHANDLED_CUDA: StaticString = "unhandled cuda/hip error"
+comptime _ERR_SYSTEM: StaticString = "system error"
+comptime _ERR_INTERNAL: StaticString = "internal error"
+comptime _ERR_INVALID_ARGUMENT: StaticString = "invalid argument"
+comptime _ERR_INVALID_USAGE: StaticString = (
+    "invalid usage (not implemented by mojoccl)"
+)
+comptime _ERR_REMOTE: StaticString = "remote error (a peer's barrier timed out)"
+comptime _ERR_IN_PROGRESS: StaticString = "operation in progress"
+comptime _ERR_UNKNOWN: StaticString = "unknown result code"
+
+
+@export
+def ncclGetErrorString(
+    result: Int32,
+) abi("C") -> Pointer[UInt8, ImmStaticOrigin]:
+    if result == NCCL_SUCCESS:
+        return _ERR_SUCCESS.unsafe_ptr()
+    elif result == NCCL_UNHANDLED_CUDA_ERROR:
+        return _ERR_UNHANDLED_CUDA.unsafe_ptr()
+    elif result == NCCL_SYSTEM_ERROR:
+        return _ERR_SYSTEM.unsafe_ptr()
+    elif result == NCCL_INTERNAL_ERROR:
+        return _ERR_INTERNAL.unsafe_ptr()
+    elif result == NCCL_INVALID_ARGUMENT:
+        return _ERR_INVALID_ARGUMENT.unsafe_ptr()
+    elif result == NCCL_INVALID_USAGE:
+        return _ERR_INVALID_USAGE.unsafe_ptr()
+    elif result == NCCL_REMOTE_ERROR:
+        return _ERR_REMOTE.unsafe_ptr()
+    elif result == NCCL_IN_PROGRESS:
+        return _ERR_IN_PROGRESS.unsafe_ptr()
+    else:
+        return _ERR_UNKNOWN.unsafe_ptr()
+
+
+@export
+def ncclGetUniqueId(uid_out: Pointer[UInt8, MutAnyOrigin]) abi("C") -> Int32:
+    try:
+        var dir = create_rendezvous_dir()
+        encode_dir(dir, uid_out)
+        return NCCL_SUCCESS
+    except e:
+        return NCCL_SYSTEM_ERROR
+
+
+# ---------------------------------------------------------------------------
+# ncclCommInitRank -- the one struct-by-value export. `ncclUniqueId commId`
+# is 128 bytes, SysV MEMORY class: it consumes no integer register and is
+# pushed on the stack by a real C caller, so `rank` (declared after it) gets
+# the next FREE register (rdx), not the one following `nranks` textually.
+# Mirrored here by 3 real leading params (comm/nranks/rank -> rdi/esi/edx),
+# 3 Int64 dummies exhausting rcx/r8/r9, then 16 UInt64 stack params that ARE
+# the struct -- the callee-side twin of the caller-side shim
+# proto/ipc_probe.mojo uses for cuIpcOpenMemHandle. Verified host-only with
+# ctypes against this exact parameter shape (register/stack layout, no GPU
+# needed): a probe function of this shape decoded nranks, rank and a
+# checksum of the 16 id words correctly when called exactly as
+# ncclCommInitRank(comm, nranks, ncclUniqueId, rank) would be.
+# ---------------------------------------------------------------------------
+
+
+@export
+def ncclCommInitRank(
+    comm_out: Pointer[Int64, MutAnyOrigin],
+    nranks: Int32,
+    rank: Int32,
+    _r1: Int64,
+    _r2: Int64,
+    _r3: Int64,
+    id0: UInt64,
+    id1: UInt64,
+    id2: UInt64,
+    id3: UInt64,
+    id4: UInt64,
+    id5: UInt64,
+    id6: UInt64,
+    id7: UInt64,
+    id8: UInt64,
+    id9: UInt64,
+    id10: UInt64,
+    id11: UInt64,
+    id12: UInt64,
+    id13: UInt64,
+    id14: UInt64,
+    id15: UInt64,
+) abi("C") -> Int32:
+    try:
+        var idbuf = unsafe_alloc[UInt8](UID_BYTES)
+        var idbuf64 = idbuf.unsafe_bitcast[UInt64]()
+        idbuf64[unsafe_offset=0] = id0
+        idbuf64[unsafe_offset=1] = id1
+        idbuf64[unsafe_offset=2] = id2
+        idbuf64[unsafe_offset=3] = id3
+        idbuf64[unsafe_offset=4] = id4
+        idbuf64[unsafe_offset=5] = id5
+        idbuf64[unsafe_offset=6] = id6
+        idbuf64[unsafe_offset=7] = id7
+        idbuf64[unsafe_offset=8] = id8
+        idbuf64[unsafe_offset=9] = id9
+        idbuf64[unsafe_offset=10] = id10
+        idbuf64[unsafe_offset=11] = id11
+        idbuf64[unsafe_offset=12] = id12
+        idbuf64[unsafe_offset=13] = id13
+        idbuf64[unsafe_offset=14] = id14
+        idbuf64[unsafe_offset=15] = id15
+        var dir = decode_dir(_any(idbuf))
+
+        var lib = open_driver()
+        var ordinal = current_device_ordinal(lib)
+        var ctx = DeviceContext(device_id=ordinal)
+
+        var cap_bytes = _region_cap_bytes()
+        var region_bytes = signal_bytes() + 2 * cap_bytes
+        var base = alloc_region(lib, region_bytes)
+        region_init(ctx, base)
+
+        var my_handle = unsafe_alloc[UInt8](HANDLE_BYTES)
+        get_handle(lib, base, _any(my_handle))
+        write_rank_handle(dir, Int(rank), ordinal, _any(my_handle))
+
+        var timeout_s = _bootstrap_timeout_s()
+        var regions = StaticTuple[Int, MAX_WORLD](fill=0)
+        regions[Int(rank)] = base
+        var peer_handle = unsafe_alloc[UInt8](HANDLE_BYTES)
+        for r in range(Int(nranks)):
+            if r == Int(rank):
+                continue
+            wait_for_rank(dir, r, timeout_s)
+            _ = read_rank_handle(dir, r, _any(peer_handle))
+            regions[r] = open_handle(lib, _any(peer_handle))
+
+        var state = CommState(
+            rank=Int(rank),
+            world=Int(nranks),
+            ordinal=ordinal,
+            ctx=ctx,
+            driver=lib^,
+            cap_bytes=cap_bytes,
+            regions=regions,
+            owned_base=base,
+        )
+        var handle_ptr = unsafe_alloc[CommState](1)
+        handle_ptr.unsafe_write(state^)
+        comm_out[] = Int64(Int(handle_ptr))
+        return NCCL_SUCCESS
+    except e:
+        return NCCL_INTERNAL_ERROR
+
+
+# ---------------------------------------------------------------------------
+# Communicator lifecycle
+# ---------------------------------------------------------------------------
+
+
+@export
+def ncclCommDestroy(comm: Int64) abi("C") -> Int32:
+    try:
+        var ptr = _comm_ptr(comm)
+        ref state = ptr[]
+        if not state.aborted:
+            state.ctx.synchronize()
+            for r in range(state.world):
+                if r != state.rank:
+                    close_handle(state.driver, state.regions[r])
+            free_region(state.driver, state.owned_base)
+        return NCCL_SUCCESS
+    except e:
+        return NCCL_INTERNAL_ERROR
+
+
+@export
+def ncclCommAbort(comm: Int64) abi("C") -> Int32:
+    ref state = _comm_ptr(comm)[]
+    # No wait, no cleanup of GPU resources here (a dead peer may hang
+    # forever inside its own barrier spin) -- matches ncclCommAbort's
+    # documented "don't wait" contract. ncclCommDestroy is never called
+    # after abort() by nccl.py's NcclComm.
+    state.aborted = True
+    return NCCL_SUCCESS
+
+
+@export
+def ncclCommGetAsyncError(
+    comm: Int64, err_out: Pointer[Int32, MutAnyOrigin]
+) abi("C") -> Int32:
+    try:
+        ref state = _comm_ptr(comm)[]
+        if state.aborted:
+            err_out[] = NCCL_SYSTEM_ERROR
+            return NCCL_SUCCESS
+        if state.last_stream != 0:
+            var s = _wrap_stream(state.ctx, state.last_stream)
+            s.synchronize()
+        var err_word = Pointer[UInt64, MutAnyOrigin](
+            unsafe_from_address=state.regions[state.rank] + error_offset()
+        )
+        err_out[] = NCCL_REMOTE_ERROR if Int(err_word[]) != 0 else NCCL_SUCCESS
+        return NCCL_SUCCESS
+    except e:
+        return NCCL_INTERNAL_ERROR
+
+
+@export
+def ncclCommCount(
+    comm: Int64, count_out: Pointer[Int32, MutAnyOrigin]
+) abi("C") -> Int32:
+    ref state = _comm_ptr(comm)[]
+    count_out[] = Int32(state.world)
+    return NCCL_SUCCESS
+
+
+@export
+def ncclCommUserRank(
+    comm: Int64, rank_out: Pointer[Int32, MutAnyOrigin]
+) abi("C") -> Int32:
+    ref state = _comm_ptr(comm)[]
+    rank_out[] = Int32(state.rank)
+    return NCCL_SUCCESS
+
+
+# ---------------------------------------------------------------------------
+# Group semantics: every op here already executes on the same stream, in
+# issue order, so aggregating a group buys nothing -- immediate execution is
+# correct, per the design brief.
+# ---------------------------------------------------------------------------
+
+
+@export
+def ncclGroupStart() abi("C") -> Int32:
+    return NCCL_SUCCESS
+
+
+@export
+def ncclGroupEnd() abi("C") -> Int32:
+    return NCCL_SUCCESS
+
+
+# ---------------------------------------------------------------------------
+# Collectives
+# ---------------------------------------------------------------------------
+
+
+@export
+def ncclAllReduce(
+    sendbuff: Int64,
+    recvbuff: Int64,
+    count: Int64,
+    datatype: Int32,
+    op: Int32,
+    comm: Int64,
+    stream: Int64,
+) abi("C") -> Int32:
+    try:
+        var item = _dtype_item_bytes(datatype)
+        if item == 0:
+            return NCCL_INVALID_ARGUMENT
+        if op != NCCL_SUM and op != NCCL_AVG:
+            return NCCL_INVALID_USAGE
+        var ptr = _comm_ptr(comm)
+        ref state = ptr[]
+        if state.aborted:
+            return NCCL_INVALID_USAGE
+        state.last_stream = stream
+        var s = _wrap_stream(state.ctx, stream)
+        var scale = Float32(1.0)
+        if op == NCCL_AVG:
+            scale = Float32(1.0) / Float32(state.world)
+        var max_elems = max(1, state.cap_bytes // item)
+        var total = Int(count)
+        var done = 0
+        while done < total:
+            var chunk = min(max_elems, total - done)
+            state.generation += 1
+            var off = done * item
+            if datatype == NCCL_INT32:
+                allreduce[DType.int32](
+                    state.ctx,
+                    s,
+                    state.rank,
+                    state.world,
+                    state.regions,
+                    Int(sendbuff) + off,
+                    Int(recvbuff) + off,
+                    chunk,
+                    state.cap_bytes,
+                    scale,
+                    state.generation,
+                )
+            elif datatype == NCCL_INT64:
+                allreduce[DType.int64](
+                    state.ctx,
+                    s,
+                    state.rank,
+                    state.world,
+                    state.regions,
+                    Int(sendbuff) + off,
+                    Int(recvbuff) + off,
+                    chunk,
+                    state.cap_bytes,
+                    scale,
+                    state.generation,
+                )
+            elif datatype == NCCL_FLOAT16:
+                allreduce[DType.float16](
+                    state.ctx,
+                    s,
+                    state.rank,
+                    state.world,
+                    state.regions,
+                    Int(sendbuff) + off,
+                    Int(recvbuff) + off,
+                    chunk,
+                    state.cap_bytes,
+                    scale,
+                    state.generation,
+                )
+            elif datatype == NCCL_FLOAT32:
+                allreduce[DType.float32](
+                    state.ctx,
+                    s,
+                    state.rank,
+                    state.world,
+                    state.regions,
+                    Int(sendbuff) + off,
+                    Int(recvbuff) + off,
+                    chunk,
+                    state.cap_bytes,
+                    scale,
+                    state.generation,
+                )
+            else:  # NCCL_BFLOAT16, ruled in by _dtype_item_bytes above
+                allreduce[DType.bfloat16](
+                    state.ctx,
+                    s,
+                    state.rank,
+                    state.world,
+                    state.regions,
+                    Int(sendbuff) + off,
+                    Int(recvbuff) + off,
+                    chunk,
+                    state.cap_bytes,
+                    scale,
+                    state.generation,
+                )
+            done += chunk
+        return NCCL_SUCCESS
+    except e:
+        return NCCL_INTERNAL_ERROR
+
+
+@export
+def ncclBroadcast(
+    sendbuff: Int64,
+    recvbuff: Int64,
+    count: Int64,
+    datatype: Int32,
+    root: Int32,
+    comm: Int64,
+    stream: Int64,
+) abi("C") -> Int32:
+    try:
+        var item = _dtype_item_bytes(datatype)
+        if item == 0:
+            return NCCL_INVALID_ARGUMENT
+        var ptr = _comm_ptr(comm)
+        ref state = ptr[]
+        if state.aborted:
+            return NCCL_INVALID_USAGE
+        if Int(root) < 0 or Int(root) >= state.world:
+            return NCCL_INVALID_ARGUMENT
+        state.last_stream = stream
+        var s = _wrap_stream(state.ctx, stream)
+        var total_bytes = Int(count) * item
+        var max_bytes = max(item, state.cap_bytes)
+        var done = 0
+        while done < total_bytes:
+            var chunk = min(max_bytes, total_bytes - done)
+            state.generation += 1
+            broadcast(
+                state.ctx,
+                s,
+                state.rank,
+                Int(root),
+                state.world,
+                state.regions,
+                Int(sendbuff) + done,
+                Int(recvbuff) + done,
+                chunk,
+                state.cap_bytes,
+                state.generation,
+            )
+            done += chunk
+        return NCCL_SUCCESS
+    except e:
+        return NCCL_INTERNAL_ERROR
+
+
+@export
+def ncclAllGather(
+    sendbuff: Int64,
+    recvbuff: Int64,
+    sendcount: Int64,
+    datatype: Int32,
+    comm: Int64,
+    stream: Int64,
+) abi("C") -> Int32:
+    try:
+        var item = _dtype_item_bytes(datatype)
+        if item == 0:
+            return NCCL_INVALID_ARGUMENT
+        var ptr = _comm_ptr(comm)
+        ref state = ptr[]
+        if state.aborted:
+            return NCCL_INVALID_USAGE
+        state.last_stream = stream
+        var s = _wrap_stream(state.ctx, stream)
+        var per_rank_bytes = Int(sendcount) * item
+        var max_bytes = max(item, state.cap_bytes)
+        var done = 0
+        while done < per_rank_bytes:
+            var chunk = min(max_bytes, per_rank_bytes - done)
+            state.generation += 1
+            allgather(
+                state.ctx,
+                s,
+                state.rank,
+                state.world,
+                state.regions,
+                Int(sendbuff) + done,
+                Int(recvbuff) + done,
+                chunk,
+                state.cap_bytes,
+                state.generation,
+                stride_bytes=per_rank_bytes,
+            )
+            done += chunk
+        return NCCL_SUCCESS
+    except e:
+        return NCCL_INTERNAL_ERROR
+
+
+# ---------------------------------------------------------------------------
+# Not implemented: DDP on GPT-2 needs only AllReduce/Broadcast/AllGather (+
+# barrier, which routes to gloo -- see process_group.py). Returning
+# ncclInvalidUsage rather than silently mis-computing is the point.
+# ---------------------------------------------------------------------------
+
+
+@export
+def ncclReduce(
+    sendbuff: Int64,
+    recvbuff: Int64,
+    count: Int64,
+    datatype: Int32,
+    op: Int32,
+    root: Int32,
+    comm: Int64,
+    stream: Int64,
+) abi("C") -> Int32:
+    return NCCL_INVALID_USAGE
+
+
+@export
+def ncclReduceScatter(
+    sendbuff: Int64,
+    recvbuff: Int64,
+    count: Int64,
+    datatype: Int32,
+    op: Int32,
+    comm: Int64,
+    stream: Int64,
+) abi("C") -> Int32:
+    return NCCL_INVALID_USAGE
+
+
+@export
+def ncclSend(
+    sendbuff: Int64,
+    count: Int64,
+    datatype: Int32,
+    peer: Int32,
+    comm: Int64,
+    stream: Int64,
+) abi("C") -> Int32:
+    return NCCL_INVALID_USAGE
+
+
+@export
+def ncclRecv(
+    recvbuff: Int64,
+    count: Int64,
+    datatype: Int32,
+    peer: Int32,
+    comm: Int64,
+    stream: Int64,
+) abi("C") -> Int32:
+    return NCCL_INVALID_USAGE

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -69,18 +69,23 @@ from std.gpu import global_idx
 from std.memory.alloc import unsafe_alloc
 from std.os import getenv
 from std.sys import size_of
+from std.time import perf_counter_ns, sleep
 from std.utils import StaticTuple
 from max.gpu.host import DeviceContext, DeviceBuffer, DeviceStream
 
 from driver import (
     HANDLE_BYTES,
+    alloc_host,
     alloc_region,
     close_handle,
     current_device_ordinal,
+    free_host,
     free_region,
     get_handle,
+    host_device_ptr,
     open_driver,
     open_handle,
+    stream_done,
 )
 from bootstrap import (
     UID_BYTES,
@@ -100,6 +105,7 @@ from collectives_kernels import (
     allreduce,
     broadcast,
     error_offset,
+    install_abort_word,
     region_init,
     reduce_scatter_stage,
     shard_range,
@@ -120,6 +126,7 @@ from internode import (
     ib_npeers,
     ib_port_lid,
     ib_port_mtu,
+    ib_set_abort_word,
     ib_setup,
     ib_signal_abort,
     ib_teardown,
@@ -235,6 +242,22 @@ descriptors are bound (`MOJOCCL_SOCKET_DIR`). Node-local by definition -- a
 shared filesystem would work too but buys nothing, since the ranks that talk
 over it are on one host. NCCL puts its own at /tmp as well
 (nccl:src/os/linux_ipcsocket.cc)."""
+
+comptime ABORT_QUIESCE_TIMEOUT_S: Float64 = 5.0
+"""How long `ncclCommAbort` polls for local work to stop before it gives up on
+reclaiming the region and the IB state.
+
+Deliberately not `MOJOCCL_IB_TIMEOUT_S`: raising the abort word releases every
+device spin within about a millisecond, so this bounds only the tail of what
+was already running -- a large copy kernel, a launch queue draining -- and
+abort's contract is not to wait. Past it the resources are left allocated,
+which is a leak until the process exits and is the safe half of the trade:
+freeing a region a kernel may still be reading is a fault.
+"""
+
+comptime ABORT_WORD_BYTES = 64
+"""Pinned host bytes per communicator for the abort word (a whole cache line,
+so raising it cannot invalidate anything else a spin is reading)."""
 
 comptime NVLS_FD_TIMEOUT_S: Float64 = 30.0
 """Bound on one fd hand-off. The whole bring-up is 150-230 ms when it works,
@@ -356,6 +379,14 @@ struct CommState(Movable):
     var generation: Int
     var last_stream: Int64
     var aborted: Bool
+    # Set once every resource below has been released (by destroy, or by an
+    # abort that reached quiescence); makes the other one a no-op.
+    var released: Bool
+    # The abort word: pinned host memory the device spins poll through
+    # `install_abort_word`'s slot in each arena header. `abort_host` is what
+    # `ncclCommAbort` stores into, `abort_dev` what a kernel addresses.
+    var abort_host: Int
+    var abort_dev: Int
     var stream_cache: Dict[Int64, DeviceStream]
     var local_rank: Int
     var local_world: Int
@@ -401,6 +432,8 @@ struct CommState(Movable):
         nvls_on: Bool,
         nvls_grid: Int,
         nvls_min: Int,
+        abort_host: Int,
+        abort_dev: Int,
     ):
         self.rank = rank
         self.world = world
@@ -413,6 +446,9 @@ struct CommState(Movable):
         self.generation = 0
         self.last_stream = 0
         self.aborted = False
+        self.released = False
+        self.abort_host = abort_host
+        self.abort_dev = abort_dev
         self.stream_cache = Dict[Int64, DeviceStream]()
         self.local_rank = local_rank
         self.local_world = local_world
@@ -464,9 +500,44 @@ def _lock(mut state: CommState):
         _ = external_call["sched_yield", Int32]()
 
 
+def _try_lock(mut state: CommState, deadline_ns: Int) -> Bool:
+    """`_lock` with a deadline, for `ncclCommAbort`.
+
+    Abort must never block behind a submitter, but it does have to own the
+    communicator before it frees anything under one. The submitter it can be
+    waiting for is running host code only -- a few launches -- and the abort
+    word has already released whatever the GPU was spinning on, so this
+    normally takes microseconds; the deadline is what keeps the promise if it
+    does not.
+    """
+    var p = Pointer(to=state.lock).unsafe_origin_cast[MutAnyOrigin]()
+    while True:
+        var expected: Int64 = 0
+        if Atomic[DType.int64].compare_exchange[
+            success_ordering = Ordering.ACQUIRE,
+            failure_ordering = Ordering.RELAXED,
+        ](p, expected, 1):
+            return True
+        if perf_counter_ns() > deadline_ns:
+            return False
+        _ = external_call["sched_yield", Int32]()
+
+
 def _unlock(mut state: CommState):
     Atomic[DType.int64].store[ordering = Ordering.RELEASE](
         Pointer(to=state.lock).unsafe_origin_cast[MutAnyOrigin](), 0
+    )
+
+
+@always_inline
+def _raise_abort_word(state: CommState):
+    """Store 1 into the pinned abort word: every device spin leaves at its
+    next check, and no driver call is needed to do it."""
+    if state.abort_host == 0:
+        return
+    Atomic[DType.uint64].store[ordering = Ordering.RELEASE](
+        Pointer[UInt64, MutAnyOrigin](unsafe_from_address=state.abort_host),
+        UInt64(1),
     )
 
 
@@ -795,12 +866,18 @@ def _unwind_init(
     regions: StaticTuple[Int, MAX_WORLD],
     local_world: Int,
     local_rank: Int,
+    abort_host: Int,
 ):
     """Release what `_bootstrap` acquired before it failed: the IB state
     (progress thread, QPs, MRs, pinned mailbox), the peer mappings opened so
-    far, and the region itself. Best effort -- the error that got us here is
-    the one worth reporting."""
+    far, the pinned abort word, and the region itself. Best effort -- the
+    error that got us here is the one worth reporting."""
     ib_teardown(ib)
+    try:
+        if abort_host != 0:
+            free_host(lib, abort_host)
+    except:
+        pass
     try:
         if use_nvls:
             nvls_teardown(nvls, lib, ordinal)
@@ -1032,9 +1109,24 @@ def _bootstrap(
     var ib = 0
     var regions = StaticTuple[Int, MAX_WORLD](fill=0)
     var nvls_min = _nvls_min_bytes()
+    var abort_host = 0
+    var abort_dev = 0
     try:
+        # The abort word, before any spin can start: pinned host memory, so
+        # `ncclCommAbort` raises it with one store and no driver call, and
+        # device-mapped, so a spinning kernel can read it. Its device address
+        # goes in every arena's header -- the six launcher signatures in
+        # collectives_kernels.mojo are fixed, so that slot is how the kernels
+        # find it.
+        abort_host = alloc_host(lib, ABORT_WORD_BYTES)
+        for i in range(ABORT_WORD_BYTES // 8):
+            Pointer[UInt64, MutAnyOrigin](unsafe_from_address=abort_host)[
+                unsafe_offset=i
+            ] = 0
+        abort_dev = host_device_ptr(lib, abort_host)
         for a in range(narenas):
             region_init(ctx, base + a * arena_stride)
+            install_abort_word(ctx, base + a * arena_stride, abort_dev)
 
         if topo.nnodes > 1:
             ib = ib_setup(
@@ -1048,6 +1140,7 @@ def _bootstrap(
                 INBOX_SLOTS,
                 net_off,
             )
+            ib_set_abort_word(ib, abort_dev)
 
         # Round 2: IPC handle + IB connection data + the geometry every rank has
         # to agree on. `MOJOCCL_REGION_MB` reaching one rank and not another
@@ -1165,6 +1258,7 @@ def _bootstrap(
             regions,
             topo.local_world,
             topo.my_local_rank,
+            abort_host,
         )
         raise e
 
@@ -1199,6 +1293,8 @@ def _bootstrap(
         nvls_on=use_nvls,
         nvls_grid=nvls_grid,
         nvls_min=nvls_min,
+        abort_host=abort_host,
+        abort_dev=abort_dev,
     )
     var handle_ptr = unsafe_alloc[CommState](1)
     handle_ptr.unsafe_write(state^)
@@ -1248,45 +1344,118 @@ def ncclCommDestroy(comm: Int64) abi("C") -> Int32:
     return rc
 
 
+def _release_resources(mut state: CommState) raises:
+    """Give every resource this communicator owns back, once nothing can be
+    using it. Shared by `ncclCommDestroy` and by an abort that reached
+    quiescence, and it is the same unwind `_unwind_init` runs on a failed
+    bring-up.
+    """
+    ib_teardown(state.ib)
+    state.ib = 0
+    if state.nvls_on:
+        # One call releases the peer mappings, both of my own, the multicast
+        # binding and every handle; there is no cuIpc mapping and no
+        # cuMemAlloc block to free.
+        nvls_teardown(state.nvls, state.driver, state.ordinal)
+    else:
+        for r in range(state.local_world):
+            if r != state.local_rank:
+                close_handle(state.driver, state.regions[r])
+        free_region(state.driver, state.owned_base)
+    if state.abort_host != 0:
+        free_host(state.driver, state.abort_host)
+        state.abort_host = 0
+        state.abort_dev = 0
+    state.released = True
+
+
 def _destroy_locked(comm: Int64) -> Int32:
     try:
         ref state = _comm_ptr(comm)[]
-        if not state.aborted:
-            # The inter-node callbacks were enqueued on the CALLER's stream(s),
-            # not on the context's own, and they dereference the IbState this
-            # tears down -- so drain every cached stream too before touching
-            # it, not just the last one used (see `_drain_all_streams`).
-            _drain_all_streams(state)
-            state.ctx.synchronize()
-            ib_teardown(state.ib)
-            if state.nvls_on:
-                # One call releases the peer mappings, both of my own, the
-                # multicast binding and every handle; there is no cuIpc
-                # mapping and no cuMemAlloc block to free.
-                nvls_teardown(state.nvls, state.driver, state.ordinal)
-            else:
-                for r in range(state.local_world):
-                    if r != state.local_rank:
-                        close_handle(state.driver, state.regions[r])
-                free_region(state.driver, state.owned_base)
+        # Destroy after abort is legal (nccl.h.in) and has nothing left to do:
+        # abort either ran this same unwind or decided it could not safely.
+        if state.released or state.aborted:
+            return NCCL_SUCCESS
+        # The inter-node callbacks were enqueued on the CALLER's stream(s),
+        # not on the context's own, and they dereference the IbState this
+        # tears down -- so drain every cached stream too before touching
+        # it, not just the last one used (see `_drain_all_streams`).
+        _drain_all_streams(state)
+        state.ctx.synchronize()
+        _release_resources(state)
         return NCCL_SUCCESS
     except:
         return NCCL_INTERNAL_ERROR
 
 
+def _abort_quiesced(state: CommState, deadline_ns: Int) -> Bool:
+    """Poll every stream a collective ran on until all are idle, or the
+    deadline passes.
+
+    `cuStreamQuery`, not `cuStreamSynchronize`: the point of the abort word is
+    that the spin kernels are already on their way out, and a synchronize
+    would be exactly the unbounded wait abort promises not to do.
+    """
+    var handles = _cached_stream_handles(state)
+    while True:
+        var pending = False
+        for i in range(len(handles)):
+            if not stream_done(state.driver, Int(handles[i])):
+                pending = True
+                break
+        if not pending:
+            return True
+        if perf_counter_ns() > deadline_ns:
+            return False
+        sleep(0.001)
+
+
 @export
 def ncclCommAbort(comm: Int64) abi("C") -> Int32:
     ref state = _comm_ptr(comm)[]
-    # No wait, no cleanup of GPU or IB resources here (a dead peer may hang
-    # forever inside its own barrier spin, and a queue pair torn down under
-    # an in-flight RDMA write is worse than one left alone) -- matches
-    # ncclCommAbort's documented "don't wait" contract. ncclCommDestroy is
-    # never called after abort() by nccl.py's NcclComm. The progress thread
-    # is the one thing still stopped here: left running it spins a CPU core
-    # for the rest of the process, and `ib_signal_abort`'s join is bounded so
-    # this still does not wait in the way the contract forbids.
+    if state.released:
+        return NCCL_SUCCESS
+    # nccl.h.in's contract: stop submissions, abort the device operations, and
+    # free the communicator's resources -- without waiting on peers, which may
+    # be dead. All three, in that order.
+    #
+    #   1. `aborted` makes every later collective return ncclInvalidUsage and
+    #      `ncclCommGetAsyncError` report ncclSystemError.
+    #   2. the abort word releases the device spins (the intra-node barriers,
+    #      the NVLS barrier, the proxy wait kernel) within a check interval,
+    #      each with its region's error word set, instead of holding the
+    #      stream to a 60 s deadline; the progress thread stops too.
+    #   3. once nothing local is running any more -- polled, with a bound, and
+    #      never a wait on a peer -- the region, the peer mappings, the IB
+    #      state and the pinned word go back.
+    #
+    # Step 3 is best effort by construction: a local kernel that will not
+    # quiesce inside `ABORT_QUIESCE_TIMEOUT_S` keeps its memory, because
+    # freeing a region a kernel is still reading faults the process.
     state.aborted = True
+    _raise_abort_word(state)
     ib_signal_abort(state.ib)
+    var deadline = perf_counter_ns() + Int(ABORT_QUIESCE_TIMEOUT_S * 1.0e9)
+    if not _try_lock(state, deadline):
+        print(
+            "mojoccl: ncclCommAbort left the region allocated -- another"
+            " thread still holds the submission lock"
+        )
+        return NCCL_SUCCESS
+    var quiesced = _abort_quiesced(state, deadline)
+    if quiesced:
+        try:
+            _release_resources(state)
+        except e:
+            print("mojoccl: ncclCommAbort could not release cleanly:", e)
+    else:
+        print(
+            "mojoccl: ncclCommAbort left the region allocated -- the device"
+            " was still busy after",
+            ABORT_QUIESCE_TIMEOUT_S,
+            "s",
+        )
+    _unlock(state)
     return NCCL_SUCCESS
 
 

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -12,12 +12,26 @@
 # TORCH_MOJO_BACKEND_CCL=mojo is set).
 #
 # One process per GPU. Within a node, one region per rank of raw
-# driver-owned memory shared with legacy IPC (driver.mojo) -- MAX's own
-# allocator memory cannot be exported that way (see
-# docs/mojo_collectives_feasibility.md, section 5.6) -- and the collectives
-# of collectives_kernels.mojo run over the peer mappings. Across nodes,
-# GPUDirect RDMA written here over libibverbs (ibverbs.mojo,
+# driver-owned memory -- MAX's own allocator memory cannot be shared across
+# processes at all (see docs/mojo_collectives_feasibility.md, section 5.6) --
+# and the collectives of collectives_kernels.mojo run over the peer mappings.
+# Across nodes, GPUDirect RDMA written here over libibverbs (ibverbs.mojo,
 # internode.mojo): no vendor collective library takes part at any level.
+#
+# That region comes in two shapes, chosen once per communicator in round 1 of
+# the bootstrap and identical on every rank:
+#
+#   default   `cuMemAlloc` / `hipExtMallocWithFlags`, shared with legacy IPC
+#             (driver.mojo). Every node count, every vendor.
+#   NVLS      single node, every local device reporting
+#             CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED: VMM memory bound to a
+#             per-node multicast object and mapped twice (vmm.mojo), so that
+#             allreduces of MOJOCCL_NVLS_MIN_MB or more can go through the
+#             NVSwitch's own reduction engine (nvls_kernels.mojo) instead of
+#             over unicast NVLink. Peers are imported through the same
+#             file-descriptor exchange rather than with cuIpcOpenMemHandle,
+#             which cannot open VMM memory. The unicast kernels see no
+#             difference: same layout, same offsets, the plain mapping.
 #
 # A multi-node communicator runs each collective hierarchically:
 #
@@ -125,7 +139,6 @@ from vmm import (
     multicast_granularity,
     nvls_bind_and_map,
     nvls_create_and_share,
-    nvls_fit_cap,
     nvls_teardown,
     scm_bind,
     scm_unbind,
@@ -268,6 +281,14 @@ def _nvls_min_bytes() -> Int:
         return Int(s) * 1024 * 1024
     except:
         return nvls_min_bytes()
+
+
+def _nvls_recommended_granularity() -> Bool:
+    """`MOJOCCL_NVLS_GRANULARITY=rec` sizes the multicast object with
+    `CU_MULTICAST_GRANULARITY_RECOMMENDED`, which is what NCCL does and what
+    the prototype measured; the default `min` allocates what the region asked
+    for. The two measured the same on H100 -- see docs/distributed.md."""
+    return getenv("MOJOCCL_NVLS_GRANULARITY", String("min")) == String("rec")
 
 
 def _socket_dir() -> String:
@@ -854,14 +875,18 @@ def _bootstrap(
     var use_nvls = all_caps and topo.nnodes == 1 and topo.local_world >= 2
     var granularity = 0
     if use_nvls:
+        # The region is rounded up to this. `MOJOCCL_REGION_MB` still means
+        # what it says because vmm.mojo asks for the MINIMUM granularity
+        # (2 MiB on H100) rather than NCCL's RECOMMENDED (512 MiB); every rank
+        # derives the same number from the same device property, and round 2
+        # checks that they agree.
         granularity = multicast_granularity(
-            lib, topo.local_world, ordinal, signal_bytes() + 2 * cap_bytes
+            lib,
+            topo.local_world,
+            ordinal,
+            signal_bytes() + 2 * cap_bytes,
+            _nvls_recommended_granularity(),
         )
-        # The multicast object can only be a multiple of the granularity, so
-        # the rounding is paid either way; spend it on the staging halves
-        # rather than waste it. Every rank derives the same number from the
-        # same device property, and round 2 checks that.
-        cap_bytes = nvls_fit_cap(signal_bytes(), cap_bytes, granularity)
 
     var layout = region_layout(cap_bytes, topo.nnodes)
     var narenas = layout[0]
@@ -1459,9 +1484,13 @@ def _do_allreduce_nvls[
     """
     comptime item = size_of[dtype]()
     var world = state.local_world
-    # A chunk is padded up to whole per-rank 16-byte slices, so the largest
-    # message a staging half holds is a whole number of them.
-    var max_elems = (state.cap_bytes // 16) // world * world * (16 // item)
+    # The whole `2 * cap` arena, not one half: this kernel stages one buffer
+    # and no other collective is live while it runs (its start barrier is what
+    # guarantees that), so a 512 MiB allreduce is one launch on the default
+    # 256 MiB region. Rounded down to whole per-rank 16-byte slices, which is
+    # what the padding rule needs.
+    var payload = 2 * state.cap_bytes
+    var max_elems = (payload // 16) // world * world * (16 // item)
     var done = 0
     while done < count:
         var chunk = min(max_elems, count - done)
@@ -1478,7 +1507,7 @@ def _do_allreduce_nvls[
             sendbuff + done * item,
             recvbuff + done * item,
             chunk,
-            state.cap_bytes,
+            payload,
             scale,
             target,
             state.nvls_grid,

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -676,24 +676,29 @@ def _copy_error_word(
         dst[unsafe_offset=0] = src[unsafe_offset=0]
 
 
-def _read_error_word(
-    mut state: CommState, stream: DeviceStream, region: Int
-) raises -> UInt64:
+def _read_error_word(mut state: CommState, region: Int) raises -> UInt64:
     """The UInt64 error word at `region + error_offset()`, fetched to the
     host via a real device-to-host copy (see `_copy_error_word`).
 
-    Enqueues the copy kernel on `stream` -- ordered after whatever
-    collective on it last wrote the word -- then a D2H `enqueue_copy`, then
-    blocks for both. Callers that need the fully up-to-date word (a peer's
-    in-flight barrier timeout, not just what already landed) must
-    synchronize `stream` themselves first, as `ncclCommGetAsyncError` does.
+    Kernel and D2H copy both run on the context's own stream, so the copy is
+    ordered after the read that fills the buffer. Putting the kernel on the
+    caller's stream and the copy on the context's -- which is what
+    `enqueue_copy` uses -- left them on two streams with nothing between
+    them, and the copy could win. Nothing is lost by not touching the
+    caller's stream: the caller has already synchronized it, which is what
+    makes the word final (`ncclCommGetAsyncError` does exactly that).
     Kernel, device word and host word are all cached on the communicator.
     """
     var src = Pointer[UInt64, MutAnyOrigin](
         unsafe_from_address=region + error_offset()
     )
     _enqueue_cached[_copy_error_word](
-        state.ctx, stream, "errword", 1, state.err_buf.unsafe_ptr(), src
+        state.ctx,
+        state.ctx.stream(),
+        "errword",
+        1,
+        state.err_buf.unsafe_ptr(),
+        src,
     )
     var host_word = Pointer[UInt64, MutUntrackedOrigin](
         unsafe_from_address=state.err_host
@@ -1463,7 +1468,7 @@ def ncclCommAbort(comm: Int64) abi("C") -> Int32:
     # freeing a region a kernel is still reading faults the process.
     state.aborted = True
     _raise_abort_word(state)
-    ib_signal_abort(state.ib)
+    var proxy_stopped = ib_signal_abort(state.ib)
     var deadline = perf_counter_ns() + Int(ABORT_QUIESCE_TIMEOUT_S * 1.0e9)
     if not _try_lock(state, deadline):
         print(
@@ -1472,11 +1477,19 @@ def ncclCommAbort(comm: Int64) abi("C") -> Int32:
         )
         return NCCL_SUCCESS
     var quiesced = _abort_quiesced(state, deadline)
-    if quiesced:
+    if quiesced and proxy_stopped:
         try:
             _release_resources(state)
         except e:
             print("mojoccl: ncclCommAbort could not release cleanly:", e)
+    elif not proxy_stopped:
+        # `ib_teardown` joins the progress thread unconditionally, so
+        # reclaiming here would be both an unbounded wait and a free under a
+        # thread still reading the state.
+        print(
+            "mojoccl: ncclCommAbort left the resources allocated -- the"
+            " progress thread did not stop"
+        )
     else:
         print(
             "mojoccl: ncclCommAbort left the region allocated -- the device"
@@ -1526,7 +1539,6 @@ def ncclCommGetAsyncError(
         for a in range(state.narenas):
             var word = _read_error_word(
                 state,
-                s,
                 state.regions[state.local_rank] + a * state.arena_stride,
             )
             if Int(word) != 0:

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -1031,6 +1031,7 @@ def _bootstrap(
     # which the caller could.
     var ib = 0
     var regions = StaticTuple[Int, MAX_WORLD](fill=0)
+    var nvls_min = _nvls_min_bytes()
     try:
         for a in range(narenas):
             region_init(ctx, base + a * arena_stride)
@@ -1052,8 +1053,10 @@ def _bootstrap(
         # to agree on. `MOJOCCL_REGION_MB` reaching one rank and not another
         # (a per-node environment, a stale export) silently gives the peers
         # different arena and inbox offsets, which is a data race, not an error;
-        # checking two integers here turns it into a message.
-        comptime CFG_BYTES = 16
+        # a per-rank `MOJOCCL_NVLS_MIN_MB` sends one rank into the multicast
+        # counter barrier and another into the flag barrier, which is a hang.
+        # Checking three integers here turns both into a message.
+        comptime CFG_BYTES = 24
         comptime BLOB2 = HANDLE_BYTES + IB_BLOB_BYTES + CFG_BYTES
         var b2 = unsafe_alloc[UInt8](BLOB2)
         for i in range(BLOB2):
@@ -1083,6 +1086,7 @@ def _bootstrap(
         cfg[unsafe_offset=1] = Int64(
             narenas * 1000 + INBOX_SLOTS + (1_000_000 if use_nvls else 0)
         )
+        cfg[unsafe_offset=2] = Int64(nvls_min if use_nvls else 0)
         var t2 = unsafe_alloc[UInt8](BLOB2 * nranks)
         bootstrap_allgather(conn, _any(b2), BLOB2, _any(t2), timeout_s)
         for r in range(nranks):
@@ -1095,6 +1099,7 @@ def _bootstrap(
             if (
                 rcfg[unsafe_offset=0] != cfg[unsafe_offset=0]
                 or rcfg[unsafe_offset=1] != cfg[unsafe_offset=1]
+                or rcfg[unsafe_offset=2] != cfg[unsafe_offset=2]
             ):
                 raise Error(
                     "mojoccl: rank "
@@ -1103,11 +1108,16 @@ def _bootstrap(
                     + String(Int(rcfg[unsafe_offset=0]) // (1024 * 1024))
                     + " MiB with layout code "
                     + String(Int(rcfg[unsafe_offset=1]))
-                    + ", this rank "
+                    + " and NVLS floor "
+                    + String(Int(rcfg[unsafe_offset=2]) // (1024 * 1024))
+                    + " MiB, this rank "
                     + String(cap_bytes // (1024 * 1024))
                     + " MiB / "
                     + String(Int(cfg[unsafe_offset=1]))
-                    + "; MOJOCCL_REGION_MB must match on every rank"
+                    + " / "
+                    + String(Int(cfg[unsafe_offset=2]) // (1024 * 1024))
+                    + " MiB; MOJOCCL_REGION_MB and MOJOCCL_NVLS_MIN_MB must match"
+                    " on every rank"
                 )
 
         # Same-node peers only: an IPC handle from another host is meaningless.
@@ -1188,7 +1198,7 @@ def _bootstrap(
         nvls=nvls^,
         nvls_on=use_nvls,
         nvls_grid=nvls_grid,
-        nvls_min=_nvls_min_bytes(),
+        nvls_min=nvls_min,
     )
     var handle_ptr = unsafe_alloc[CommState](1)
     handle_ptr.unsafe_write(state^)

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -33,7 +33,18 @@
 #              node * local_world + local_rank)
 #
 # Broadcast and allgather run once at init and are written for clarity
-# rather than speed; allreduce is the one the DDP step waits on.
+# rather than speed, and stay unpipelined for the same reason; allreduce is
+# the one the DDP step waits on, and it is PIPELINED: the bucket is cut into
+# K chunks and issued on the one comm stream as
+#
+#   RS(0) release(0) RS(1) release(1) ... wait(0) add(0) AG(0) RS(3) ...
+#
+# with at most `PIPE_ARENAS` chunks alive, so the proxy exchanges chunk k
+# while the GPU reduce-scatters later chunks and all-gathers earlier ones.
+# Two things make that safe and neither is stream order across ranks: the
+# staging arena is replicated `PIPE_ARENAS` times so concurrent chunks never
+# share stage_in/stage_out (`_arena_regions`), and the inbox is reused only
+# against an explicit credit from the peer's add kernel (internode.mojo).
 #
 # Single-node communicators never touch libibverbs at all -- same fused
 # kernels, same numbers as before this file learned about nodes.
@@ -80,13 +91,17 @@ from collectives_kernels import (
     signal_bytes,
 )
 from internode import (
+    CREDIT_AREA_BYTES,
     IB_BLOB_BYTES,
     MAX_NODES,
+    PIPE_MAX_SLOTS,
     ib_connect,
-    ib_enqueue,
+    ib_enqueue_request,
+    ib_enqueue_wait,
     ib_error,
     ib_local_info,
     ib_next_seq,
+    ib_note_consumed,
     ib_npeers,
     ib_port_lid,
     ib_port_mtu,
@@ -130,14 +145,52 @@ comptime NCCL_AVG: Int32 = 4
 # Every exchange is all-to-all among the ranks sharing a local_rank, even
 # when only one of them has data (a broadcast, or an allreduce whose shard
 # table leaves this rank empty), and that is a correctness requirement, not
-# tidiness. The inbox is double buffered by the exchange counter's parity
-# (`_inbox_base`), so what has to be true is: peer B's write for exchange
-# e+2 lands after MY add kernel for exchange e has read that half. All-to-all
-# makes it a proof -- B cannot post e+2 before its callback for e+1 returned,
-# which needed MY e+1 message, which my stream sent only after running my add
-# kernel for e. Let one exchange be one-directional and that chain breaks,
-# leaving nothing but a timing margin between B's write and my read.
-comptime CREDIT_BYTES = 16
+# tidiness: an exchange completes when its arrival tally reaches `npeers`,
+# so a rank that stayed silent would hang its peers. (Inbox REUSE is a
+# separate question, answered by the credit protocol in internode.mojo, not
+# by this.)
+comptime EMPTY_SHARD_BYTES = 16
+
+# Pipeline depth of the multi-node allreduce: how many staging arenas the
+# region is carved into, and therefore how many chunks may be alive at once.
+# Chunk k uses arena `k % PIPE_ARENAS`, and the schedule enqueues chunk k's
+# all-gather before chunk k+PIPE_ARENAS's reduce-scatter, so the arena's own
+# start barrier is what orders the reuse -- the invariant one arena already
+# had, applied per arena.
+#
+# 4 is the measured default: the pipeline is GPU-bound at every size that
+# gets chunked (the reduce-scatter plus all-gather of one chunk outlasts its
+# RDMA), so depth 2 would already overlap in principle, but the overlap
+# window at depth 2 is one reduce-scatter and the progress thread's idle
+# backoff alone (MOJOCCL_IB_PROXY_IDLE_US, 20 us) can eat that. Depth 4
+# gives a window of two whole chunks. It costs region layout, not memory:
+# each arena is 1/4 of the staging, so the total is what it always was.
+comptime PIPE_ARENAS = 4
+
+# Fixed inbox slot groups. One more than the arenas on purpose: a peer needs
+# my credit for exchange e-INBOX_SLOTS before it may post e, and my credits
+# ride on my own requests (`credit_upto`), so an extra group means the credit
+# it needs went out one chunk before it was needed instead of exactly when.
+comptime INBOX_SLOTS = PIPE_ARENAS + 1
+
+# Largest number of pipeline chunks one collective is cut into.
+comptime PIPE_MAX_CHUNKS = 16
+
+# Chunking constant, in bytes: the optimum split of a `B`-byte multi-node
+# allreduce is `K = sqrt(B / (local_world * PIPE_SPLIT_UNIT))`.
+#
+# Derivation. An extra chunk costs one more reduce-scatter and one more
+# all-gather launch, each a kernel launch plus an 8-way start barrier, about
+# 8 us each on this cluster (docs/mojo_collectives_kernel_results.md 10.3
+# reads the pair at 15.9 us for a 4-byte message, which is all fixed cost).
+# Pipelining hides all but ~1/K of the network, and the network of a B-byte
+# allreduce is B/(local_world * 40 GB/s) with the RDMA measured at 40-45 GB/s
+# per rank (one HCA each, job 234072). Minimising 16K + B/(L*40000) us over K
+# gives K = sqrt(B / (L * 640000)). The rule also keeps a chunk's shard
+# comfortably above 1 MiB, where the RDMA is still at line rate, without a
+# second clause: at K > 1 the shard is sqrt(B * 640000 / L) bytes, 1.5 MB at
+# the 27 MiB bucket and 3.8 MB at 168 MiB.
+comptime PIPE_SPLIT_UNIT = 640_000
 
 comptime DEFAULT_REGION_MB = 256
 comptime DEFAULT_BOOTSTRAP_TIMEOUT_S: Float64 = 120.0
@@ -229,6 +282,10 @@ struct CommState(Movable):
     var rank_at: List[Int]
     var ib: Int
     var net_off: Int
+    var narenas: Int
+    var arena_cap: Int
+    var arena_stride: Int
+    var nslots: Int
 
     def __init__(
         out self,
@@ -247,6 +304,10 @@ struct CommState(Movable):
         var rank_at: List[Int],
         ib: Int,
         net_off: Int,
+        narenas: Int,
+        arena_cap: Int,
+        arena_stride: Int,
+        nslots: Int,
     ):
         self.rank = rank
         self.world = world
@@ -267,11 +328,86 @@ struct CommState(Movable):
         self.rank_at = rank_at^
         self.ib = ib
         self.net_off = net_off
+        self.narenas = narenas
+        self.arena_cap = arena_cap
+        self.arena_stride = arena_stride
+        self.nslots = nslots
 
 
 @always_inline
 def _align_up(x: Int, a: Int) -> Int:
     return (x + a - 1) // a * a
+
+
+# ---------------------------------------------------------------------------
+# Region geometry -- pure integer arithmetic, no communicator state, so
+# tests/multinode/selftest/geometry_test.mojo can sweep it over every region
+# size, local_world and node count this library claims to support. Every rank
+# derives the same numbers from `(cap_bytes, nnodes)` alone, which is what
+# makes a sender's address arithmetic agree with its receiver's.
+# ---------------------------------------------------------------------------
+
+
+def region_layout(cap_bytes: Int, nnodes: Int) -> Tuple[Int, Int, Int, Int]:
+    """`(narenas, arena_cap, arena_stride, region_bytes)`.
+
+    Single node: one arena of `cap_bytes` halves and no network area -- the
+    layout this library had before it learned about nodes, byte for byte.
+    Multi-node: `PIPE_ARENAS` arenas of `cap/PIPE_ARENAS` halves (so the
+    staging total is unchanged) plus one cap-sized network area.
+    """
+    var narenas = PIPE_ARENAS if nnodes > 1 else 1
+    var arena_cap = cap_bytes // narenas // 4096 * 4096
+    var arena_stride = signal_bytes() + 2 * arena_cap
+    var net_bytes = cap_bytes if nnodes > 1 else 0
+    return Tuple(
+        narenas, arena_cap, arena_stride, narenas * arena_stride + net_bytes
+    )
+
+
+def net_stage_bytes(cap_bytes: Int) -> Int:
+    """Staging bytes broadcast and allgather may use in the network area."""
+    return cap_bytes // 2 - CREDIT_AREA_BYTES
+
+
+def inbox_group_bytes(cap_bytes: Int, nslots: Int) -> Int:
+    """Bytes of one of the `nslots` fixed inbox slot groups."""
+    return (cap_bytes // 2) // nslots // 4096 * 4096
+
+
+def max_chunk_bytes(
+    cap_bytes: Int, arena_cap: Int, nslots: Int, local_world: Int, nnodes: Int
+) -> Int:
+    """Largest allreduce chunk whose inbox slot group fits.
+
+    A chunk of `B` bytes puts `B/L` bytes in each of the `N-1` slots of one
+    group, so `B <= group * L / (N-1)`, less a page of alignment slop (the
+    shard size is rounded up to a 16-byte vector per rank) -- and never more
+    than one arena's `arena_cap`, which the intra-node kernels require. With
+    the 256 MiB default region and 4 arenas that is 64 MiB at 2 nodes and
+    36 MiB at 8; the pipeline split usually asks for less.
+    """
+    var b = (
+        inbox_group_bytes(cap_bytes, nslots) * local_world // (nnodes - 1)
+    ) - 2 * 4096
+    b = min(b, arena_cap)
+    if b < 4096:
+        return 4096
+    return b // 4096 * 4096
+
+
+def pipeline_chunk_bytes(
+    max_chunk: Int, local_world: Int, total_bytes: Int
+) -> Int:
+    """Chunk size of a pipelined multi-node allreduce; see PIPE_SPLIT_UNIT
+    for where the square root comes from."""
+    var unit = local_world * PIPE_SPLIT_UNIT
+    var k = 1
+    while k < PIPE_MAX_CHUNKS and (k + 1) * (k + 1) * unit <= total_bytes:
+        k += 1
+    var chunk = _align_up((total_bytes + k - 1) // k, 4096)
+    chunk = min(chunk, max_chunk)
+    return max(chunk, 4096)
 
 
 @always_inline
@@ -562,24 +698,46 @@ def _bootstrap(
     # collectives form 16-byte aligned for every supported dtype.
     if cap_bytes <= 0 or cap_bytes % 4096 != 0:
         raise Error("mojoccl: MOJOCCL_REGION_MB must be a positive 4 KiB multiple")
-    # A multi-node communicator gets a third cap-sized area on top of
-    # [signal | stage_in | stage_out]: everything the network touches --
-    # the inbox the peers RDMA into, and the staging broadcast and
-    # allgather need because user buffers are not registered -- lives
-    # there and nowhere else, carved as
-    # [staging: cap/2 | inbox half0: cap/4 | inbox half1: cap/4]
-    # (`_inbox_base`). Aliasing it onto stage_in would have been free in
-    # memory and wrong in fact: a peer node writes my inbox as soon as ITS
-    # reduce-scatter is done, which is not ordered against MY
-    # reduce-scatter still using stage_in, nor against a local peer still
-    # reading the previous generation's staging. A single-node
-    # communicator allocates none of it and keeps exactly the old
-    # region.
-    var net_bytes = cap_bytes if topo.nnodes > 1 else 0
-    var net_off = signal_bytes() + 2 * cap_bytes
-    var region_bytes = net_off + net_bytes
+    # Region layout.
+    #
+    # Single node, unchanged: one arena, [signal | stage_in cap | stage_out
+    # cap], and nothing else -- same bytes, same offsets, same numbers as
+    # before this file learned about nodes.
+    #
+    # Multi-node: PIPE_ARENAS of those, each a complete region in its own
+    # right with `arena_cap = cap/PIPE_ARENAS` halves, followed by one
+    # cap-sized network area
+    #
+    #     [credits 4 KiB | staging cap/2 - 4 KiB | inbox: INBOX_SLOTS groups]
+    #
+    # The arenas are what let pipeline chunks run concurrently without a new
+    # kernel parameter: `_arena_regions` hands the split kernels a shifted
+    # base and `arena_cap`, and each arena keeps its own flag matrix, so
+    # concurrent chunks cannot collide in stage_in's push slots or in
+    # stage_out's shard. Total staging is 2*cap either way, so the region is
+    # the size it always was, plus PIPE_ARENAS-1 extra 128 KiB signal areas.
+    #
+    # Everything the network touches lives in the network area and nowhere
+    # else. Aliasing it onto stage_in would have been free in memory and
+    # wrong in fact: a peer node writes my inbox as soon as ITS
+    # reduce-scatter is done, which is not ordered against MY reduce-scatter
+    # still using stage_in, nor against a local peer still reading the
+    # previous generation's staging.
+    var layout = region_layout(cap_bytes, topo.nnodes)
+    var narenas = layout[0]
+    var arena_cap = layout[1]
+    var arena_stride = layout[2]
+    var region_bytes = layout[3]
+    if arena_cap < 4096:
+        raise Error(
+            "mojoccl: MOJOCCL_REGION_MB is too small to carve "
+            + String(narenas)
+            + " pipeline arenas out of"
+        )
+    var net_off = narenas * arena_stride
     var base = alloc_region(lib, region_bytes)
-    region_init(ctx, base)
+    for a in range(narenas):
+        region_init(ctx, base + a * arena_stride)
 
     var ib = 0
     if topo.nnodes > 1:
@@ -591,10 +749,17 @@ def _bootstrap(
             topo.nnodes,
             base,
             region_bytes,
+            INBOX_SLOTS,
+            net_off,
         )
 
-    # Round 2: IPC handle + IB connection data.
-    comptime BLOB2 = HANDLE_BYTES + IB_BLOB_BYTES
+    # Round 2: IPC handle + IB connection data + the geometry every rank has
+    # to agree on. `MOJOCCL_REGION_MB` reaching one rank and not another
+    # (a per-node environment, a stale export) silently gives the peers
+    # different arena and inbox offsets, which is a data race, not an error;
+    # checking two integers here turns it into a message.
+    comptime CFG_BYTES = 16
+    comptime BLOB2 = HANDLE_BYTES + IB_BLOB_BYTES + CFG_BYTES
     var b2 = unsafe_alloc[UInt8](BLOB2)
     for i in range(BLOB2):
         b2[unsafe_offset=i] = 0
@@ -612,8 +777,34 @@ def _bootstrap(
             my_lid,
             my_mtu,
         )
+    var cfg = Pointer[Int64, MutAnyOrigin](
+        unsafe_from_address=Int(b2) + HANDLE_BYTES + IB_BLOB_BYTES
+    )
+    cfg[unsafe_offset=0] = Int64(cap_bytes)
+    cfg[unsafe_offset=1] = Int64(narenas * 1000 + INBOX_SLOTS)
     var t2 = unsafe_alloc[UInt8](BLOB2 * nranks)
     bootstrap_allgather(conn, _any(b2), BLOB2, _any(t2), timeout_s)
+    for r in range(nranks):
+        var rcfg = Pointer[Int64, MutAnyOrigin](
+            unsafe_from_address=Int(t2) + r * BLOB2 + HANDLE_BYTES + IB_BLOB_BYTES
+        )
+        if (
+            rcfg[unsafe_offset=0] != cfg[unsafe_offset=0]
+            or rcfg[unsafe_offset=1] != cfg[unsafe_offset=1]
+        ):
+            raise Error(
+                "mojoccl: rank "
+                + String(r)
+                + " built a region of "
+                + String(Int(rcfg[unsafe_offset=0]) // (1024 * 1024))
+                + " MiB with layout code "
+                + String(Int(rcfg[unsafe_offset=1]))
+                + ", this rank "
+                + String(cap_bytes // (1024 * 1024))
+                + " MiB / "
+                + String(Int(cfg[unsafe_offset=1]))
+                + "; MOJOCCL_REGION_MB must match on every rank"
+            )
 
     # Same-node peers only: an IPC handle from another host is meaningless.
     var regions = StaticTuple[Int, MAX_WORLD](fill=0)
@@ -666,6 +857,10 @@ def _bootstrap(
         rank_at=rank_at^,
         ib=ib,
         net_off=net_off,
+        narenas=narenas,
+        arena_cap=arena_cap,
+        arena_stride=arena_stride,
+        nslots=INBOX_SLOTS,
     )
     var handle_ptr = unsafe_alloc[CommState](1)
     handle_ptr.unsafe_write(state^)
@@ -776,10 +971,19 @@ def ncclCommGetAsyncError(
             else DeviceStream(state.ctx)
         )
         s.synchronize()
-        var word = _read_error_word(
-            state.ctx, s, state.regions[state.local_rank]
-        )
-        err_out[] = NCCL_REMOTE_ERROR if Int(word) != 0 else NCCL_SUCCESS
+        # One error word per pipeline arena: a multi-node allreduce spreads
+        # its chunks over all of them, and a barrier that gave up did so in
+        # exactly one.
+        for a in range(state.narenas):
+            var word = _read_error_word(
+                state.ctx,
+                s,
+                state.regions[state.local_rank] + a * state.arena_stride,
+            )
+            if Int(word) != 0:
+                err_out[] = NCCL_REMOTE_ERROR
+                return NCCL_SUCCESS
+        err_out[] = NCCL_SUCCESS
         return NCCL_SUCCESS
     except:
         return NCCL_INTERNAL_ERROR
@@ -825,27 +1029,115 @@ def ncclGroupEnd() abi("C") -> Int32:
 # ---------------------------------------------------------------------------
 
 
-def _inter_node_exchange[
+def _arena_regions(state: CommState, arena: Int) -> StaticTuple[Int, MAX_WORLD]:
+    """Peer bases of one pipeline arena.
+
+    Each arena is a complete region as far as collectives_kernels.mojo is
+    concerned -- its own signal area at offset 0, its own [stage_in |
+    stage_out] of `arena_cap` bytes each -- so concurrent pipeline chunks are
+    kept apart by handing the split kernels a shifted base and a smaller cap,
+    with no change to their device code and no new parameter. Only the
+    `local_world` entries a node actually has are shifted; the rest stay 0 and
+    are never read (`_region_ptrs` fills them with this rank's own base).
+    """
+    var out = StaticTuple[Int, MAX_WORLD](fill=0)
+    for r in range(state.local_world):
+        out[r] = state.regions[r] + arena * state.arena_stride
+    return out
+
+
+def _arena_shard(state: CommState, arena: Int, byte_off: Int) -> Int:
+    """Address of this rank's shard inside one arena's stage_out."""
+    return (
+        state.owned_base
+        + arena * state.arena_stride
+        + signal_bytes()
+        + state.arena_cap
+        + byte_off
+    )
+
+
+def _net_stage_off(state: CommState) -> Int:
+    """Region offset of the staging half broadcast and allgather copy
+    through (user buffers are not registered, so the NIC cannot read them)."""
+    return state.net_off + CREDIT_AREA_BYTES
+
+
+def _net_stage_bytes(state: CommState) -> Int:
+    return net_stage_bytes(state.cap_bytes)
+
+
+def _inbox_group_bytes(state: CommState) -> Int:
+    """Bytes of one inbox slot group. See `_inbox_base`."""
+    return inbox_group_bytes(state.cap_bytes, state.nslots)
+
+
+def _inbox_base(state: CommState, seq: Int) -> Int:
+    """Region offset of exchange `seq`'s inbox slot group.
+
+    FIXED, not derived from the message: the second half of the network area
+    is carved once into `nslots` equal groups and `seq % nslots` picks one.
+
+    That the groups do not move is what makes reuse a matter of one credit
+    rather than of two messages happening to be the same shape. Sizing a
+    group from the current message -- which an early version did, with two
+    parity halves -- kept e and e+nslots apart but let e and e+1 OVERLAP
+    whenever consecutive exchanges had different geometry, and DDP produces
+    exactly that: a 4-byte AVG allreduce (slot 16 B) next to a 27 MiB bucket
+    put the small exchange's second half at `net_off+16` and the big one's
+    first at `net_off+0`. Nothing orders a peer's e+1 write against my e
+    consumer -- the peer's e+1 send is gated on its own credits, not on my
+    consumption -- so the overlap is a silent data race on the inbox, and
+    mixing collectives (an allreduce's group against a broadcast's staged
+    chunk) is the same bug once more.
+    """
+    return (
+        state.net_off
+        + state.cap_bytes // 2
+        + (seq % state.nslots) * _inbox_group_bytes(state)
+    )
+
+
+def _max_chunk_bytes(state: CommState) -> Int:
+    if state.nnodes <= 1:
+        return state.cap_bytes
+    return max_chunk_bytes(
+        state.cap_bytes,
+        state.arena_cap,
+        state.nslots,
+        state.local_world,
+        state.nnodes,
+    )
+
+
+def _pipeline_chunk_bytes(state: CommState, total_bytes: Int) -> Int:
+    return pipeline_chunk_bytes(
+        _max_chunk_bytes(state), state.local_world, total_bytes
+    )
+
+
+def _exchange_release[
     dtype: DType
 ](
     mut state: CommState,
     stream: DeviceStream,
     raw_stream: Int64,
+    arena: Int,
     numel: Int,
-) raises:
-    """The middle third of a multi-node allreduce, for one chunk.
+) raises -> Int:
+    """Release one chunk's shard to the network and return its exchange
+    counter.
 
-    On entry this rank's node-local sum of its own shard sits in its
-    stage_out (that is `reduce_scatter_stage`'s contract). This enqueues, on
-    the caller's stream: a host callback that RDMA-writes that shard to the
-    same-local_rank rank of every other node and waits for theirs, then the
-    kernel that adds what arrived. On exit the shard holds the sum over the
-    WHOLE communicator, ready for `allgather_finish`.
+    On entry this rank's node-local sum of the chunk's shard sits in arena
+    `arena`'s stage_out (that is `reduce_scatter_stage`'s contract). This
+    enqueues the release only; the stream runs straight on into the next
+    chunk's reduce-scatter, and `_exchange_consume` is what eventually waits.
 
-    Slot geometry is derived from `(numel, local_world, item)` alone so that
-    a sender computes the same addresses as its receiver: a half holds
+    Slot geometry is derived from `(numel, local_world, item)` alone so a
+    sender computes the same addresses as its receiver: a group holds
     `(nnodes-1)` slots of one shard each, at the fixed base `_inbox_base`
-    picks by parity. `_max_chunk_bytes` keeps a half inside its quarter.
+    picks by `seq % nslots`. `_max_chunk_bytes` keeps a group inside its
+    share of the network area.
     """
     comptime item = size_of[dtype]()
     var sr = shard_range(numel, state.local_world, state.local_rank, item)
@@ -854,28 +1146,26 @@ def _inter_node_exchange[
     var seq = ib_next_seq(state.ib)
     var npeers = ib_npeers(state.ib)
     var nbytes = cnt_e * item
-    var slot_bytes = _align_up(max(nbytes, CREDIT_BYTES), 16)
-    if npeers * slot_bytes > _inbox_half_bytes(state):
+    var slot_bytes = _align_up(max(nbytes, EMPTY_SHARD_BYTES), 16)
+    if npeers * slot_bytes > _inbox_group_bytes(state):
         raise Error(
             "mojoccl: the inter-node inbox overflows the network area; this"
             " is a chunking bug"
         )
     var inbox_base = _inbox_base(state, seq)
-    var shard = (
-        state.owned_base + signal_bytes() + state.cap_bytes + off_e * item
-    )
+    var shard = _arena_shard(state, arena, off_e * item)
     # A rank with an empty shard (numel below local_world's rounded-up shard
     # size -- DDP's 4-byte AVG allreduce does exactly this on 7 of 8 local
-    # ranks) still exchanges, with CREDIT_BYTES of ignored payload. See
-    # `CREDIT_BYTES` for why every exchange has to be all-to-all.
-    ib_enqueue(
+    # ranks) still exchanges, with EMPTY_SHARD_BYTES of ignored payload. See
+    # `EMPTY_SHARD_BYTES` for why every exchange has to be all-to-all.
+    ib_enqueue_request(
         state.ib,
         state.driver,
         state.ctx,
         stream,
         Int(raw_stream),
         shard if cnt_e > 0 else state.owned_base,
-        nbytes if cnt_e > 0 else CREDIT_BYTES,
+        nbytes if cnt_e > 0 else EMPTY_SHARD_BYTES,
         inbox_base,
         slot_bytes,
         True,
@@ -883,68 +1173,43 @@ def _inter_node_exchange[
         state.owned_base + inbox_base if cnt_e > 0 else 0,
         seq,
     )
+    return seq
+
+
+def _exchange_consume[
+    dtype: DType
+](
+    mut state: CommState,
+    stream: DeviceStream,
+    arena: Int,
+    seq: Int,
+    numel: Int,
+) raises:
+    """Wait for exchange `seq`, add what arrived, and release its inbox slot.
+
+    `ib_note_consumed` is the credit: it records that the add kernel is
+    enqueued, and the number rides out to the peers on this rank's next
+    request, by which point that kernel has run (stream order). On exit the
+    shard holds the sum over the WHOLE communicator, ready for
+    `allgather_finish`.
+    """
+    comptime item = size_of[dtype]()
+    var sr = shard_range(numel, state.local_world, state.local_rank, item)
+    var cnt_e = sr[1]
+    var npeers = ib_npeers(state.ib)
+    var slot_bytes = _align_up(max(cnt_e * item, EMPTY_SHARD_BYTES), 16)
+    ib_enqueue_wait(state.ib, state.ctx, stream, seq)
     if cnt_e > 0:
         inbox_add[dtype](
             state.ctx,
             stream,
-            shard,
-            state.owned_base + inbox_base,
+            _arena_shard(state, arena, sr[0] * item),
+            state.owned_base + _inbox_base(state, seq),
             cnt_e,
             slot_bytes,
             npeers,
         )
-
-
-def _inbox_half_bytes(state: CommState) -> Int:
-    """Bytes each parity half of the inbox may hold. See `_inbox_base`."""
-    return state.cap_bytes // 4
-
-
-def _inbox_base(state: CommState, seq: Int) -> Int:
-    """Region offset of exchange `seq`'s inbox half.
-
-    FIXED, not derived from the message: the network area is carved once as
-    `[staging: cap/2 | half0: cap/4 | half1: cap/4]` and the exchange
-    counter's parity picks a half.
-
-    That the halves do not move is what makes the double buffer a proof
-    rather than a timing margin. Sizing a half from the current message --
-    which is what this used to do -- kept e and e+2 apart but let e and e+1
-    OVERLAP whenever consecutive exchanges had different geometry, and DDP
-    produces exactly that: a 4-byte AVG allreduce (slot 16 B, half 16 B)
-    next to a 27 MiB bucket (half 3.4 MiB) put the small exchange's half 1
-    at `net_off+16` and the big one's half 0 at `net_off+0`. Nothing orders
-    a peer's e+1 write against MY e add kernel -- the peer's e+1 send is
-    gated on its own e completing, not on my consumption -- so the overlap
-    is a silent data race on the inbox, and mixing collectives (an
-    allreduce's half 0 at `net_off` against a broadcast's staged chunk,
-    also at `net_off`) is the same bug once more.
-    """
-    return (
-        state.net_off
-        + state.cap_bytes // 2
-        + (seq & 1) * _inbox_half_bytes(state)
-    )
-
-
-def _max_chunk_bytes(state: CommState) -> Int:
-    """Largest allreduce chunk whose inbox half fits.
-
-    A chunk of `B` bytes puts `B/L` bytes in each of the `N-1` slots of one
-    half, so `B <= (cap/4) * L / (N-1)`, less a page of alignment slop --
-    and never more than `cap`, which the intra-node kernels require anyway.
-    At the shapes DDP produces (27 MiB buckets against a 256 MiB region)
-    the cap never binds: 256 MiB at 2 nodes, 73 MiB at 8.
-    """
-    if state.nnodes <= 1:
-        return state.cap_bytes
-    var b = (
-        _inbox_half_bytes(state) * state.local_world // (state.nnodes - 1)
-    ) - 2 * 4096
-    b = min(b, state.cap_bytes)
-    if b < 4096:
-        return 4096
-    return b // 4096 * 4096
+    ib_note_consumed(state.ib, seq)
 
 
 def _do_allreduce[
@@ -959,12 +1224,11 @@ def _do_allreduce[
     scale: Float32,
 ) raises:
     comptime item = size_of[dtype]()
-    var max_elems = max(1, _max_chunk_bytes(state) // item)
-    var done = 0
-    while done < count:
-        var chunk = min(max_elems, count - done)
-        var off = done * item
-        if state.nnodes == 1:
+    if state.nnodes == 1:
+        var max_elems = max(1, state.cap_bytes // item)
+        var done = 0
+        while done < count:
+            var chunk = min(max_elems, count - done)
             state.generation += 1
             allreduce[dtype](
                 state.ctx,
@@ -972,41 +1236,74 @@ def _do_allreduce[
                 state.local_rank,
                 state.local_world,
                 state.regions,
-                sendbuff + off,
-                recvbuff + off,
+                sendbuff + done * item,
+                recvbuff + done * item,
                 chunk,
                 state.cap_bytes,
                 scale,
                 state.generation,
             )
-        else:
-            state.generation += 1
+            done += chunk
+        return
+
+    # Multi-node: hierarchical and pipelined. Chunk k is issued as
+    # reduce-scatter, release; its wait / add / all-gather come `depth-1`
+    # chunks later, so between them the GPU runs whole chunks of other work
+    # while the proxy exchanges this one. `depth <= narenas` is what keeps
+    # chunk k+narenas's reduce-scatter enqueued AFTER chunk k's all-gather,
+    # which is what the arena's start barrier needs to order the reuse.
+    var chunk_elems = max(
+        1, _pipeline_chunk_bytes(state, count * item) // item
+    )
+    var nchunks = (count + chunk_elems - 1) // chunk_elems
+    var depth = min(state.narenas, nchunks)
+    # Two generations per chunk, reserved up front, so each chunk's
+    # all-gather is its own reduce-scatter's plus one (the split kernels'
+    # documented pairing) even though the enqueue order interleaves chunks.
+    # Per arena the values are still strictly increasing, which is the rule
+    # that matters.
+    var g0 = state.generation + 1
+    state.generation += 2 * nchunks
+    var seqs = List[Int]()
+    for _ in range(nchunks):
+        seqs.append(0)
+    for k in range(nchunks + depth - 1):
+        if k < nchunks:
+            var off = k * chunk_elems
+            var cnt = min(chunk_elems, count - off)
             reduce_scatter_stage[dtype](
                 state.ctx,
                 stream,
                 state.local_rank,
                 state.local_world,
-                state.regions,
-                sendbuff + off,
-                chunk,
-                state.cap_bytes,
-                state.generation,
+                _arena_regions(state, k % state.narenas),
+                sendbuff + off * item,
+                cnt,
+                state.arena_cap,
+                g0 + 2 * k,
             )
-            _inter_node_exchange[dtype](state, stream, raw_stream, chunk)
-            state.generation += 1
+            seqs[k] = _exchange_release[dtype](
+                state, stream, raw_stream, k % state.narenas, cnt
+            )
+        var j = k - (depth - 1)
+        if j >= 0:
+            var off = j * chunk_elems
+            var cnt = min(chunk_elems, count - off)
+            _exchange_consume[dtype](
+                state, stream, j % state.narenas, seqs[j], cnt
+            )
             allgather_finish[dtype](
                 state.ctx,
                 stream,
                 state.local_rank,
                 state.local_world,
-                state.regions,
-                recvbuff + off,
-                chunk,
-                state.cap_bytes,
+                _arena_regions(state, j % state.narenas),
+                recvbuff + off * item,
+                cnt,
+                state.arena_cap,
                 scale,
-                state.generation,
+                g0 + 2 * j + 1,
             )
-        done += chunk
 
 
 @export
@@ -1140,7 +1437,7 @@ def _broadcast_multinode(
     The rank that receives on node j is the one sharing the root's
     local_rank, because that is the only rank the root has a queue pair to.
     Every OTHER rank still runs a credit-only exchange with its own
-    same-local_rank peers (CREDIT_BYTES). Correct and simple beats fast
+    same-local_rank peers (EMPTY_SHARD_BYTES). Correct and simple beats fast
     here: broadcast runs at DDP init, on parameters, not in the step.
     """
     var lw = state.local_world
@@ -1155,13 +1452,17 @@ def _broadcast_multinode(
     var i_am_local_root = state.local_rank == root_lr
     var receives = i_am_local_root and state.my_node != root_node
     # The root's staged chunk goes in the network area's staging half; a
-    # peer slot has to fit an inbox quarter, one slot PER PEER now that the
-    # exchange is all-to-all.
+    # peer slot has to fit inside one inbox slot group, one slot PER PEER
+    # since the exchange is all-to-all. The node-local half runs in arena 0,
+    # so the chunk is bounded by `arena_cap` too.
     var npeers = ib_npeers(state.ib)
     var max_bytes = max(
         4096,
         (
-            min(state.cap_bytes // 2, _inbox_half_bytes(state) // npeers)
+            min(
+                min(_net_stage_bytes(state), state.arena_cap),
+                _inbox_group_bytes(state) // npeers,
+            )
             - 2 * 4096
         )
         // 4096
@@ -1172,7 +1473,7 @@ def _broadcast_multinode(
         var chunk = min(max_bytes, total_bytes - done)
         var seq = ib_next_seq(state.ib)
         var slot_bytes = _align_up(chunk, 16)
-        if npeers * slot_bytes > _inbox_half_bytes(state):
+        if npeers * slot_bytes > _inbox_group_bytes(state):
             raise Error("mojoccl: broadcast inbox does not fit; chunking bug")
         var inbox_base = _inbox_base(state, seq)
         var recv_slot = 0
@@ -1180,9 +1481,9 @@ def _broadcast_multinode(
             recv_slot = root_node if root_node < state.my_node else root_node - 1
         var send_ptr = recvbuff + done
         # Everyone in this local_rank group exchanges; only the root's
-        # payload is real (see CREDIT_BYTES).
+        # payload is real (see EMPTY_SHARD_BYTES).
         var send_addr = state.owned_base
-        var send_bytes = CREDIT_BYTES
+        var send_bytes = EMPTY_SHARD_BYTES
         var flush_addr = 0
         if i_am_root:
             # The user buffer is not registered, so the root's payload has to
@@ -1190,11 +1491,11 @@ def _broadcast_multinode(
             copy_bytes(
                 state.ctx,
                 stream,
-                state.owned_base + state.net_off,
+                state.owned_base + _net_stage_off(state),
                 sendbuff + done,
                 chunk,
             )
-            send_addr = state.owned_base + state.net_off
+            send_addr = state.owned_base + _net_stage_off(state)
             send_bytes = chunk
             send_ptr = sendbuff + done
         elif receives:
@@ -1202,7 +1503,7 @@ def _broadcast_multinode(
                 state.owned_base + inbox_base + recv_slot * slot_bytes
             )
             send_ptr = flush_addr
-        ib_enqueue(
+        ib_enqueue_request(
             state.ib,
             state.driver,
             state.ctx,
@@ -1217,6 +1518,11 @@ def _broadcast_multinode(
             flush_addr,
             seq,
         )
+        # Unpipelined on purpose: one exchange at a time, waited for right
+        # where it is released. Broadcast's fan-out is a different shape from
+        # the allreduce's (only one rank per node has real data) and it runs
+        # at DDP init, not in the step.
+        ib_enqueue_wait(state.ib, state.ctx, stream, seq)
         state.generation += 1
         broadcast(
             state.ctx,
@@ -1224,13 +1530,16 @@ def _broadcast_multinode(
             state.local_rank,
             root_lr,
             lw,
-            state.regions,
+            _arena_regions(state, 0),
             send_ptr,
             recvbuff + done,
             chunk,
-            state.cap_bytes,
+            state.arena_cap,
             state.generation,
         )
+        # The node-local broadcast is what reads the inbox slot, so the
+        # credit is only due now.
+        ib_note_consumed(state.ib, seq)
         done += chunk
 
 
@@ -1305,11 +1614,12 @@ def _allgather_multinode(
     """
     var lw = state.local_world
     var npeers = ib_npeers(state.ib)
-    var block_stage = state.owned_base + state.net_off
-    # One node block (lw * chunk) in the staging half; an inbox quarter has
-    # to hold npeers of them.
+    var block_stage = state.owned_base + _net_stage_off(state)
+    # One node block (lw * chunk) in the staging half; an inbox slot group
+    # has to hold npeers of them, and the node-local half runs in arena 0.
     var max_block = min(
-        state.cap_bytes // 2, _inbox_half_bytes(state) // npeers
+        min(_net_stage_bytes(state), state.arena_cap),
+        _inbox_group_bytes(state) // npeers,
     )
     var max_bytes = max(16, ((max_block - 8192) // lw) // 16 * 16)
     var done = 0
@@ -1321,21 +1631,21 @@ def _allgather_multinode(
             stream,
             state.local_rank,
             lw,
-            state.regions,
+            _arena_regions(state, 0),
             sendbuff + done,
             block_stage,
             chunk,
-            state.cap_bytes,
+            state.arena_cap,
             state.generation,
             stride_bytes=chunk,
         )
         var seq = ib_next_seq(state.ib)
         var block = lw * chunk
         var slot_bytes = _align_up(block, 16)
-        if npeers * slot_bytes > _inbox_half_bytes(state):
+        if npeers * slot_bytes > _inbox_group_bytes(state):
             raise Error("mojoccl: allgather inbox does not fit; chunking bug")
         var inbox_base = _inbox_base(state, seq)
-        ib_enqueue(
+        ib_enqueue_request(
             state.ib,
             state.driver,
             state.ctx,
@@ -1350,6 +1660,8 @@ def _allgather_multinode(
             state.owned_base + inbox_base,
             seq,
         )
+        # Unpipelined, like broadcast: one exchange, waited for in place.
+        ib_enqueue_wait(state.ib, state.ctx, stream, seq)
         _place_node_block(
             state, stream, recvbuff, block_stage, state.my_node, chunk, done,
             per_rank_bytes,
@@ -1369,6 +1681,8 @@ def _allgather_multinode(
                 per_rank_bytes,
             )
             slot += 1
+        # `place_blocks` above is what read the inbox slots.
+        ib_note_consumed(state.ib, seq)
         done += chunk
 
 

--- a/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/mojoccl.mojo
@@ -360,6 +360,15 @@ def ncclCommInitRank(
         var ctx = DeviceContext(device_id=ordinal)
 
         var cap_bytes = _region_cap_bytes()
+        # A positive multiple of 4096 (the production kernel's own
+        # precondition, RESULTS.md §9) is what keeps every per-chunk offset
+        # `ncclAllReduce` forms (multiples of cap_bytes, one full chunk at a
+        # time) 16-byte aligned for every supported dtype -- 4096 divides
+        # evenly by 2, 4 and 8. A misconfigured MOJOCCL_REGION_MB (e.g. 0)
+        # would otherwise degrade chunk offsets to non-16-byte-aligned
+        # single-element steps.
+        if cap_bytes <= 0 or cap_bytes % 4096 != 0:
+            return NCCL_INVALID_ARGUMENT
         var region_bytes = signal_bytes() + 2 * cap_bytes
         var base = alloc_region(lib, region_bytes)
         region_init(ctx, base)
@@ -511,6 +520,15 @@ def ncclAllReduce(
             return NCCL_INVALID_ARGUMENT
         if op != NCCL_SUM and op != NCCL_AVG:
             return NCCL_INVALID_USAGE
+        # The production kernel's payload loops use 16-byte vector
+        # loads/stores on in_ptr/out_ptr and fault on a misaligned address
+        # (RESULTS.md §9). Every allocator-returned pointer and every chunk
+        # offset this function forms satisfy that (cap_bytes is validated a
+        # multiple of 4096 at init) -- only a mid-tensor view the caller
+        # passes directly can violate it, so reject that case here with a
+        # clear error instead of letting the kernel raise.
+        if Int(sendbuff) % 16 != 0 or Int(recvbuff) % 16 != 0:
+            return NCCL_INVALID_ARGUMENT
         var ptr = _comm_ptr(comm)
         ref state = ptr[]
         if state.aborted:

--- a/torch_mojo_backend/distributed/mojoccl/nvls_kernels.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/nvls_kernels.mojo
@@ -63,6 +63,7 @@ from max.gpu.sync import barrier
 from collectives_kernels import (
     BLOCK,
     DEFAULT_TIMEOUT_NS,
+    _abort_raised,
     _enqueue_cached,
     signal_bytes,
 )
@@ -255,9 +256,10 @@ def _nvls_sync(
     and releases the local blocks. Targets advance by `world` per barrier and
     are never reset, so a rank a whole call ahead cannot deadlock one behind.
 
-    Returns False if the deadline passed. The whole block learns that through
-    shared memory so no thread is stuck inside a `barrier()`, and the local
-    release is published anyway so the other blocks are not wedged either.
+    Returns False if the deadline passed or the host raised the abort word.
+    The whole block learns that through shared memory so no thread is stuck
+    inside a `barrier()`, and the local release is published anyway so the
+    other blocks are not wedged either.
     """
     var failed = stack_allocation[
         1, DType.uint32, address_space=AddressSpace.SHARED
@@ -290,6 +292,9 @@ def _nvls_sync(
                 spins += 1
                 if spins >= _SPIN_CHECK:
                     spins = 0
+                    if _abort_raised(uc):
+                        failed[unsafe_offset=0] = 1
+                        break
                     # Same-GPU timer difference only, never across GPUs.
                     if global_perf_counter_ns() - t0 > timeout_ns:
                         failed[unsafe_offset=0] = 1
@@ -305,6 +310,9 @@ def _nvls_sync(
                 spins += 1
                 if spins >= _SPIN_CHECK:
                     spins = 0
+                    if _abort_raised(uc):
+                        failed[unsafe_offset=0] = 1
+                        break
                     if global_perf_counter_ns() - t0 > timeout_ns:
                         failed[unsafe_offset=0] = 1
                         break

--- a/torch_mojo_backend/distributed/mojoccl/nvls_kernels.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/nvls_kernels.mojo
@@ -1,0 +1,670 @@
+# NVLS (NVSwitch multicast) allreduce: the one collective in this library
+# whose traffic goes through the switch's reduction engine instead of over
+# unicast NVLink.
+#
+# Ported from the measured prototype (`nvls/mckernels.mojo` in the
+# mojo_collectives worktree, schedule `-D nvls_pipe=1`, the shape its
+# RESULTS.md section 6.4 recorded at 786 us / 168 MiB and 2217 us / 512 MiB
+# against NCCL's 749 / 2143 on 8xH100). Three differences from the prototype,
+# all of them because this is library code:
+#
+#   * the counters live in the region's existing signal area (the first page,
+#     which collectives_kernels.mojo reserves) instead of a private header, so
+#     the unicast kernels and this one share one region;
+#   * they are UInt64, not UInt32 -- the prototype's u32 would wrap after
+#     ~10^8 calls, about a day of DDP;
+#   * the grid, the reducer share and the chunk size are runtime arguments,
+#     not `-D` defines, so one build serves every message size.
+#
+# Shape = NCCL's runNVLS (nccl:src/device/all_reduce.h:410-457): every rank
+# copies its input into its own bound region, rank r `multimem.ld_reduce`s
+# slice r (the switch sums the eight contributions and returns one value) and
+# `multimem.st`s the result back into all eight regions, and every rank copies
+# the region out to its user tensor. Per GPU that is `bytes` of NVLink each
+# way against `2*(world-1)/world*bytes` for a unicast reduce-scatter +
+# all-gather -- 1.75x less at world 8 -- paid for with ~1.5x the HBM traffic,
+# which is why it only wins above `NVLS_MIN_BYTES` (48 MiB, measured).
+#
+# The region must be VMM memory bound to a multicast object (vmm.mojo); `mc`
+# is the multicast VA, which only `multimem.*` may touch, and `uc` is a plain
+# mapping of the same physical bytes, which is what the copies and the flag
+# spin use. Everything here is behind `NVLS_ARCH` (sm_90+, where `multimem`
+# exists) and, at runtime, behind the communicator having brought that region
+# up; AMD and pre-Hopper NVIDIA keep the unicast kernels.
+#
+# Builds for both targets:
+#   uv run --no-sync mojo build nvls_kernels.mojo --target-accelerator sm_90a
+#   uv run --no-sync mojo build nvls_kernels.mojo --target-accelerator gfx942
+
+from std.atomic import Atomic, Ordering
+from std.gpu import (
+    MAX_THREADS_PER_BLOCK_METADATA,
+    block_idx,
+    global_idx,
+    grid_dim,
+    thread_idx,
+)
+from std.gpu.intrinsics import Scope
+from std.memory import AddressSpace, stack_allocation
+from std.sys import size_of
+from std.sys._assembly import inlined_assembly
+from std.sys.info import _has_sm_9x_or_newer
+from std.time import global_perf_counter_ns
+from std.utils import StaticTuple
+from max.gpu.host import DeviceContext, DeviceStream
+from max.gpu.memory import (
+    Consistency,
+    ReduceOp,
+    multimem_ld_reduce,
+    multimem_st,
+)
+from max.gpu.sync import barrier
+
+from collectives_kernels import (
+    BLOCK,
+    DEFAULT_TIMEOUT_NS,
+    _enqueue_cached,
+    signal_bytes,
+)
+
+
+comptime NVLS_ARCH = _has_sm_9x_or_newer()
+"""`multimem` is an sm_90+ instruction and RCCL has no equivalent, so every
+line that emits one is behind this. A build for gfx942 or sm_80 elaborates
+none of it; `nvls_available()` is the runtime half of the same gate."""
+
+# ===-------------------------------------------------------------------=== #
+# Region geometry. The three counters live in the first page of the signal
+# area, which collectives_kernels.mojo holds free next to the error word at
+# offset 0 (its own flag matrix starts at 4096).
+# ===-------------------------------------------------------------------=== #
+
+comptime FLAG_OFF = 64
+"""Cross-GPU arrival counter, the address `multimem.red.add` targets."""
+comptime ARRIVE_OFF = 128
+"""This GPU's per-block arrival counter (plain memory, device scope)."""
+comptime RELEASE_OFF = 192
+"""What the last block of this GPU publishes to free the others."""
+
+comptime ERR_NVLS_SYNC = 6
+"""Error code written to the region's error word on a barrier timeout;
+continues collectives_kernels.mojo's ERR_* numbering."""
+
+comptime NVLS_MIN_BYTES = 48 * 1024 * 1024
+"""Below this the unicast push/reduce/pull kernels win and keep the traffic.
+
+Measured crossover, ABBA-interleaved against the unicast kernels over the same
+user tensors on 8xH100 (prototype RESULTS.md 6.5): NVLS/unicast is 1.043 at
+40 MiB and 0.963 at 48 MiB, then falls monotonically to 0.773 at 512 MiB. fp32
+and bf16 land on the same crossover to within 0.3%, so one constant covers
+both. Fitted on H100/NVSwitch; re-fit on another fabric."""
+
+comptime NVLS_MAX_BLOCKS = 216
+"""Grid cap, fitted on H100 (132 SMs). The barrier below is a FULL barrier --
+every block of the grid must be resident at once or it deadlocks -- so
+`nvls_blocks()` also clamps to what two blocks per SM allows, and
+`nvvm.minctasm=2` makes ptxas leave room for two."""
+
+comptime NVLS_REDUCE_PCT = 25
+"""Share of the grid that drives the switch; the rest drives HBM.
+
+Not 50: the switch phase saturates at about 33k threads (the whole-grid sweep
+of the unpipelined kernel moves 2% between 64 and 264 blocks) while the copies
+want every thread they can get. Measured at 168 MiB: 60% 927 us, 50% 877,
+40% 843, 30% 824, 25% 819, 20% 805 -- and 25% wins once the chunk size is also
+tuned (786 vs 805). H100."""
+
+comptime _CHUNK_DIV = 4
+comptime _CHUNK_MIN = 21 * 1024 * 1024
+comptime _CHUNK_MAX = 86 * 1024 * 1024
+"""Pipeline chunk = clamp(bytes / 4, 21 MiB, 86 MiB).
+
+One barrier per chunk, worth about 10 us, against a shorter overlap window per
+chunk. Measured at 168 MiB: 2.6 MiB chunks 1374 us, 5 MiB 1163, 10 MiB 1030,
+21 MiB 927, 43 MiB 786; at 512 MiB 43 MiB gives 2217 and 86 MiB 2191. The
+clamp fits every point measured (H100)."""
+
+comptime _U = 2
+"""16-byte vectors in flight per thread in the HBM copy loops."""
+
+comptime _MMU = 2
+"""multimem loads in flight per thread.
+
+`multimem_ld_reduce`/`multimem_st` are `inlined_assembly` with a `~{memory}`
+clobber, so the compiler may not reorder them: issuing `_MMU` loads before the
+matching stores is the only way to get more than one switch round trip in
+flight. Deeper does not help -- the switch phase at 168 MiB is 684 us with 2,
+726 with 4, 777 with 8, i.e. a throughput ceiling of 250-270 GB/s per
+direction, not a latency wall."""
+
+comptime _SPIN_CHECK = 4096
+
+
+def nvls_available() -> Bool:
+    """Whether this build can emit `multimem` at all. The communicator also
+    has to have brought a multicast region up; see vmm.mojo."""
+    return NVLS_ARCH
+
+
+def nvls_min_bytes() -> Int:
+    return NVLS_MIN_BYTES
+
+
+def nvls_blocks(sm_count: Int) -> Int:
+    """Grid for the NVLS kernel on a device with `sm_count` SMs.
+
+    The full barrier needs the whole grid resident, so this never exceeds two
+    blocks per SM (which `nvvm.minctasm=2` and the 256-thread block make fit at
+    up to 128 registers). A grid that is not fully resident deadlocks -- the
+    prototype hung at 216 blocks of 512 threads and at 396 blocks of 512, and
+    ran at every geometry that stayed inside occupancy.
+    """
+    var by_occupancy = 2 * sm_count if sm_count > 0 else NVLS_MAX_BLOCKS
+    return max(2, min(NVLS_MAX_BLOCKS, by_occupancy))
+
+
+def nvls_chunk_bytes(total_bytes: Int) -> Int:
+    """`clamp(total_bytes / 4, 21 MiB, 86 MiB)`; see `_CHUNK_DIV`."""
+    var c = total_bytes // _CHUNK_DIV
+    c = max(c, _CHUNK_MIN)
+    return min(c, _CHUNK_MAX)
+
+
+def nvls_chunk_vecs(chunk_bytes: Int, world: Int) -> Int:
+    """Chunk size in 16-byte vectors, rounded to a whole number of per-rank
+    slices so the reduce phase of every chunk divides evenly by `world`."""
+    var q = max(1, world)
+    var v = max(q, chunk_bytes // 16)
+    return v // q * q
+
+
+def nvls_padded_vecs(numel: Int, world: Int, esize: Int) -> Int:
+    """16-byte vectors the payload occupies once padded up to a whole number
+    of per-rank slices. `multimem.ld_reduce.v4` needs a full-width, 16-byte
+    aligned operand (nccl:src/device/common_kernel.h:208-255 falls back to
+    scalar multimem otherwise, at a large cost), so the copy-in zero-fills the
+    pad rather than leaving a ragged tail."""
+    var w = 16 // esize
+    var q = max(1, world * w)
+    return ((numel + q - 1) // q * q) // w
+
+
+def nvls_barriers_per_call(numel: Int, world: Int, esize: Int, cv: Int) -> Int:
+    """How far the host must advance the flag target for one call: one barrier
+    before the pipeline and one per chunk."""
+    var nvec = nvls_padded_vecs(numel, world, esize)
+    return (nvec + cv - 1) // cv + 1
+
+
+# ===-------------------------------------------------------------------=== #
+# Device-side primitives
+# ===-------------------------------------------------------------------=== #
+
+
+@always_inline
+def _mm_red_add_u64(
+    addr: Pointer[UInt64, MutAnyOrigin, address_space=AddressSpace.GLOBAL],
+    v: UInt64,
+):
+    """Add `v` to this address on every device bound to the multicast object.
+
+    The Mojo stdlib wraps `multimem.ld_reduce` and `multimem.st` but not
+    `multimem.red`. `.release.sys` so the payload stores this block made are
+    visible to the other GPUs before the counter moves.
+    """
+    inlined_assembly[
+        "multimem.red.release.sys.global.add.u64 [$0], $1;",
+        NoneType,
+        constraints="l,l,~{memory}",
+        has_side_effect=True,
+    ](addr.unsafe_bitcast[NoneType](), v)
+
+
+@always_inline
+def _record_error(uc: Pointer[UInt8, MutAnyOrigin], phase: Int):
+    if thread_idx.x == 0:
+        Atomic[DType.uint64].store[ordering=Ordering.RELEASE](
+            uc.unsafe_bitcast[UInt64](),
+            UInt64(ERR_NVLS_SYNC) * 1_000_000 + UInt64(phase),
+        )
+
+
+@always_inline
+def _nvls_sync(
+    mc: Pointer[UInt8, MutAnyOrigin],
+    uc: Pointer[UInt8, MutAnyOrigin],
+    target: UInt64,
+    t0: UInt64,
+    timeout_ns: UInt64,
+) -> Bool:
+    """Full barrier: every block of every rank.
+
+    It has to be full, not the block-index-matched barrier the unicast kernels
+    use: there, block b only ever consumes bytes block b of a peer produced,
+    but here the reduce phase reads a contiguous slice that EVERY block of
+    every peer helped stage. The prototype measured the index-matched version
+    passing every small case and failing from n = 65537 up, 3-6 wrong elements
+    per rank -- exactly the kind of bug that ships.
+
+    Level 1 is a device-scope arrival counter: the last block of this GPU to
+    arrive has, by the release/acquire pair on it, every other block's payload
+    stores in front of it. Level 2 is one
+    `multimem.red.release.sys.global.add.u64`, which posts that GPU's arrival
+    to all eight counters in one instruction; the same thread then waits on its
+    own copy through the plain mapping (so the wait costs no fabric traffic)
+    and releases the local blocks. Targets advance by `world` per barrier and
+    are never reset, so a rank a whole call ahead cannot deadlock one behind.
+
+    Returns False if the deadline passed. The whole block learns that through
+    shared memory so no thread is stuck inside a `barrier()`, and the local
+    release is published anyway so the other blocks are not wedged either.
+    """
+    var failed = stack_allocation[
+        1, DType.uint32, address_space=AddressSpace.SHARED
+    ]()
+    if thread_idx.x == 0:
+        failed[unsafe_offset=0] = 0
+    barrier()
+
+    if thread_idx.x == 0:
+        var nb = Int(grid_dim.x)
+        var arrive = uc.unsafe_offset(ARRIVE_OFF).unsafe_bitcast[UInt64]()
+        var release = uc.unsafe_offset(RELEASE_OFF).unsafe_bitcast[UInt64]()
+        var mine = uc.unsafe_offset(FLAG_OFF).unsafe_bitcast[UInt64]()
+        var seen = Atomic[DType.uint64].fetch_add(arrive, UInt64(1))
+        var spins = 0
+        # The grid is the same on every call of a process (`nvls_blocks` reads
+        # only the device), so arrivals group cleanly into runs of `nb`.
+        if (Int(seen) + 1) % nb == 0:
+            comptime if NVLS_ARCH:
+                _mm_red_add_u64(
+                    mc.unsafe_offset(FLAG_OFF)
+                    .unsafe_bitcast[UInt64]()
+                    .unsafe_address_space_cast[AddressSpace.GLOBAL](),
+                    UInt64(1),
+                )
+            while (
+                Atomic[DType.uint64].load[ordering=Ordering.ACQUIRE](mine)
+                < target
+            ):
+                spins += 1
+                if spins >= _SPIN_CHECK:
+                    spins = 0
+                    # Same-GPU timer difference only, never across GPUs.
+                    if global_perf_counter_ns() - t0 > timeout_ns:
+                        failed[unsafe_offset=0] = 1
+                        break
+            Atomic[DType.uint64].store[ordering=Ordering.RELEASE](
+                release, target
+            )
+        else:
+            while (
+                Atomic[DType.uint64].load[ordering=Ordering.ACQUIRE](release)
+                < target
+            ):
+                spins += 1
+                if spins >= _SPIN_CHECK:
+                    spins = 0
+                    if global_perf_counter_ns() - t0 > timeout_ns:
+                        failed[unsafe_offset=0] = 1
+                        break
+    barrier()
+    return failed[unsafe_offset=0] == 0
+
+
+@always_inline
+def _copy_vec[
+    dtype: DType, W: Int
+](
+    dst: Pointer[Scalar[dtype], MutAnyOrigin],
+    src: Pointer[Scalar[dtype], MutAnyOrigin],
+    nvec: Int,
+    tid: Int,
+    stride: Int,
+):
+    """Grid-stride copy of `nvec` 16-byte vectors, `_U` of them in flight."""
+    var v = tid
+    var lim = nvec - (_U - 1) * stride
+    while v < lim:
+        var tmp = StaticTuple[SIMD[dtype, W], _U]()
+        comptime for u in range(_U):
+            tmp[u] = src.unsafe_load[width=W, alignment=16](
+                (v + u * stride) * W
+            )
+        comptime for u in range(_U):
+            dst.unsafe_store[width=W, alignment=16](
+                (v + u * stride) * W, tmp[u]
+            )
+        v += _U * stride
+    while v < nvec:
+        dst.unsafe_store[width=W, alignment=16](
+            v * W, src.unsafe_load[width=W, alignment=16](v * W)
+        )
+        v += stride
+
+
+@always_inline
+def _copy_in_span[
+    dtype: DType, W: Int
+](
+    uc_pay: Pointer[Scalar[dtype], MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    v0: Int,
+    v1: Int,
+    n: Int,
+    tid: Int,
+    stride: Int,
+):
+    """Stage vectors [v0, v1); the vectors past element `n` are zero filled so
+    the multimem phase runs on whole 16-byte operands (see
+    `nvls_padded_vecs`)."""
+    var nfull = n // W
+    var lo = min(v0, nfull)
+    var hi = min(v1, nfull)
+    _copy_vec[dtype, W](
+        uc_pay.unsafe_offset(lo * W),
+        in_ptr.unsafe_offset(lo * W),
+        hi - lo,
+        tid,
+        stride,
+    )
+    var v = hi + tid
+    while v < v1:
+        var x = SIMD[dtype, W](0)
+        comptime for k in range(W):
+            var idx = v * W + k
+            if idx < n:
+                x[k] = in_ptr[unsafe_offset=idx]
+        uc_pay.unsafe_store[width=W, alignment=16](v * W, x)
+        v += stride
+
+
+@always_inline
+def _copy_out_span[
+    dtype: DType, W: Int
+](
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    uc_pay: Pointer[Scalar[dtype], MutAnyOrigin],
+    v0: Int,
+    v1: Int,
+    n: Int,
+    tid: Int,
+    stride: Int,
+):
+    var nfull = n // W
+    var lo = min(v0, nfull)
+    var hi = min(v1, nfull)
+    _copy_vec[dtype, W](
+        out_ptr.unsafe_offset(lo * W),
+        uc_pay.unsafe_offset(lo * W),
+        hi - lo,
+        tid,
+        stride,
+    )
+    # The `n % W` elements no 16-byte vector covers, once, on the last chunk.
+    if v1 * W >= n and n % W != 0:
+        var i = nfull * W + tid
+        while i < n:
+            out_ptr[unsafe_offset=i] = uc_pay[unsafe_offset=i]
+            i += stride
+
+
+@always_inline
+def _reduce_span[
+    dtype: DType, W: Int
+](
+    mc_pay: Pointer[Scalar[dtype], MutAnyOrigin],
+    v0: Int,
+    v1: Int,
+    scale: Float32,
+    tid: Int,
+    stride: Int,
+):
+    """`multimem.ld_reduce` + `multimem.st` over vectors [v0, v1).
+
+    Only the rank that owns the span ever touches it, so its read and its write
+    need no ordering against each other across ranks: one barrier before (every
+    rank's copy-in is in) and one after (every rank's store landed).
+
+    `scale` is applied here, on the one value that reaches all eight regions,
+    through an fp32 accumulator for the half dtypes -- the same rule
+    `_copy_span_scaled` follows in collectives_kernels.mojo. Integer dtypes
+    never reach this kernel.
+    """
+    comptime accum = DType.float32 if (
+        dtype == DType.bfloat16 or dtype == DType.float16
+    ) else dtype
+    var unit = scale == Float32(1.0)
+    var sv = SIMD[accum, W](scale.cast[accum]())
+    var v = v0 + tid
+    var lim = v1 - (_MMU - 1) * stride
+    while v < lim:
+        var acc = StaticTuple[SIMD[dtype, W], _MMU]()
+        comptime for u in range(_MMU):
+            acc[u] = multimem_ld_reduce[
+                dtype,
+                simd_width=W,
+                reduction=ReduceOp.ADD,
+                scope=Scope.SYSTEM,
+                consistency=Consistency.RELAXED,
+            ](
+                mc_pay.unsafe_offset(
+                    (v + u * stride) * W
+                ).unsafe_address_space_cast[AddressSpace.GLOBAL]()
+            )
+        comptime for u in range(_MMU):
+            var x = acc[u] if unit else (acc[u].cast[accum]() * sv).cast[
+                dtype
+            ]()
+            multimem_st[
+                dtype,
+                simd_width=W,
+                scope=Scope.SYSTEM,
+                consistency=Consistency.RELAXED,
+            ](
+                mc_pay.unsafe_offset(
+                    (v + u * stride) * W
+                ).unsafe_address_space_cast[AddressSpace.GLOBAL](),
+                x,
+            )
+        v += _MMU * stride
+    while v < v1:
+        var a = mc_pay.unsafe_offset(v * W).unsafe_address_space_cast[
+            AddressSpace.GLOBAL
+        ]()
+        var one = multimem_ld_reduce[
+            dtype,
+            simd_width=W,
+            reduction=ReduceOp.ADD,
+            scope=Scope.SYSTEM,
+            consistency=Consistency.RELAXED,
+        ](a)
+        var y = one if unit else (one.cast[accum]() * sv).cast[dtype]()
+        multimem_st[
+            dtype,
+            simd_width=W,
+            scope=Scope.SYSTEM,
+            consistency=Consistency.RELAXED,
+        ](a, y)
+        v += stride
+
+
+# ===-------------------------------------------------------------------=== #
+# The kernel
+# ===-------------------------------------------------------------------=== #
+
+
+@__llvm_metadata(
+    MAX_THREADS_PER_BLOCK_METADATA=StaticTuple[Int32, 1](Int32(BLOCK)),
+    `nvvm.minctasm`=SIMDLength(2),
+)
+@__name(t"ccl_nvls_allreduce_multimem_{dtype}")
+def _nvls_ar_kernel[
+    dtype: DType, W: Int
+](
+    mc: Pointer[UInt8, MutAnyOrigin],
+    uc: Pointer[UInt8, MutAnyOrigin],
+    in_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    out_ptr: Pointer[Scalar[dtype], MutAnyOrigin],
+    numel: Int64,
+    chunk_vecs: Int64,
+    payload_off: Int64,
+    rank_i: Int32,
+    world_i: Int32,
+    reduce_blocks: Int32,
+    scale: Float32,
+    target: UInt64,
+    timeout_ns: UInt64,
+):
+    """Split grid: the low `reduce_blocks` blocks only drive the switch, the
+    rest only drive HBM, so chunk c's reduction runs at the same time as chunk
+    c+1's copy-in and chunk c-1's copy-out. One barrier per chunk covers all
+    three -- they touch disjoint byte ranges of the region.
+
+    The alternative (every thread both reduces and copies, with the copies
+    issued inside the switch round trip) was built and measured 6% slower --
+    830 us against 786 at 168 MiB -- because a thread's copy pairs are a chain
+    of dependent load-then-store pairs that serialize on HBM latency. See the
+    prototype's section 6.3.
+    """
+    var t0 = global_perf_counter_ns()
+    var n = Int(numel)
+    var world = Int(world_i)
+    var rank = Int(rank_i)
+    var q = world * W
+    var nvec = ((n + q - 1) // q * q) // W
+    var uc_pay = uc.unsafe_offset(Int(payload_off)).unsafe_bitcast[
+        Scalar[dtype]
+    ]()
+    var mc_pay = mc.unsafe_offset(Int(payload_off)).unsafe_bitcast[
+        Scalar[dtype]
+    ]()
+
+    var nb = Int(grid_dim.x)
+    var rb = min(max(1, Int(reduce_blocks)), nb - 1)
+    var is_reducer = Int(block_idx.x) < rb
+    var rtid = Int(block_idx.x) * BLOCK + Int(thread_idx.x)
+    var rstride = rb * BLOCK
+    var ctid = (Int(block_idx.x) - rb) * BLOCK + Int(thread_idx.x)
+    var cstride = (nb - rb) * BLOCK
+    var cv = Int(chunk_vecs)
+    var nch = (nvec + cv - 1) // cv
+    var bar = target
+
+    if not is_reducer:
+        _copy_in_span[dtype, W](
+            uc_pay, in_ptr, 0, min(cv, nvec), n, ctid, cstride
+        )
+    if not _nvls_sync(mc, uc, bar, t0, timeout_ns):
+        _record_error(uc, 0)
+        return
+    bar += UInt64(world)
+
+    for c in range(nch):
+        var s0 = c * cv
+        var s1 = min(s0 + cv, nvec)
+        if is_reducer:
+            var per = (s1 - s0) // world
+            _reduce_span[dtype, W](
+                mc_pay,
+                s0 + rank * per,
+                s0 + rank * per + per,
+                scale,
+                rtid,
+                rstride,
+            )
+        else:
+            if c + 1 < nch:
+                _copy_in_span[dtype, W](
+                    uc_pay, in_ptr, s1, min(s1 + cv, nvec), n, ctid, cstride
+                )
+            if c > 0:
+                _copy_out_span[dtype, W](
+                    out_ptr, uc_pay, (c - 1) * cv, s0, n, ctid, cstride
+                )
+        if not _nvls_sync(mc, uc, bar, t0, timeout_ns):
+            _record_error(uc, c + 1)
+            return
+        bar += UInt64(world)
+
+    if not is_reducer:
+        _copy_out_span[dtype, W](
+            out_ptr, uc_pay, (nch - 1) * cv, nvec, n, ctid, cstride
+        )
+
+
+# ===-------------------------------------------------------------------=== #
+# Public API
+# ===-------------------------------------------------------------------=== #
+
+
+def nvls_allreduce[
+    dtype: DType
+](
+    ctx: DeviceContext,
+    stream: DeviceStream,
+    rank: Int,
+    world: Int,
+    mc_base: Int,
+    uc_base: Int,
+    in_ptr: Int,
+    out_ptr: Int,
+    numel: Int,
+    cap_bytes: Int,
+    scale: Float32,
+    target: Int,
+    blocks: Int,
+    chunk_vecs: Int,
+) raises:
+    """Elementwise `out[i] = scale * sum over ranks of in_r[i]` through the
+    NVSwitch, on `stream`. `in_ptr` may equal `out_ptr`.
+
+    `mc_base`/`uc_base` are this rank's multicast and unicast mappings of the
+    same region; the payload lives in the region's first staging half
+    (`signal_bytes()`, `cap_bytes` long) and the counters in its signal area.
+    `target` is the flag value the FIRST of this call's barriers waits for; the
+    caller advances its own counter by `world * nvls_barriers_per_call(...)`.
+    """
+    comptime if not NVLS_ARCH:
+        raise Error("collectives: this build has no NVLS path (needs sm_90+)")
+    comptime W = 16 // size_of[dtype]()
+    comptime if dtype.is_integral():
+        raise Error("collectives: the NVLS path is float only")
+    if numel <= 0:
+        return
+    if world < 2 or world > 8:
+        raise Error("collectives: the NVLS path needs 2..8 local ranks")
+    if rank < 0 or rank >= world:
+        raise Error("collectives: rank out of range")
+    if (in_ptr | out_ptr) % 16 != 0:
+        raise Error("collectives: NVLS needs 16-byte aligned in_ptr/out_ptr")
+    if mc_base == 0 or uc_base == 0:
+        raise Error("collectives: NVLS called without a multicast region")
+    var nvec = nvls_padded_vecs(numel, world, size_of[dtype]())
+    # The pad rounds the payload up to a whole per-rank slice, so the region
+    # has to hold slightly more than the message.
+    if nvec * 16 > cap_bytes:
+        raise Error("collectives: NVLS message exceeds cap_bytes")
+    if chunk_vecs < world or chunk_vecs % world != 0:
+        raise Error("collectives: NVLS chunk must be whole per-rank slices")
+    var rb = max(1, min(blocks - 1, blocks * NVLS_REDUCE_PCT // 100))
+    comptime if NVLS_ARCH:
+        _enqueue_cached[_nvls_ar_kernel[dtype, W]](
+            ctx,
+            stream,
+            String(t"nvls_{dtype}"),
+            blocks,
+            Pointer[UInt8, MutAnyOrigin](unsafe_from_address=mc_base),
+            Pointer[UInt8, MutAnyOrigin](unsafe_from_address=uc_base),
+            Pointer[Scalar[dtype], MutAnyOrigin](unsafe_from_address=in_ptr),
+            Pointer[Scalar[dtype], MutAnyOrigin](unsafe_from_address=out_ptr),
+            Int64(numel),
+            Int64(chunk_vecs),
+            Int64(signal_bytes()),
+            Int32(rank),
+            Int32(world),
+            Int32(rb),
+            scale,
+            UInt64(target),
+            UInt64(DEFAULT_TIMEOUT_NS),
+        )

--- a/torch_mojo_backend/distributed/mojoccl/nvls_kernels.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/nvls_kernels.mojo
@@ -344,6 +344,47 @@ def _copy_vec[
 
 
 @always_inline
+def _copy_vec_scaled[
+    dtype: DType, W: Int
+](
+    dst: Pointer[Scalar[dtype], MutAnyOrigin],
+    src: Pointer[Scalar[dtype], MutAnyOrigin],
+    nvec: Int,
+    tid: Int,
+    stride: Int,
+    scale: Float32,
+):
+    """`_copy_vec` times `scale`, through an fp32 accumulator for the half
+    dtypes."""
+    comptime accum = DType.float32 if (
+        dtype == DType.bfloat16 or dtype == DType.float16
+    ) else dtype
+    var sv = SIMD[accum, W](scale.cast[accum]())
+    var v = tid
+    var lim = nvec - (_U - 1) * stride
+    while v < lim:
+        var tmp = StaticTuple[SIMD[dtype, W], _U]()
+        comptime for u in range(_U):
+            tmp[u] = src.unsafe_load[width=W, alignment=16](
+                (v + u * stride) * W
+            )
+        comptime for u in range(_U):
+            dst.unsafe_store[width=W, alignment=16](
+                (v + u * stride) * W, (tmp[u].cast[accum]() * sv).cast[dtype]()
+            )
+        v += _U * stride
+    while v < nvec:
+        dst.unsafe_store[width=W, alignment=16](
+            v * W,
+            (
+                src.unsafe_load[width=W, alignment=16](v * W).cast[accum]()
+                * sv
+            ).cast[dtype](),
+        )
+        v += stride
+
+
+@always_inline
 def _copy_in_span[
     dtype: DType, W: Int
 ](
@@ -354,27 +395,51 @@ def _copy_in_span[
     n: Int,
     tid: Int,
     stride: Int,
+    scale: Float32,
 ):
-    """Stage vectors [v0, v1); the vectors past element `n` are zero filled so
-    the multimem phase runs on whole 16-byte operands (see
-    `nvls_padded_vecs`)."""
+    """Stage vectors [v0, v1) times `scale`; the vectors past element `n` are
+    zero filled so the multimem phase runs on whole 16-byte operands (see
+    `nvls_padded_vecs`).
+
+    `scale` is applied HERE, to each rank's input, and not to the reduced
+    value: `multimem.ld_reduce` accumulates in fp32 but returns the sum
+    narrowed to the wire dtype, so two fp16 ranks averaging 40000 would read
+    inf before any scaling. Pre-scaling the inputs is NCCL's PreMulSum for
+    AVG (nccl:src/enqueue/enqueue.cc:2517); for a power-of-two world x/world
+    is exact, so it costs no rounding.
+    """
+    comptime accum = DType.float32 if (
+        dtype == DType.bfloat16 or dtype == DType.float16
+    ) else dtype
     var nfull = n // W
     var lo = min(v0, nfull)
     var hi = min(v1, nfull)
-    _copy_vec[dtype, W](
-        uc_pay.unsafe_offset(lo * W),
-        in_ptr.unsafe_offset(lo * W),
-        hi - lo,
-        tid,
-        stride,
-    )
+    if scale == Float32(1.0):
+        _copy_vec[dtype, W](
+            uc_pay.unsafe_offset(lo * W),
+            in_ptr.unsafe_offset(lo * W),
+            hi - lo,
+            tid,
+            stride,
+        )
+    else:
+        _copy_vec_scaled[dtype, W](
+            uc_pay.unsafe_offset(lo * W),
+            in_ptr.unsafe_offset(lo * W),
+            hi - lo,
+            tid,
+            stride,
+            scale,
+        )
     var v = hi + tid
     while v < v1:
         var x = SIMD[dtype, W](0)
         comptime for k in range(W):
             var idx = v * W + k
             if idx < n:
-                x[k] = in_ptr[unsafe_offset=idx]
+                x[k] = (
+                    in_ptr[unsafe_offset=idx].cast[accum]() * scale.cast[accum]()
+                ).cast[dtype]()
         uc_pay.unsafe_store[width=W, alignment=16](v * W, x)
         v += stride
 
@@ -416,7 +481,6 @@ def _reduce_span[
     mc_pay: Pointer[Scalar[dtype], MutAnyOrigin],
     v0: Int,
     v1: Int,
-    scale: Float32,
     tid: Int,
     stride: Int,
 ):
@@ -424,18 +488,10 @@ def _reduce_span[
 
     Only the rank that owns the span ever touches it, so its read and its write
     need no ordering against each other across ranks: one barrier before (every
-    rank's copy-in is in) and one after (every rank's store landed).
-
-    `scale` is applied here, on the one value that reaches all eight regions,
-    through an fp32 accumulator for the half dtypes -- the same rule
-    `_copy_span_scaled` follows in collectives_kernels.mojo. Integer dtypes
-    never reach this kernel.
+    rank's copy-in is in) and one after (every rank's store landed). Any AVG
+    scale was applied at copy-in (`_copy_in_span`); the switch's sum is stored
+    as is. Integer dtypes never reach this kernel.
     """
-    comptime accum = DType.float32 if (
-        dtype == DType.bfloat16 or dtype == DType.float16
-    ) else dtype
-    var unit = scale == Float32(1.0)
-    var sv = SIMD[accum, W](scale.cast[accum]())
     var v = v0 + tid
     var lim = v1 - (_MMU - 1) * stride
     while v < lim:
@@ -453,9 +509,6 @@ def _reduce_span[
                 ).unsafe_address_space_cast[AddressSpace.GLOBAL]()
             )
         comptime for u in range(_MMU):
-            var x = acc[u] if unit else (acc[u].cast[accum]() * sv).cast[
-                dtype
-            ]()
             multimem_st[
                 dtype,
                 simd_width=W,
@@ -465,7 +518,7 @@ def _reduce_span[
                 mc_pay.unsafe_offset(
                     (v + u * stride) * W
                 ).unsafe_address_space_cast[AddressSpace.GLOBAL](),
-                x,
+                acc[u],
             )
         v += _MMU * stride
     while v < v1:
@@ -479,13 +532,12 @@ def _reduce_span[
             scope=Scope.SYSTEM,
             consistency=Consistency.RELAXED,
         ](a)
-        var y = one if unit else (one.cast[accum]() * sv).cast[dtype]()
         multimem_st[
             dtype,
             simd_width=W,
             scope=Scope.SYSTEM,
             consistency=Consistency.RELAXED,
-        ](a, y)
+        ](a, one)
         v += stride
 
 
@@ -568,7 +620,7 @@ def _nvls_ar_kernel[
 
     if not is_reducer:
         _copy_in_span[dtype, W](
-            uc_pay, in_ptr, 0, min(cv, nvec), n, ctid, cstride
+            uc_pay, in_ptr, 0, min(cv, nvec), n, ctid, cstride, scale
         )
     if not _nvls_sync(mc, uc, bar, t0, timeout_ns):
         _record_error(uc, 1)
@@ -584,14 +636,13 @@ def _nvls_ar_kernel[
                 mc_pay,
                 s0 + rank * per,
                 s0 + rank * per + per,
-                scale,
                 rtid,
                 rstride,
             )
         else:
             if c + 1 < nch:
                 _copy_in_span[dtype, W](
-                    uc_pay, in_ptr, s1, min(s1 + cv, nvec), n, ctid, cstride
+                    uc_pay, in_ptr, s1, min(s1 + cv, nvec), n, ctid, cstride, scale
                 )
             if c > 0:
                 _copy_out_span[dtype, W](

--- a/torch_mojo_backend/distributed/mojoccl/nvls_kernels.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/nvls_kernels.mojo
@@ -385,8 +385,7 @@ def _copy_vec_scaled[
         dst.unsafe_store[width=W, alignment=16](
             v * W,
             (
-                src.unsafe_load[width=W, alignment=16](v * W).cast[accum]()
-                * sv
+                src.unsafe_load[width=W, alignment=16](v * W).cast[accum]() * sv
             ).cast[dtype](),
         )
         v += stride
@@ -446,7 +445,8 @@ def _copy_in_span[
             var idx = v * W + k
             if idx < n:
                 x[k] = (
-                    in_ptr[unsafe_offset=idx].cast[accum]() * scale.cast[accum]()
+                    in_ptr[unsafe_offset=idx].cast[accum]()
+                    * scale.cast[accum]()
                 ).cast[dtype]()
         uc_pay.unsafe_store[width=W, alignment=16](v * W, x)
         v += stride
@@ -650,7 +650,14 @@ def _nvls_ar_kernel[
         else:
             if c + 1 < nch:
                 _copy_in_span[dtype, W](
-                    uc_pay, in_ptr, s1, min(s1 + cv, nvec), n, ctid, cstride, scale
+                    uc_pay,
+                    in_ptr,
+                    s1,
+                    min(s1 + cv, nvec),
+                    n,
+                    ctid,
+                    cstride,
+                    scale,
                 )
             if c > 0:
                 _copy_out_span[dtype, W](

--- a/torch_mojo_backend/distributed/mojoccl/nvls_kernels.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/nvls_kernels.mojo
@@ -62,10 +62,10 @@ from max.gpu.sync import barrier
 
 from collectives_kernels import (
     BLOCK,
-    DEFAULT_TIMEOUT_NS,
     _abort_raised,
     _enqueue_cached,
     signal_bytes,
+    spin_timeout_ns,
 )
 
 
@@ -743,5 +743,5 @@ def nvls_allreduce[
             Int32(rb),
             scale,
             UInt64(target),
-            UInt64(DEFAULT_TIMEOUT_NS),
+            spin_timeout_ns(),
         )

--- a/torch_mojo_backend/distributed/mojoccl/nvls_kernels.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/nvls_kernels.mojo
@@ -190,10 +190,10 @@ def nvls_padded_vecs(numel: Int, world: Int, esize: Int) -> Int:
 
 
 def nvls_barriers_per_call(numel: Int, world: Int, esize: Int, cv: Int) -> Int:
-    """How far the host must advance the flag target for one call: one barrier
-    before the pipeline and one per chunk."""
+    """How far the host must advance the flag target for one call: the start
+    barrier, the one that publishes the first chunk, and one per chunk."""
     var nvec = nvls_padded_vecs(numel, world, esize)
-    return (nvec + cv - 1) // cv + 1
+    return (nvec + cv - 1) // cv + 2
 
 
 # ===-------------------------------------------------------------------=== #
@@ -551,12 +551,27 @@ def _nvls_ar_kernel[
     var nch = (nvec + cv - 1) // cv
     var bar = target
 
+    # Start barrier, before a single byte of staging is written.
+    #
+    # The whole `2 * cap` arena is shared scratch, and the one rule that keeps
+    # collectives of different shapes and sizes from colliding in it is that
+    # every kernel opens with a barrier: no generation writes the arena until
+    # every rank has finished READING it for the previous one. This kernel
+    # needs that rule for the same reason the unicast ones do -- a broadcast or
+    # an all-gather retiring just before it has its peers reading my staging,
+    # which is exactly where the copy-in below writes. It is one barrier
+    # (~8 us) per call, not per chunk.
+    if not _nvls_sync(mc, uc, bar, t0, timeout_ns):
+        _record_error(uc, 0)
+        return
+    bar += UInt64(world)
+
     if not is_reducer:
         _copy_in_span[dtype, W](
             uc_pay, in_ptr, 0, min(cv, nvec), n, ctid, cstride
         )
     if not _nvls_sync(mc, uc, bar, t0, timeout_ns):
-        _record_error(uc, 0)
+        _record_error(uc, 1)
         return
     bar += UInt64(world)
 
@@ -583,7 +598,7 @@ def _nvls_ar_kernel[
                     out_ptr, uc_pay, (c - 1) * cv, s0, n, ctid, cstride
                 )
         if not _nvls_sync(mc, uc, bar, t0, timeout_ns):
-            _record_error(uc, c + 1)
+            _record_error(uc, c + 2)
             return
         bar += UInt64(world)
 
@@ -610,7 +625,7 @@ def nvls_allreduce[
     in_ptr: Int,
     out_ptr: Int,
     numel: Int,
-    cap_bytes: Int,
+    payload_bytes: Int,
     scale: Float32,
     target: Int,
     blocks: Int,
@@ -620,10 +635,13 @@ def nvls_allreduce[
     NVSwitch, on `stream`. `in_ptr` may equal `out_ptr`.
 
     `mc_base`/`uc_base` are this rank's multicast and unicast mappings of the
-    same region; the payload lives in the region's first staging half
-    (`signal_bytes()`, `cap_bytes` long) and the counters in its signal area.
-    `target` is the flag value the FIRST of this call's barriers waits for; the
-    caller advances its own counter by `world * nvls_barriers_per_call(...)`.
+    same region; the payload starts at `signal_bytes()` and may use
+    `payload_bytes`, which is the WHOLE `2 * cap` arena -- this kernel needs
+    one buffer, not two, and the start barrier above is what lets it spread
+    over the same bytes a broadcast or a one-shot allreduce uses. The counters
+    live in the signal area. `target` is the flag value the FIRST of this
+    call's barriers waits for; the caller advances its own counter by
+    `world * nvls_barriers_per_call(...)`.
     """
     comptime if not NVLS_ARCH:
         raise Error("collectives: this build has no NVLS path (needs sm_90+)")
@@ -643,8 +661,8 @@ def nvls_allreduce[
     var nvec = nvls_padded_vecs(numel, world, size_of[dtype]())
     # The pad rounds the payload up to a whole per-rank slice, so the region
     # has to hold slightly more than the message.
-    if nvec * 16 > cap_bytes:
-        raise Error("collectives: NVLS message exceeds cap_bytes")
+    if nvec * 16 > payload_bytes:
+        raise Error("collectives: NVLS message exceeds the staging arena")
     if chunk_vecs < world or chunk_vecs % world != 0:
         raise Error("collectives: NVLS chunk must be whole per-rank slices")
     var rb = max(1, min(blocks - 1, blocks * NVLS_REDUCE_PCT // 100))

--- a/torch_mojo_backend/distributed/mojoccl/vmm.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/vmm.mojo
@@ -69,7 +69,16 @@ comptime AF_UNIX: Int32 = 1
 comptime SOCK_DGRAM: Int32 = 2
 comptime SOL_SOCKET: Int32 = 1
 comptime SO_RCVTIMEO: Int32 = 20
+comptime SO_SNDTIMEO: Int32 = 21
 comptime SCM_RIGHTS = 1
+# MSG_DONTWAIT: every sendmsg/recvmsg below is one non-blocking attempt, and
+# the wait is the caller's deadline loop. A blocking `sendmsg` on an AF_UNIX
+# datagram socket waits for room in the RECEIVER's queue, which is bounded by
+# `net.unix.max_dgram_qlen`; with eight ranks each sending to the seven others
+# before receiving anything, a small qlen wedges the whole node's bring-up in
+# a syscall no deadline can reach.
+comptime MSG_DONTWAIT: Int32 = 0x40
+comptime EAGAIN: Int32 = 11
 
 comptime MSG_KIND_MC = 0
 """Payload word 0 of the datagram carrying the multicast object's fd."""
@@ -80,6 +89,12 @@ peer's local rank."""
 comptime NVLS_AVAILABLE = not has_amd_gpu_accelerator()
 """Every entry point below is CUDA-only; HIP has no multicast equivalent and
 RCCL none either, so an AMD build never reaches them."""
+
+
+def _errno() -> Int32:
+    return external_call[
+        "__errno_location", Pointer[Int32, MutAnyOrigin]
+    ]()[unsafe_offset=0]
 
 
 def _cu(lib: OwnedDLHandle, rc: Int32, what: String) raises:
@@ -298,19 +313,27 @@ def scm_unbind(libc: OwnedDLHandle, sock: Int, path: String) raises:
     _ = libc.get_function[Int32]("unlink")(_sockaddr(path).unsafe_offset(2))
 
 
-def scm_send(
-    libc: OwnedDLHandle,
-    path: String,
-    fd: Int,
-    kind: Int,
-    tag: Int,
-    timeout_s: Float64,
-) raises:
-    """Send `fd`, plus an 8-byte `(kind, tag)` payload, to the socket at
-    `path`. Retries while the peer has not bound yet."""
+def _send_socket(libc: OwnedDLHandle, timeout_s: Float64) raises -> Int32:
+    """A datagram socket for sending fds. `SO_SNDTIMEO` is a backstop only --
+    every send below passes `MSG_DONTWAIT` -- but it is what bounds a send
+    that somehow blocks anyway."""
     var s = libc.get_function[Int32]("socket")(AF_UNIX, SOCK_DGRAM, Int32(0))
     if s < 0:
         raise Error("mojoccl: socket(AF_UNIX) failed")
+    var tv = unsafe_alloc[Int64](2)  # struct timeval
+    tv[unsafe_offset=0] = Int64(timeout_s)
+    tv[unsafe_offset=1] = 0
+    _ = libc.get_function[Int32]("setsockopt")(
+        s, SOL_SOCKET, SO_SNDTIMEO, tv, Int32(16)
+    )
+    return s
+
+
+def _fd_msghdr(
+    sa: Pointer[UInt8, MutUntrackedOrigin], fd: Int, kind: Int, tag: Int
+) -> Pointer[UInt64, MutUntrackedOrigin]:
+    """`struct msghdr` (56 B) carrying one SCM_RIGHTS descriptor and an
+    8-byte `(kind, tag)` payload, to the address in `sa`."""
     var payload = unsafe_alloc[UInt32](2)
     payload[unsafe_offset=0] = UInt32(kind)
     payload[unsafe_offset=1] = UInt32(tag)
@@ -321,18 +344,45 @@ def scm_send(
     ctl[unsafe_offset=0] = 20  # cmsg_len = CMSG_LEN(4)
     ctl[unsafe_offset=1] = UInt64(SOL_SOCKET) | (UInt64(SCM_RIGHTS) << 32)
     ctl[unsafe_offset=2] = UInt64(UInt32(fd))  # the fd itself, at CMSG_DATA
-    var msg = unsafe_alloc[UInt64](7)  # struct msghdr, 56 B
-    msg[unsafe_offset=0] = UInt64(Int(_sockaddr(path)))  # msg_name
+    var msg = unsafe_alloc[UInt64](7)
+    msg[unsafe_offset=0] = UInt64(Int(sa))  # msg_name
     msg[unsafe_offset=1] = 110  # msg_namelen (u32 at +8)
     msg[unsafe_offset=2] = UInt64(Int(iov))  # msg_iov
     msg[unsafe_offset=3] = 1  # msg_iovlen
     msg[unsafe_offset=4] = UInt64(Int(ctl))  # msg_control
     msg[unsafe_offset=5] = 24  # msg_controllen
     msg[unsafe_offset=6] = 0  # msg_flags
-    var sendmsg = libc.get_function[Int]("sendmsg")
+    return msg
+
+
+def _send_once(
+    libc: OwnedDLHandle, sock: Int32, msg: Pointer[UInt64, MutUntrackedOrigin]
+) raises -> Int32:
+    """One `MSG_DONTWAIT` sendmsg. 0 on success, else the errno -- EAGAIN for
+    "the peer's queue is full", ENOENT/ECONNREFUSED for "it has not bound
+    yet"; both are retried by the caller under its deadline."""
+    if libc.get_function[Int]("sendmsg")(sock, msg, MSG_DONTWAIT) >= 0:
+        return 0
+    return _errno()
+
+
+def scm_send(
+    libc: OwnedDLHandle,
+    path: String,
+    fd: Int,
+    kind: Int,
+    tag: Int,
+    timeout_s: Float64,
+) raises:
+    """Send `fd`, plus an 8-byte `(kind, tag)` payload, to the socket at
+    `path`. Retries while the peer has not bound yet, or while its datagram
+    queue is full, until `timeout_s` -- and never blocks in the syscall, so
+    the deadline is real."""
+    var s = _send_socket(libc, timeout_s)
+    var msg = _fd_msghdr(_sockaddr(path), fd, kind, tag)
     var deadline = perf_counter_ns() + Int(timeout_s * 1.0e9)
     while True:
-        if sendmsg(s, msg, Int32(0)) >= 0:
+        if _send_once(libc, s, msg) == 0:
             break
         if perf_counter_ns() > deadline:
             _ = libc.get_function[Int32]("close")(s)
@@ -341,8 +391,23 @@ def scm_send(
     _ = libc.get_function[Int32]("close")(s)
 
 
+def scm_try_recv(
+    libc: OwnedDLHandle, sock: Int
+) raises -> Tuple[Int, Int, Int]:
+    """One non-blocking `recvmsg`. Returns `(-1, 0, 0)` when nothing is
+    queued."""
+    return _recv_impl(libc, sock, MSG_DONTWAIT)
+
+
 def scm_recv(libc: OwnedDLHandle, sock: Int) raises -> Tuple[Int, Int, Int]:
-    """Receive one fd and its `(kind, tag)`; returns `(fd, kind, tag)`."""
+    """Receive one fd and its `(kind, tag)`; returns `(fd, kind, tag)`.
+    Blocking, bounded by the `SO_RCVTIMEO` `scm_bind` set."""
+    return _recv_impl(libc, sock, Int32(0))
+
+
+def _recv_impl(
+    libc: OwnedDLHandle, sock: Int, flags: Int32
+) raises -> Tuple[Int, Int, Int]:
     var payload = unsafe_alloc[UInt32](2)
     payload[unsafe_offset=0] = 0
     payload[unsafe_offset=1] = 0
@@ -360,7 +425,9 @@ def scm_recv(libc: OwnedDLHandle, sock: Int) raises -> Tuple[Int, Int, Int]:
     msg[unsafe_offset=4] = UInt64(Int(ctl))
     msg[unsafe_offset=5] = 24
     msg[unsafe_offset=6] = 0
-    if libc.get_function[Int]("recvmsg")(Int32(sock), msg, Int32(0)) < 0:
+    if libc.get_function[Int]("recvmsg")(Int32(sock), msg, flags) < 0:
+        if flags == MSG_DONTWAIT and _errno() == EAGAIN:
+            return Tuple(-1, 0, 0)
         raise Error("mojoccl: recvmsg on the fd socket failed or timed out")
     if ctl[unsafe_offset=0] != 20:
         raise Error("mojoccl: datagram carried no SCM_RIGHTS control message")
@@ -369,6 +436,64 @@ def scm_recv(libc: OwnedDLHandle, sock: Int) raises -> Tuple[Int, Int, Int]:
         Int(payload[unsafe_offset=0]),
         Int(payload[unsafe_offset=1]),
     )
+
+
+def scm_exchange_fds(
+    libc: OwnedDLHandle,
+    sock: Int,
+    paths: List[String],
+    my_fd: Int,
+    kind: Int,
+    tag: Int,
+    timeout_s: Float64,
+) raises -> List[Tuple[Int, Int, Int]]:
+    """Send `my_fd` to every path AND receive one datagram from each, with the
+    two interleaved.
+
+    The all-to-all round of the NVLS bring-up cannot send everything first:
+    `local_world` ranks each pushing `local_world - 1` datagrams before they
+    read one can fill every queue at once, and on a host with a small
+    `net.unix.max_dgram_qlen` a blocking sender then waits on a receiver who
+    is itself blocked sending. Both halves here are one non-blocking attempt
+    per turn, so a rank that cannot send drains its own queue instead -- and
+    the absolute deadline covers the whole exchange, not one syscall.
+    Returns `(fd, kind, tag)` per datagram; the caller validates and closes.
+    """
+    var send_sock = _send_socket(libc, timeout_s)
+    var msgs = List[Pointer[UInt64, MutUntrackedOrigin]]()
+    for i in range(len(paths)):
+        msgs.append(_fd_msghdr(_sockaddr(paths[i]), my_fd, kind, tag))
+    var got = List[Tuple[Int, Int, Int]]()
+    var sent = 0
+    var deadline = perf_counter_ns() + Int(timeout_s * 1.0e9)
+    while sent < len(paths) or len(got) < len(paths):
+        var moved = False
+        if sent < len(paths):
+            if _send_once(libc, send_sock, msgs[sent]) == 0:
+                sent += 1
+                moved = True
+        if len(got) < len(paths):
+            var r = scm_try_recv(libc, sock)
+            if r[0] >= 0:
+                got.append(r)
+                moved = True
+        if moved:
+            continue
+        if perf_counter_ns() > deadline:
+            _ = libc.get_function[Int32]("close")(send_sock)
+            for i in range(len(got)):
+                _ = libc.get_function[Int32]("close")(Int32(got[i][0]))
+            raise Error(
+                "mojoccl: the fd exchange timed out after sending "
+                + String(sent)
+                + " and receiving "
+                + String(len(got))
+                + " of "
+                + String(len(paths))
+            )
+        sleep(0.0005)
+    _ = libc.get_function[Int32]("close")(send_sock)
+    return got^
 
 
 # ===-------------------------------------------------------------------=== #
@@ -598,59 +723,60 @@ def nvls_bind_and_map(
     region.uc = _map(lib, memh, size, region.granularity, ordinal)
     region.peer_va[local_rank] = region.uc
 
-    # Trade unicast handles. Every rank sends before it receives; the
-    # datagrams are buffered by the kernel, and the receive is bounded by
-    # SO_RCVTIMEO.
+    # Trade unicast handles, sending and receiving at the same time: see
+    # `scm_exchange_fds` for why "everyone sends, then everyone receives"
+    # cannot be safe on a host with a small `net.unix.max_dgram_qlen`.
+    # One export covers every peer -- SCM_RIGHTS installs a new descriptor in
+    # each receiver, and a descriptor already in flight stays valid after the
+    # sender closes it.
+    var paths = List[String]()
     for r in range(local_world):
-        if r == local_rank:
-            continue
-        var fd: Int32 = -1
-        _cu(
-            lib,
-            lib.get_function[Int32]("cuMemExportToShareableHandle")(
-                Pointer(to=fd),
-                memh,
-                Int32(CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR),
-                UInt64(0),
-            ),
-            "cuMemExportToShareableHandle(unicast)",
-        )
-        try:
-            scm_send(
-                libc,
-                socket_path(dir, magic, r),
-                Int(fd),
-                MSG_KIND_UC,
-                local_rank,
-                timeout_s,
-            )
-        except e:
-            _ = libc.get_function[Int32]("close")(fd)
-            raise e
-        _ = libc.get_function[Int32]("close")(fd)
-    for _ in range(local_world - 1):
-        var got = scm_recv(libc, sock)
-        if got[1] != MSG_KIND_UC or got[2] < 0 or got[2] >= local_world:
-            _ = libc.get_function[Int32]("close")(Int32(got[0]))
-            raise Error(
-                "mojoccl: unexpected datagram on the fd socket, kind "
-                + String(got[1])
-                + " tag "
-                + String(got[2])
-            )
-        var ph: UInt64 = 0
-        var rc = lib.get_function[Int32]("cuMemImportFromShareableHandle")(
-            Pointer(to=ph),
-            got[0],
+        if r != local_rank:
+            paths.append(socket_path(dir, magic, r))
+    var fd: Int32 = -1
+    _cu(
+        lib,
+        lib.get_function[Int32]("cuMemExportToShareableHandle")(
+            Pointer(to=fd),
+            memh,
             Int32(CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR),
+            UInt64(0),
+        ),
+        "cuMemExportToShareableHandle(unicast)",
+    )
+    try:
+        var got = scm_exchange_fds(
+            libc, sock, paths, Int(fd), MSG_KIND_UC, local_rank, timeout_s
         )
-        _ = libc.get_function[Int32]("close")(Int32(got[0]))
-        _cu(lib, rc, "cuMemImportFromShareableHandle(peer)")
-        # Recorded before `_map` can raise, so `nvls_teardown` releases it.
-        region.peer_handle[got[2]] = ph
-        region.peer_va[got[2]] = _map(
-            lib, ph, size, region.granularity, ordinal
-        )
+        for i in range(len(got)):
+            var g = got[i]
+            if g[1] != MSG_KIND_UC or g[2] < 0 or g[2] >= local_world:
+                _ = libc.get_function[Int32]("close")(Int32(g[0]))
+                raise Error(
+                    "mojoccl: unexpected datagram on the fd socket, kind "
+                    + String(g[1])
+                    + " tag "
+                    + String(g[2])
+                )
+            var ph: UInt64 = 0
+            var rc = lib.get_function[Int32](
+                "cuMemImportFromShareableHandle"
+            )(
+                Pointer(to=ph),
+                g[0],
+                Int32(CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR),
+            )
+            _ = libc.get_function[Int32]("close")(Int32(g[0]))
+            _cu(lib, rc, "cuMemImportFromShareableHandle(peer)")
+            # Recorded before `_map` can raise, so teardown releases it.
+            region.peer_handle[g[2]] = ph
+            region.peer_va[g[2]] = _map(
+                lib, ph, size, region.granularity, ordinal
+            )
+    except e:
+        _ = libc.get_function[Int32]("close")(fd)
+        raise e
+    _ = libc.get_function[Int32]("close")(fd)
     for r in range(local_world):
         if region.peer_va[r] == 0:
             raise Error(

--- a/torch_mojo_backend/distributed/mojoccl/vmm.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/vmm.mojo
@@ -30,11 +30,14 @@
 # `std.ffi` has no C-struct ABI, so msghdr/cmsghdr/sockaddr_un are written out
 # over UInt64 words, field offsets from the glibc headers.
 #
-# Granularity: `cuMulticastGetGranularity(RECOMMENDED)` is 512 MiB on H100 and
-# the bound size must be a multiple of it, so the region is rounded up and the
-# caller is told to spend the rounding rather than waste it (see
-# `nvls_fit_cap`). MINIMUM is 2 MiB there and was never measured; NCCL uses
-# RECOMMENDED and so does this.
+# Granularity: the bound size must be a multiple of what
+# `cuMulticastGetGranularity` reports, and on H100 that is 512 MiB for
+# RECOMMENDED against 2 MiB for MINIMUM. This asks for MINIMUM, unlike NCCL,
+# so that `MOJOCCL_REGION_MB` keeps meaning what it says -- at RECOMMENDED the
+# default 256 MiB region (128 KiB + 2 x 256 MiB) rounds up to a 1 GiB
+# allocation per rank, and even a deliberately tiny test region costs 512 MiB.
+# `MOJOCCL_NVLS_GRANULARITY=rec` asks for NCCL's choice back; the two measured
+# the same on H100 (docs/distributed.md).
 
 from std.ffi import OwnedDLHandle, external_call
 from std.memory.alloc import unsafe_alloc
@@ -55,6 +58,7 @@ comptime CU_MEM_LOCATION_TYPE_DEVICE = 1
 # CUmemAccess_flags
 comptime CU_MEM_ACCESS_FLAGS_PROT_READWRITE = 3
 # CUmulticastGranularity_flags / CUmemAllocationGranularity_flags
+comptime GRANULARITY_MINIMUM = 0
 comptime GRANULARITY_RECOMMENDED = 1
 # CUdevice_attribute
 comptime ATTR_MULTIPROCESSOR_COUNT = 16
@@ -161,16 +165,25 @@ def _access_desc(ordinal: Int) -> Pointer[UInt64, MutUntrackedOrigin]:
 
 
 def multicast_granularity(
-    lib: OwnedDLHandle, world: Int, ordinal: Int, want_bytes: Int
+    lib: OwnedDLHandle,
+    world: Int,
+    ordinal: Int,
+    want_bytes: Int,
+    recommended: Bool,
 ) raises -> Int:
     """The alignment both the multicast object and the physical allocation
-    need; the region is rounded up to a multiple of it."""
+    need; the region is rounded up to a multiple of it. See the header for why
+    `recommended` defaults to False."""
     var probe = _mc_prop(world, max(want_bytes, 1))
     var g_mc: Int = 0
     _cu(
         lib,
         lib.get_function[Int32]("cuMulticastGetGranularity")(
-            Pointer(to=g_mc), probe, Int32(GRANULARITY_RECOMMENDED)
+            Pointer(to=g_mc),
+            probe,
+            Int32(
+                GRANULARITY_RECOMMENDED if recommended else GRANULARITY_MINIMUM
+            ),
         ),
         "cuMulticastGetGranularity",
     )
@@ -211,7 +224,7 @@ def multicast_capable(
             return False
         if not probe_create:
             return True
-        var g = multicast_granularity(lib, world, ordinal, 1)
+        var g = multicast_granularity(lib, world, ordinal, 1, False)
         var h: UInt64 = 0
         var rc = lib.get_function[Int32]("cuMulticastCreate")(
             Pointer(to=h), _mc_prop(world, g)
@@ -222,22 +235,6 @@ def multicast_capable(
         return True
     except:
         return False
-
-
-def nvls_fit_cap(region_overhead: Int, cap_bytes: Int, granularity: Int) -> Int:
-    """Payload cap to use once the region is rounded to `granularity`.
-
-    A region is `region_overhead + 2 * cap` bytes and the multicast object can
-    only be a multiple of the granularity (512 MiB on H100), so the rounding is
-    paid whether or not it is used. Spending it on the staging halves instead
-    of wasting it is free and strictly better: the single-node allreduce is cut
-    into `ceil(bytes / cap)` chunks, so a bigger cap is fewer launches and
-    fewer barriers. Never returns less than the caller asked for.
-    """
-    var want = region_overhead + 2 * cap_bytes
-    var rounded = _align_up(want, granularity)
-    var fitted = (rounded - region_overhead) // 2 // 4096 * 4096
-    return max(cap_bytes, fitted)
 
 
 # ===-------------------------------------------------------------------=== #

--- a/torch_mojo_backend/distributed/mojoccl/vmm.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/vmm.mojo
@@ -409,7 +409,8 @@ def _map(
     lib: OwnedDLHandle, handle: UInt64, size: Int, gran: Int, ordinal: Int
 ) raises -> Int:
     """Reserve a VA range, map `handle` into it, and grant this device
-    read/write."""
+    read/write. A step that fails releases what the earlier steps took, so
+    the caller only ever owns a fully mapped VA or nothing."""
     var va: Int = 0
     _cu(
         lib,
@@ -418,20 +419,18 @@ def _map(
         ),
         "cuMemAddressReserve",
     )
-    _cu(
-        lib,
-        lib.get_function[Int32]("cuMemMap")(
-            va, size, Int(0), handle, UInt64(0)
-        ),
-        "cuMemMap",
+    var rc = lib.get_function[Int32]("cuMemMap")(
+        va, size, Int(0), handle, UInt64(0)
     )
-    _cu(
-        lib,
-        lib.get_function[Int32]("cuMemSetAccess")(
-            va, size, _access_desc(ordinal), Int(1)
-        ),
-        "cuMemSetAccess",
+    if rc != 0:
+        _ = lib.get_function[Int32]("cuMemAddressFree")(va, size)
+        _cu(lib, rc, "cuMemMap")
+    rc = lib.get_function[Int32]("cuMemSetAccess")(
+        va, size, _access_desc(ordinal), Int(1)
     )
+    if rc != 0:
+        _unmap(lib, va, size)
+        _cu(lib, rc, "cuMemSetAccess")
     return va
 
 
@@ -506,6 +505,9 @@ def nvls_create_and_share(
             ),
             "cuMulticastCreate",
         )
+        # Owned by the region from this line on, so a failure in the export
+        # or the fd hand-off below is released by `nvls_teardown`.
+        region.mc_handle = mch
         var fd: Int32 = -1
         _cu(
             lib,
@@ -517,33 +519,35 @@ def nvls_create_and_share(
             ),
             "cuMemExportToShareableHandle(multicast)",
         )
-        for r in range(1, local_world):
-            scm_send(
-                libc,
-                socket_path(dir, magic, r),
-                Int(fd),
-                MSG_KIND_MC,
-                0,
-                timeout_s,
-            )
+        try:
+            for r in range(1, local_world):
+                scm_send(
+                    libc,
+                    socket_path(dir, magic, r),
+                    Int(fd),
+                    MSG_KIND_MC,
+                    0,
+                    timeout_s,
+                )
+        except e:
+            _ = libc.get_function[Int32]("close")(fd)
+            raise e
         _ = libc.get_function[Int32]("close")(fd)
     else:
         var got = scm_recv(libc, sock)
         if got[1] != MSG_KIND_MC:
+            _ = libc.get_function[Int32]("close")(Int32(got[0]))
             raise Error(
                 "mojoccl: expected the multicast fd, got kind " + String(got[1])
             )
-        _cu(
-            lib,
-            lib.get_function[Int32]("cuMemImportFromShareableHandle")(
-                Pointer(to=mch),
-                got[0],
-                Int32(CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR),
-            ),
-            "cuMemImportFromShareableHandle(multicast)",
+        var rc = lib.get_function[Int32]("cuMemImportFromShareableHandle")(
+            Pointer(to=mch),
+            got[0],
+            Int32(CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR),
         )
         _ = libc.get_function[Int32]("close")(Int32(got[0]))
-    region.mc_handle = mch
+        _cu(lib, rc, "cuMemImportFromShareableHandle(multicast)")
+        region.mc_handle = mch
     _cu(
         lib,
         lib.get_function[Int32]("cuMulticastAddDevice")(mch, Int32(ordinal)),
@@ -611,18 +615,23 @@ def nvls_bind_and_map(
             ),
             "cuMemExportToShareableHandle(unicast)",
         )
-        scm_send(
-            libc,
-            socket_path(dir, magic, r),
-            Int(fd),
-            MSG_KIND_UC,
-            local_rank,
-            timeout_s,
-        )
+        try:
+            scm_send(
+                libc,
+                socket_path(dir, magic, r),
+                Int(fd),
+                MSG_KIND_UC,
+                local_rank,
+                timeout_s,
+            )
+        except e:
+            _ = libc.get_function[Int32]("close")(fd)
+            raise e
         _ = libc.get_function[Int32]("close")(fd)
     for _ in range(local_world - 1):
         var got = scm_recv(libc, sock)
         if got[1] != MSG_KIND_UC or got[2] < 0 or got[2] >= local_world:
+            _ = libc.get_function[Int32]("close")(Int32(got[0]))
             raise Error(
                 "mojoccl: unexpected datagram on the fd socket, kind "
                 + String(got[1])
@@ -630,16 +639,14 @@ def nvls_bind_and_map(
                 + String(got[2])
             )
         var ph: UInt64 = 0
-        _cu(
-            lib,
-            lib.get_function[Int32]("cuMemImportFromShareableHandle")(
-                Pointer(to=ph),
-                got[0],
-                Int32(CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR),
-            ),
-            "cuMemImportFromShareableHandle(peer)",
+        var rc = lib.get_function[Int32]("cuMemImportFromShareableHandle")(
+            Pointer(to=ph),
+            got[0],
+            Int32(CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR),
         )
         _ = libc.get_function[Int32]("close")(Int32(got[0]))
+        _cu(lib, rc, "cuMemImportFromShareableHandle(peer)")
+        # Recorded before `_map` can raise, so `nvls_teardown` releases it.
         region.peer_handle[got[2]] = ph
         region.peer_va[got[2]] = _map(
             lib, ph, size, region.granularity, ordinal

--- a/torch_mojo_backend/distributed/mojoccl/vmm.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/vmm.mojo
@@ -92,9 +92,9 @@ RCCL none either, so an AMD build never reaches them."""
 
 
 def _errno() -> Int32:
-    return external_call[
-        "__errno_location", Pointer[Int32, MutAnyOrigin]
-    ]()[unsafe_offset=0]
+    return external_call["__errno_location", Pointer[Int32, MutAnyOrigin]]()[
+        unsafe_offset=0
+    ]
 
 
 def _cu(lib: OwnedDLHandle, rc: Int32, what: String) raises:
@@ -391,9 +391,7 @@ def scm_send(
     _ = libc.get_function[Int32]("close")(s)
 
 
-def scm_try_recv(
-    libc: OwnedDLHandle, sock: Int
-) raises -> Tuple[Int, Int, Int]:
+def scm_try_recv(libc: OwnedDLHandle, sock: Int) raises -> Tuple[Int, Int, Int]:
     """One non-blocking `recvmsg`. Returns `(-1, 0, 0)` when nothing is
     queued."""
     return _recv_impl(libc, sock, MSG_DONTWAIT)
@@ -759,9 +757,7 @@ def nvls_bind_and_map(
                     + String(g[2])
                 )
             var ph: UInt64 = 0
-            var rc = lib.get_function[Int32](
-                "cuMemImportFromShareableHandle"
-            )(
+            var rc = lib.get_function[Int32]("cuMemImportFromShareableHandle")(
                 Pointer(to=ph),
                 g[0],
                 Int32(CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR),

--- a/torch_mojo_backend/distributed/mojoccl/vmm.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/vmm.mojo
@@ -1,0 +1,654 @@
+# CUDA VMM + NVSwitch-multicast bring-up for the region nvls_kernels.mojo
+# reduces through, called into libcuda.so.1 with the `OwnedDLHandle`
+# driver.mojo already opened (MAX exposes none of this API).
+#
+# The sequence mirrors NCCL's `nccl:src/transport/nvls.cc` and is the one the
+# prototype measured working end to end (`nvls/mcsetup.mojo`, its RESULTS.md
+# section 2):
+#
+#   local rank 0 : cuMulticastGetGranularity -> cuMulticastCreate -> export as
+#                  a POSIX fd, send it to the node's other ranks
+#   all          : cuMemImportFromShareableHandle, cuMulticastAddDevice(mine)
+#   BARRIER        (every device must be in the team before any memory binds)
+#   all          : cuMemCreate(own physical memory, POSIX-fd handle type)
+#                  cuMulticastBindMem(mc, 0, mine, 0, size)  -- every rank at
+#                  multicast offset 0, so ONE multicast address covers the
+#                  node's eight distinct physical allocations
+#                  cuMemAddressReserve/Map/SetAccess twice: once against the
+#                  multicast handle (the address `multimem.*` takes) and once
+#                  against my own memory (ordinary loads and stores)
+#   all          : export my own handle as an fd too and send it to each local
+#                  peer, import theirs, map them -- this replaces
+#                  cuIpcOpenMemHandle, which cannot open VMM memory
+#   BARRIER        (nobody issues a multimem instruction before all have mapped)
+#
+# fd transport is SCM_RIGHTS over an AF_UNIX SOCK_DGRAM socket, what NCCL does
+# (nccl:src/os/linux_ipcsocket.cc:171-245). NOT pidfd_getfd: that needs
+# PTRACE_MODE_ATTACH, i.e. /proc/sys/kernel/yama/ptrace_scope <= 1, and it is 1
+# on stock Ubuntu and 2 or 3 on hardened images -- a collective that silently
+# loses NVLS to a sysctl is worse than 70 lines of hand-laid-out `sendmsg`.
+# `std.ffi` has no C-struct ABI, so msghdr/cmsghdr/sockaddr_un are written out
+# over UInt64 words, field offsets from the glibc headers.
+#
+# Granularity: `cuMulticastGetGranularity(RECOMMENDED)` is 512 MiB on H100 and
+# the bound size must be a multiple of it, so the region is rounded up and the
+# caller is told to spend the rounding rather than waste it (see
+# `nvls_fit_cap`). MINIMUM is 2 MiB there and was never measured; NCCL uses
+# RECOMMENDED and so does this.
+
+from std.ffi import OwnedDLHandle, external_call
+from std.memory.alloc import unsafe_alloc
+from std.sys import has_amd_gpu_accelerator
+from std.time import perf_counter_ns, sleep
+from std.utils import StaticTuple
+
+from collectives_kernels import MAX_WORLD
+
+comptime LIBC = "libc.so.6"
+
+# CUmemAllocationHandleType
+comptime CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR = 1
+# CUmemAllocationType
+comptime CU_MEM_ALLOCATION_TYPE_PINNED = 1
+# CUmemLocationType
+comptime CU_MEM_LOCATION_TYPE_DEVICE = 1
+# CUmemAccess_flags
+comptime CU_MEM_ACCESS_FLAGS_PROT_READWRITE = 3
+# CUmulticastGranularity_flags / CUmemAllocationGranularity_flags
+comptime GRANULARITY_RECOMMENDED = 1
+# CUdevice_attribute
+comptime ATTR_MULTIPROCESSOR_COUNT = 16
+comptime ATTR_MULTICAST_SUPPORTED = 132
+
+# libc / linux
+comptime AF_UNIX: Int32 = 1
+comptime SOCK_DGRAM: Int32 = 2
+comptime SOL_SOCKET: Int32 = 1
+comptime SO_RCVTIMEO: Int32 = 20
+comptime SCM_RIGHTS = 1
+
+comptime MSG_KIND_MC = 0
+"""Payload word 0 of the datagram carrying the multicast object's fd."""
+comptime MSG_KIND_UC = 1
+"""...and of the one carrying a peer's own memory handle; word 1 is that
+peer's local rank."""
+
+comptime NVLS_AVAILABLE = not has_amd_gpu_accelerator()
+"""Every entry point below is CUDA-only; HIP has no multicast equivalent and
+RCCL none either, so an AMD build never reaches them."""
+
+
+def _cu(lib: OwnedDLHandle, rc: Int32, what: String) raises:
+    if rc != 0:
+        raise Error("mojoccl: " + what + " failed, driver rc=" + String(rc))
+
+
+def _align_up(x: Int, a: Int) -> Int:
+    return (x + a - 1) // a * a
+
+
+def device_attribute(lib: OwnedDLHandle, attr: Int, ordinal: Int) raises -> Int:
+    """`cuDeviceGetAttribute`, or a negative driver rc. Never raises: every
+    caller here treats "could not ask" as "not supported"."""
+    var v: Int32 = -1
+    var rc = lib.get_function[Int32]("cuDeviceGetAttribute")(
+        Pointer(to=v), Int32(attr), Int32(ordinal)
+    )
+    if rc != 0:
+        return -Int(rc)
+    return Int(v)
+
+
+def sm_count(lib: OwnedDLHandle, ordinal: Int) -> Int:
+    """SMs on this device, for the NVLS grid (which must be fully resident).
+    0 if the driver refuses to say, which `nvls_blocks` reads as "use the
+    fitted default"."""
+    comptime if not NVLS_AVAILABLE:
+        return 0
+    try:
+        var n = device_attribute(lib, ATTR_MULTIPROCESSOR_COUNT, ordinal)
+        return n if n > 0 else 0
+    except:
+        return 0
+
+
+# ===-------------------------------------------------------------------=== #
+# Driver property blocks, laid out by hand over UInt64 words (field offsets
+# from cuda.h; `std.ffi` has no C-struct ABI).
+# ===-------------------------------------------------------------------=== #
+
+
+def _mc_prop(world: Int, size: Int) -> Pointer[UInt64, MutUntrackedOrigin]:
+    """CUmulticastObjectProp{numDevices, size, handleTypes, flags}, 32 B."""
+    var p = unsafe_alloc[UInt64](4)
+    p[unsafe_offset=0] = UInt64(UInt32(world))  # numDevices +0, pad +4
+    p[unsafe_offset=1] = UInt64(size)  # size +8
+    p[unsafe_offset=2] = UInt64(
+        CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR
+    )  # handleTypes +16
+    p[unsafe_offset=3] = 0  # flags +24
+    return p
+
+
+def _mem_prop(ordinal: Int) -> Pointer[UInt64, MutUntrackedOrigin]:
+    """CUmemAllocationProp{type, requestedHandleTypes, location, win32, flags}.
+    """
+    var p = unsafe_alloc[UInt64](4)
+    p[unsafe_offset=0] = UInt64(CU_MEM_ALLOCATION_TYPE_PINNED) | (
+        UInt64(CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) << 32
+    )
+    p[unsafe_offset=1] = UInt64(CU_MEM_LOCATION_TYPE_DEVICE) | (
+        UInt64(UInt32(ordinal)) << 32
+    )
+    p[unsafe_offset=2] = 0
+    p[unsafe_offset=3] = 0
+    return p
+
+
+def _access_desc(ordinal: Int) -> Pointer[UInt64, MutUntrackedOrigin]:
+    """CUmemAccessDesc{location{type,id}, flags}."""
+    var p = unsafe_alloc[UInt64](2)
+    p[unsafe_offset=0] = UInt64(CU_MEM_LOCATION_TYPE_DEVICE) | (
+        UInt64(UInt32(ordinal)) << 32
+    )
+    p[unsafe_offset=1] = UInt64(CU_MEM_ACCESS_FLAGS_PROT_READWRITE)
+    return p
+
+
+# ===-------------------------------------------------------------------=== #
+# Capability probe and sizing
+# ===-------------------------------------------------------------------=== #
+
+
+def multicast_granularity(
+    lib: OwnedDLHandle, world: Int, ordinal: Int, want_bytes: Int
+) raises -> Int:
+    """The alignment both the multicast object and the physical allocation
+    need; the region is rounded up to a multiple of it."""
+    var probe = _mc_prop(world, max(want_bytes, 1))
+    var g_mc: Int = 0
+    _cu(
+        lib,
+        lib.get_function[Int32]("cuMulticastGetGranularity")(
+            Pointer(to=g_mc), probe, Int32(GRANULARITY_RECOMMENDED)
+        ),
+        "cuMulticastGetGranularity",
+    )
+    var g_mem: Int = 0
+    _cu(
+        lib,
+        lib.get_function[Int32]("cuMemGetAllocationGranularity")(
+            Pointer(to=g_mem),
+            _mem_prop(ordinal),
+            Int32(GRANULARITY_RECOMMENDED),
+        ),
+        "cuMemGetAllocationGranularity",
+    )
+    var g = max(g_mc, g_mem)
+    if g <= 0:
+        raise Error("mojoccl: multicast granularity came back as " + String(g))
+    return g
+
+
+def multicast_capable(
+    lib: OwnedDLHandle, ordinal: Int, world: Int, probe_create: Bool
+) -> Bool:
+    """Can this rank take the NVLS path?
+
+    Attribute first (`CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED`), then -- on the
+    one rank per node that will actually create the object -- a real
+    `cuMulticastCreate` of a granularity-sized object, released immediately.
+    The create is where a broken fabric-manager configuration shows up (NCCL
+    calls its bind "where we normally see issues if the system NVLS/Multicast
+    support is broken", nccl:src/transport/nvls.cc:369), and finding out here
+    costs 88 us and lets every rank agree to fall back BEFORE anything is
+    allocated.
+    """
+    comptime if not NVLS_AVAILABLE:
+        return False
+    try:
+        if device_attribute(lib, ATTR_MULTICAST_SUPPORTED, ordinal) != 1:
+            return False
+        if not probe_create:
+            return True
+        var g = multicast_granularity(lib, world, ordinal, 1)
+        var h: UInt64 = 0
+        var rc = lib.get_function[Int32]("cuMulticastCreate")(
+            Pointer(to=h), _mc_prop(world, g)
+        )
+        if rc != 0:
+            return False
+        _ = lib.get_function[Int32]("cuMemRelease")(h)
+        return True
+    except:
+        return False
+
+
+def nvls_fit_cap(region_overhead: Int, cap_bytes: Int, granularity: Int) -> Int:
+    """Payload cap to use once the region is rounded to `granularity`.
+
+    A region is `region_overhead + 2 * cap` bytes and the multicast object can
+    only be a multiple of the granularity (512 MiB on H100), so the rounding is
+    paid whether or not it is used. Spending it on the staging halves instead
+    of wasting it is free and strictly better: the single-node allreduce is cut
+    into `ceil(bytes / cap)` chunks, so a bigger cap is fewer launches and
+    fewer barriers. Never returns less than the caller asked for.
+    """
+    var want = region_overhead + 2 * cap_bytes
+    var rounded = _align_up(want, granularity)
+    var fitted = (rounded - region_overhead) // 2 // 4096 * 4096
+    return max(cap_bytes, fitted)
+
+
+# ===-------------------------------------------------------------------=== #
+# fd transport: SCM_RIGHTS over AF_UNIX SOCK_DGRAM
+# ===-------------------------------------------------------------------=== #
+
+
+def socket_path(dir: String, magic: UInt64, local_rank: Int) -> String:
+    """Where local rank `local_rank` of the communicator `magic` listens.
+
+    Derived, not exchanged: every rank of a node computes the same name from
+    the unique id it was already given, so the TCP bootstrap carries no extra
+    round. The magic is per-`ncclGetUniqueId`, so two communicators alive at
+    once do not collide.
+    """
+    return dir + "/mojoccl-" + hex(magic) + "-" + String(local_rank) + ".sock"
+
+
+def _sockaddr(path: String) raises -> Pointer[UInt8, MutUntrackedOrigin]:
+    """sockaddr_un{u16 family; char path[108]}, zero filled."""
+    var sa = unsafe_alloc[UInt8](112)
+    for i in range(112):
+        sa[unsafe_offset=i] = 0
+    sa.unsafe_bitcast[UInt16]()[unsafe_offset=0] = UInt16(AF_UNIX)
+    var b = path.as_bytes()
+    if len(b) >= 107:
+        raise Error("mojoccl: unix socket path too long: " + path)
+    for i in range(len(b)):
+        sa[unsafe_offset=2 + i] = b[i]
+    return sa
+
+
+def scm_bind(
+    libc: OwnedDLHandle, path: String, timeout_s: Float64
+) raises -> Int:
+    """Create and bind a datagram socket that receives one fd per message.
+
+    `SO_RCVTIMEO` matters: without it a rank whose peer died during bring-up
+    blocks in `recvmsg` forever, and the communicator hangs instead of
+    failing.
+    """
+    _ = libc.get_function[Int32]("unlink")(_sockaddr(path).unsafe_offset(2))
+    var s = libc.get_function[Int32]("socket")(AF_UNIX, SOCK_DGRAM, Int32(0))
+    if s < 0:
+        raise Error("mojoccl: socket(AF_UNIX) failed")
+    if libc.get_function[Int32]("bind")(s, _sockaddr(path), Int32(110)) != 0:
+        _ = libc.get_function[Int32]("close")(s)
+        raise Error("mojoccl: bind(" + path + ") failed")
+    var tv = unsafe_alloc[Int64](2)  # struct timeval
+    tv[unsafe_offset=0] = Int64(timeout_s)
+    tv[unsafe_offset=1] = 0
+    _ = libc.get_function[Int32]("setsockopt")(
+        s, SOL_SOCKET, SO_RCVTIMEO, tv, Int32(16)
+    )
+    return Int(s)
+
+
+def scm_unbind(libc: OwnedDLHandle, sock: Int, path: String) raises:
+    if sock > 0:
+        _ = libc.get_function[Int32]("close")(Int32(sock))
+    _ = libc.get_function[Int32]("unlink")(_sockaddr(path).unsafe_offset(2))
+
+
+def scm_send(
+    libc: OwnedDLHandle,
+    path: String,
+    fd: Int,
+    kind: Int,
+    tag: Int,
+    timeout_s: Float64,
+) raises:
+    """Send `fd`, plus an 8-byte `(kind, tag)` payload, to the socket at
+    `path`. Retries while the peer has not bound yet."""
+    var s = libc.get_function[Int32]("socket")(AF_UNIX, SOCK_DGRAM, Int32(0))
+    if s < 0:
+        raise Error("mojoccl: socket(AF_UNIX) failed")
+    var payload = unsafe_alloc[UInt32](2)
+    payload[unsafe_offset=0] = UInt32(kind)
+    payload[unsafe_offset=1] = UInt32(tag)
+    var iov = unsafe_alloc[UInt64](2)  # struct iovec
+    iov[unsafe_offset=0] = UInt64(Int(payload))
+    iov[unsafe_offset=1] = 8
+    var ctl = unsafe_alloc[UInt64](3)  # CMSG_SPACE(sizeof(int)) == 24
+    ctl[unsafe_offset=0] = 20  # cmsg_len = CMSG_LEN(4)
+    ctl[unsafe_offset=1] = UInt64(SOL_SOCKET) | (UInt64(SCM_RIGHTS) << 32)
+    ctl[unsafe_offset=2] = UInt64(UInt32(fd))  # the fd itself, at CMSG_DATA
+    var msg = unsafe_alloc[UInt64](7)  # struct msghdr, 56 B
+    msg[unsafe_offset=0] = UInt64(Int(_sockaddr(path)))  # msg_name
+    msg[unsafe_offset=1] = 110  # msg_namelen (u32 at +8)
+    msg[unsafe_offset=2] = UInt64(Int(iov))  # msg_iov
+    msg[unsafe_offset=3] = 1  # msg_iovlen
+    msg[unsafe_offset=4] = UInt64(Int(ctl))  # msg_control
+    msg[unsafe_offset=5] = 24  # msg_controllen
+    msg[unsafe_offset=6] = 0  # msg_flags
+    var sendmsg = libc.get_function[Int]("sendmsg")
+    var deadline = perf_counter_ns() + Int(timeout_s * 1.0e9)
+    while True:
+        if sendmsg(s, msg, Int32(0)) >= 0:
+            break
+        if perf_counter_ns() > deadline:
+            _ = libc.get_function[Int32]("close")(s)
+            raise Error("mojoccl: sendmsg to " + path + " timed out")
+        sleep(0.005)
+    _ = libc.get_function[Int32]("close")(s)
+
+
+def scm_recv(libc: OwnedDLHandle, sock: Int) raises -> Tuple[Int, Int, Int]:
+    """Receive one fd and its `(kind, tag)`; returns `(fd, kind, tag)`."""
+    var payload = unsafe_alloc[UInt32](2)
+    payload[unsafe_offset=0] = 0
+    payload[unsafe_offset=1] = 0
+    var iov = unsafe_alloc[UInt64](2)
+    iov[unsafe_offset=0] = UInt64(Int(payload))
+    iov[unsafe_offset=1] = 8
+    var ctl = unsafe_alloc[UInt64](3)
+    for i in range(3):
+        ctl[unsafe_offset=i] = 0
+    var msg = unsafe_alloc[UInt64](7)
+    msg[unsafe_offset=0] = 0
+    msg[unsafe_offset=1] = 0
+    msg[unsafe_offset=2] = UInt64(Int(iov))
+    msg[unsafe_offset=3] = 1
+    msg[unsafe_offset=4] = UInt64(Int(ctl))
+    msg[unsafe_offset=5] = 24
+    msg[unsafe_offset=6] = 0
+    if libc.get_function[Int]("recvmsg")(Int32(sock), msg, Int32(0)) < 0:
+        raise Error("mojoccl: recvmsg on the fd socket failed or timed out")
+    if ctl[unsafe_offset=0] != 20:
+        raise Error("mojoccl: datagram carried no SCM_RIGHTS control message")
+    return Tuple(
+        Int(UInt32(ctl[unsafe_offset=2] & 0xFFFFFFFF)),
+        Int(payload[unsafe_offset=0]),
+        Int(payload[unsafe_offset=1]),
+    )
+
+
+# ===-------------------------------------------------------------------=== #
+# The region
+# ===-------------------------------------------------------------------=== #
+
+
+struct NvlsRegion(Movable):
+    """One rank's slice of a node-wide multicast allocation.
+
+    `mc` is the multicast VA -- only `multimem.*` may touch it. `uc` is a plain
+    mapping of the same physical bytes and is what every unicast kernel, the
+    staging copies and the flag spin use; it is also what `regions[local_rank]`
+    holds, so collectives_kernels.mojo never learns that the region changed.
+    """
+
+    var mc: Int
+    var uc: Int
+    var size: Int
+    var granularity: Int
+    var mc_handle: UInt64
+    var mem_handle: UInt64
+    var peer_va: StaticTuple[Int, MAX_WORLD]
+    var peer_handle: StaticTuple[UInt64, MAX_WORLD]
+
+    def __init__(out self):
+        self.mc = 0
+        self.uc = 0
+        self.size = 0
+        self.granularity = 0
+        self.mc_handle = 0
+        self.mem_handle = 0
+        self.peer_va = StaticTuple[Int, MAX_WORLD](fill=0)
+        self.peer_handle = StaticTuple[UInt64, MAX_WORLD](fill=0)
+
+
+def _map(
+    lib: OwnedDLHandle, handle: UInt64, size: Int, gran: Int, ordinal: Int
+) raises -> Int:
+    """Reserve a VA range, map `handle` into it, and grant this device
+    read/write."""
+    var va: Int = 0
+    _cu(
+        lib,
+        lib.get_function[Int32]("cuMemAddressReserve")(
+            Pointer(to=va), size, gran, Int(0), UInt64(0)
+        ),
+        "cuMemAddressReserve",
+    )
+    _cu(
+        lib,
+        lib.get_function[Int32]("cuMemMap")(
+            va, size, Int(0), handle, UInt64(0)
+        ),
+        "cuMemMap",
+    )
+    _cu(
+        lib,
+        lib.get_function[Int32]("cuMemSetAccess")(
+            va, size, _access_desc(ordinal), Int(1)
+        ),
+        "cuMemSetAccess",
+    )
+    return va
+
+
+def _unmap(lib: OwnedDLHandle, va: Int, size: Int) raises:
+    if va == 0:
+        return
+    _ = lib.get_function[Int32]("cuMemUnmap")(va, size)
+    _ = lib.get_function[Int32]("cuMemAddressFree")(va, size)
+
+
+def nvls_teardown(
+    mut region: NvlsRegion, lib: OwnedDLHandle, ordinal: Int
+) raises:
+    """Release everything the bring-up took, in reverse, and blank the struct
+    so a second call is a no-op. Tolerates a partly built region, which is
+    what lets the failure path call it too."""
+    comptime if not NVLS_AVAILABLE:
+        return
+    for r in range(MAX_WORLD):
+        if region.peer_va[r] != region.uc:
+            _unmap(lib, region.peer_va[r], region.size)
+        if region.peer_handle[r] != 0:
+            _ = lib.get_function[Int32]("cuMemRelease")(region.peer_handle[r])
+        region.peer_va[r] = 0
+        region.peer_handle[r] = 0
+    _unmap(lib, region.uc, region.size)
+    _unmap(lib, region.mc, region.size)
+    if region.mc_handle != 0 and region.mem_handle != 0:
+        _ = lib.get_function[Int32]("cuMulticastUnbind")(
+            region.mc_handle, Int32(ordinal), Int(0), region.size
+        )
+    if region.mem_handle != 0:
+        _ = lib.get_function[Int32]("cuMemRelease")(region.mem_handle)
+    if region.mc_handle != 0:
+        _ = lib.get_function[Int32]("cuMemRelease")(region.mc_handle)
+    region.uc = 0
+    region.mc = 0
+    region.mem_handle = 0
+    region.mc_handle = 0
+    region.size = 0
+
+
+def nvls_create_and_share(
+    lib: OwnedDLHandle,
+    libc: OwnedDLHandle,
+    dir: String,
+    magic: UInt64,
+    local_rank: Int,
+    local_world: Int,
+    ordinal: Int,
+    size: Int,
+    gran: Int,
+    sock: Int,
+    timeout_s: Float64,
+    mut region: NvlsRegion,
+) raises:
+    """Steps 1-3 of the bring-up: the multicast object exists on every rank and
+    every device has joined it. The caller barriers after this, then calls
+    `nvls_bind_and_map` -- the split is where the "every device in the team
+    before any memory is bound" rule lives.
+    """
+    comptime if not NVLS_AVAILABLE:
+        raise Error("mojoccl: NVLS is CUDA-only")
+    region.size = size
+    region.granularity = gran
+    var mch: UInt64 = 0
+    if local_rank == 0:
+        _cu(
+            lib,
+            lib.get_function[Int32]("cuMulticastCreate")(
+                Pointer(to=mch), _mc_prop(local_world, size)
+            ),
+            "cuMulticastCreate",
+        )
+        var fd: Int32 = -1
+        _cu(
+            lib,
+            lib.get_function[Int32]("cuMemExportToShareableHandle")(
+                Pointer(to=fd),
+                mch,
+                Int32(CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR),
+                UInt64(0),
+            ),
+            "cuMemExportToShareableHandle(multicast)",
+        )
+        for r in range(1, local_world):
+            scm_send(
+                libc,
+                socket_path(dir, magic, r),
+                Int(fd),
+                MSG_KIND_MC,
+                0,
+                timeout_s,
+            )
+        _ = libc.get_function[Int32]("close")(fd)
+    else:
+        var got = scm_recv(libc, sock)
+        if got[1] != MSG_KIND_MC:
+            raise Error(
+                "mojoccl: expected the multicast fd, got kind " + String(got[1])
+            )
+        _cu(
+            lib,
+            lib.get_function[Int32]("cuMemImportFromShareableHandle")(
+                Pointer(to=mch),
+                got[0],
+                Int32(CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR),
+            ),
+            "cuMemImportFromShareableHandle(multicast)",
+        )
+        _ = libc.get_function[Int32]("close")(Int32(got[0]))
+    region.mc_handle = mch
+    _cu(
+        lib,
+        lib.get_function[Int32]("cuMulticastAddDevice")(mch, Int32(ordinal)),
+        "cuMulticastAddDevice",
+    )
+
+
+def nvls_bind_and_map(
+    lib: OwnedDLHandle,
+    libc: OwnedDLHandle,
+    dir: String,
+    magic: UInt64,
+    local_rank: Int,
+    local_world: Int,
+    ordinal: Int,
+    sock: Int,
+    timeout_s: Float64,
+    mut region: NvlsRegion,
+) raises:
+    """Steps 4-6: bind my physical memory into the object, map it twice, and
+    trade unicast handles with the node's other ranks.
+
+    The peers' mappings replace `cuIpcOpenMemHandle`, which cannot open VMM
+    memory; this is also what NCCL's P2P transport does with driver >= 12.0
+    (nccl:src/transport/p2p.cc:267-327). The caller barriers after this: no
+    rank may issue a multimem instruction before every rank has mapped.
+    """
+    comptime if not NVLS_AVAILABLE:
+        raise Error("mojoccl: NVLS is CUDA-only")
+    var size = region.size
+    var memh: UInt64 = 0
+    _cu(
+        lib,
+        lib.get_function[Int32]("cuMemCreate")(
+            Pointer(to=memh), size, _mem_prop(ordinal), UInt64(0)
+        ),
+        "cuMemCreate",
+    )
+    region.mem_handle = memh
+    _cu(
+        lib,
+        lib.get_function[Int32]("cuMulticastBindMem")(
+            region.mc_handle, Int(0), memh, Int(0), size, UInt64(0)
+        ),
+        "cuMulticastBindMem",
+    )
+    region.mc = _map(lib, region.mc_handle, size, region.granularity, ordinal)
+    region.uc = _map(lib, memh, size, region.granularity, ordinal)
+    region.peer_va[local_rank] = region.uc
+
+    # Trade unicast handles. Every rank sends before it receives; the
+    # datagrams are buffered by the kernel, and the receive is bounded by
+    # SO_RCVTIMEO.
+    for r in range(local_world):
+        if r == local_rank:
+            continue
+        var fd: Int32 = -1
+        _cu(
+            lib,
+            lib.get_function[Int32]("cuMemExportToShareableHandle")(
+                Pointer(to=fd),
+                memh,
+                Int32(CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR),
+                UInt64(0),
+            ),
+            "cuMemExportToShareableHandle(unicast)",
+        )
+        scm_send(
+            libc,
+            socket_path(dir, magic, r),
+            Int(fd),
+            MSG_KIND_UC,
+            local_rank,
+            timeout_s,
+        )
+        _ = libc.get_function[Int32]("close")(fd)
+    for _ in range(local_world - 1):
+        var got = scm_recv(libc, sock)
+        if got[1] != MSG_KIND_UC or got[2] < 0 or got[2] >= local_world:
+            raise Error(
+                "mojoccl: unexpected datagram on the fd socket, kind "
+                + String(got[1])
+                + " tag "
+                + String(got[2])
+            )
+        var ph: UInt64 = 0
+        _cu(
+            lib,
+            lib.get_function[Int32]("cuMemImportFromShareableHandle")(
+                Pointer(to=ph),
+                got[0],
+                Int32(CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR),
+            ),
+            "cuMemImportFromShareableHandle(peer)",
+        )
+        _ = libc.get_function[Int32]("close")(Int32(got[0]))
+        region.peer_handle[got[2]] = ph
+        region.peer_va[got[2]] = _map(
+            lib, ph, size, region.granularity, ordinal
+        )
+    for r in range(local_world):
+        if region.peer_va[r] == 0:
+            raise Error(
+                "mojoccl: local rank " + String(r) + " never sent its region"
+            )

--- a/torch_mojo_backend/distributed/mojoccl/vmm.mojo
+++ b/torch_mojo_backend/distributed/mojoccl/vmm.mojo
@@ -10,7 +10,8 @@
 #                  a POSIX fd, send it to the node's other ranks
 #   all          : cuMemImportFromShareableHandle, cuMulticastAddDevice(mine)
 #   BARRIER        (every device must be in the team before any memory binds)
-#   all          : cuMemCreate(own physical memory, POSIX-fd handle type)
+#   all          : cuMemCreate(own physical memory, POSIX-fd handle type,
+#                  GPUDirect-RDMA-capable so an HCA can register it)
 #                  cuMulticastBindMem(mc, 0, mine, 0, size)  -- every rank at
 #                  multicast offset 0, so ONE multicast address covers the
 #                  node's eight distinct physical allocations
@@ -63,6 +64,7 @@ comptime GRANULARITY_RECOMMENDED = 1
 # CUdevice_attribute
 comptime ATTR_MULTIPROCESSOR_COUNT = 16
 comptime ATTR_MULTICAST_SUPPORTED = 132
+comptime ATTR_GPU_DIRECT_RDMA_WITH_CUDA_VMM_SUPPORTED = 110
 
 # libc / linux
 comptime AF_UNIX: Int32 = 1
@@ -149,8 +151,16 @@ def _mc_prop(world: Int, size: Int) -> Pointer[UInt64, MutUntrackedOrigin]:
     return p
 
 
-def _mem_prop(ordinal: Int) -> Pointer[UInt64, MutUntrackedOrigin]:
+def _mem_prop(
+    lib: OwnedDLHandle, ordinal: Int
+) raises -> Pointer[UInt64, MutUntrackedOrigin]:
     """CUmemAllocationProp{type, requestedHandleTypes, location, win32, flags}.
+
+    `allocFlags.gpuDirectRDMACapable` is set whenever the device supports it,
+    as NCCL does (nccl:src/include/alloc.h:329) and as MAX's own arena does:
+    nvidia_peermem refuses to pin a VMM chunk created without it, so
+    `ibv_reg_mr` on the unicast mapping returned NULL (EFAULT) until this was
+    set (docs/mojo_collectives_nvls_results.md §4).
     """
     var p = unsafe_alloc[UInt64](4)
     p[unsafe_offset=0] = UInt64(CU_MEM_ALLOCATION_TYPE_PINNED) | (
@@ -160,7 +170,14 @@ def _mem_prop(ordinal: Int) -> Pointer[UInt64, MutUntrackedOrigin]:
         UInt64(UInt32(ordinal)) << 32
     )
     p[unsafe_offset=2] = 0
-    p[unsafe_offset=3] = 0
+    # CUmemAllocationFlags{compressionType: u8, gpuDirectRDMACapable: u8, usage: u16}
+    var rdma = (
+        device_attribute(
+            lib, ATTR_GPU_DIRECT_RDMA_WITH_CUDA_VMM_SUPPORTED, ordinal
+        )
+        == 1
+    )
+    p[unsafe_offset=3] = UInt64(1) << 8 if rdma else UInt64(0)
     return p
 
 
@@ -207,7 +224,7 @@ def multicast_granularity(
         lib,
         lib.get_function[Int32]("cuMemGetAllocationGranularity")(
             Pointer(to=g_mem),
-            _mem_prop(ordinal),
+            _mem_prop(lib, ordinal),
             Int32(GRANULARITY_RECOMMENDED),
         ),
         "cuMemGetAllocationGranularity",
@@ -705,7 +722,7 @@ def nvls_bind_and_map(
     _cu(
         lib,
         lib.get_function[Int32]("cuMemCreate")(
-            Pointer(to=memh), size, _mem_prop(ordinal), UInt64(0)
+            Pointer(to=memh), size, _mem_prop(lib, ordinal), UInt64(0)
         ),
         "cuMemCreate",
     )

--- a/torch_mojo_backend/distributed/mojoccl_build.py
+++ b/torch_mojo_backend/distributed/mojoccl_build.py
@@ -1,0 +1,31 @@
+"""Builds libmojoccl.so on first use and returns its cached path.
+
+Reuses the eager-kernel loader's ungated-build machinery (`_build_extension`
+in `torch_mojo_backend/eager_kernels/__init__.py`): the same file-lock,
+atomic-rename and `__mojocache__` cache tensor_holder.mojo builds through,
+just pointed at `mojoccl.mojo` instead. That path builds a Python CPython
+extension normally, but `_build_extension` itself only runs `mojo build
+--emit shared-lib` and returns the output path -- nothing about it assumes a
+`PyInit_*` symbol, so it works unchanged for a plain C-ABI shared library
+loaded with ctypes rather than importlib.
+"""
+
+import threading
+from pathlib import Path
+
+from torch_mojo_backend.eager_kernels import _build_extension
+
+_ENTRY = Path(__file__).parent / "mojoccl" / "mojoccl.mojo"
+
+_LOCK = threading.Lock()
+_CACHED: list[Path] = []
+
+
+def ensure_built() -> str:
+    """Build (if needed) and return the path to libmojoccl.so."""
+    with _LOCK:
+        if _CACHED:
+            return str(_CACHED[0])
+        path = _build_extension(_ENTRY, None)
+        _CACHED.append(path)
+        return str(path)

--- a/torch_mojo_backend/distributed/nccl.py
+++ b/torch_mojo_backend/distributed/nccl.py
@@ -33,6 +33,7 @@ import functools
 import os
 from pathlib import Path
 
+from torch_mojo_backend.distributed import mojoccl_build
 from torch_mojo_backend.mojo_device import cuda_peer, hip_peer
 
 # nccl.h: ncclResult_t
@@ -62,6 +63,10 @@ NCCL_UNIQUE_ID_BYTES = 128
 
 _NCCL_LIB_ENV = "TORCH_MOJO_BACKEND_NCCL_LIB"
 _RCCL_LIB_ENV = "TORCH_MOJO_BACKEND_RCCL_LIB"
+# "mojo": build (first use only, cached) and use libmojoccl.so -- the
+# in-repo NCCL-API implementation (torch_mojo_backend/distributed/mojoccl) --
+# instead of vendor NCCL/RCCL. Same C ABI, same `_declare()` argtypes below.
+_CCL_ENV = "TORCH_MOJO_BACKEND_CCL"
 
 # MAX's `Device.api` string -> the library implementing the NCCL API there.
 _LIBRARY_NAME_OF = {"cuda": "NCCL", "hip": "RCCL"}
@@ -253,6 +258,11 @@ def load(api: str) -> CclLibrary:
             f"no NCCL-API collective library for the {api!r} device api; the "
             "mojo distributed backend supports NVIDIA (NCCL) and AMD (RCCL) GPUs"
         ) from None
+    if os.environ.get(_CCL_ENV) == "mojo":
+        path = mojoccl_build.ensure_built()
+        lib = ctypes.CDLL(path, mode=ctypes.RTLD_GLOBAL)
+        _declare(lib)
+        return CclLibrary(lib, path, "mojoccl")
     paths = _candidate_librccl_paths() if api == "hip" else _candidate_libnccl_paths()
     errors = []
     for path in paths:

--- a/torch_mojo_backend/eager_flash_attention/__init__.py
+++ b/torch_mojo_backend/eager_flash_attention/__init__.py
@@ -4,13 +4,14 @@ The large vendored kernels deliberately live outside ``eager_kernels`` so a
 FlashAttention change does not invalidate every ordinary eager extension.
 """
 
-import fcntl
 import hashlib
 import importlib
 from pathlib import Path
 from types import ModuleType
 
 import mojo.importer  # noqa: F401 - installs the .mojo import hook
+
+from torch_mojo_backend import eager_kernels
 
 _PACKAGE_DIR = Path(__file__).parent
 _CACHE_DIR = _PACKAGE_DIR / "__mojocache__"
@@ -40,7 +41,9 @@ def load_fa4_ops() -> ModuleType:
 
     _CACHE_DIR.mkdir(exist_ok=True)
     with open(_CACHE_DIR / ".compile.lock", "w") as lock_file:
-        fcntl.flock(lock_file, fcntl.LOCK_EX)
+        # Dedupes concurrent builds only; NFS homes without a lock manager
+        # raise ENOLCK, and building redundantly is the right fallback there.
+        eager_kernels._flock_or_none(lock_file)
         _MODULE = importlib.import_module(
             "torch_mojo_backend.eager_flash_attention.fa4_ops"
         )

--- a/torch_mojo_backend/eager_kernels/__init__.py
+++ b/torch_mojo_backend/eager_kernels/__init__.py
@@ -50,6 +50,7 @@ import subprocess
 import sys
 import threading
 import time
+import uuid
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
@@ -502,7 +503,18 @@ def _build_extension(src: Path, defines: CanonicalDefines | None) -> Path:
         # runs WITHOUT the lock — a reader must never see a partial .so.
         # The temp name keeps the .so suffix (mojo normalizes others) and a
         # leading dot so no cache scan ever picks it up.
-        tmp = out.with_name(f".tmp{os.getpid()}.{out.name}")
+        #
+        # A random suffix, not the pid: the flock above is on the NFS home,
+        # which does not serialize two NODES, so a cold build under a
+        # multi-node job runs concurrently on each of them — and two hosts
+        # hand out the same pid all the time. Both then built to the same
+        # temp path and the first one's `finally` unlinked the other's output
+        # mid-compile, which surfaces as `mojo: error: failed to produce an
+        # archive for the module: No such file or directory` on one node and
+        # `ncclCommInitRank failed: internal error` on the other (its peers
+        # never came up). Seen at 2x8 ranks; the builds are idempotent, so
+        # letting them race to distinct temp paths is the whole fix.
+        tmp = out.with_name(f".tmp{uuid.uuid4().hex}.{out.name}")
         started = time.monotonic()
         try:
             proc = subprocess.run(

--- a/torch_mojo_backend/eager_kernels/__init__.py
+++ b/torch_mojo_backend/eager_kernels/__init__.py
@@ -530,7 +530,16 @@ def _build_extension(src: Path, defines: CanonicalDefines | None) -> Path:
                     f"mojo build failed for {src.stem} "
                     f"({_defines_tag(defines)}):\n{proc.stderr}"
                 )
-            os.replace(tmp, out)
+            if out.is_file():
+                # Another builder installed this immutable output while ours
+                # ran (the lock was unavailable, or it was another node).
+                # Keep theirs: a second os.replace over a path a reader has
+                # already resolved hands that reader a stale NFS handle
+                # (`cannot stat shared object: Stale file handle` on dlopen,
+                # seen once per 24-rank cold start over three nodes).
+                _trace(f"{label} was installed concurrently; reusing it")
+            else:
+                os.replace(tmp, out)
             _trace(f"built {label} in {elapsed:.2f}s")
         finally:
             tmp.unlink(missing_ok=True)

--- a/torch_mojo_backend/eager_kernels/__mojocache__
+++ b/torch_mojo_backend/eager_kernels/__mojocache__
@@ -1,1 +1,0 @@
-/home/gabriel/projects/torch-mojo-backend/torch_mojo_backend/eager_kernels/__mojocache__

--- a/torch_mojo_backend/eager_kernels/__mojocache__
+++ b/torch_mojo_backend/eager_kernels/__mojocache__
@@ -1,0 +1,1 @@
+/home/gabriel/projects/torch-mojo-backend/torch_mojo_backend/eager_kernels/__mojocache__


### PR DESCRIPTION
## Summary

Stacked on #452 (single-node `mojoccl`, the Mojo implementation of NCCL's C ABI): review and merge that one first; this PR's own diff is the commits after 667dbc5.

Multi-node communicators now run **all in Mojo, with no vendor collective library on any hop**. Per chunk: the intra-node reduce-scatter (`reduce_scatter_stage`, split out of the fused allreduce with byte-identical device code for the existing entry points) leaves each rank its node-reduced shard; each rank RDMA-writes the shard to its counterpart (same `local_rank`) on every other node over libibverbs with GPUDirect RDMA (`nvidia_peermem`), a small kernel sums the arrivals, and the intra-node all-gather (`allgather_finish`) assembles the result. Broadcast and all-gather use the same RDMA path with simpler schedules. Single-node communicators keep the fused fast path and never touch IB.

- **Bootstrap**: a TCP socket opened by `ncclGetUniqueId` on rank 0, its `{ipv4, port, magic}` in the 128-byte unique id (NCCL's shape), three relayed all-gathers in `ncclCommInitRank`. Replaces the `/dev/shm` rendezvous for every case.
- **Transport** (`mojoccl/{ibverbs,internode,internode_kernels}.mojo`): libibverbs dlopened; the static-inline data path (`ibv_post_send`/`post_recv`/`poll_cq`) reached through the `ibv_context_ops` table like NCCL's `ibvwrap`, every struct offset and constant verified against the installed headers with a C `offsetof` program; one RC QP per remote node with `net_ib/connect.cc`'s attributes (cited); one `ibv_reg_mr` of the whole region; `RDMA_WRITE_WITH_IMM` per shard + a self-QP `RDMA_READ` flush to order the GPU-memory payload behind the host-memory completion; a double-buffered inbox with fixed halves and parity in the immediate, sound because every exchange is all-to-all (empty shards post a credit); a per-rank progress thread through a pinned device-mapped mailbox, spinning only during an exchange (the stream-callback alternative costs ~480 µs fixed per exchange and stays behind `MOJOCCL_IB_PROXY=0`).
- **Limits**: 8 ranks/node, 16 nodes, one IB subnet (LID addressing); Slingshot (Adastra) needs a second, libfabric/cxi backend and fails clearly. Env vars in `docs/distributed.md` ("Multi-node").
- **Tests**: `tests/multinode/run_two_node_checks.sbatch` (2×8 GPUs: ddp_worker collectives/DDP-parity/stress under NCCL and Mojo, allreduce bench ABBA, nanoGPT DDP ABBA) + `summarize.py`; two GPU-free self-tests of the bootstrap and the RDMA transport in `tests/multinode/selftest/` (they run on an IB host without GPUs and caught six bugs before any GPU time). Also cherry-picks #451 (FA4 loader `flock` fallback), without which cold 16-rank runs die on this NFS home.

## Results, 16 ranks on 2×8 H100 (job 234072; NCCL 2.31.2 `NVLS_TREE/SIMPLE`)

| MiB | Mojo fp32 | NCCL fp32 | ratio |
|---|---|---|---|
| 1 | 60 µs | 153 µs | 0.39 |
| 9 (bucket 0) | 119 µs | 174 µs | 0.69 |
| 27 (DDP buckets) | 278 µs | 266 µs | 1.04 |
| 168 (tail bucket) | 1532 µs | 939 µs | 1.63 |
| 512 | 4.64 ms | 2.36 ms | 1.96 |

bf16 within 1% of fp32. All six correctness legs pass at 16 ranks; nanoGPT reaches the same losses under both. With `MOJOCCL_IB_TRACE=1` the RDMA runs at 40–45 GB/s per rank (line rate for one 400 Gb/s HCA). Above the bucket the gap is the intra-node half (unicast vs NVLS multicast), not the network. End-to-end nanoGPT throughput: after the progress thread learned to back off when idle (it competed with the host-bound Python dispatch thread), one 2-node job measured parity (4.03 vs 3.99 M tok/s) and another a 10% gap with NCCL itself varying 4% across node pairs; a six-run single-pair ABBA (job 234185) then gave median step times of 49.7 ms (NCCL) vs 51.4 ms (Mojo), 1.036×, with the three adjacent pairs at 1.035 / 1.084 / 0.996, i.e. the gap is within the run-to-run noise of these shared nodes. On `--exclusive` nodes (job 234455, same six-run design) NCCL is tight at 44.6–44.9 ms per step while Mojo reads 45.1, 45.7 and 50.1 ms: the best-decile steps are within 1.7% of NCCL and the slow run is a scheduling mode (a steady 51 ms for steps 12–35, 45–46 before and after) initially attributed to the progress thread. Pinning it by default (now the policy) did not remove it; binding each rank's whole process to a compact eighth of the task's CPUs did (job 234658, exclusive nodes, `tests/multinode/rank_bind.py`): **NCCL 46.30 ms vs Mojo 46.37 ms pooled median step time, ratio 1.001**, adjacent pairs 0.968 / 1.005 / 1.030, and the remaining plateaus occur under both libraries alike. End to end the Mojo path is at parity with NCCL on this cluster.

## Pipelining (added)

The three phases now overlap: each bucket is cut into K chunks (K = floor(sqrt(bytes / (local_world × 640 000))), i.e. 1 up to 9 MiB, 2 at 27 MiB, 5 at 168 MiB, 10 at 512 MiB), issued on the one comm stream as RS(0) rel(0) … RS(3) rel(3) | wait(0) add(0) AG(0) RS(4) rel(4) | …, with four complete staging arenas (chunk k uses arena k % 4) and five fixed inbox slots protected by explicit credits: a peer may post exchange e into slot e % 5 only once every receiver has reported consuming e−5, the credit riding as a bit in the immediate of the next request (NCCL's head/tail in miniature). Same node pair, same job (234237), ABBA medians in µs:

| MiB | K | before | after | NCCL | after/NCCL |
|---|---|---|---|---|---|
| 9 | 1 | 187 | 187 | 175 | 1.07 |
| 27 (DDP bucket) | 2 | 342 | 282 | 267 | 1.06 |
| 168 (tail bucket) | 5 | 1606 | 1192 | 941 | 1.27 |
| 512 | 10 | 4762 | 3541 | 2359 | 1.50 |

Per-exchange IB latency differs several-fold between node pairs (~19 µs on the pair of job 234072, ~87 µs on this one), which is why the unpipelined numbers moved between jobs while NCCL, which pipelines, did not. Correctness at 16 ranks (collectives, DDP parity, stress incl. 256 MiB messages cut into 7 chunks) and single-node unchanged; new GPU-free self-tests ib_pipeline (200 exchanges past the slot count) and geometry_test (98 939 layout cases). Also cherry-picked out as #454: cold builds used a pid-named temp file, and two nodes building the same kernel into the NFS cache clobbered each other.

## NVLS (added)

Single-node communicators on NVIDIA nodes whose devices report multicast support now allreduce sizes ≥ 48 MiB (the measured crossover; `MOJOCCL_NVLS_MIN_MB`) through the NVSwitch: the staging region is `cuMemCreate` memory bound to a per-node multicast object (created by local rank 0, its POSIX fd passed over AF_UNIX SCM_RIGHTS), mapped twice (unicast for the existing kernels, multicast for `multimem.ld_reduce`/`multimem.st`), peers imported with `cuMemImportFromShareableHandle`. The capability is voted in bootstrap round 1 before any allocation, so a communicator either builds the whole NVLS region or today's `cuMemAlloc` one; `MOJOCCL_NVLS=0` disables it; AMD and integer dtypes keep unicast. Multi-node stays on the unicast split kernels: its pipeline chunks (33.6 MiB at 168 MiB) sit below the crossover and RDMA registration of the multicast-bound VMM mapping is unproven on this cluster. Allocation granularity is the driver MINIMUM (2 MiB) so `MOJOCCL_REGION_MB` keeps its meaning (`MOJOCCL_NVLS_GRANULARITY=rec` restores NCCL's 512 MiB choice; measured identical).

8×H100, six palindromic legs (job 234314), µs:

| dtype | MiB | unicast | NVLS | NCCL | NVLS/NCCL |
|---|---|---|---|---|---|
| fp32 | 27 | 165 | 164 (unicast path) | 182 | 0.91 |
| fp32 | 168 | 988 | 799 | 756 | 1.06 |
| fp32 | 512 | 2991 | 2218 | 2154 | 1.03 |
| bf16 | 168 | 994 | 798 | 745 | 1.07 |
| bf16 | 512 | 2988 | 2213 | 2126 | 1.04 |

Correctness: the stress mode (256 MiB messages, every dtype × ragged size × SUM/AVG × placement), a new `tests/nvls_check.py` at world 2 and 4 straddling the 48 MiB floor and the arena, the 2-node suite with no regression (285/1185/3545 µs at 16 ranks). Prototype report: `docs/mojo_collectives_nvls_results.md`.

## Review

Two independent reviews of the multi-node + NVLS change set, then a fix pass:

- **Fable** (Claude), in a worktree, with fixes: found the send-completion accounting bug independently (global `sends_completed` across queue pairs lets an exchange retire while another node's NIC still reads its source; only reachable at ≥ 3 nodes, verified fixed at 24 ranks on 3 nodes), an AVG overflow in the split path (unscaled node sums stored in fp16/bf16; fixed as NCCL's pre-multiply, tests added at overflowing magnitudes), init-failure leaks (region, MRs/QPs, mailbox, thread; now unwound), missing per-communicator serialization of multi-launch submissions (now a per-comm lock, ~20 ns uncontended), a 16-byte heap leak per idle sleep of the progress thread, the NVLS threshold read per rank (now agreed at init), an async-error race, VMM ownership gaps, docs and annotation-rule slips, and an NFS cold-build ESTALE race in the loader (cherry-picked to #454).
- **GPT-6 Astra** (Codex, read-only): report at `~/ddp_work/mojo_collectives/reviews/codex_review_raw.md`. Its four High findings coincided with or added to the above (all fixed); it also verified the verbs and CUDA struct layouts with gcc and confirmed the credit protocol, the flush, and the NVLS barriers.
- Follow-up pass (Opus) for the two items the reviewers had left as limitations: `ncclCommAbort` now has NCCL's contract (a device-mapped abort word every spin loop probes on its existing slow path; device released in 0.07–0.11 s where it used to run to the 60 s deadline; resources reclaimed after a bounded quiesce; destroy afterwards is a no-op), and every bootstrap and fd-exchange socket is non-blocking with `poll` against the absolute deadline (a connect to an unroutable address returned after 129 s on a 1.5 s deadline before; 1.50 s now). Plus one timeout variable for every spin, no per-poll allocations in the error query, and tests for all of it (`sock_deadline` self-test, an `abort` worker mode). The 27 MiB allreduce is unchanged (165/163 µs, ABBA) with the abort check in place.

Commits by the Opus/Sonnet/Fable agents carry their own `Co-Authored-By`; coordinated in this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167VthrN76wtxabswrkrnJB




