### PR TITLE
eager_kernels: give each cold build a unique temp path, not the pid's

### DIFF
--- a/torch_mojo_backend/eager_kernels/__init__.py
+++ b/torch_mojo_backend/eager_kernels/__init__.py
@@ -50,6 +50,7 @@ import subprocess
 import sys
 import threading
 import time
+import uuid
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
@@ -502,7 +503,18 @@ def _build_extension(src: Path, defines: CanonicalDefines | None) -> Path:
         # runs WITHOUT the lock — a reader must never see a partial .so.
         # The temp name keeps the .so suffix (mojo normalizes others) and a
         # leading dot so no cache scan ever picks it up.
-        tmp = out.with_name(f".tmp{os.getpid()}.{out.name}")
+        #
+        # A random suffix, not the pid: the flock above is on the NFS home,
+        # which does not serialize two NODES, so a cold build under a
+        # multi-node job runs concurrently on each of them — and two hosts
+        # hand out the same pid all the time. Both then built to the same
+        # temp path and the first one's `finally` unlinked the other's output
+        # mid-compile, which surfaces as `mojo: error: failed to produce an
+        # archive for the module: No such file or directory` on one node and
+        # `ncclCommInitRank failed: internal error` on the other (its peers
+        # never came up). Seen at 2x8 ranks; the builds are idempotent, so
+        # letting them race to distinct temp paths is the whole fix.
+        tmp = out.with_name(f".tmp{uuid.uuid4().hex}.{out.name}")
         started = time.monotonic()
         try:
             proc = subprocess.run(

--- a/torch_mojo_backend/eager_kernels/__init__.py
+++ b/torch_mojo_backend/eager_kernels/__init__.py
@@ -530,7 +530,16 @@ def _build_extension(src: Path, defines: CanonicalDefines | None) -> Path:
                     f"mojo build failed for {src.stem} "
                     f"({_defines_tag(defines)}):\n{proc.stderr}"
                 )
-            os.replace(tmp, out)
+            if out.is_file():
+                # Another builder installed this immutable output while ours
+                # ran (the lock was unavailable, or it was another node).
+                # Keep theirs: a second os.replace over a path a reader has
+                # already resolved hands that reader a stale NFS handle
+                # (`cannot stat shared object: Stale file handle` on dlopen,
+                # seen once per 24-rank cold start over three nodes).
+                _trace(f"{label} was installed concurrently; reusing it")
+            else:
+                os.replace(tmp, out)
             _trace(f"built {label} in {elapsed:.2f}s")
         finally:
             tmp.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary

`_build_extension` writes each cold `mojo build` to `.tmp<pid>.<name>.so` and renames it into place. The build lock is an `flock` on the NFS home, which serializes the ranks of one node but not two nodes (and does not even lock at all where NFS has no lock manager), so under a multi-node job the same kernel builds concurrently on each node. Two hosts hand out the same pid all the time: the first to finish renamed its file into place and its `finally` then unlinked the path the other node's compiler was still writing to. That surfaced as `mojo: error: failed to produce an archive for the module: No such file or directory` on one node and a spurious `NotImplementedError` / init failure on the other.

This is the failure I had attributed to a "bad node" earlier today (every build on `par2dc5-ai-prd-cl02s03dgx01` failed while another job on another node was compiling the same variants). Builds are idempotent, so distinct temp paths (a uuid) are the whole fix.

Found by the Opus agent pipelining the mojoccl multi-node allreduce (job 234229); cherry-picked from the `mojo-collectives-multinode` branch so it can land on `main` independently.

## Testing

`ruff`, `ty` clean. The multi-node runs that used to die on a cold cache pass with it (16 ranks, jobs 234229/234237).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167VthrN76wtxabswrkrnJB


**Second commit** (found by the review pass on the multi-node work, job 234396): when the NFS home refuses `flock`, 24 ranks each `os.replace`d their own build over the same output and one rank's `dlopen` hit `ESTALE` on a file that had just been replaced under it. The loader now keeps an extension a concurrent builder installed first instead of replacing it.
